### PR TITLE
feat: add every-X-minutes routines

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,9 +304,13 @@ pnpm package:linux # Ubuntu x64 .deb + AppImage → release/
 
 ### Routines and webhook triggers
 
-Routines can run once or on selected weekdays, using either a MAUS's configured model/computer or the
-Cloud VM runner. Webhook triggers are independent from schedules but reuse the same queued task executor
-and calendar receipts.
+Routines can run once, on selected weekdays, or every 5–1,440 minutes, using either a MAUS's configured
+model/computer or the Cloud VM runner. Interval schedules stay aligned to their chosen start time and skip
+an occurrence when the previous run is still active, so slow work cannot build an unbounded queue. A
+separate optional Advanced run limit can safely stop stuck work; no timeout is imposed unless one is chosen.
+The existing duration field remains calendar/display metadata. Webhook triggers are independent from schedules
+but reuse the same queued task executor and calendar
+receipts.
 
 OpenMausBot starts a webhook-only receiver on `127.0.0.1:8800` by default (or one port above `OMB_PORT`).
 Set `OMB_WEBHOOK_PORT` to choose another port. A webhook secret is shown once when the trigger is created

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/RoutineEditorSheet.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/RoutineEditorSheet.kt
@@ -17,9 +17,9 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DatePicker
@@ -28,6 +28,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
@@ -62,6 +63,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.openmausbot.companion.R
@@ -132,8 +134,29 @@ internal fun RoutineEditorSheet(
     var weekdays by rememberSaveable(stateSaver = WeekdaysSaver) {
         mutableStateOf(seed?.schedule?.weekdays?.toSet() ?: RoutineRules.DEFAULT_WEEKDAYS)
     }
-    var duration by rememberSaveable {
-        mutableIntStateOf(seed?.durationMinutes ?: RoutineRules.DEFAULT_DURATION)
+    var intervalMinutesText by rememberSaveable {
+        mutableStateOf(
+            (seed?.schedule?.everyMinutes ?: RoutineRules.DEFAULT_INTERVAL).toString(),
+        )
+    }
+    var intervalAnchor by rememberSaveable(stateSaver = OnceDraftSaver) {
+        mutableStateOf(
+            OnceDraft(
+                seed?.schedule?.anchorAt
+                    ?: RoutineRules.defaultIntervalAnchor(
+                        nowMillis = System.currentTimeMillis(),
+                        everyMinutes = seed?.schedule?.everyMinutes ?: RoutineRules.DEFAULT_INTERVAL,
+                    ),
+            ),
+        )
+    }
+    val legacyDurationMinutes = seed?.durationMinutes ?: RoutineRules.LEGACY_DURATION_MINUTES
+    var timeoutMinutes by rememberSaveable { mutableStateOf(seed?.timeoutMinutes) }
+    var newIntervalTimeoutApplied by rememberSaveable { mutableStateOf(seed != null) }
+    var advancedExpanded by rememberSaveable {
+        mutableStateOf(
+            seed?.timeoutMinutes?.let { it != RoutineRules.DEFAULT_INTERVAL_TIMEOUT } ?: false,
+        )
     }
     var saving by remember { mutableStateOf(false) }
     var availability by remember { mutableStateOf<RoutineRunAvailability?>(null) }
@@ -156,7 +179,16 @@ internal fun RoutineEditorSheet(
     }
 
     val cloudSelectable = RoutineRules.cloudSelectable(availability, runOn)
-    val canSave = RoutineRules.canSave(saving, kind, name, prompt, agent.botId, weekdays)
+    val intervalMinutes = RoutineRules.intervalMinutes(intervalMinutesText)
+    val canSave = RoutineRules.canSave(
+        saving = saving,
+        kind = kind,
+        name = name,
+        prompt = prompt,
+        botId = agent.botId,
+        weekdays = weekdays,
+        everyMinutes = intervalMinutes,
+    )
 
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
@@ -186,10 +218,15 @@ internal fun RoutineEditorSheet(
                             saving = true
                             val schedule = RoutineRules.schedule(
                                 kind = kind,
-                                onceAtMillis = once.millis.toDouble(),
+                                onceAtMillis = if (kind == RoutineSchedule.Kind.INTERVAL) {
+                                    intervalAnchor.millis.toDouble()
+                                } else {
+                                    once.millis.toDouble()
+                                },
                                 hour = dailyMinuteOfDay / 60,
                                 minute = dailyMinuteOfDay % 60,
                                 weekdays = weekdays,
+                                everyMinutes = intervalMinutes ?: RoutineRules.DEFAULT_INTERVAL,
                             )
                             val saved = session.saveRoutine(
                                 RoutineRules.input(
@@ -199,7 +236,8 @@ internal fun RoutineEditorSheet(
                                     runOn = runOn,
                                     enabled = opened.enabled,
                                     schedule = schedule,
-                                    durationMinutes = duration,
+                                    durationMinutes = legacyDurationMinutes,
+                                    timeoutMinutes = timeoutMinutes,
                                 ),
                                 opened.routineId,
                             )
@@ -241,43 +279,6 @@ internal fun RoutineEditorSheet(
                     modifier = Modifier.fillMaxWidth(),
                 )
 
-                Row(
-                    modifier = Modifier.fillMaxWidth().heightIn(min = MIN_TOUCH_TARGET),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = "Allow up to $duration minutes",
-                        fontSize = 15.sp,
-                        modifier = Modifier.weight(1f),
-                    )
-                    ChromeButton(
-                        painter = painterResource(R.drawable.ic_remove),
-                        contentDescription = "Fewer minutes",
-                        enabled = duration > RoutineRules.DURATION_RANGE.first,
-                        onClick = {
-                            duration = RoutineRules.steppedDuration(
-                                duration,
-                                -RoutineRules.DURATION_STEP,
-                            )
-                        },
-                        size = 40.dp,
-                        glyph = 18.dp,
-                    )
-                    Box(modifier = Modifier.size(8.dp))
-                    ChromeButton(
-                        icon = Icons.Filled.Add,
-                        contentDescription = "More minutes",
-                        enabled = duration < RoutineRules.DURATION_RANGE.last,
-                        onClick = {
-                            duration = RoutineRules.steppedDuration(
-                                duration,
-                                RoutineRules.DURATION_STEP,
-                            )
-                        },
-                        size = 40.dp,
-                        glyph = 18.dp,
-                    )
-                }
             }
 
             FormSection(
@@ -317,7 +318,14 @@ internal fun RoutineEditorSheet(
                 }
             }
 
-            FormSection(header = "Schedule", footer = RoutineRules.SCHEDULE_FOOTER) {
+            FormSection(
+                header = "Schedule",
+                footer = if (kind == RoutineSchedule.Kind.INTERVAL) {
+                    RoutineRules.INTERVAL_SCHEDULE_FOOTER
+                } else {
+                    RoutineRules.SCHEDULE_FOOTER
+                },
+            ) {
                 if (kind == RoutineSchedule.Kind.UNKNOWN) {
                     RadioRow(
                         label = "Newer schedule",
@@ -335,6 +343,18 @@ internal fun RoutineEditorSheet(
                     label = "Selected days",
                     selected = kind == RoutineSchedule.Kind.DAILY,
                     onSelect = { kind = RoutineSchedule.Kind.DAILY },
+                )
+                RadioRow(
+                    label = "Every few minutes",
+                    selected = kind == RoutineSchedule.Kind.INTERVAL,
+                    onSelect = {
+                        kind = RoutineSchedule.Kind.INTERVAL
+                        timeoutMinutes = RoutineRules.intervalTimeoutOnFirstSelection(
+                            current = timeoutMinutes,
+                            defaultAlreadyApplied = newIntervalTimeoutApplied,
+                        )
+                        newIntervalTimeoutApplied = true
+                    },
                 )
 
                 when (kind) {
@@ -371,32 +391,94 @@ internal fun RoutineEditorSheet(
                             }
                         }
                     }
+                    RoutineSchedule.Kind.INTERVAL -> {
+                        FlowRow(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            RoutineRules.INTERVAL_PRESETS.forEach { minutes ->
+                                FilterChip(
+                                    selected = intervalMinutes == minutes,
+                                    onClick = { intervalMinutesText = minutes.toString() },
+                                    label = { Text("$minutes min") },
+                                    modifier = Modifier.semantics {
+                                        contentDescription = "Every $minutes minutes"
+                                    },
+                                )
+                            }
+                        }
+                        OutlinedTextField(
+                            value = intervalMinutesText,
+                            onValueChange = { value ->
+                                if (value.length <= 4 && value.all(Char::isDigit)) {
+                                    intervalMinutesText = value
+                                }
+                            },
+                            label = { Text("Every (minutes)") },
+                            supportingText = { Text("From 5 minutes to 24 hours") },
+                            isError = intervalMinutes == null,
+                            singleLine = true,
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        ValueRow(
+                            label = "Aligned from",
+                            value = RelativeStamp.dateAndTime(intervalAnchor.millis.toDouble(), zone),
+                            onClick = { pickingDate = true },
+                        )
+                    }
                     RoutineSchedule.Kind.UNKNOWN -> IconNote(
                         text = RoutineRules.UNKNOWN_SCHEDULE_NOTE,
                         icon = Icons.Filled.Warning,
                     )
                 }
             }
+
+            FormSection(
+                header = null,
+                footer = if (advancedExpanded) {
+                    "Optional. This only stops a stuck run; it does not control how often the routine starts."
+                } else {
+                    null
+                },
+            ) {
+                ValueRow(
+                    label = "Advanced",
+                    value = if (advancedExpanded) {
+                        "Hide"
+                    } else {
+                        timeoutMinutes?.let { "$it min limit" } ?: "No limit"
+                    },
+                    onClick = { advancedExpanded = !advancedExpanded },
+                )
+                if (advancedExpanded) {
+                    TimeoutPicker(value = timeoutMinutes, onSelect = { timeoutMinutes = it })
+                }
+            }
         }
     }
 
     if (pickingDate) {
+        val editingIntervalAnchor = kind == RoutineSchedule.Kind.INTERVAL
+        val draft = if (editingIntervalAnchor) intervalAnchor else once
         val today = remember { LocalDate.now(zone) }
-        val opensOn = remember(once) { once.date(zone) }
+        val opensOn = remember(draft) { draft.date(zone) }
         val datePickerState = rememberDatePickerState(
             initialSelectedDateMillis = opensOn
                 .atStartOfDay(ZoneOffset.UTC)
                 .toInstant()
                 .toEpochMilli(),
-            selectableDates = remember(today) {
+            selectableDates = remember(today, editingIntervalAnchor) {
                 object : SelectableDates {
                     override fun isSelectableDate(utcTimeMillis: Long): Boolean =
-                        !Instant.ofEpochMilli(utcTimeMillis)
+                        editingIntervalAnchor || !Instant.ofEpochMilli(utcTimeMillis)
                             .atZone(ZoneOffset.UTC)
                             .toLocalDate()
                             .isBefore(today)
 
-                    override fun isSelectableYear(year: Int): Boolean = year >= today.year
+                    override fun isSelectableYear(year: Int): Boolean =
+                        editingIntervalAnchor || year >= today.year
                 }
             },
         )
@@ -405,7 +487,11 @@ internal fun RoutineEditorSheet(
             // the committed instant does not.
             onDismissRequest = {
                 pickingDate = false
-                once = once.discard()
+                if (editingIntervalAnchor) {
+                    intervalAnchor = intervalAnchor.discard()
+                } else {
+                    once = once.discard()
+                }
             },
             confirmButton = {
                 TextButton(
@@ -414,11 +500,14 @@ internal fun RoutineEditorSheet(
                         // Staged, not written. `Date()...` bounds the instant the
                         // user confirms, and they have not confirmed one yet.
                         if (picked != null) {
-                            once = once.stage(
-                                Instant.ofEpochMilli(picked)
-                                    .atZone(ZoneOffset.UTC)
-                                    .toLocalDate(),
-                            )
+                            val date = Instant.ofEpochMilli(picked)
+                                .atZone(ZoneOffset.UTC)
+                                .toLocalDate()
+                            if (editingIntervalAnchor) {
+                                intervalAnchor = intervalAnchor.stage(date)
+                            } else {
+                                once = once.stage(date)
+                            }
                         }
                         pickingDate = false
                         // The instant is a day and a time; Material picks them in
@@ -431,7 +520,11 @@ internal fun RoutineEditorSheet(
                 TextButton(
                     onClick = {
                         pickingDate = false
-                        once = once.discard()
+                        if (editingIntervalAnchor) {
+                            intervalAnchor = intervalAnchor.discard()
+                        } else {
+                            once = once.discard()
+                        }
                     },
                 ) { Text("Cancel") }
             },
@@ -441,16 +534,20 @@ internal fun RoutineEditorSheet(
     }
 
     if (pickingTime) {
+        val editingIntervalAnchor = kind == RoutineSchedule.Kind.INTERVAL
+        val draft = if (editingIntervalAnchor) intervalAnchor else once
         val bounded = kind == RoutineSchedule.Kind.ONCE
-        val day = remember(once) { once.date(zone) }
-        val start = remember(bounded, once, dailyMinuteOfDay) {
+        val day = remember(draft) { draft.date(zone) }
+        val start = remember(bounded, draft, dailyMinuteOfDay) {
             if (bounded) {
                 RoutineRules.onceTimeStart(
                     date = day,
-                    time = once.time(zone),
+                    time = draft.time(zone),
                     now = Instant.now(),
                     zone = zone,
                 )
+            } else if (editingIntervalAnchor) {
+                draft.time(zone)
             } else {
                 LocalTime.of(dailyMinuteOfDay / 60, dailyMinuteOfDay % 60)
             }
@@ -462,7 +559,11 @@ internal fun RoutineEditorSheet(
         )
         val cancel = {
             pickingTime = false
-            once = once.discard()
+            if (editingIntervalAnchor) {
+                intervalAnchor = intervalAnchor.discard()
+            } else {
+                once = once.discard()
+            }
         }
         // The Material dialog rather than an AlertDialog with a TimePicker in
         // its text slot: the clock face is wider than a platform-default alert,
@@ -485,7 +586,13 @@ internal fun RoutineEditorSheet(
                     enabled = selectable,
                     onClick = {
                         pickingTime = false
-                        if (bounded) {
+                        if (editingIntervalAnchor) {
+                            intervalAnchor = intervalAnchor.confirm(
+                                timeState.hour,
+                                timeState.minute,
+                                zone,
+                            )
+                        } else if (bounded) {
                             once = once.confirm(timeState.hour, timeState.minute, zone)
                         } else {
                             // "Selected days" never opens the date dialog, so
@@ -500,9 +607,58 @@ internal fun RoutineEditorSheet(
             dismissButton = {
                 TextButton(onClick = cancel) { Text("Cancel") }
             },
-            title = { Text(if (bounded) "Run" else "Time") },
+            title = {
+                Text(
+                    when (kind) {
+                        RoutineSchedule.Kind.INTERVAL -> "Alignment time"
+                        RoutineSchedule.Kind.ONCE -> "Run"
+                        else -> "Time"
+                    },
+                )
+            },
         ) {
             TimePicker(state = timeState)
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TimeoutPicker(value: Int?, onSelect: (Int?) -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        OutlinedTextField(
+            value = value?.let { "$it minutes" } ?: "No limit",
+            onValueChange = {},
+            readOnly = true,
+            label = { Text("Stop if still running after") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
+                .fillMaxWidth()
+                .semantics { contentDescription = "Routine timeout" },
+        )
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            DropdownMenuItem(
+                text = { Text("No limit") },
+                onClick = {
+                    expanded = false
+                    onSelect(null)
+                },
+            )
+            RoutineRules.TIMEOUT_OPTIONS.forEach { minutes ->
+                DropdownMenuItem(
+                    text = { Text("$minutes minutes") },
+                    onClick = {
+                        expanded = false
+                        onSelect(minutes)
+                    },
+                )
+            }
         }
     }
 }

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/RoutineEditorSheet.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/RoutineEditorSheet.kt
@@ -24,11 +24,11 @@ import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
@@ -139,6 +139,12 @@ internal fun RoutineEditorSheet(
             (seed?.schedule?.everyMinutes ?: RoutineRules.DEFAULT_INTERVAL).toString(),
         )
     }
+    var intervalUsesCustom by rememberSaveable {
+        mutableStateOf(
+            seed?.schedule?.everyMinutes?.let { it !in RoutineRules.INTERVAL_PRESETS } ?: false,
+        )
+    }
+    var intervalMenuExpanded by remember { mutableStateOf(false) }
     var intervalAnchor by rememberSaveable(stateSaver = OnceDraftSaver) {
         mutableStateOf(
             OnceDraft(
@@ -345,7 +351,7 @@ internal fun RoutineEditorSheet(
                     onSelect = { kind = RoutineSchedule.Kind.DAILY },
                 )
                 RadioRow(
-                    label = "Every few minutes",
+                    label = "Every X minutes",
                     selected = kind == RoutineSchedule.Kind.INTERVAL,
                     onSelect = {
                         kind = RoutineSchedule.Kind.INTERVAL
@@ -394,39 +400,99 @@ internal fun RoutineEditorSheet(
                     RoutineSchedule.Kind.INTERVAL -> {
                         FlowRow(
                             modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(6.dp),
-                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                            horizontalArrangement = Arrangement.spacedBy(2.dp),
+                            verticalArrangement = Arrangement.spacedBy(2.dp),
                         ) {
-                            RoutineRules.INTERVAL_PRESETS.forEach { minutes ->
-                                FilterChip(
-                                    selected = intervalMinutes == minutes,
-                                    onClick = { intervalMinutesText = minutes.toString() },
-                                    label = { Text("$minutes min") },
+                            Text(
+                                "Runs every",
+                                style = MaterialTheme.typography.bodyLarge,
+                                modifier = Modifier.padding(vertical = 12.dp),
+                            )
+                            Box {
+                                TextButton(
+                                    onClick = { intervalMenuExpanded = true },
                                     modifier = Modifier.semantics {
-                                        contentDescription = "Every $minutes minutes"
+                                        contentDescription = if (intervalUsesCustom) {
+                                            "Choose a custom repeat interval"
+                                        } else {
+                                            "Repeat interval, $intervalMinutesText minutes"
+                                        }
                                     },
+                                ) {
+                                    Text(
+                                        if (intervalUsesCustom) "Custom" else intervalMinutesText,
+                                        style = MaterialTheme.typography.bodyLarge,
+                                    )
+                                    ExposedDropdownMenuDefaults.TrailingIcon(
+                                        expanded = intervalMenuExpanded,
+                                    )
+                                }
+                                DropdownMenu(
+                                    expanded = intervalMenuExpanded,
+                                    onDismissRequest = { intervalMenuExpanded = false },
+                                ) {
+                                    RoutineRules.INTERVAL_PRESETS.forEach { minutes ->
+                                        DropdownMenuItem(
+                                            text = { Text(minutes.toString()) },
+                                            onClick = {
+                                                intervalMenuExpanded = false
+                                                intervalUsesCustom = false
+                                                intervalMinutesText = minutes.toString()
+                                            },
+                                        )
+                                    }
+                                    DropdownMenuItem(
+                                        text = { Text("Custom") },
+                                        onClick = {
+                                            intervalMenuExpanded = false
+                                            if (!intervalUsesCustom) intervalMinutesText = ""
+                                            intervalUsesCustom = true
+                                        },
+                                    )
+                                }
+                            }
+                            Text(
+                                "minutes, starting",
+                                style = MaterialTheme.typography.bodyLarge,
+                                modifier = Modifier.padding(vertical = 12.dp),
+                            )
+                            TextButton(
+                                onClick = { pickingDate = true },
+                                modifier = Modifier.semantics {
+                                    contentDescription = "Change when the interval starts"
+                                },
+                            ) {
+                                Text(
+                                    RelativeStamp.dateAndTime(
+                                        intervalAnchor.millis.toDouble(),
+                                        zone,
+                                    ),
+                                    style = MaterialTheme.typography.bodyLarge,
                                 )
                             }
+                            Text(
+                                ".",
+                                style = MaterialTheme.typography.bodyLarge,
+                                modifier = Modifier.padding(vertical = 12.dp),
+                            )
                         }
-                        OutlinedTextField(
-                            value = intervalMinutesText,
-                            onValueChange = { value ->
-                                if (value.length <= 4 && value.all(Char::isDigit)) {
-                                    intervalMinutesText = value
-                                }
-                            },
-                            label = { Text("Every (minutes)") },
-                            supportingText = { Text("From 5 minutes to 24 hours") },
-                            isError = intervalMinutes == null,
-                            singleLine = true,
-                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                        ValueRow(
-                            label = "Aligned from",
-                            value = RelativeStamp.dateAndTime(intervalAnchor.millis.toDouble(), zone),
-                            onClick = { pickingDate = true },
-                        )
+                        if (intervalUsesCustom) {
+                            OutlinedTextField(
+                                value = intervalMinutesText,
+                                onValueChange = { value ->
+                                    if (value.length <= 4 && value.all(Char::isDigit)) {
+                                        intervalMinutesText = value
+                                    }
+                                },
+                                label = { Text("Custom interval") },
+                                suffix = { Text("minutes") },
+                                supportingText = { Text("From 5 minutes to 24 hours") },
+                                isError = intervalMinutes == null,
+                                singleLine = true,
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
                     }
                     RoutineSchedule.Kind.UNKNOWN -> IconNote(
                         text = RoutineRules.UNKNOWN_SCHEDULE_NOTE,

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/RoutineRules.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/RoutineRules.kt
@@ -28,10 +28,17 @@ object RoutineRules {
     /** `String(prompt.trimming….prefix(20_000))`. */
     const val PROMPT_LIMIT: Int = 20_000
 
-    /** `Stepper(value: $duration, in: 5...240, step: 5)`. */
-    val DURATION_RANGE: IntRange = 5..240
-    const val DURATION_STEP: Int = 5
-    const val DEFAULT_DURATION: Int = 30
+    /** Kept on requests for compatibility with desktop builds that still require the field. */
+    const val LEGACY_DURATION_MINUTES: Int = 30
+
+    /** Optional execution guard. It is deliberately separate from cadence and calendar size. */
+    val TIMEOUT_RANGE: IntRange = 5..240
+    val TIMEOUT_OPTIONS: List<Int> = TIMEOUT_RANGE.step(5).toList()
+    const val DEFAULT_INTERVAL_TIMEOUT: Int = 30
+
+    val INTERVAL_RANGE: IntRange = 5..1_440
+    val INTERVAL_PRESETS: List<Int> = listOf(5, 10, 15, 30, 60)
+    const val DEFAULT_INTERVAL: Int = 15
 
     /** `.prefix(50)` on the sorted receipts. */
     const val RECEIPT_LIMIT: Int = 50
@@ -73,9 +80,12 @@ object RoutineRules {
 
     const val SCHEDULE_FOOTER: String =
         "Each occurrence creates a fresh task. No cron syntax is used."
+    const val INTERVAL_SCHEDULE_FOOTER: String =
+        "Occurrences stay aligned to the chosen time. If the previous run is still active, " +
+            "the next occurrence is skipped instead of queued."
     const val UNKNOWN_SCHEDULE_NOTE: String =
-        "This routine uses a schedule added by a newer OpenMausBot. Choose One time or " +
-            "Selected days before saving."
+        "This routine uses a schedule added by a newer OpenMausBot. Choose One time, " +
+            "Selected days, or Every few minutes before saving."
 
     const val CHECKING_CLOUD: String = "Checking Cloud VM availability…"
     const val CLOUD_STATUS_UNAVAILABLE: String = "Cloud VM status is unavailable"
@@ -119,6 +129,12 @@ object RoutineRules {
             RoutineSchedule.Kind.ONCE -> {
                 val at = schedule.at ?: return "One time · date unavailable"
                 return RelativeStamp.dateAndTime(at, zone, locale)
+            }
+            RoutineSchedule.Kind.INTERVAL -> {
+                val minutes = schedule.everyMinutes ?: return "Interval unavailable"
+                val cadence = "Every $minutes min"
+                val anchor = schedule.anchorAt ?: return cadence
+                return "$cadence · aligned from ${RelativeStamp.dateAndTime(anchor.toDouble(), zone, locale)}"
             }
             RoutineSchedule.Kind.UNKNOWN -> return "Newer schedule"
             RoutineSchedule.Kind.DAILY -> Unit
@@ -202,12 +218,26 @@ object RoutineRules {
         prompt: String,
         botId: String,
         weekdays: Set<Int>,
+        everyMinutes: Int? = null,
     ): Boolean = !saving &&
         kind != RoutineSchedule.Kind.UNKNOWN &&
         name.trim().isNotEmpty() &&
         prompt.trim().isNotEmpty() &&
         botId.isNotEmpty() &&
-        !(kind == RoutineSchedule.Kind.DAILY && weekdays.isEmpty())
+        !(kind == RoutineSchedule.Kind.DAILY && weekdays.isEmpty()) &&
+        !(kind == RoutineSchedule.Kind.INTERVAL &&
+            (everyMinutes == null || everyMinutes !in INTERVAL_RANGE))
+
+    fun intervalMinutes(raw: String): Int? =
+        raw.trim().toIntOrNull()?.takeIf { it in INTERVAL_RANGE }
+
+    fun defaultIntervalAnchor(nowMillis: Long, everyMinutes: Int = DEFAULT_INTERVAL): Long =
+        nowMillis + everyMinutes * 60_000L
+
+    fun intervalTimeoutOnFirstSelection(current: Int?, defaultAlreadyApplied: Boolean): Int? =
+        if (defaultAlreadyApplied) current else DEFAULT_INTERVAL_TIMEOUT
+
+    fun validTimeout(minutes: Int?): Boolean = minutes == null || minutes in TIMEOUT_RANGE
 
     /** `"%02d:%02d"` — what `DateFormatter("HH:mm")` writes for a wall-clock time. */
     fun timeText(hour: Int, minute: Int): String =
@@ -282,10 +312,14 @@ object RoutineRules {
         hour: Int,
         minute: Int,
         weekdays: Set<Int>,
-    ): RoutineSchedule = if (kind == RoutineSchedule.Kind.ONCE) {
-        RoutineSchedule.once(onceAtMillis)
-    } else {
-        RoutineSchedule.daily(timeText(hour, minute), weekdays.sorted())
+        everyMinutes: Int = DEFAULT_INTERVAL,
+    ): RoutineSchedule = when (kind) {
+        RoutineSchedule.Kind.ONCE -> RoutineSchedule.once(onceAtMillis)
+        RoutineSchedule.Kind.DAILY ->
+            RoutineSchedule.daily(timeText(hour, minute), weekdays.sorted())
+        RoutineSchedule.Kind.INTERVAL ->
+            RoutineSchedule.interval(everyMinutes, onceAtMillis.toLong())
+        RoutineSchedule.Kind.UNKNOWN -> RoutineSchedule(kind)
     }
 
     fun input(
@@ -296,18 +330,22 @@ object RoutineRules {
         enabled: Boolean?,
         schedule: RoutineSchedule,
         durationMinutes: Int,
-    ): RoutineInput = RoutineInput(
-        name = name.trim().take(NAME_LIMIT),
-        prompt = prompt.trim().take(PROMPT_LIMIT),
-        botId = botId,
-        runOn = runOn.wireValue,
-        enabled = enabled,
-        schedule = schedule,
-        durationMinutes = durationMinutes,
-    )
-
-    fun steppedDuration(current: Int, delta: Int): Int =
-        (current + delta).coerceIn(DURATION_RANGE.first, DURATION_RANGE.last)
+        timeoutMinutes: Int? = null,
+    ): RoutineInput {
+        require(validTimeout(timeoutMinutes)) {
+            "Timeout must be empty or a whole number from 5 to 240"
+        }
+        return RoutineInput(
+            name = name.trim().take(NAME_LIMIT),
+            prompt = prompt.trim().take(PROMPT_LIMIT),
+            botId = botId,
+            runOn = runOn.wireValue,
+            enabled = enabled,
+            schedule = schedule,
+            durationMinutes = durationMinutes,
+            timeoutMinutes = timeoutMinutes,
+        )
+    }
 }
 
 /**

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/RoutineRules.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/RoutineRules.kt
@@ -81,11 +81,11 @@ object RoutineRules {
     const val SCHEDULE_FOOTER: String =
         "Each occurrence creates a fresh task. No cron syntax is used."
     const val INTERVAL_SCHEDULE_FOOTER: String =
-        "Occurrences stay aligned to the chosen time. If the previous run is still active, " +
+        "Each occurrence creates a fresh task. If the previous run is still active, " +
             "the next occurrence is skipped instead of queued."
     const val UNKNOWN_SCHEDULE_NOTE: String =
         "This routine uses a schedule added by a newer OpenMausBot. Choose One time, " +
-            "Selected days, or Every few minutes before saving."
+            "Selected days, or Every X minutes before saving."
 
     const val CHECKING_CLOUD: String = "Checking Cloud VM availability…"
     const val CLOUD_STATUS_UNAVAILABLE: String = "Cloud VM status is unavailable"
@@ -134,7 +134,7 @@ object RoutineRules {
                 val minutes = schedule.everyMinutes ?: return "Interval unavailable"
                 val cadence = "Every $minutes min"
                 val anchor = schedule.anchorAt ?: return cadence
-                return "$cadence · aligned from ${RelativeStamp.dateAndTime(anchor.toDouble(), zone, locale)}"
+                return "$cadence · starting ${RelativeStamp.dateAndTime(anchor.toDouble(), zone, locale)}"
             }
             RoutineSchedule.Kind.UNKNOWN -> return "Newer schedule"
             RoutineSchedule.Kind.DAILY -> Unit

--- a/android/app/src/test/kotlin/com/openmausbot/companion/ui/ProfileRoutineWireTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/ui/ProfileRoutineWireTest.kt
@@ -216,7 +216,15 @@ class ProfileRoutineWireTest {
         assertEquals("/api/routines", request.path)
         val sent = body(request)
         assertEquals(
-            setOf("name", "prompt", "botId", "runOn", "schedule", "durationMinutes"),
+            setOf(
+                "name",
+                "prompt",
+                "botId",
+                "runOn",
+                "schedule",
+                "durationMinutes",
+                "timeoutMinutes",
+            ),
             sent.keys,
             "a new routine sends no enabled flag",
         )
@@ -224,6 +232,7 @@ class ProfileRoutineWireTest {
         assertEquals("Do the thing", sent.getValue("prompt").jsonPrimitive.content)
         assertEquals("maus", sent.getValue("runOn").jsonPrimitive.content)
         assertEquals(45, sent.getValue("durationMinutes").jsonPrimitive.int)
+        assertEquals(JsonNull, sent.getValue("timeoutMinutes"))
 
         val wire = sent.getValue("schedule").jsonObject
         assertEquals(setOf("type", "time", "weekdays"), wire.keys, "no cron field, and no instant")
@@ -233,6 +242,42 @@ class ProfileRoutineWireTest {
             listOf(1, 5),
             wire.getValue("weekdays").jsonArray.map { it.jsonPrimitive.int },
         )
+    }
+
+    @Test
+    fun `an interval routine posts only its cadence and anchor`() = runTest {
+        val session = session()
+        server.enqueue(json("""{"routine":${CompanionJson.encodeToString(routineJson())}}"""))
+
+        session.saveRoutine(
+            RoutineRules.input(
+                name = "Frequent check",
+                prompt = "Check for updates",
+                botId = "bot-1",
+                runOn = RoutineRunLocation.MAUS,
+                enabled = null,
+                schedule = RoutineRules.schedule(
+                    kind = RoutineSchedule.Kind.INTERVAL,
+                    onceAtMillis = 1_700_000_000_000.0,
+                    hour = 0,
+                    minute = 0,
+                    weekdays = emptySet(),
+                    everyMinutes = 5,
+                ),
+                durationMinutes = RoutineRules.LEGACY_DURATION_MINUTES,
+                timeoutMinutes = RoutineRules.DEFAULT_INTERVAL_TIMEOUT,
+            ),
+            id = null,
+        )
+
+        val sent = body(server.takeRequest())
+        assertEquals(30, sent.getValue("durationMinutes").jsonPrimitive.int)
+        assertEquals(30, sent.getValue("timeoutMinutes").jsonPrimitive.int)
+        val wire = sent.getValue("schedule").jsonObject
+        assertEquals(setOf("type", "everyMinutes", "anchorAt"), wire.keys)
+        assertEquals("interval", wire.getValue("type").jsonPrimitive.content)
+        assertEquals(5, wire.getValue("everyMinutes").jsonPrimitive.int)
+        assertEquals("1700000000000", wire.getValue("anchorAt").jsonPrimitive.content)
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/openmausbot/companion/ui/RoutineRulesTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/ui/RoutineRulesTest.kt
@@ -100,7 +100,7 @@ class RoutineRulesTest {
     @Test
     fun `an interval schedule reads as its cadence`() {
         assertEquals(
-            "Every 5 min · aligned from Nov 14, 2023, 10:13 PM",
+            "Every 5 min · starting Nov 14, 2023, 10:13 PM",
             spacesNormalized(
                 RoutineRules.scheduleSummary(
                     RoutineSchedule.interval(5, 1_700_000_000_000L),

--- a/android/app/src/test/kotlin/com/openmausbot/companion/ui/RoutineRulesTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/ui/RoutineRulesTest.kt
@@ -18,6 +18,7 @@ import java.time.ZoneId
 import java.util.Locale
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -94,6 +95,24 @@ class RoutineRulesTest {
         val schedule = RoutineSchedule(RoutineSchedule.Kind.UNKNOWN)
 
         assertEquals("Newer schedule", RoutineRules.scheduleSummary(schedule, utc, en))
+    }
+
+    @Test
+    fun `an interval schedule reads as its cadence`() {
+        assertEquals(
+            "Every 5 min · aligned from Nov 14, 2023, 10:13 PM",
+            spacesNormalized(
+                RoutineRules.scheduleSummary(
+                    RoutineSchedule.interval(5, 1_700_000_000_000L),
+                    utc,
+                    en,
+                ),
+            ),
+        )
+        assertEquals(
+            "Interval unavailable",
+            RoutineRules.scheduleSummary(RoutineSchedule(RoutineSchedule.Kind.INTERVAL), utc, en),
+        )
     }
 
     @Test
@@ -303,6 +322,29 @@ class RoutineRulesTest {
         assertTrue(ok(RoutineSchedule.Kind.DAILY, setOf(1)))
         assertFalse(ok(RoutineSchedule.Kind.DAILY, emptySet()))
         assertTrue(ok(RoutineSchedule.Kind.ONCE, emptySet()), "one-time needs no weekdays")
+        assertFalse(ok(RoutineSchedule.Kind.INTERVAL, emptySet()), "an interval needs its cadence")
+        assertTrue(
+            RoutineRules.canSave(
+                false,
+                RoutineSchedule.Kind.INTERVAL,
+                "n",
+                "p",
+                "b",
+                emptySet(),
+                everyMinutes = 5,
+            ),
+        )
+        assertFalse(
+            RoutineRules.canSave(
+                false,
+                RoutineSchedule.Kind.INTERVAL,
+                "n",
+                "p",
+                "b",
+                emptySet(),
+                everyMinutes = 4,
+            ),
+        )
         assertFalse(ok(RoutineSchedule.Kind.UNKNOWN, setOf(1)))
 
         assertFalse(RoutineRules.canSave(true, RoutineSchedule.Kind.ONCE, "n", "p", "b", setOf(1)))
@@ -321,6 +363,7 @@ class RoutineRulesTest {
             enabled = false,
             schedule = RoutineSchedule.daily("09:00", listOf(1)),
             durationMinutes = 5,
+            timeoutMinutes = 45,
         )
 
         assertEquals(80, input.name.length)
@@ -328,6 +371,7 @@ class RoutineRulesTest {
         assertEquals("cloud", input.runOn)
         assertEquals(false, input.enabled)
         assertEquals(5, input.durationMinutes)
+        assertEquals(45, input.timeoutMinutes)
     }
 
     @Test
@@ -339,11 +383,12 @@ class RoutineRulesTest {
             runOn = RoutineRunLocation.MAUS,
             enabled = null,
             schedule = RoutineSchedule.daily("09:00", listOf(1)),
-            durationMinutes = RoutineRules.DEFAULT_DURATION,
+            durationMinutes = RoutineRules.LEGACY_DURATION_MINUTES,
         )
 
         assertNull(input.enabled)
         assertEquals(30, input.durationMinutes)
+        assertNull(input.timeoutMinutes)
     }
 
     @Test
@@ -697,6 +742,54 @@ class RoutineRulesTest {
         assertNull(daily.at)
         assertEquals("07:05", daily.time)
         assertEquals(listOf(1, 3), daily.weekdays, "weekdays go out sorted")
+
+        val interval = RoutineRules.schedule(
+            RoutineSchedule.Kind.INTERVAL,
+            onceAtMillis = 1_700_000_000_000.0,
+            hour = 7,
+            minute = 5,
+            weekdays = setOf(1),
+            everyMinutes = 15,
+        )
+        assertNull(interval.at)
+        assertNull(interval.time)
+        assertNull(interval.weekdays)
+        assertEquals(15, interval.everyMinutes)
+        assertEquals(1_700_000_000_000L, interval.anchorAt)
+    }
+
+    @Test
+    fun `interval minutes accept five minutes through one day`() {
+        assertEquals(listOf(5, 10, 15, 30, 60), RoutineRules.INTERVAL_PRESETS)
+        assertEquals(15, RoutineRules.DEFAULT_INTERVAL)
+        assertEquals(5, RoutineRules.intervalMinutes("5"))
+        assertEquals(1_440, RoutineRules.intervalMinutes(" 1440 "))
+        assertNull(RoutineRules.intervalMinutes(""))
+        assertNull(RoutineRules.intervalMinutes("4"))
+        assertNull(RoutineRules.intervalMinutes("1441"))
+        assertNull(RoutineRules.intervalMinutes("five"))
+    }
+
+    @Test
+    fun `a new interval starts one default cadence from now and gets one timeout default`() {
+        val now = 1_700_000_000_000L
+
+        assertEquals(
+            now + 15 * 60_000L,
+            RoutineRules.defaultIntervalAnchor(now),
+        )
+        assertEquals(
+            30,
+            RoutineRules.intervalTimeoutOnFirstSelection(null, defaultAlreadyApplied = false),
+        )
+        assertNull(
+            RoutineRules.intervalTimeoutOnFirstSelection(null, defaultAlreadyApplied = true),
+            "an existing routine with no timeout must stay at No limit",
+        )
+        assertEquals(
+            45,
+            RoutineRules.intervalTimeoutOnFirstSelection(45, defaultAlreadyApplied = true),
+        )
     }
 
     @Test
@@ -719,15 +812,32 @@ class RoutineRulesTest {
     }
 
     @Test
-    fun `the duration stepper walks 5 to 240 in five minute steps`() {
-        assertEquals(5, RoutineRules.DURATION_RANGE.first)
-        assertEquals(240, RoutineRules.DURATION_RANGE.last)
-        assertEquals(5, RoutineRules.DURATION_STEP)
-        assertEquals(30, RoutineRules.DEFAULT_DURATION)
-        assertEquals(5, RoutineRules.steppedDuration(5, -5))
-        assertEquals(10, RoutineRules.steppedDuration(5, 5))
-        assertEquals(240, RoutineRules.steppedDuration(240, 5))
-        assertEquals(235, RoutineRules.steppedDuration(240, -5))
+    fun `timeout is optional and only offers valid five-minute choices`() {
+        assertEquals(30, RoutineRules.LEGACY_DURATION_MINUTES)
+        assertEquals(30, RoutineRules.DEFAULT_INTERVAL_TIMEOUT)
+        assertEquals(5, RoutineRules.TIMEOUT_RANGE.first)
+        assertEquals(240, RoutineRules.TIMEOUT_RANGE.last)
+        assertEquals(5, RoutineRules.TIMEOUT_OPTIONS.first())
+        assertEquals(240, RoutineRules.TIMEOUT_OPTIONS.last())
+        assertEquals(48, RoutineRules.TIMEOUT_OPTIONS.size)
+        assertTrue(RoutineRules.validTimeout(null))
+        assertTrue(RoutineRules.validTimeout(5))
+        assertTrue(RoutineRules.validTimeout(240))
+        assertFalse(RoutineRules.validTimeout(4))
+        assertFalse(RoutineRules.validTimeout(241))
+
+        assertFailsWith<IllegalArgumentException> {
+            RoutineRules.input(
+                name = "Nightly",
+                prompt = "Do the thing",
+                botId = "bot-1",
+                runOn = RoutineRunLocation.MAUS,
+                enabled = null,
+                schedule = RoutineSchedule.daily("09:00", listOf(1)),
+                durationMinutes = RoutineRules.LEGACY_DURATION_MINUTES,
+                timeoutMinutes = 4,
+            )
+        }
     }
 
     @Test

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Client.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Client.kt
@@ -20,6 +20,7 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -354,6 +355,7 @@ class CompanionClient(
 
     suspend fun createRoutine(input: RoutineInput): Routine {
         requireSupported(input.schedule)
+        requireValidTimeout(input.timeoutMinutes)
         return send<RoutineResponse>(
             makeRequest("POST", "/api/routines", body = routineBody(input)),
         ).routine
@@ -361,6 +363,7 @@ class CompanionClient(
 
     suspend fun updateRoutine(id: String, input: RoutineInput): Routine {
         requireSupported(input.schedule)
+        requireValidTimeout(input.timeoutMinutes)
         return send<RoutineResponse>(
             makeRequest("PATCH", "/api/routines/${segment(id)}", body = routineBody(input)),
         ).routine
@@ -730,6 +733,20 @@ class CompanionClient(
             if (schedule.type == RoutineSchedule.Kind.UNKNOWN) {
                 throw APIError.Transport("Choose a supported schedule before saving this routine.")
             }
+            if (
+                schedule.type == RoutineSchedule.Kind.INTERVAL &&
+                ((schedule.everyMinutes ?: 0) !in 5..1_440 || schedule.anchorAt == null)
+            ) {
+                throw APIError.Transport(
+                    "Choose an interval from 5 to 1,440 minutes and an alignment time.",
+                )
+            }
+        }
+
+        private fun requireValidTimeout(timeoutMinutes: Int?) {
+            if (timeoutMinutes != null && timeoutMinutes !in 5..240) {
+                throw APIError.Transport("Choose no timeout or a whole number from 5 to 240 minutes.")
+            }
         }
 
         private fun routineBody(input: RoutineInput): JsonObject = buildJsonObject {
@@ -745,8 +762,14 @@ class CompanionClient(
                 input.schedule.weekdays?.let { days ->
                     put("weekdays", JsonArray(days.map(::JsonPrimitive)))
                 }
+                input.schedule.everyMinutes?.let { put("everyMinutes", it) }
+                input.schedule.anchorAt?.let { put("anchorAt", it) }
             })
             put("durationMinutes", input.durationMinutes)
+            put(
+                "timeoutMinutes",
+                input.timeoutMinutes?.let(::JsonPrimitive) ?: JsonNull,
+            )
         }
 
         suspend fun pair(

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Models.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Models.kt
@@ -778,15 +778,24 @@ data class RoutineSchedule(
     val at: Double? = null,
     val time: String? = null,
     val weekdays: List<Int>? = null,
+    val everyMinutes: Int? = null,
+    val anchorAt: Long? = null,
 ) {
     @Serializable(with = RoutineScheduleKindSerializer::class)
-    enum class Kind { ONCE, DAILY, UNKNOWN }
+    enum class Kind { ONCE, DAILY, INTERVAL, UNKNOWN }
 
     companion object {
         fun once(atMillis: Double): RoutineSchedule = RoutineSchedule(Kind.ONCE, at = atMillis)
 
         fun daily(time: String, weekdays: List<Int>): RoutineSchedule =
             RoutineSchedule(Kind.DAILY, time = time, weekdays = weekdays)
+
+        fun interval(everyMinutes: Int, anchorAtMillis: Long): RoutineSchedule =
+            RoutineSchedule(
+                Kind.INTERVAL,
+                everyMinutes = everyMinutes,
+                anchorAt = anchorAtMillis,
+            )
     }
 }
 
@@ -796,6 +805,7 @@ object RoutineScheduleKindSerializer : KSerializer<RoutineSchedule.Kind> {
     override fun deserialize(decoder: Decoder): RoutineSchedule.Kind = when (decoder.decodeString()) {
         "once" -> RoutineSchedule.Kind.ONCE
         "daily" -> RoutineSchedule.Kind.DAILY
+        "interval" -> RoutineSchedule.Kind.INTERVAL
         else -> RoutineSchedule.Kind.UNKNOWN
     }
 
@@ -813,7 +823,10 @@ data class Routine(
     val runOn: String,
     val enabled: Boolean,
     val schedule: RoutineSchedule,
+    /** Legacy calendar/display length retained for older desktop compatibility. */
     val durationMinutes: Int,
+    /** Optional execution guard. Missing means the routine has no time limit. */
+    val timeoutMinutes: Int? = null,
     val nextRunAt: Double? = null,
     val createdAt: Double,
     val updatedAt: Double,
@@ -824,6 +837,8 @@ data class Routine(
 
     fun canToggle(atMillis: Double = System.currentTimeMillis().toDouble()): Boolean = when (schedule.type) {
         RoutineSchedule.Kind.DAILY -> true
+        RoutineSchedule.Kind.INTERVAL ->
+            (schedule.everyMinutes ?: 0) in 5..1_440 && schedule.anchorAt != null
         RoutineSchedule.Kind.ONCE -> (schedule.at ?: Double.NEGATIVE_INFINITY) > atMillis
         RoutineSchedule.Kind.UNKNOWN -> false
     }
@@ -835,7 +850,10 @@ data class RoutineRun(
     val routineId: String,
     val routineName: String,
     val prompt: String? = null,
+    /** Legacy calendar/display length snapshot. */
     val durationMinutes: Int? = null,
+    /** Optional execution-guard snapshot. */
+    val timeoutMinutes: Int? = null,
     val botId: String,
     val runOn: String,
     val scheduledFor: Double,
@@ -859,7 +877,10 @@ data class RoutineInput(
     val runOn: String = "maus",
     val enabled: Boolean? = null,
     val schedule: RoutineSchedule,
+    /** Still required by older paired desktops; it is not the execution timeout. */
     val durationMinutes: Int = 30,
+    /** `null` deliberately removes an existing execution timeout. */
+    val timeoutMinutes: Int? = null,
 )
 
 @Serializable

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/DecodingTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/DecodingTest.kt
@@ -72,6 +72,34 @@ class DecodingTest {
     }
 
     @Test
+    fun intervalRoutineScheduleDecodesItsCadenceAndAnchor() {
+        val schedule = CompanionJson.decodeFromString<RoutineSchedule>(
+            """{"type":"interval","everyMinutes":5,"anchorAt":1700000000000}""",
+        )
+
+        assertEquals(RoutineSchedule.Kind.INTERVAL, schedule.type)
+        assertEquals(5, schedule.everyMinutes)
+        assertEquals(1_700_000_000_000L, schedule.anchorAt)
+    }
+
+    @Test
+    fun routineTimeoutIsOptionalForOlderDesktopPayloads() {
+        val base = """{
+            "id":"routine-1","name":"Brief","prompt":"Summarize","botId":"bot-1",
+            "runOn":"maus","enabled":true,
+            "schedule":{"type":"daily","time":"09:00","weekdays":[1]},
+            "durationMinutes":30,"createdAt":1,"updatedAt":2
+        }""".trimIndent()
+
+        assertNull(CompanionJson.decodeFromString<Routine>(base).timeoutMinutes)
+        val guarded = base.replace(
+            "\"durationMinutes\":30",
+            "\"durationMinutes\":30,\"timeoutMinutes\":45",
+        )
+        assertEquals(45, CompanionJson.decodeFromString<Routine>(guarded).timeoutMinutes)
+    }
+
+    @Test
     fun decodesTheCloudBackendAndItsAbsence() {
         val fleet = CompanionJson.decodeFromString<Fleet>(
             """{"bots":[

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/ProfileRoutinePolicyTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/ProfileRoutinePolicyTest.kt
@@ -12,6 +12,8 @@ class ProfileRoutinePolicyTest {
         val now = 2_000_000.0
 
         assertTrue(routine(RoutineSchedule.daily("09:00", listOf(1))).canToggle(now))
+        assertTrue(routine(RoutineSchedule.interval(5, now.toLong())).canToggle(now))
+        assertFalse(routine(RoutineSchedule(RoutineSchedule.Kind.INTERVAL, everyMinutes = 4)).canToggle(now))
         assertTrue(routine(RoutineSchedule.once(now + 1_000)).canToggle(now))
         assertFalse(routine(RoutineSchedule.once(now)).canToggle(now))
         assertFalse(routine(RoutineSchedule.once(now - 1_000)).canToggle(now))

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/RoutineClientTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/RoutineClientTest.kt
@@ -1,6 +1,7 @@
 package com.openmausbot.companion.core
 
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -39,6 +40,7 @@ class RoutineClientTest {
             """{"routine":$routine}""",
             """{"routine":$routine}""",
             """{"routine":$routine}""",
+            """{"routine":$routine}""",
             """{"run":$run}""",
             "{}",
         ).forEach { server.enqueue(json(it)) }
@@ -46,6 +48,8 @@ class RoutineClientTest {
         val listed = client.routines()
         assertEquals(listOf("routine-1"), listed.routines.map(Routine::id))
         assertEquals(listOf("run-1"), listed.runs.map(RoutineRun::id))
+        assertEquals(null, listed.routines.single().timeoutMinutes)
+        assertEquals(null, listed.runs.single().timeoutMinutes)
 
         val exactName = "n".repeat(80)
         val exactPrompt = "p".repeat(20_000)
@@ -68,17 +72,32 @@ class RoutineClientTest {
                 enabled = false,
                 schedule = RoutineSchedule.daily("08:05", listOf(1, 2, 3, 4, 5)),
                 durationMinutes = 240,
+                timeoutMinutes = 240,
+            ),
+        )
+        client.updateRoutine(
+            "routine-1",
+            RoutineInput(
+                name = exactName,
+                prompt = exactPrompt,
+                botId = "bot-1",
+                schedule = RoutineSchedule.interval(
+                    everyMinutes = 15,
+                    anchorAtMillis = 2_500_000L,
+                ),
+                timeoutMinutes = 30,
             ),
         )
         client.setRoutineEnabled("routine-1", true)
         client.runRoutine("routine-1")
         client.deleteRoutine("routine-1")
 
-        val requests = List(6) { server.takeRequest() }
+        val requests = List(7) { server.takeRequest() }
         assertEquals(
             listOf(
                 "GET /api/routines",
                 "POST /api/routines",
+                "PATCH /api/routines/routine-1",
                 "PATCH /api/routines/routine-1",
                 "PATCH /api/routines/routine-1",
                 "POST /api/routines/routine-1/run",
@@ -90,13 +109,22 @@ class RoutineClientTest {
 
         val create = CompanionJson.parseToJsonElement(requests[1].body.readUtf8()).jsonObject
         assertEquals(
-            setOf("name", "prompt", "botId", "runOn", "schedule", "durationMinutes"),
+            setOf(
+                "name",
+                "prompt",
+                "botId",
+                "runOn",
+                "schedule",
+                "durationMinutes",
+                "timeoutMinutes",
+            ),
             create.keys,
         )
         assertEquals(exactName, create.getValue("name").jsonPrimitive.content)
         assertEquals(exactPrompt, create.getValue("prompt").jsonPrimitive.content)
         assertEquals("maus", create.getValue("runOn").jsonPrimitive.content)
         assertEquals(5, create.getValue("durationMinutes").jsonPrimitive.content.toInt())
+        assertEquals(JsonNull, create.getValue("timeoutMinutes"))
         assertEquals(
             mapOf("type" to "once", "at" to "2000000.0"),
             create.getValue("schedule").jsonObject.mapValues { it.value.jsonPrimitive.content },
@@ -106,6 +134,7 @@ class RoutineClientTest {
         assertEquals("cloud", update.getValue("runOn").jsonPrimitive.content)
         assertFalse(update.getValue("enabled").jsonPrimitive.content.toBoolean())
         assertEquals(240, update.getValue("durationMinutes").jsonPrimitive.content.toInt())
+        assertEquals(240, update.getValue("timeoutMinutes").jsonPrimitive.content.toInt())
         val schedule = update.getValue("schedule").jsonObject
         assertEquals("daily", schedule.getValue("type").jsonPrimitive.content)
         assertEquals("08:05", schedule.getValue("time").jsonPrimitive.content)
@@ -114,13 +143,25 @@ class RoutineClientTest {
             schedule.getValue("weekdays").jsonArray.map { it.jsonPrimitive.content.toInt() },
         )
 
+        val intervalUpdate = CompanionJson.parseToJsonElement(requests[3].body.readUtf8()).jsonObject
+        val interval = intervalUpdate.getValue("schedule").jsonObject
+        assertEquals(
+            mapOf(
+                "type" to "interval",
+                "everyMinutes" to "15",
+                "anchorAt" to "2500000",
+            ),
+            interval.mapValues { it.value.jsonPrimitive.content },
+        )
+        assertEquals(30, intervalUpdate.getValue("timeoutMinutes").jsonPrimitive.content.toInt())
+
         assertEquals(
             mapOf("enabled" to "true"),
-            CompanionJson.parseToJsonElement(requests[3].body.readUtf8())
+            CompanionJson.parseToJsonElement(requests[4].body.readUtf8())
                 .jsonObject.mapValues { it.value.jsonPrimitive.content },
         )
-        assertEquals(0, requests[4].bodySize)
         assertEquals(0, requests[5].bodySize)
+        assertEquals(0, requests[6].bodySize)
 
         assertFailsWith<APIError.Transport> {
             client.createRoutine(
@@ -136,7 +177,32 @@ class RoutineClientTest {
                 ),
             )
         }
-        assertEquals(6, server.requestCount)
+        assertFailsWith<APIError.Transport> {
+            client.createRoutine(
+                RoutineInput(
+                    name = "Broken interval",
+                    prompt = "Do work",
+                    botId = "bot-1",
+                    schedule = RoutineSchedule(
+                        type = RoutineSchedule.Kind.INTERVAL,
+                        everyMinutes = 4,
+                        anchorAt = 2_500_000L,
+                    ),
+                ),
+            )
+        }
+        assertFailsWith<APIError.Transport> {
+            client.createRoutine(
+                RoutineInput(
+                    name = "Broken timeout",
+                    prompt = "Do work",
+                    botId = "bot-1",
+                    schedule = RoutineSchedule.daily("09:00", listOf(1)),
+                    timeoutMinutes = 241,
+                ),
+            )
+        }
+        assertEquals(7, server.requestCount)
     }
 
     private fun json(body: String): MockResponse = MockResponse()

--- a/ios/App/TasksRoutinesView.swift
+++ b/ios/App/TasksRoutinesView.swift
@@ -288,7 +288,7 @@ private struct RoutineEditorView: View {
                         }
                         Text("One time").tag(RoutineSchedule.Kind.once)
                         Text("Selected days").tag(RoutineSchedule.Kind.daily)
-                        Text("Every few minutes").tag(RoutineSchedule.Kind.interval)
+                        Text("Every X minutes").tag(RoutineSchedule.Kind.interval)
                     }
                     if kind == .once {
                         DatePicker("Run", selection: $onceAt, in: Date()...)
@@ -305,18 +305,40 @@ private struct RoutineEditorView: View {
                             }
                         }
                     } else if kind == .interval {
-                        Picker("Frequency", selection: $intervalPreset) {
-                            ForEach(Self.intervalPresets, id: \.self) { minutes in
-                                Text("Every \(minutes) minutes").tag(minutes)
+                        HStack(spacing: 5) {
+                            Text(intervalPreset == 0 ? "Runs on" : "Runs every")
+                            Menu {
+                                ForEach(Self.intervalPresets, id: \.self) { minutes in
+                                    Button("\(minutes) minutes") {
+                                        intervalPreset = minutes
+                                    }
+                                }
+                                Divider()
+                                Button("Custom interval…") {
+                                    intervalPreset = 0
+                                }
+                            } label: {
+                                HStack(spacing: 3) {
+                                    Text(intervalPreset == 0 ? "a custom interval" : "\(intervalPreset)")
+                                        .fontWeight(.semibold)
+                                    Image(systemName: "chevron.up.chevron.down")
+                                        .font(.caption2)
+                                }
                             }
-                            Text("Custom").tag(0)
+                            .accessibilityLabel("How often this routine runs")
+                            .accessibilityValue(intervalFrequencyAccessibilityValue)
+                            if intervalPreset != 0 {
+                                Text("minutes")
+                            }
+                            Spacer(minLength: 0)
                         }
                         if intervalPreset == 0 {
                             HStack {
-                                Text("Every")
-                                TextField("Minutes", value: $customIntervalMinutes, format: .number)
+                                Text("Set the interval to")
+                                TextField("5–1,440", value: $customIntervalMinutes, format: .number)
                                     .keyboardType(.numberPad)
                                     .multilineTextAlignment(.trailing)
+                                    .frame(minWidth: 72)
                                     .accessibilityLabel("Custom interval in minutes")
                                 Text("minutes")
                                     .foregroundStyle(.secondary)
@@ -327,10 +349,10 @@ private struct RoutineEditorView: View {
                                     .foregroundStyle(.red)
                             }
                         }
-                        DatePicker("Starts", selection: $intervalAnchor)
+                        DatePicker("Starting", selection: $intervalAnchor)
                     } else {
                         Label(
-                            "This routine uses a schedule added by a newer OpenMausBot. Choose One time, Selected days, or Every few minutes before saving.",
+                            "This routine uses a schedule added by a newer OpenMausBot. Choose One time, Selected days, or Every X minutes before saving.",
                             systemImage: "exclamationmark.triangle"
                         )
                         .font(.footnote)
@@ -400,6 +422,10 @@ private struct RoutineEditorView: View {
         let minutes = intervalPreset == 0 ? customIntervalMinutes : intervalPreset
         guard let minutes, (5...1_440).contains(minutes) else { return nil }
         return minutes
+    }
+
+    private var intervalFrequencyAccessibilityValue: String {
+        intervalPreset == 0 ? "Custom interval" : "Every \(intervalPreset) minutes"
     }
 
     private func save() async {
@@ -480,7 +506,7 @@ private extension RoutineSchedule {
             guard let anchorAt else { return cadence }
             let start = Date(timeIntervalSince1970: Double(anchorAt) / 1_000)
                 .formatted(date: .abbreviated, time: .shortened)
-            return "\(cadence) · aligned from \(start)"
+            return "\(cadence) · starting \(start)"
         case .daily:
             break
         }

--- a/ios/App/TasksRoutinesView.swift
+++ b/ios/App/TasksRoutinesView.swift
@@ -204,7 +204,13 @@ private struct RoutineEditorView: View {
     @State private var onceAt: Date
     @State private var dailyTime: Date
     @State private var weekdays: Set<Int>
+    @State private var intervalAnchor: Date
+    @State private var intervalPreset: Int
+    @State private var customIntervalMinutes: Int?
     @State private var duration: Int
+    @State private var timeoutMinutes: Int?
+    @State private var intervalTimeoutDefaultApplied: Bool
+    @State private var advancedExpanded: Bool
     @State private var saving = false
 
     init(routine: Routine?, onSaved: @escaping () async -> Void) {
@@ -222,7 +228,16 @@ private struct RoutineEditorView: View {
         let time = Calendar.current.date(bySettingHour: parts.first ?? 9, minute: parts.count > 1 ? parts[1] : 0, second: 0, of: Date()) ?? Date()
         _dailyTime = State(initialValue: time)
         _weekdays = State(initialValue: Set(routine?.schedule.weekdays ?? [1, 2, 3, 4, 5]))
-        _duration = State(initialValue: routine?.durationMinutes ?? 30)
+        _intervalAnchor = State(initialValue: routine?.schedule.anchorAt.map { Date(timeIntervalSince1970: Double($0) / 1_000) } ?? Date().addingTimeInterval(15 * 60))
+        let everyMinutes = routine?.schedule.everyMinutes ?? 15
+        _intervalPreset = State(initialValue: Self.intervalPresets.contains(everyMinutes) ? everyMinutes : 0)
+        _customIntervalMinutes = State(initialValue: everyMinutes)
+        let duration = routine?.durationMinutes ?? 30
+        _duration = State(initialValue: duration)
+        let timeoutMinutes = routine?.timeoutMinutes
+        _timeoutMinutes = State(initialValue: timeoutMinutes)
+        _intervalTimeoutDefaultApplied = State(initialValue: routine != nil)
+        _advancedExpanded = State(initialValue: timeoutMinutes != nil && timeoutMinutes != 30)
     }
 
     var body: some View {
@@ -235,7 +250,6 @@ private struct RoutineEditorView: View {
                         ForEach(session.state.bots.filter { $0.hidden != true }) { bot in Text(bot.name).tag(bot.id) }
                     }
                     TextField("What should the agent do?", text: $prompt, axis: .vertical).lineLimit(4...10)
-                    Stepper("Allow up to \(duration) minutes", value: $duration, in: 5...240, step: 5)
                 }
 
                 Section {
@@ -274,6 +288,7 @@ private struct RoutineEditorView: View {
                         }
                         Text("One time").tag(RoutineSchedule.Kind.once)
                         Text("Selected days").tag(RoutineSchedule.Kind.daily)
+                        Text("Every few minutes").tag(RoutineSchedule.Kind.interval)
                     }
                     if kind == .once {
                         DatePicker("Run", selection: $onceAt, in: Date()...)
@@ -289,9 +304,33 @@ private struct RoutineEditorView: View {
                                 .accessibilityLabel(Self.dayNames[day])
                             }
                         }
+                    } else if kind == .interval {
+                        Picker("Frequency", selection: $intervalPreset) {
+                            ForEach(Self.intervalPresets, id: \.self) { minutes in
+                                Text("Every \(minutes) minutes").tag(minutes)
+                            }
+                            Text("Custom").tag(0)
+                        }
+                        if intervalPreset == 0 {
+                            HStack {
+                                Text("Every")
+                                TextField("Minutes", value: $customIntervalMinutes, format: .number)
+                                    .keyboardType(.numberPad)
+                                    .multilineTextAlignment(.trailing)
+                                    .accessibilityLabel("Custom interval in minutes")
+                                Text("minutes")
+                                    .foregroundStyle(.secondary)
+                            }
+                            if selectedIntervalMinutes == nil {
+                                Text("Enter a whole number from 5 to 1,440 minutes.")
+                                    .font(.footnote)
+                                    .foregroundStyle(.red)
+                            }
+                        }
+                        DatePicker("Starts", selection: $intervalAnchor)
                     } else {
                         Label(
-                            "This routine uses a schedule added by a newer OpenMausBot. Choose One time or Selected days before saving.",
+                            "This routine uses a schedule added by a newer OpenMausBot. Choose One time, Selected days, or Every few minutes before saving.",
                             systemImage: "exclamationmark.triangle"
                         )
                         .font(.footnote)
@@ -300,7 +339,28 @@ private struct RoutineEditorView: View {
                 } header: {
                     Text("Schedule")
                 } footer: {
-                    Text("Each occurrence creates a fresh task. No cron syntax is used.")
+                    if kind == .interval {
+                        Text("Each occurrence creates a fresh task. If the previous run is still active, the next occurrence is skipped instead of queued.")
+                    } else {
+                        Text("Each occurrence creates a fresh task. No cron syntax is used.")
+                    }
+                }
+
+                Section {
+                    DisclosureGroup(isExpanded: $advancedExpanded) {
+                        Picker("Stop if still running after", selection: $timeoutMinutes) {
+                            Text("No limit").tag(nil as Int?)
+                            ForEach(Self.timeoutOptions, id: \.self) { minutes in
+                                Text(Self.durationLabel(minutes)).tag(Optional(minutes))
+                            }
+                        }
+                    } label: {
+                        Text("Advanced · \(timeoutMinutes.map { "\(Self.durationLabel($0)) run limit" } ?? "no run limit")")
+                    }
+                } footer: {
+                    if advancedExpanded {
+                        Text("Optional. The clock starts when work actually begins and does not control how often the routine starts.")
+                    }
                 }
             }
             .navigationTitle(routine == nil ? "New routine" : "Edit routine")
@@ -309,10 +369,22 @@ private struct RoutineEditorView: View {
                 ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") { Task { await save() } }
-                        .disabled(saving || kind == .unknown || name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || botId.isEmpty || (kind == .daily && weekdays.isEmpty))
+                        .disabled(
+                            saving || kind == .unknown
+                                || name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                || prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                || botId.isEmpty
+                                || (kind == .daily && weekdays.isEmpty)
+                                || (kind == .interval && selectedIntervalMinutes == nil)
+                        )
                 }
             }
             .onAppear { if botId.isEmpty { botId = session.state.bots.first(where: { $0.hidden != true })?.id ?? "" } }
+            .onChange(of: kind) { _, nextKind in
+                guard nextKind == .interval, !intervalTimeoutDefaultApplied else { return }
+                timeoutMinutes = timeoutMinutes ?? 30
+                intervalTimeoutDefaultApplied = true
+            }
             .task {
                 runAvailability = await session.loadRoutineRunAvailability()
                 availabilityLoaded = true
@@ -322,6 +394,12 @@ private struct RoutineEditorView: View {
 
     private var cloudSelectable: Bool {
         runAvailability?.canSelect(.cloud, preserving: runOn) ?? (runOn == .cloud)
+    }
+
+    private var selectedIntervalMinutes: Int? {
+        let minutes = intervalPreset == 0 ? customIntervalMinutes : intervalPreset
+        guard let minutes, (5...1_440).contains(minutes) else { return nil }
+        return minutes
     }
 
     private func save() async {
@@ -335,12 +413,30 @@ private struct RoutineEditorView: View {
         formatter.calendar = Calendar(identifier: .gregorian)
         formatter.timeZone = .current
         formatter.dateFormat = "HH:mm"
-        let schedule = kind == .once ? RoutineSchedule.once(at: onceAt) : .daily(time: formatter.string(from: dailyTime), weekdays: weekdays.sorted())
+        let schedule: RoutineSchedule
+        switch kind {
+        case .once:
+            schedule = .once(at: onceAt)
+        case .daily:
+            schedule = .daily(time: formatter.string(from: dailyTime), weekdays: weekdays.sorted())
+        case .interval:
+            guard let minutes = selectedIntervalMinutes else {
+                session.actionError = "Choose an interval from 5 to 1,440 minutes."
+                saving = false
+                return
+            }
+            let anchor = Calendar.current.date(bySetting: .second, value: 0, of: intervalAnchor)
+                ?? intervalAnchor
+            schedule = .interval(everyMinutes: minutes, anchorAt: anchor)
+        case .unknown:
+            saving = false
+            return
+        }
         let input = RoutineInput(
             name: String(name.trimmingCharacters(in: .whitespacesAndNewlines).prefix(80)),
             prompt: String(prompt.trimmingCharacters(in: .whitespacesAndNewlines).prefix(20_000)),
             botId: botId, runOn: runOn.rawValue, enabled: routine?.enabled,
-            schedule: schedule, durationMinutes: duration
+            schedule: schedule, durationMinutes: duration, timeoutMinutes: timeoutMinutes
         )
         if await session.saveRoutine(input, id: routine?.id) != nil {
             await onSaved()
@@ -351,6 +447,14 @@ private struct RoutineEditorView: View {
 
     private static let dayLetters = ["S", "M", "T", "W", "T", "F", "S"]
     fileprivate static let dayNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+    private static let intervalPresets = [5, 10, 15, 30, 60]
+    private static let timeoutOptions = stride(from: 5, through: 240, by: 5).map { $0 }
+
+    private static func durationLabel(_ minutes: Int) -> String {
+        if minutes < 60 { return "\(minutes) min" }
+        if minutes % 60 == 0 { return "\(minutes / 60) hr" }
+        return "\(minutes / 60) hr \(minutes % 60) min"
+    }
 }
 
 private extension RoutineRunLocation {
@@ -370,6 +474,13 @@ private extension RoutineSchedule {
             return Date(timeIntervalSince1970: at / 1_000).formatted(date: .abbreviated, time: .shortened)
         case .unknown:
             return "Newer schedule"
+        case .interval:
+            guard let everyMinutes else { return "Interval unavailable" }
+            let cadence = "Every \(everyMinutes) min"
+            guard let anchorAt else { return cadence }
+            let start = Date(timeIntervalSince1970: Double(anchorAt) / 1_000)
+                .formatted(date: .abbreviated, time: .shortened)
+            return "\(cadence) · aligned from \(start)"
         case .daily:
             break
         }

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -1098,9 +1098,12 @@ public struct CompanionClient: Sendable {
         if let at = input.schedule.at { schedule["at"] = at }
         if let time = input.schedule.time { schedule["time"] = time }
         if let weekdays = input.schedule.weekdays { schedule["weekdays"] = weekdays }
+        if let everyMinutes = input.schedule.everyMinutes { schedule["everyMinutes"] = everyMinutes }
+        if let anchorAt = input.schedule.anchorAt { schedule["anchorAt"] = anchorAt }
         var body: [String: Any] = [
             "name": input.name, "prompt": input.prompt, "botId": input.botId,
             "runOn": input.runOn, "schedule": schedule, "durationMinutes": input.durationMinutes,
+            "timeoutMinutes": input.timeoutMinutes ?? NSNull(),
         ]
         if let enabled = input.enabled { body["enabled"] = enabled }
         return body

--- a/ios/Sources/CompanionCore/Models.swift
+++ b/ios/Sources/CompanionCore/Models.swift
@@ -655,7 +655,7 @@ public struct Voice: Codable, Hashable, Identifiable, Sendable {
 
 public struct RoutineSchedule: Codable, Hashable, Sendable {
     public enum Kind: String, Codable, Sendable {
-        case once, daily
+        case once, daily, interval
         /// A schedule introduced by a newer desktop. It remains visible but
         /// cannot be toggled or saved until the user chooses a supported kind.
         case unknown
@@ -674,6 +674,8 @@ public struct RoutineSchedule: Codable, Hashable, Sendable {
     public var at: Double?
     public var time: String?
     public var weekdays: [Int]?
+    public var everyMinutes: Int?
+    public var anchorAt: Int64?
 
     public static func once(at: Date) -> Self {
         .init(type: .once, at: at.timeIntervalSince1970 * 1_000, time: nil, weekdays: nil)
@@ -681,6 +683,17 @@ public struct RoutineSchedule: Codable, Hashable, Sendable {
 
     public static func daily(time: String, weekdays: [Int]) -> Self {
         .init(type: .daily, at: nil, time: time, weekdays: weekdays)
+    }
+
+    public static func interval(everyMinutes: Int, anchorAt: Date) -> Self {
+        .init(
+            type: .interval,
+            at: nil,
+            time: nil,
+            weekdays: nil,
+            everyMinutes: everyMinutes,
+            anchorAt: Int64((anchorAt.timeIntervalSince1970 * 1_000).rounded())
+        )
     }
 }
 
@@ -693,6 +706,7 @@ public struct Routine: Codable, Hashable, Identifiable, Sendable {
     public var enabled: Bool
     public var schedule: RoutineSchedule
     public var durationMinutes: Int
+    public var timeoutMinutes: Int?
     public var nextRunAt: Double?
     public var createdAt: Double
     public var updatedAt: Double
@@ -704,6 +718,7 @@ public struct RoutineRun: Codable, Hashable, Identifiable, Sendable {
     public var routineName: String
     public var prompt: String?
     public var durationMinutes: Int?
+    public var timeoutMinutes: Int?
     public var botId: String
     public var runOn: String
     public var scheduledFor: Double
@@ -727,10 +742,12 @@ public struct RoutineInput: Encodable, Sendable {
     public var enabled: Bool?
     public var schedule: RoutineSchedule
     public var durationMinutes: Int
+    public var timeoutMinutes: Int?
 
     public init(
         name: String, prompt: String, botId: String, runOn: String = "maus",
-        enabled: Bool? = nil, schedule: RoutineSchedule, durationMinutes: Int = 30
+        enabled: Bool? = nil, schedule: RoutineSchedule, durationMinutes: Int = 30,
+        timeoutMinutes: Int? = nil
     ) {
         self.name = name
         self.prompt = prompt
@@ -739,6 +756,7 @@ public struct RoutineInput: Encodable, Sendable {
         self.enabled = enabled
         self.schedule = schedule
         self.durationMinutes = durationMinutes
+        self.timeoutMinutes = timeoutMinutes
     }
 }
 
@@ -780,6 +798,8 @@ public extension Routine {
         switch schedule.type {
         case .daily:
             true
+        case .interval:
+            (5...1_440).contains(schedule.everyMinutes ?? 0) && schedule.anchorAt != nil
         case .once:
             (schedule.at ?? -.infinity) > date.timeIntervalSince1970 * 1_000
         case .unknown:

--- a/ios/Tests/CompanionCoreTests/DecodingTests.swift
+++ b/ios/Tests/CompanionCoreTests/DecodingTests.swift
@@ -100,6 +100,20 @@ final class DecodingTests: XCTestCase {
         XCTAssertEqual(schedule.weekdays, [1])
     }
 
+    func testDecodesAnIntervalRoutineSchedule() throws {
+        let schedule = try JSONDecoder().decode(
+            RoutineSchedule.self,
+            from: Data(#"{"type":"interval","everyMinutes":5,"anchorAt":1788384600000}"#.utf8)
+        )
+
+        XCTAssertEqual(schedule.type, .interval)
+        XCTAssertEqual(schedule.everyMinutes, 5)
+        XCTAssertEqual(schedule.anchorAt, 1_788_384_600_000)
+        XCTAssertNil(schedule.at)
+        XCTAssertNil(schedule.time)
+        XCTAssertNil(schedule.weekdays)
+    }
+
     func testNotificationTargetRequiresBothExactIds() {
         XCTAssertEqual(
             NotificationTarget(payload: ["botId": "bot-1", "threadId": "detached-task-2"]),

--- a/ios/Tests/CompanionCoreTests/ProfileRoutinePolicyTests.swift
+++ b/ios/Tests/CompanionCoreTests/ProfileRoutinePolicyTests.swift
@@ -6,6 +6,16 @@ final class ProfileRoutinePolicyTests: XCTestCase {
         let now = Date(timeIntervalSince1970: 2_000)
 
         XCTAssertTrue(routine(schedule: .daily(time: "09:00", weekdays: [1])).canToggle(at: now))
+        XCTAssertTrue(
+            routine(schedule: .interval(everyMinutes: 5, anchorAt: now.addingTimeInterval(-3_600)))
+                .canToggle(at: now),
+            "an interval remains resumable after its anchor because future occurrences still exist"
+        )
+        XCTAssertFalse(
+            routine(schedule: .init(type: .interval, everyMinutes: 4, anchorAt: 1_000))
+                .canToggle(at: now),
+            "a malformed interval must not become toggleable merely because its type is known"
+        )
         XCTAssertTrue(routine(schedule: .once(at: now.addingTimeInterval(1))).canToggle(at: now))
         XCTAssertFalse(routine(schedule: .once(at: now)).canToggle(at: now))
         XCTAssertFalse(routine(schedule: .once(at: now.addingTimeInterval(-1))).canToggle(at: now))
@@ -98,6 +108,7 @@ final class ProfileRoutinePolicyTests: XCTestCase {
             enabled: false,
             schedule: schedule,
             durationMinutes: 30,
+            timeoutMinutes: nil,
             nextRunAt: nil,
             createdAt: 1,
             updatedAt: 1

--- a/ios/Tests/CompanionCoreTests/RoutineClientTests.swift
+++ b/ios/Tests/CompanionCoreTests/RoutineClientTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import XCTest
+@testable import CompanionCore
+
+private final class RoutineRequestStub: URLProtocol {
+    static var capturedRequest: URLRequest?
+    static var capturedBody: Data?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.capturedRequest = request
+        Self.capturedBody = Self.readBody(from: request)
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.response)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func readBody(from request: URLRequest) -> Data? {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 1_024)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count >= 0 else { return nil }
+            if count == 0 { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+
+    private static let response = Data(#"""
+    {
+      "routine": {
+        "id":"routine-1","name":"Pulse","prompt":"Check status","botId":"bot-1",
+        "runOn":"maus","enabled":true,
+        "schedule":{"type":"interval","everyMinutes":5,"anchorAt":1788384600000},
+        "durationMinutes":30,"timeoutMinutes":30,
+        "nextRunAt":1788384900000,"createdAt":1,"updatedAt":1
+      }
+    }
+    """#.utf8)
+}
+
+final class RoutineClientTests: XCTestCase {
+    private var session: URLSession!
+    private var client: CompanionClient!
+
+    override func setUp() {
+        super.setUp()
+        RoutineRequestStub.capturedRequest = nil
+        RoutineRequestStub.capturedBody = nil
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [RoutineRequestStub.self]
+        session = URLSession(configuration: configuration)
+        client = CompanionClient(
+            connection: Connection(name: "Mac", host: "127.0.0.1", port: 8810),
+            token: "paired-token",
+            session: session
+        )
+    }
+
+    override func tearDown() {
+        session.invalidateAndCancel()
+        session = nil
+        client = nil
+        super.tearDown()
+    }
+
+    func testCreatesAnIntervalRoutineWithItsAnchorAndSafetyTimeout() async throws {
+        let anchor = Date(timeIntervalSince1970: 1_788_384_600)
+        let created = try await client.createRoutine(RoutineInput(
+            name: "Pulse",
+            prompt: "Check status",
+            botId: "bot-1",
+            schedule: .interval(everyMinutes: 5, anchorAt: anchor),
+            durationMinutes: 30,
+            timeoutMinutes: 30
+        ))
+
+        let request = try XCTUnwrap(RoutineRequestStub.capturedRequest)
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.path, "/api/routines")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer paired-token")
+
+        let data = try XCTUnwrap(RoutineRequestStub.capturedBody)
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let schedule = try XCTUnwrap(body["schedule"] as? [String: Any])
+        XCTAssertEqual(schedule["type"] as? String, "interval")
+        XCTAssertEqual(schedule["everyMinutes"] as? Int, 5)
+        XCTAssertEqual((schedule["anchorAt"] as? NSNumber)?.int64Value, 1_788_384_600_000)
+        XCTAssertNil(schedule["at"])
+        XCTAssertNil(schedule["time"])
+        XCTAssertNil(schedule["weekdays"])
+        XCTAssertEqual(body["durationMinutes"] as? Int, 30)
+        XCTAssertEqual(body["timeoutMinutes"] as? Int, 30)
+        XCTAssertEqual(created.timeoutMinutes, 30)
+        XCTAssertEqual(created.schedule.type, .interval)
+    }
+
+    func testSendsNullToRemoveAnOptionalRunLimit() async throws {
+        _ = try await client.createRoutine(RoutineInput(
+            name: "Pulse",
+            prompt: "Check status",
+            botId: "bot-1",
+            schedule: .interval(everyMinutes: 15, anchorAt: Date()),
+            timeoutMinutes: nil
+        ))
+
+        let data = try XCTUnwrap(RoutineRequestStub.capturedBody)
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertTrue(body["timeoutMinutes"] is NSNull)
+    }
+}

--- a/server/bot-package.test.ts
+++ b/server/bot-package.test.ts
@@ -102,6 +102,50 @@ describe("bot packages", () => {
     })).toThrow(/expected number to be >=5/);
   });
 
+  it("round-trips interval routine schedules", () => {
+    const document = {
+      ...validPackage,
+      package: {
+        ...validPackage.package,
+        routines: [{
+          key: "frequent-check",
+          name: "Frequent check",
+          agent: "lead",
+          prompt: "Check the queue.",
+          runOn: "maus",
+          schedule: { type: "interval", everyMinutes: 15, anchorAt: 1_788_254_400_000 },
+          durationMinutes: 30,
+          timeoutMinutes: 20,
+          enabledAfterInstall: false,
+        }],
+      },
+    };
+
+    const parsed = parseBotPackage(document);
+    expect(parsed.package.routines?.[0]?.schedule).toEqual({
+      type: "interval",
+      everyMinutes: 15,
+      anchorAt: 1_788_254_400_000,
+    });
+    expect(parsed.package.routines?.[0]?.timeoutMinutes).toBe(20);
+    expect(renderBotPackageMarkdown(parsed)).toContain("every 15 minutes");
+    expect(renderBotPackageMarkdown(parsed)).toContain("**Run limit:** 20 minutes");
+    expect(() => parseBotPackage({
+      ...document,
+      package: {
+        ...document.package,
+        routines: [{
+          ...document.package.routines[0],
+          schedule: {
+            type: "interval",
+            everyMinutes: 15,
+            anchorAt: Number.MAX_SAFE_INTEGER,
+          },
+        }],
+      },
+    })).toThrow();
+  });
+
   it("rejects dangling agent, room, playbook, chief, and routine references", () => {
     expect(() => parseBotPackage({
       ...validPackage,

--- a/server/bot-package.ts
+++ b/server/bot-package.ts
@@ -35,6 +35,7 @@ const optionalText = (max: number) =>
 const key = requiredText(64).regex(/^[a-z0-9][a-z0-9_-]*$/, {
   message: "may only contain lowercase letters, numbers, - and _",
 });
+const MAX_DATE_MS = 8_640_000_000_000_000;
 
 const packageSchema = z.object({
   format: z.literal(BOT_PACKAGE_FORMAT, { error: "This is not an OpenMaus package" }),
@@ -99,8 +100,14 @@ const packageSchema = z.object({
           time: requiredText(5).regex(/^([01]\d|2[0-3]):[0-5]\d$/, { message: "must use HH:MM" }),
           weekdays: z.array(z.number().int().min(0).max(6)).min(1).max(7),
         }),
+        z.object({
+          type: z.literal("interval"),
+          everyMinutes: z.number().int().min(5).max(1_440),
+          anchorAt: z.number().int().nonnegative().max(MAX_DATE_MS),
+        }),
       ]),
       durationMinutes: z.number().int().min(5).max(240),
+      timeoutMinutes: z.number().int().min(5).max(240).optional(),
       enabledAfterInstall: z.literal(false),
     })).max(50).optional(),
     playbooks: z.array(z.object({
@@ -224,7 +231,14 @@ export function renderBotPackageMarkdown(document: ParsedBotPackage): string {
   const routines = (pkg.routines ?? []).map((routine) => [
     `### ${routine.name}`,
     `**Owner:** \`${routine.agent}\`  `,
-    `**Schedule:** ${routine.schedule.type === "daily" ? `${routine.schedule.time} on weekdays ${routine.schedule.weekdays.join(", ")}` : `once at ${routine.schedule.at}`}  `,
+    `**Schedule:** ${
+      routine.schedule.type === "daily"
+        ? `${routine.schedule.time} on weekdays ${routine.schedule.weekdays.join(", ")}`
+        : routine.schedule.type === "interval"
+          ? `every ${routine.schedule.everyMinutes} minutes from ${new Date(routine.schedule.anchorAt).toISOString()}`
+          : `once at ${routine.schedule.at}`
+    }  `,
+    `**Run limit:** ${routine.timeoutMinutes === undefined ? "none" : `${routine.timeoutMinutes} minutes`}  `,
     "**Initial state:** paused — the user must enable it",
     "",
     routine.prompt,

--- a/server/drivers/agents-proxy.test.ts
+++ b/server/drivers/agents-proxy.test.ts
@@ -250,7 +250,7 @@ describe("agents-proxy MCP surface", () => {
     expect(JSON.stringify(create.inputSchema)).not.toMatch(/"oneOf"|"anyOf"|"allOf"|"const"/);
     expect(schedule.type).toBe("object");
     expect(schedule.required).toEqual(["type"]);
-    expect(schedule.properties.type.enum).toEqual(["once", "weekly", "daily"]);
+    expect(schedule.properties.type.enum).toEqual(["once", "weekly", "daily", "interval"]);
     expect(schedule.properties.weekdays.items.enum).toEqual([
       "monday",
       "tuesday",
@@ -260,7 +260,10 @@ describe("agents-proxy MCP surface", () => {
       "saturday",
       "sunday",
     ]);
-    expect(create.inputSchema.properties.duration_minutes).toMatchObject({ minimum: 5, maximum: 240 });
+    expect(create.inputSchema.properties).not.toHaveProperty("duration_minutes");
+    expect(create.inputSchema.properties.timeout_minutes).toMatchObject({ minimum: 5, maximum: 240 });
+    expect(create.inputSchema.properties.clear_timeout.type).toBe("boolean");
+    expect(schedule.properties.every_minutes).toMatchObject({ minimum: 5, maximum: 1_440 });
     expect(create.description).toContain("does NOT enable");
   });
 
@@ -481,6 +484,7 @@ describe("agents-proxy MCP surface", () => {
       schedule: { type: "weekly", time: "09:00", weekdays: ["monday", "friday"] },
       run_on: "maus",
       duration_minutes: 45,
+      timeout_minutes: 15,
     });
     expect(lastRoutineRequestBody).toEqual({
       fromBotId: "bot-asker",
@@ -491,7 +495,7 @@ describe("agents-proxy MCP surface", () => {
         instructions: "Summarize today's priorities.",
         schedule: { type: "weekly", time: "09:00", weekdays: ["monday", "friday"] },
         runOn: "maus",
-        durationMinutes: 45,
+        timeoutMinutes: 15,
       },
     });
     expect(res.result.content[0].text).toContain("confirmation card");
@@ -527,18 +531,35 @@ describe("agents-proxy MCP surface", () => {
     });
   });
 
+  it("proposes an interval routine with an optional start anchor", async () => {
+    await callTool("propose_routine", {
+      name: "Frequent check",
+      instructions: "Check the queue.",
+      schedule: {
+        type: "interval",
+        every_minutes: 5,
+        starts_at: "2026-09-01T09:00:00+05:30",
+      },
+    });
+    expect(lastRoutineRequestBody.routine.schedule).toEqual({
+      type: "interval",
+      everyMinutes: 5,
+      anchorAt: "2026-09-01T09:00:00+05:30",
+    });
+  });
+
   it("proposes routine updates and destructive actions without applying them", async () => {
     const update = await callTool("propose_routine_action", {
       routine_id: "routine-1",
       action: "update",
-      changes: { name: "Weekday brief", duration_minutes: 60 },
+      changes: { name: "Weekday brief", clear_timeout: true },
     });
     expect(lastRoutineRequestBody).toEqual({
       fromBotId: "bot-asker",
       fromThreadId: "thread-asker-routine",
       action: "update",
       routineId: "routine-1",
-      changes: { name: "Weekday brief", durationMinutes: 60 },
+      changes: { name: "Weekday brief", timeoutMinutes: null },
     });
     expect(update.result.content[0].text).toContain("has not been applied");
 
@@ -582,7 +603,7 @@ describe("agents-proxy MCP surface", () => {
     expect(lastRoutineRequestBody.routine.schedule).toEqual({ type: "weekly", time: "09:00", weekdays: ["monday"] });
   });
 
-  it("answers unsupported schedules with instructions, before calling the harness", async () => {
+  it("answers invalid and unsupported schedules with instructions, before calling the harness", async () => {
     lastRoutineRequestBody = null;
     const interval = await callTool("propose_routine", {
       name: "Interval",
@@ -590,8 +611,7 @@ describe("agents-proxy MCP surface", () => {
       schedule: { type: "interval", minutes: 30 },
     });
     expect(interval.result.isError).toBe(true);
-    expect(interval.result.content[0].text).toContain("sub-day intervals");
-    expect(interval.result.content[0].text).toContain('"type":"daily"');
+    expect(interval.result.content[0].text).toContain("every_minutes");
 
     const noDays = await callTool("propose_routine", {
       name: "NoDays",

--- a/server/drivers/agents-proxy.ts
+++ b/server/drivers/agents-proxy.ts
@@ -58,12 +58,12 @@ const ROUTINE_SCHEDULE_SCHEMA = {
   type: "object",
   additionalProperties: false,
   description:
-    'Either {"type":"once","at":RFC3339} for one future run, {"type":"weekly","time":"HH:MM","weekdays":[...]} for chosen days, or {"type":"daily","time":"HH:MM"} to run every day. Sub-day intervals (every N minutes/hours) are not supported.',
+    'Either {"type":"once","at":RFC3339} for one future run, {"type":"weekly","time":"HH:MM","weekdays":[...]} for chosen days, {"type":"daily","time":"HH:MM"} for every day, or {"type":"interval","every_minutes":15,"starts_at":RFC3339} to repeat from an optional starting point.',
   properties: {
     type: {
       type: "string",
-      enum: ["once", "weekly", "daily"],
-      description: "once = a single future run; weekly = chosen weekdays; daily = every day of the week.",
+      enum: ["once", "weekly", "daily", "interval"],
+      description: "once = a single future run; weekly = chosen weekdays; daily = every day; interval = every N minutes.",
     },
     at: {
       type: "string",
@@ -78,6 +78,17 @@ const ROUTINE_SCHEDULE_SCHEMA = {
       type: "array",
       items: { type: "string", enum: WEEKDAYS },
       description: "Only for type weekly: which days the routine runs, in the computer's local timezone.",
+    },
+    every_minutes: {
+      type: "integer",
+      minimum: 5,
+      maximum: 1_440,
+      description: "Only for type interval: whole minutes between runs, from 5 to 1440.",
+    },
+    starts_at: {
+      type: "string",
+      description:
+        "Optional for type interval: RFC3339 date-time with an explicit timezone offset that anchors the cadence. Omit to start one interval after confirmation.",
     },
   },
   required: ["type"],
@@ -98,7 +109,8 @@ const SHORT_WEEKDAYS = {
 
 const SUPPORTED_SCHEDULES =
   'Supported schedules: {"type":"once","at":"2026-09-01T09:00:00+05:30"} (future RFC3339 with explicit offset), ' +
-  '{"type":"weekly","time":"09:00","weekdays":["monday","friday"]}, or {"type":"daily","time":"09:00"} for every day.';
+  '{"type":"weekly","time":"09:00","weekdays":["monday","friday"]}, {"type":"daily","time":"09:00"}, ' +
+  'or {"type":"interval","every_minutes":15}.';
 
 /** The outcome of coercing a model-sent schedule: the harness-dialect
  * schedule, or a message telling the model exactly what to send instead. */
@@ -155,8 +167,26 @@ function normalizeScheduleInput(args: Json): NormalizedSchedule {
     }
     return { schedule: { type: "weekly", time, weekdays: normalized } };
   }
-  if (type === "interval" || type === "cron" || type === "hourly" || type === "minutes") {
-    return { error: `Routines cannot run on sub-day intervals. ${SUPPORTED_SCHEDULES} Pick the closest daily or weekly time and tell the user about this limit.` };
+  if (type === "interval") {
+    const rawMinutes = raw.every_minutes ?? raw.everyMinutes;
+    const everyMinutes = Number(rawMinutes);
+    if (!Number.isInteger(everyMinutes) || everyMinutes < 5 || everyMinutes > 1_440) {
+      return { error: 'An interval schedule needs "every_minutes": a whole number from 5 to 1440.' };
+    }
+    const rawStart = raw.starts_at ?? raw.anchorAt;
+    if (rawStart !== undefined && (typeof rawStart !== "string" || !rawStart.trim())) {
+      return { error: '"starts_at" must be an RFC3339 date-time with an explicit timezone offset.' };
+    }
+    return {
+      schedule: {
+        type: "interval",
+        everyMinutes,
+        ...(typeof rawStart === "string" ? { anchorAt: rawStart.trim() } : {}),
+      },
+    };
+  }
+  if (type === "cron" || type === "hourly" || type === "minutes") {
+    return { error: `Use an interval schedule for every-N-minutes work. ${SUPPORTED_SCHEDULES}` };
   }
   return { error: `Unknown schedule type "${type || "(missing)"}". ${SUPPORTED_SCHEDULES}` };
 }
@@ -175,11 +205,16 @@ const ROUTINE_FIELDS_SCHEMA = {
     enum: ["maus", "cloud"],
     description: "Where the routine runs. Defaults to maus (this OpenMausBot setup).",
   },
-  duration_minutes: {
+  timeout_minutes: {
     type: "integer",
     minimum: 5,
     maximum: 240,
-    description: "Maximum run duration in minutes. Defaults to 30.",
+    description:
+      "Optional safety limit for active work, from 5 to 240 minutes. Omit for no limit.",
+  },
+  clear_timeout: {
+    type: "boolean",
+    description: "Only for updates: set true to remove an existing safety limit. Do not combine with timeout_minutes.",
   },
 } as const;
 
@@ -402,6 +437,9 @@ function routineAction(value: unknown): RoutineAction | null {
 
 function routineFields(args: Json): { fields: Json; error?: string } {
   const fields: Json = {};
+  if (args.clear_timeout === true && typeof args.timeout_minutes === "number") {
+    return { fields, error: "Choose timeout_minutes or clear_timeout, not both." };
+  }
   if (typeof args.name === "string") fields.name = args.name.trim();
   if (typeof args.instructions === "string") fields.instructions = args.instructions.trim();
   if (args.schedule !== undefined && args.schedule !== null) {
@@ -410,7 +448,8 @@ function routineFields(args: Json): { fields: Json; error?: string } {
     fields.schedule = normalized.schedule;
   }
   if (typeof args.run_on === "string") fields.runOn = args.run_on;
-  if (typeof args.duration_minutes === "number") fields.durationMinutes = args.duration_minutes;
+  if (args.clear_timeout === true) fields.timeoutMinutes = null;
+  else if (typeof args.timeout_minutes === "number") fields.timeoutMinutes = args.timeout_minutes;
   return { fields };
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1129,7 +1129,7 @@ function finishGroupGoalRun(
     : status === "needs-input"
       ? "needs your input"
       : status === "limit-reached"
-        ? "reached its turn limit"
+        ? "reached its limit"
         : status;
   store.patchMessage(operation.threadId, run.cardMessageId, {
     text: `Goal ${fallbackState}: ${card.detail || card.goal}`,
@@ -1286,12 +1286,19 @@ async function waitForChatRoomMember(
   }
 }
 
-function cancelGroupTurnOperations(groupId: string, threadId: string) {
+function cancelGroupTurnOperations(
+  groupId: string,
+  threadId: string,
+  outcome: { status: "stopped" | "limit-reached"; detail: string } = {
+    status: "stopped",
+    detail: "Stopped by you.",
+  },
+) {
   for (const operation of groupTurnOperations.get(groupId) ?? []) {
     if (operation.threadId !== threadId) continue;
     operation.cancelled = true;
     operation.cancellation.abort();
-    finishGroupGoalRun(groupId, operation, "stopped", "Stopped by you.");
+    finishGroupGoalRun(groupId, operation, outcome.status, outcome.detail);
     if (operation.providerHandshakePending) {
       markCancelledProviderHandshake(operation.threadId, `group:${operation.id}`);
     }
@@ -3519,7 +3526,7 @@ function routineRunFallbackText(card: NonNullable<Message["routineRun"]>): strin
     : card.goalStatus === "blocked"
       ? "was blocked"
       : card.goalStatus === "limit-reached"
-        ? "reached its turn limit"
+        ? "reached its limit"
         : card.goalStatus === "stopped"
           ? "was stopped"
           : card.goalStatus === "failed"
@@ -3578,10 +3585,14 @@ function syncRoutineRunToSource(run: RoutineRun): string | null {
   return sourceThreadId;
 }
 
-async function interruptRoutineGroupGoal(groupId: string, threadId: string): Promise<void> {
+async function interruptRoutineGroupGoal(
+  groupId: string,
+  threadId: string,
+  outcome?: { status: "stopped" | "limit-reached"; detail: string },
+): Promise<void> {
   const speaker = groupSpeakers.get(threadId);
   const bot = speaker ? store.bot(speaker.botId) : undefined;
-  cancelGroupTurnOperations(groupId, threadId);
+  cancelGroupTurnOperations(groupId, threadId, outcome);
   await releaseBrowserCapabilityForThread(threadId);
   await (bot ? registry.get(bot.modelSelection.instanceId) : undefined)
     ?.adapter.interruptTurn(threadId)
@@ -3635,7 +3646,12 @@ routines = new RoutineManager({
       : bot
         ? registry.get(bot.modelSelection.instanceId)
         : null;
-    await instance?.adapter.interruptTurn(threadId);
+    try {
+      await releaseBrowserCapabilityForThread(threadId);
+      await instance?.adapter.interruptTurn(threadId);
+    } finally {
+      closeOpenApprovals(threadId);
+    }
   },
   interruptGoal: interruptRoutineGroupGoal,
   onRunChanged: syncRoutineRunToSource,
@@ -3760,13 +3776,20 @@ const agentRoutine = (
     enabled: routine.enabled,
     runOn: routine.runOn,
     durationMinutes: routine.durationMinutes,
+    ...(routine.timeoutMinutes === undefined ? {} : { timeoutMinutes: routine.timeoutMinutes }),
     schedule: routine.schedule.type === "once"
       ? { type: "once" as const, at: new Date(routine.schedule.at).toISOString() }
-      : {
-          type: "weekly" as const,
-          time: routine.schedule.time,
-          weekdays: routine.schedule.weekdays.map((day) => ROUTINE_WEEKDAY_NAMES[day]),
-        },
+      : routine.schedule.type === "interval"
+        ? {
+            type: "interval" as const,
+            everyMinutes: routine.schedule.everyMinutes,
+            anchorAt: new Date(routine.schedule.anchorAt).toISOString(),
+          }
+        : {
+            type: "weekly" as const,
+            time: routine.schedule.time,
+            weekdays: routine.schedule.weekdays.map((day) => ROUTINE_WEEKDAY_NAMES[day]),
+          },
     nextRunAt: routine.nextRunAt === null ? null : new Date(routine.nextRunAt).toISOString(),
     latestRun: latestRun
       ? {
@@ -7371,6 +7394,7 @@ const server = createServer(async (req, res) => {
             enabled: false,
             schedule: routine.schedule,
             durationMinutes: routine.durationMinutes,
+            ...(routine.timeoutMinutes === undefined ? {} : { timeoutMinutes: routine.timeoutMinutes }),
           });
           createdRoutineIds.push(created.id);
         }

--- a/server/package-export.test.ts
+++ b/server/package-export.test.ts
@@ -82,9 +82,30 @@ describe("package export", () => {
           createdAt: 1,
           updatedAt: 1,
         },
+        {
+          id: "private-interval-routine-id",
+          name: "Frequent release check",
+          prompt: "Watch release readiness.",
+          target: "bot",
+          botId: "private-id",
+          runOn: "maus",
+          enabled: true,
+          schedule: { type: "interval", everyMinutes: 15, anchorAt: 1_788_254_400_000 },
+          durationMinutes: 30,
+          timeoutMinutes: 20,
+          nextRunAt: 789,
+          createdAt: 1,
+          updatedAt: 1,
+        },
       ],
     });
-    expect(exported.package.routines).toHaveLength(1);
+    expect(exported.package.routines).toHaveLength(2);
+    expect(exported.package.routines?.[1]?.schedule).toEqual({
+      type: "interval",
+      everyMinutes: 15,
+      anchorAt: 1_788_254_400_000,
+    });
+    expect(exported.package.routines?.[1]?.timeoutMinutes).toBe(20);
 
     expect(exported).toMatchObject({
       format: "openmaus.package",
@@ -92,7 +113,10 @@ describe("package export", () => {
         chiefOfStaff: "lead",
         requirements: { apps: [{ slug: "github" }] },
         rooms: [{ members: ["lead"], defaultResponder: { kind: "agent", agent: "lead" } }],
-        routines: [{ agent: "lead", enabledAfterInstall: false }],
+        routines: [
+          { agent: "lead", enabledAfterInstall: false },
+          { agent: "lead", enabledAfterInstall: false },
+        ],
         playbooks: [{ key: "launch" }],
       },
     });

--- a/server/package-export.ts
+++ b/server/package-export.ts
@@ -103,8 +103,15 @@ export function createBotPackageExport(input: {
       runOn: routine.runOn,
       schedule: routine.schedule.type === "once"
         ? { type: "once", at: routine.schedule.at }
-        : { type: "daily", time: routine.schedule.time, weekdays: [...routine.schedule.weekdays] },
+        : routine.schedule.type === "interval"
+          ? {
+              type: "interval",
+              everyMinutes: routine.schedule.everyMinutes,
+              anchorAt: routine.schedule.anchorAt,
+            }
+          : { type: "daily", time: routine.schedule.time, weekdays: [...routine.schedule.weekdays] },
       durationMinutes: routine.durationMinutes,
+      ...(routine.timeoutMinutes === undefined ? {} : { timeoutMinutes: routine.timeoutMinutes }),
       enabledAfterInstall: false as const,
     }];
   });

--- a/server/routine-requests.test.ts
+++ b/server/routine-requests.test.ts
@@ -144,7 +144,13 @@ describe("RoutineRequestService", () => {
           durationMinutes: routine.durationMinutes,
           schedule: routine.schedule.type === "once"
             ? { at: routine.schedule.at, type: "once" }
-            : { weekdays: [...routine.schedule.weekdays], time: routine.schedule.time, type: "daily" },
+            : routine.schedule.type === "interval"
+              ? {
+                  anchorAt: routine.schedule.anchorAt,
+                  everyMinutes: routine.schedule.everyMinutes,
+                  type: "interval",
+                }
+              : { weekdays: [...routine.schedule.weekdays], time: routine.schedule.time, type: "daily" },
           instructions: routine.instructions,
           runOn: routine.runOn,
           name: routine.name,
@@ -235,6 +241,13 @@ describe("RoutineRequestService", () => {
       service.propose({
         botId: "bot-a",
         threadId: "thread-a",
+        proposal: createProposal({ timeoutMinutes: 4 }),
+      }),
+    ).rejects.toThrow("timeoutMinutes must be a whole number from 5 to 240");
+    await expect(
+      service.propose({
+        botId: "bot-a",
+        threadId: "thread-a",
         proposal: malformedProposal({
           action: "create",
           routine: {
@@ -276,6 +289,75 @@ describe("RoutineRequestService", () => {
         proposal: createProposal({ instructions: secretAtLimit }),
       }),
     ).rejects.toThrow(/20,000 characters or fewer after credentials are removed/);
+  });
+
+  it("normalizes interval schedules with an optional cadence anchor", async () => {
+    const now = Date.parse("2026-08-28T10:00:00Z");
+    const { service, store, routines, clock } = harness(now);
+    const proposed = await service.propose({
+      botId: "bot-a",
+      threadId: "thread-a",
+      proposal: createProposal({
+        schedule: {
+          type: "interval",
+          everyMinutes: 15,
+          anchorAt: "2026-08-28T10:07:00Z",
+        },
+      }),
+    });
+
+    expect(proposed.summary).toContain("Every 15 minutes");
+    expect(proposed.summary).toContain("no run limit");
+    expect(store.messagesFor("thread-a")[0]?.card?.routineRequest?.operation).toMatchObject({
+      action: "create",
+      routine: {
+        schedule: {
+          type: "interval",
+          everyMinutes: 15,
+          anchorAt: Date.parse("2026-08-28T10:07:00Z"),
+        },
+      },
+    });
+
+    const withoutAnchor = await service.propose({
+      botId: "bot-a",
+      threadId: "thread-b",
+      proposal: createProposal({ schedule: { type: "interval", everyMinutes: 5 } }),
+    });
+    expect(withoutAnchor.nextRunAt).toBeNull();
+    expect(withoutAnchor.detail).toContain("One interval after confirmation");
+    expect(store.messagesFor("thread-b")[0]?.card?.routineRequest?.operation).toMatchObject({
+      action: "create",
+      routine: { schedule: { type: "interval", everyMinutes: 5 } },
+    });
+    const deferred = store.messagesFor("thread-b")[0]?.card?.routineRequest?.operation;
+    if (deferred?.action !== "create") throw new Error("Expected a create operation");
+    expect(deferred.routine.schedule).not.toHaveProperty("anchorAt");
+
+    clock.now = now + 7 * 60_000;
+    expect(service.resolve({
+      botId: "bot-a",
+      threadId: "thread-b",
+      requestId: withoutAnchor.requestId,
+      behavior: "allow",
+    })).toMatchObject({ claimed: true, state: "applied" });
+    expect(routines.listRoutines().find((routine) => routine.sourceThreadId === "thread-b")).toMatchObject({
+      schedule: { type: "interval", everyMinutes: 5, anchorAt: clock.now },
+      nextRunAt: clock.now + 5 * 60_000,
+    });
+
+    await expect(service.propose({
+      botId: "bot-a",
+      threadId: "thread-c",
+      proposal: createProposal({ schedule: { type: "interval", everyMinutes: 4 } }),
+    })).rejects.toThrow(/5 to 1440/);
+    await expect(service.propose({
+      botId: "bot-a",
+      threadId: "thread-c",
+      proposal: createProposal({
+        schedule: { type: "interval", everyMinutes: 5, anchorAt: "1969-12-31T23:59:59Z" },
+      }),
+    })).rejects.toThrow(/valid interval start time/);
   });
 
   it("refuses a cloud routine before creating a card when cloud execution is not ready", async () => {
@@ -422,7 +504,7 @@ describe("RoutineRequestService", () => {
     const proposal = await service.propose({
       botId: "bot-a",
       threadId: "thread-a",
-      proposal: createProposal({ durationMinutes: 5 }),
+      proposal: createProposal({ durationMinutes: 5, timeoutMinutes: 15 }),
     });
 
     // Model a crash after routines.json was atomically written but before the
@@ -437,6 +519,7 @@ describe("RoutineRequestService", () => {
       enabled: true,
       schedule: { type: "daily", time: "09:00", weekdays: [1, 3] },
       durationMinutes: 5,
+      timeoutMinutes: 15,
     }, {
       requestId: proposal.requestId,
       messageId: message.id,
@@ -463,6 +546,7 @@ describe("RoutineRequestService", () => {
       name: "Morning brief",
       enabled: true,
       durationMinutes: 5,
+      timeoutMinutes: 15,
       sourceThreadId: "thread-a",
     }]);
     expect(routines.routineRequestReceipt(proposal.requestId)).toBeNull();
@@ -521,13 +605,22 @@ describe("RoutineRequestService", () => {
     await apply({
       action: "update",
       routineId: routine.id,
-      changes: { name: "New name", instructions: "New instructions", durationMinutes: 45 },
+      changes: {
+        name: "New name",
+        instructions: "New instructions",
+        durationMinutes: 45,
+        timeoutMinutes: 10,
+      },
     });
     expect(routines.listRoutines()[0]).toMatchObject({
       name: "New name",
       prompt: "New instructions",
       durationMinutes: 45,
+      timeoutMinutes: 10,
     });
+
+    await apply({ action: "update", routineId: routine.id, changes: { timeoutMinutes: null } });
+    expect(routines.listRoutines()[0]).not.toHaveProperty("timeoutMinutes");
 
     await apply({ action: "pause", routineId: routine.id });
     expect(routines.listRoutines()[0]!.enabled).toBe(false);
@@ -600,6 +693,63 @@ describe("RoutineRequestService", () => {
     })).toMatchObject({ claimed: true, state: "invalid", status: 409 });
     expect(routines.listRoutines()[0]).toMatchObject({ name: "Changed elsewhere", enabled: true });
     expect(store.messagesFor("thread-a")[0]!.card?.held).toMatch(/changed after this confirmation card/);
+  });
+
+  it("keeps a pending manage confirmation valid across recurring scheduler progress", async () => {
+    const { service, routines, clock } = harness();
+    const anchorAt = clock.now + 5 * 60_000;
+    const routine = routines.create({
+      botId: "bot-a",
+      name: "Frequent check",
+      prompt: "Check the queue",
+      schedule: { type: "interval", everyMinutes: 5, anchorAt },
+    });
+    const proposed = await service.propose({
+      botId: "bot-a",
+      threadId: "thread-a",
+      proposal: { action: "update", routineId: routine.id, changes: { name: "Frequent review" } },
+    });
+
+    clock.now = anchorAt;
+    await routines.tick();
+    expect(routines.listRoutines()[0]).toMatchObject({
+      updatedAt: routine.updatedAt,
+      nextRunAt: anchorAt + 5 * 60_000,
+    });
+    expect(service.resolve({
+      botId: "bot-a",
+      threadId: "thread-a",
+      requestId: proposed.requestId,
+      behavior: "allow",
+    })).toMatchObject({ claimed: true, state: "applied" });
+    expect(routines.listRoutines()[0]).toMatchObject({ name: "Frequent review" });
+  });
+
+  it("invalidates a pending confirmation when a one-time routine auto-disables", async () => {
+    const { service, routines, clock } = harness();
+    const scheduledAt = clock.now + 5 * 60_000;
+    const routine = routines.create({
+      botId: "bot-a",
+      name: "One-time check",
+      prompt: "Check once",
+      schedule: { type: "once", at: scheduledAt },
+    });
+    const proposed = await service.propose({
+      botId: "bot-a",
+      threadId: "thread-a",
+      proposal: { action: "update", routineId: routine.id, changes: { name: "Renamed check" } },
+    });
+
+    clock.now = scheduledAt;
+    await routines.tick();
+    expect(routines.listRoutines()[0]).toMatchObject({ enabled: false, nextRunAt: null });
+    expect(routines.listRoutines()[0]!.updatedAt).toBeGreaterThan(routine.updatedAt);
+    expect(service.resolve({
+      botId: "bot-a",
+      threadId: "thread-a",
+      requestId: proposed.requestId,
+      behavior: "allow",
+    })).toMatchObject({ claimed: true, state: "invalid", status: 409 });
   });
 
   it("settles manage cards whose requested mutation already committed before a crash", async () => {

--- a/server/routine-requests.ts
+++ b/server/routine-requests.ts
@@ -37,6 +37,7 @@ const RFC3339_WITH_OFFSET =
   /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,9})?(?:Z|[+-](\d{2}):(\d{2}))$/i;
 const TIME = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
 const ROUTINE_ID = /^[A-Za-z0-9_-]{1,128}$/;
+const MAX_DATE_MS = 8_640_000_000_000_000;
 const ACTION_COPY = {
   create: { title: "Schedule", detail: "Create routine" },
   update: { title: "Update", detail: "Update routine" },
@@ -55,6 +56,11 @@ const routineToolScheduleSchema = z.discriminatedUnion("type", [
     time: z.string().max(5),
     weekdays: z.array(z.string().max(9)).min(1).max(7),
   }).strict(),
+  z.object({
+    type: z.literal("interval"),
+    everyMinutes: z.number(),
+    anchorAt: z.string().max(64).optional(),
+  }).strict(),
 ]);
 
 const routineToolDefinitionSchema = z.object({
@@ -63,9 +69,15 @@ const routineToolDefinitionSchema = z.object({
   schedule: routineToolScheduleSchema,
   runOn: z.enum(["maus", "cloud"]).optional(),
   durationMinutes: z.number().optional(),
+  timeoutMinutes: z.number().nullable().optional(),
 }).strict();
 
-const routineToolChangesSchema = routineToolDefinitionSchema.partial().refine(
+const routineToolChangesSchema = routineToolDefinitionSchema
+  .omit({ timeoutMinutes: true })
+  .partial()
+  .extend({ timeoutMinutes: z.number().nullable().optional() })
+  .strict()
+  .refine(
   (changes) => Object.values(changes).some((value) => value !== undefined),
   "Choose at least one routine field to update",
 );
@@ -96,6 +108,11 @@ const storedScheduleSchema = z.discriminatedUnion("type", [
     time: z.string().regex(TIME),
     weekdays: storedWeekdaysSchema,
   }).strict(),
+  z.object({
+    type: z.literal("interval"),
+    everyMinutes: z.number().int().min(5).max(1_440),
+    anchorAt: z.number().int().nonnegative().max(MAX_DATE_MS).optional(),
+  }).strict(),
 ]);
 const storedDefinitionSchema = z.object({
   name: z.string().trim().min(1).max(80),
@@ -103,8 +120,14 @@ const storedDefinitionSchema = z.object({
   schedule: storedScheduleSchema,
   runOn: z.enum(["maus", "cloud"]),
   durationMinutes: z.number().int().min(5).max(240),
+  timeoutMinutes: z.number().int().min(5).max(240).optional(),
 }).strict();
-const storedChangesSchema = storedDefinitionSchema.partial().refine(
+const storedChangesSchema = storedDefinitionSchema
+  .omit({ timeoutMinutes: true })
+  .partial()
+  .extend({ timeoutMinutes: z.number().int().min(5).max(240).nullable().optional() })
+  .strict()
+  .refine(
   (changes) => Object.values(changes).some((value) => value !== undefined),
   "Stored routine update must change at least one field",
 );
@@ -270,38 +293,68 @@ function duration(value: number | undefined): number {
   return normalized;
 }
 
+function timeout(value: number | null | undefined): number | null | undefined {
+  if (value == null) return value;
+  if (!Number.isInteger(value) || value < 5 || value > 240) {
+    throw new RoutineRequestError("timeoutMinutes must be a whole number from 5 to 240");
+  }
+  return value;
+}
+
+function rfc3339Instant(value: string, offsetMessage: string): number {
+  const parts = RFC3339_WITH_OFFSET.exec(value);
+  if (!parts) throw new RoutineRequestError(offsetMessage);
+  const year = Number(parts[1]);
+  const month = Number(parts[2]);
+  const day = Number(parts[3]);
+  const hour = Number(parts[4]);
+  const minute = Number(parts[5]);
+  const second = Number(parts[6]);
+  const offsetHour = Number(parts[7] ?? 0);
+  const offsetMinute = Number(parts[8] ?? 0);
+  const daysInMonth = month >= 1 && month <= 12
+    ? new Date(Date.UTC(year, month, 0)).getUTCDate()
+    : 0;
+  if (
+    day < 1 ||
+    day > daysInMonth ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59 ||
+    offsetHour > 23 ||
+    offsetMinute > 59
+  ) {
+    throw new RoutineRequestError("Choose a valid RFC3339 date and time");
+  }
+  const at = Date.parse(value);
+  if (!Number.isFinite(at)) throw new RoutineRequestError("Choose a valid RFC3339 date and time");
+  return at;
+}
+
 function normalizeSchedule(schedule: RoutineToolScheduleInput, now: number): RoutineRequestSchedule {
   if (schedule.type === "once") {
-    const parts = RFC3339_WITH_OFFSET.exec(schedule.at);
-    if (!parts) {
-      throw new RoutineRequestError("One-time schedules need an RFC3339 date-time with an explicit timezone offset");
-    }
-    const year = Number(parts[1]);
-    const month = Number(parts[2]);
-    const day = Number(parts[3]);
-    const hour = Number(parts[4]);
-    const minute = Number(parts[5]);
-    const second = Number(parts[6]);
-    const offsetHour = Number(parts[7] ?? 0);
-    const offsetMinute = Number(parts[8] ?? 0);
-    const daysInMonth = month >= 1 && month <= 12
-      ? new Date(Date.UTC(year, month, 0)).getUTCDate()
-      : 0;
-    if (
-      day < 1 ||
-      day > daysInMonth ||
-      hour > 23 ||
-      minute > 59 ||
-      second > 59 ||
-      offsetHour > 23 ||
-      offsetMinute > 59
-    ) {
-      throw new RoutineRequestError("Choose a valid RFC3339 date and time");
-    }
-    const at = Date.parse(schedule.at);
-    if (!Number.isFinite(at)) throw new RoutineRequestError("Choose a valid date and time");
+    const at = rfc3339Instant(
+      schedule.at,
+      "One-time schedules need an RFC3339 date-time with an explicit timezone offset",
+    );
     if (at <= now) throw new RoutineRequestError("The scheduled date and time must be in the future");
     return { type: "once", at };
+  }
+  if (schedule.type === "interval") {
+    if (!Number.isInteger(schedule.everyMinutes) || schedule.everyMinutes < 5 || schedule.everyMinutes > 1_440) {
+      throw new RoutineRequestError("everyMinutes must be a whole number from 5 to 1440");
+    }
+    if (schedule.anchorAt === undefined) {
+      return { type: "interval", everyMinutes: schedule.everyMinutes };
+    }
+    const anchorAt = rfc3339Instant(
+      schedule.anchorAt,
+      "Interval starts need an RFC3339 date-time with an explicit timezone offset",
+    );
+    if (!Number.isSafeInteger(anchorAt) || anchorAt < 0 || anchorAt > MAX_DATE_MS) {
+      throw new RoutineRequestError("Choose a valid interval start time");
+    }
+    return { type: "interval", everyMinutes: schedule.everyMinutes, anchorAt };
   }
   if (!TIME.test(schedule.time)) {
     throw new RoutineRequestError("Weekly schedule time must use 24-hour HH:MM");
@@ -318,12 +371,14 @@ function normalizeSchedule(schedule: RoutineToolScheduleInput, now: number): Rou
 }
 
 function normalizeDefinition(input: RoutineToolDefinitionInput, now: number): RoutineRequestDefinition {
+  const timeoutMinutes = timeout(input.timeoutMinutes);
   return {
     name: text(input.name, "name", 80),
     instructions: text(input.instructions, "instructions", 20_000),
     schedule: normalizeSchedule(input.schedule, now),
     runOn: runOn(input.runOn),
     durationMinutes: duration(input.durationMinutes),
+    ...(timeoutMinutes == null ? {} : { timeoutMinutes }),
   };
 }
 
@@ -334,6 +389,7 @@ function normalizeChanges(input: RoutineToolChangesInput, now: number): RoutineR
   if (input.schedule !== undefined) changes.schedule = normalizeSchedule(input.schedule, now);
   if (input.runOn !== undefined) changes.runOn = runOn(input.runOn);
   if (input.durationMinutes !== undefined) changes.durationMinutes = duration(input.durationMinutes);
+  if (input.timeoutMinutes !== undefined) changes.timeoutMinutes = timeout(input.timeoutMinutes);
   return changes;
 }
 
@@ -380,14 +436,19 @@ function normalizedOperation(
   return { action: validated.action, routineId: id, expectedUpdatedAt: current.updatedAt };
 }
 
-function asSchedule(schedule: RoutineRequestSchedule): RoutineSchedule {
-  return schedule.type === "once"
-    ? { type: "once", at: schedule.at }
-    : { type: "daily", time: schedule.time, weekdays: [...schedule.weekdays] };
+function asSchedule(schedule: RoutineRequestSchedule, now: number): RoutineSchedule {
+  if (schedule.type === "once") return { type: "once", at: schedule.at };
+  if (schedule.type === "interval") {
+    return { type: "interval", everyMinutes: schedule.everyMinutes, anchorAt: schedule.anchorAt ?? now };
+  }
+  return { type: "daily", time: schedule.time, weekdays: [...schedule.weekdays] };
 }
 
 function nextForOperation(operation: RoutineRequestOperation, manager: RoutineManager, now: number): number | null {
-  if (operation.action === "create") return nextOccurrence(asSchedule(operation.routine.schedule), now);
+  if (operation.action === "create") {
+    if (operation.routine.schedule.type === "interval" && operation.routine.schedule.anchorAt === undefined) return null;
+    return nextOccurrence(asSchedule(operation.routine.schedule, now), now);
+  }
   const current = manager.listRoutines().find((routine) => routine.id === operation.routineId);
   if (!current) return null;
   if (operation.action === "pause" || operation.action === "delete") return null;
@@ -395,7 +456,8 @@ function nextForOperation(operation: RoutineRequestOperation, manager: RoutineMa
   if (operation.action === "resume") return nextOccurrence(current.schedule, now);
   if (!("changes" in operation)) return null;
   if (!current.enabled) return null;
-  const schedule = operation.changes.schedule ? asSchedule(operation.changes.schedule) : current.schedule;
+  if (operation.changes.schedule?.type === "interval" && operation.changes.schedule.anchorAt === undefined) return null;
+  const schedule = operation.changes.schedule ? asSchedule(operation.changes.schedule, now) : current.schedule;
   return nextOccurrence(schedule, now);
 }
 
@@ -413,6 +475,11 @@ function formatInstant(at: number, timeZone: string): string {
 
 function scheduleText(schedule: RoutineRequestSchedule, timeZone: string): string {
   if (schedule.type === "once") return `${formatInstant(schedule.at, timeZone)} (${timeZone})`;
+  if (schedule.type === "interval") {
+    return schedule.anchorAt === undefined
+      ? `Every ${schedule.everyMinutes} minutes, starting one interval after confirmation`
+      : `Every ${schedule.everyMinutes} minutes, anchored at ${formatInstant(schedule.anchorAt, timeZone)} (${timeZone})`;
+  }
   const days = schedule.weekdays.map((day) => WEEKDAY_LABEL[day]).join(", ");
   return `${days} at ${schedule.time} (${timeZone})`;
 }
@@ -427,8 +494,14 @@ function effectiveDefinition(operation: RoutineRequestOperation, manager: Routin
     schedule: { ...existing.schedule },
     runOn: existing.runOn,
     durationMinutes: existing.durationMinutes,
+    ...(existing.timeoutMinutes === undefined ? {} : { timeoutMinutes: existing.timeoutMinutes }),
   };
-  return operation.action === "update" ? { ...base, ...operation.changes } : base;
+  if (operation.action !== "update") return base;
+  const { timeoutMinutes, ...changes } = operation.changes;
+  const merged: RoutineRequestDefinition = { ...base, ...changes };
+  if (timeoutMinutes === null) delete merged.timeoutMinutes;
+  else if (timeoutMinutes !== undefined) merged.timeoutMinutes = timeoutMinutes;
+  return merged;
 }
 
 function cardCopy(
@@ -460,23 +533,29 @@ function cardCopy(
     ? null
     : manager.listRoutines().find((routine) => routine.id === operation.routineId) ?? null;
   const remainsPaused = operation.action === "update" && current?.enabled === false;
-  const nextDescription = nextRunAt !== null
-    ? formatInstant(nextRunAt, timeZone)
-    : remainsPaused
-      ? "None — this routine remains paused"
-      : operation.action === "pause"
-        ? "None — this routine will be paused"
-        : operation.action === "delete"
-          ? "None — this routine will be deleted"
-          : "None";
+  const deferredInterval = definition.schedule.type === "interval" && definition.schedule.anchorAt === undefined;
+  const nextDescription = remainsPaused
+    ? "None — this routine remains paused"
+    : deferredInterval
+      ? "One interval after confirmation"
+      : nextRunAt !== null
+        ? formatInstant(nextRunAt, timeZone)
+        : operation.action === "pause"
+          ? "None — this routine will be paused"
+          : operation.action === "delete"
+            ? "None — this routine will be deleted"
+            : "None";
   const status = remainsPaused ? " · Remains paused" : "";
   // Existing routines may predate nested-card redaction. The approval still
   // shows every instruction, but credential-shaped values never travel back
   // through the bot's MCP response or into the transcript.
   const visibleInstructions = redactSecretsInText(definition.instructions);
+  const runLimit = definition.timeoutMinutes === undefined
+    ? "no run limit"
+    : `${definition.timeoutMinutes} min limit`;
   return {
     title,
-    summary: `${actionLabel} “${name}”${forSuffix} · ${when} · ${destination} · ${definition.durationMinutes} min${status}`,
+    summary: `${actionLabel} “${name}”${forSuffix} · ${when} · ${destination} · ${runLimit}${status}`,
     detail: [
       `Action: ${actionCopy.detail}`,
       `Name: ${name}`,
@@ -484,7 +563,7 @@ function cardCopy(
       `Schedule: ${when}`,
       `Next run: ${nextDescription}`,
       `Runs on: ${destination}`,
-      `Maximum duration: ${definition.durationMinutes} minutes`,
+      `Run limit: ${definition.timeoutMinutes === undefined ? "No limit" : `${definition.timeoutMinutes} minutes`}`,
       "",
       "Instructions:",
       visibleInstructions,
@@ -494,25 +573,27 @@ function cardCopy(
   };
 }
 
-function inputFromDefinition(definition: RoutineRequestDefinition, botId: string): RoutineInput {
+function inputFromDefinition(definition: RoutineRequestDefinition, botId: string, now: number): RoutineInput {
   return {
     name: definition.name,
     prompt: definition.instructions,
     botId,
     runOn: definition.runOn,
     enabled: true,
-    schedule: asSchedule(definition.schedule),
+    schedule: asSchedule(definition.schedule, now),
     durationMinutes: definition.durationMinutes,
+    ...(definition.timeoutMinutes === undefined ? {} : { timeoutMinutes: definition.timeoutMinutes }),
   };
 }
 
-function updateFromChanges(changes: RoutineRequestChanges): Partial<RoutineInput> {
+function updateFromChanges(changes: RoutineRequestChanges, now: number): Partial<RoutineInput> {
   const patch: Partial<RoutineInput> = {};
   if (changes.name !== undefined) patch.name = changes.name;
   if (changes.instructions !== undefined) patch.prompt = changes.instructions;
-  if (changes.schedule !== undefined) patch.schedule = asSchedule(changes.schedule);
+  if (changes.schedule !== undefined) patch.schedule = asSchedule(changes.schedule, now);
   if (changes.runOn !== undefined) patch.runOn = changes.runOn;
   if (changes.durationMinutes !== undefined) patch.durationMinutes = changes.durationMinutes;
+  if (changes.timeoutMinutes !== undefined) patch.timeoutMinutes = changes.timeoutMinutes;
   return patch;
 }
 
@@ -885,9 +966,14 @@ export class RoutineRequestService {
 
   private apply(payload: RoutineRequestCardData, messageId: string, fingerprint: string): string {
     const operation = payload.operation;
+    const confirmationAt = this.now();
     switch (operation.action) {
       case "create":
-        return this.routines.create(inputFromDefinition(operation.routine, operation.forBot?.botId ?? payload.botId), {
+        return this.routines.create(inputFromDefinition(
+          operation.routine,
+          operation.forBot?.botId ?? payload.botId,
+          confirmationAt,
+        ), {
           requestId: payload.requestId,
           messageId,
           botId: payload.botId,
@@ -898,7 +984,7 @@ export class RoutineRequestService {
         }).id;
       case "update": {
         verifyManageSnapshot(operation, this.routines, payload.botId);
-        const updated = this.routines.update(operation.routineId, updateFromChanges(operation.changes), {
+        const updated = this.routines.update(operation.routineId, updateFromChanges(operation.changes, confirmationAt), {
           requestId: payload.requestId,
           messageId,
           botId: payload.botId,

--- a/server/routines.test.ts
+++ b/server/routines.test.ts
@@ -8,6 +8,7 @@ import {
   nextOccurrence,
   RoutineManager,
   type RoutineManagerOptions,
+  type RoutineRun,
   type RoutineSchedule,
 } from "./routines.ts";
 
@@ -39,7 +40,11 @@ function harness(start = new Date(2026, 7, 17, 8, 0, 0).getTime()) {
   const taskActivations: boolean[] = [];
   const goalTasks: Array<{ groupId: string; title: string }> = [];
   const interruptedTurns: Array<{ botId: string; threadId: string; runOn: string }> = [];
-  const interruptedGoals: Array<{ groupId: string; threadId: string }> = [];
+  const interruptedGoals: Array<{
+    groupId: string;
+    threadId: string;
+    outcome?: { status: "stopped" | "limit-reached"; detail: string };
+  }> = [];
   const emitted: any[] = [];
   const changed: any[] = [];
   const failed: any[] = [];
@@ -68,8 +73,8 @@ function harness(start = new Date(2026, 7, 17, 8, 0, 0).getTime()) {
     interruptTurn: async (botId, threadId, runOn) => {
       interruptedTurns.push({ botId, threadId, runOn });
     },
-    interruptGoal: async (groupId, threadId) => {
-      interruptedGoals.push({ groupId, threadId });
+    interruptGoal: async (groupId, threadId, outcome) => {
+      interruptedGoals.push({ groupId, threadId, ...(outcome ? { outcome } : {}) });
     },
     onRunChanged: (run) => changed.push(run),
     onRunFailed: (run) => failed.push(run),
@@ -113,6 +118,20 @@ describe("nextOccurrence", () => {
     expect(nextOccurrence({ type: "once", at: 200 }, 100)).toBe(200);
     expect(nextOccurrence({ type: "once", at: 100 }, 100)).toBeNull();
   });
+
+  it("keeps interval schedules aligned to their anchor", () => {
+    const anchorAt = Date.parse("2026-08-17T08:05:00Z");
+    const schedule: RoutineSchedule = { type: "interval", everyMinutes: 5, anchorAt };
+
+    expect(nextOccurrence(schedule, anchorAt - 1)).toBe(anchorAt);
+    expect(nextOccurrence(schedule, anchorAt)).toBe(anchorAt + 5 * 60_000);
+    expect(nextOccurrence(schedule, anchorAt + 12 * 60_000)).toBe(anchorAt + 15 * 60_000);
+    expect(nextOccurrence({
+      type: "interval",
+      everyMinutes: 5,
+      anchorAt: 8_640_000_000_000_000,
+    }, 8_640_000_000_000_000)).toBeNull();
+  });
 });
 
 describe("RoutineManager", () => {
@@ -130,6 +149,50 @@ describe("RoutineManager", () => {
     expect(create("Below minimum", 4).durationMinutes).toBe(5);
     expect(create("Default").durationMinutes).toBe(30);
     expect(create("Above maximum", 241).durationMinutes).toBe(240);
+  });
+
+  it("validates, preserves, and clears the optional safety timeout", () => {
+    const h = harness();
+    const input = {
+      name: "Bounded routine",
+      prompt: "Check the queue",
+      botId: "maus-1",
+      schedule: { type: "daily" as const, time: "09:00", weekdays: [1] },
+    };
+    const routine = h.manager.create({ ...input, timeoutMinutes: 5 });
+    expect(routine.timeoutMinutes).toBe(5);
+    expect(h.manager.update(routine.id, { timeoutMinutes: null })).not.toHaveProperty("timeoutMinutes");
+    expect(h.manager.create({ ...input, name: "Unlimited" })).not.toHaveProperty("timeoutMinutes");
+    expect(() => h.manager.create({ ...input, timeoutMinutes: 4 })).toThrow(/5 to 240/);
+    expect(() => h.manager.create({ ...input, timeoutMinutes: 241 })).toThrow(/5 to 240/);
+  });
+
+  it("validates interval cadence and preserves its explicit anchor", () => {
+    const h = harness();
+    const anchorAt = new Date(2026, 7, 17, 8, 5).getTime();
+    const routine = h.manager.create({
+      name: "Frequent check",
+      prompt: "Check the queue",
+      botId: "maus-1",
+      schedule: { type: "interval", everyMinutes: 5, anchorAt },
+    });
+
+    expect(routine.schedule).toEqual({ type: "interval", everyMinutes: 5, anchorAt });
+    expect(routine.nextRunAt).toBe(anchorAt);
+    expect(() => h.manager.create({
+      name: "Too frequent",
+      prompt: "Check too often",
+      botId: "maus-1",
+      schedule: { type: "interval", everyMinutes: 4, anchorAt },
+    })).toThrow(/5 to 1440/);
+    for (const invalidAnchor of [1.5, Number.MAX_SAFE_INTEGER, Number.NaN]) {
+      expect(() => h.manager.create({
+        name: "Bad anchor",
+        prompt: "Check later",
+        botId: "maus-1",
+        schedule: { type: "interval", everyMinutes: 5, anchorAt: invalidAnchor },
+      })).toThrow(/valid interval start time/);
+    }
   });
 
   it("stores routine data with owner-only permissions", () => {
@@ -153,6 +216,7 @@ describe("RoutineManager", () => {
       prompt: "Summarize what changed",
       botId: "maus-1",
       schedule: { type: "once", at: new Date(2026, 7, 17, 8, 5).getTime() },
+      timeoutMinutes: 15,
     });
     h.setNow(routine.nextRunAt!);
     await h.manager.tick();
@@ -167,7 +231,13 @@ describe("RoutineManager", () => {
     const reloaded = new RoutineManager(h.options);
     expect(reloaded.listRoutines()).toHaveLength(1);
     expect(reloaded.listRuns()).toMatchObject([
-      { routineId: routine.id, routineName: "Morning brief", status: "failed", threadId: "thread-1" },
+      {
+        routineId: routine.id,
+        routineName: "Morning brief",
+        status: "failed",
+        threadId: "thread-1",
+        timeoutMinutes: 15,
+      },
     ]);
     // Reload recovery truthfully marks an in-process run as interrupted.
     expect(reloaded.listRuns()[0]!.error).toContain("restarted");
@@ -183,7 +253,7 @@ describe("RoutineManager", () => {
     ]);
   });
 
-  it("persists attachment metadata and migrates old definitions and runs to empty arrays", () => {
+  it("migrates optional attachment and timeout metadata without losing legacy records", () => {
     const h = harness();
     h.setBot("busy");
     const routine = h.manager.create({
@@ -213,16 +283,20 @@ describe("RoutineManager", () => {
 
     const file = h.options.file!;
     const oldFile = JSON.parse(readFileSync(file, "utf8")) as {
-      routines: Array<{ attachments?: unknown }>;
-      runs: Array<{ attachments?: unknown }>;
+      routines: Array<{ attachments?: unknown; timeoutMinutes?: unknown }>;
+      runs: Array<{ attachments?: unknown; timeoutMinutes?: unknown }>;
     };
     delete oldFile.routines[0]!.attachments;
     delete oldFile.runs[0]!.attachments;
+    oldFile.routines[0]!.timeoutMinutes = 2;
+    oldFile.runs[0]!.timeoutMinutes = "invalid";
     writeFileSync(file, JSON.stringify(oldFile));
 
     const migrated = new RoutineManager(h.options);
     expect(migrated.listRoutines()[0]?.attachments).toEqual([]);
     expect(migrated.listRuns()[0]?.attachments).toEqual([]);
+    expect(migrated.listRoutines()[0]).not.toHaveProperty("timeoutMinutes");
+    expect(migrated.listRuns()[0]).not.toHaveProperty("timeoutMinutes");
   });
 
   it("migrates routines and run receipts without a target to bot execution", () => {
@@ -251,6 +325,31 @@ describe("RoutineManager", () => {
     expect(migrated.listRoutines()[0]?.groupId).toBeUndefined();
     expect(migrated.listRuns()[0]).toMatchObject({ target: "bot", botId: "maus-legacy" });
     expect(migrated.listRuns()[0]?.groupId).toBeUndefined();
+  });
+
+  it("ignores one malformed persisted interval without hiding valid routines", () => {
+    const h = harness();
+    const anchorAt = new Date(2026, 7, 17, 8, 5).getTime();
+    const malformed = h.manager.create({
+      name: "Malformed interval",
+      prompt: "Never load this cadence",
+      botId: "maus-legacy",
+      schedule: { type: "interval", everyMinutes: 5, anchorAt },
+    });
+    const valid = h.manager.create({
+      name: "Valid interval",
+      prompt: "Keep this cadence",
+      botId: "maus-valid",
+      schedule: { type: "interval", everyMinutes: 15, anchorAt },
+    });
+    const stored = JSON.parse(readFileSync(h.options.file!, "utf8")) as {
+      routines: Array<{ id: string; schedule: { anchorAt?: unknown } }>;
+    };
+    stored.routines.find((routine) => routine.id === malformed.id)!.schedule.anchorAt = Number.MAX_SAFE_INTEGER;
+    writeFileSync(h.options.file!, JSON.stringify(stored));
+
+    const reloaded = new RoutineManager(h.options);
+    expect(reloaded.listRoutines()).toMatchObject([{ id: valid.id, name: "Valid interval" }]);
   });
 
   it("persists confirmation receipts with the scheduler mutation and removes them after settlement", () => {
@@ -491,6 +590,270 @@ describe("RoutineManager", () => {
     expect(h.manager.activeRunForBot("maus-2")?.threadId).toBe("thread-1");
     expect(h.manager.isActiveThread("thread-1")).toBe(true);
     expect(h.taskActivations).toEqual([false]);
+  });
+
+  it("skips interval ticks while the previous run is still active", async () => {
+    const h = harness();
+    const anchorAt = new Date(2026, 7, 17, 8, 5).getTime();
+    h.manager.create({
+      name: "Frequent check",
+      prompt: "Check the queue",
+      botId: "maus-interval",
+      schedule: { type: "interval", everyMinutes: 5, anchorAt },
+      durationMinutes: 30,
+    });
+
+    h.setNow(anchorAt);
+    await h.manager.tick();
+    expect(h.manager.listRuns()).toHaveLength(1);
+    expect(h.manager.listRuns()[0]).toMatchObject({ status: "running", scheduledFor: anchorAt });
+
+    h.setNow(anchorAt + 5 * 60_000);
+    await h.manager.tick();
+    expect(h.manager.listRuns()).toHaveLength(1);
+    expect(h.manager.listRoutines()[0]?.nextRunAt).toBe(anchorAt + 10 * 60_000);
+
+    h.manager.failThread("thread-1", "Finished test run");
+    h.setNow(anchorAt + 10 * 60_000);
+    await h.manager.tick();
+    expect(h.manager.listRuns()).toHaveLength(2);
+    expect(h.started).toHaveLength(2);
+  });
+
+  it("catches up at most the latest interval occurrence without a backlog", async () => {
+    const h = harness();
+    const anchorAt = new Date(2026, 7, 17, 8, 5).getTime();
+    h.manager.create({
+      name: "Frequent check",
+      prompt: "Check the queue",
+      botId: "maus-interval",
+      schedule: { type: "interval", everyMinutes: 5, anchorAt },
+    });
+
+    h.setNow(anchorAt + 12 * 60_000);
+    await h.manager.tick();
+
+    expect(h.manager.listRuns()).toMatchObject([{
+      status: "running",
+      scheduledFor: anchorAt + 10 * 60_000,
+    }]);
+    expect(h.manager.listRoutines()[0]?.nextRunAt).toBe(anchorAt + 15 * 60_000);
+  });
+
+  it("rebases a scheduled interval queued behind a busy bot before dispatch", async () => {
+    const h = harness();
+    h.setBot("busy");
+    const anchorAt = new Date(2026, 7, 17, 8, 5).getTime();
+    h.manager.create({
+      name: "Frequent check",
+      prompt: "Check the latest queue",
+      botId: "maus-interval",
+      schedule: { type: "interval", everyMinutes: 5, anchorAt },
+    });
+
+    h.setNow(anchorAt);
+    await h.manager.tick();
+    expect(h.manager.listRuns()[0]).toMatchObject({ status: "queued", scheduledFor: anchorAt });
+
+    const readyAt = anchorAt + 12 * 60 * 60_000 + 7 * 60_000;
+    const latestAt = anchorAt + 12 * 60 * 60_000 + 5 * 60_000;
+    h.setNow(readyAt);
+    h.setBot("ready");
+    await h.manager.tick();
+
+    expect(h.manager.listRuns()).toMatchObject([{
+      status: "running",
+      scheduledFor: latestAt,
+      threadId: "thread-1",
+    }]);
+    expect(h.started).toEqual([{
+      botId: "maus-interval",
+      threadId: "thread-1",
+      prompt: "Check the latest queue",
+    }]);
+  });
+
+  it("preserves exact timestamps for manual and webhook interval work", async () => {
+    const start = new Date(2026, 7, 17, 8, 0).getTime();
+    const manualHarness = harness(start);
+    manualHarness.setBot("busy");
+    const manualRoutine = manualHarness.manager.create({
+      name: "Manual interval check",
+      prompt: "Run exactly when requested",
+      botId: "maus-manual",
+      schedule: { type: "interval", everyMinutes: 5, anchorAt: start },
+    });
+    const manual = manualHarness.manager.runNow(manualRoutine.id)!;
+    manualHarness.setNow(start + 13 * 60 * 60_000);
+    manualHarness.setBot("ready");
+    await manualHarness.manager.tick();
+    expect(manualHarness.manager.listRuns().find((run) => run.id === manual.id)).toMatchObject({
+      triggerSource: "manual",
+      scheduledFor: start,
+      status: "running",
+    });
+
+    const webhookHarness = harness(start);
+    webhookHarness.setBot("busy");
+    const webhookRoutine = webhookHarness.manager.create({
+      name: "Webhook id collision",
+      prompt: "Keep the delivery timestamp",
+      botId: "maus-webhook",
+      schedule: { type: "interval", everyMinutes: 5, anchorAt: start },
+    });
+    const webhook = webhookHarness.manager.enqueueWebhook({
+      webhookId: webhookRoutine.id,
+      webhookName: "Incoming delivery",
+      prompt: "Handle the delivery",
+      botId: "maus-webhook",
+      runOn: "maus",
+      deliveryId: "delivery-exact",
+      receivedAt: start,
+    });
+    webhookHarness.setNow(start + 13 * 60 * 60_000);
+    webhookHarness.setBot("ready");
+    await webhookHarness.manager.tick();
+    expect(webhookHarness.manager.listRuns().find((run) => run.id === webhook.id)).toMatchObject({
+      triggerSource: "webhook",
+      scheduledFor: start,
+      status: "running",
+    });
+  });
+
+  it("retains an old waiting run when trimming terminal receipt history", async () => {
+    const h = harness();
+    const routine = h.manager.create({
+      name: "Waiting approval",
+      prompt: "Wait for approval",
+      botId: "maus-waiting",
+      schedule: { type: "daily", time: "23:59", weekdays: [1] },
+    });
+    const waiting = h.manager.runNow(routine.id)!;
+    await h.manager.tick();
+    h.manager.handleRuntimeEvent({
+      eventId: "waiting-request",
+      provider: "fake",
+      threadId: "thread-1",
+      createdAt: new Date().toISOString(),
+      type: "request.opened",
+      requestType: "permission",
+      tool: "write",
+      summary: "Approve the write",
+    });
+
+    // Seed terminal history directly so this capacity regression does not do
+    // two thousand quadratic fixture writes. The final enqueue still crosses
+    // the real manager save/retention path that used to evict index zero.
+    const internal = h.manager as unknown as { runs: RoutineRun[] };
+    const base = internal.runs.find((run) => run.id === waiting.id)!;
+    for (let index = 0; index < 1_999; index += 1) {
+      internal.runs.push({
+        ...base,
+        id: `terminal-${index}`,
+        status: "completed",
+        attention: undefined,
+        finishedAt: index + 1,
+      });
+    }
+    h.setBot("busy");
+    const queued = h.manager.enqueueWebhook({
+      webhookId: "hook-capacity",
+      webhookName: "Capacity check",
+      prompt: "Keep active receipts",
+      botId: "maus-capacity",
+      runOn: "maus",
+      deliveryId: "delivery-capacity",
+      receivedAt: 2_001,
+    });
+
+    const retained = h.manager.listRuns();
+    expect(retained).toHaveLength(2_000);
+    expect(retained.some((run) => run.id === waiting.id && run.status === "waiting")).toBe(true);
+    expect(retained.some((run) => run.id === queued.id && run.status === "queued")).toBe(true);
+    expect(retained.some((run) => run.id === "terminal-0")).toBe(false);
+  });
+
+  it("enforces only the optional run limit from the actual start time", async () => {
+    const h = harness();
+    const routine = h.manager.create({
+      name: "Bounded check",
+      prompt: "Check the queue",
+      botId: "maus-timeout",
+      schedule: { type: "daily", time: "23:59", weekdays: [1] },
+      durationMinutes: 90,
+      timeoutMinutes: 5,
+    });
+    const run = h.manager.runNow(routine.id)!;
+    await h.manager.tick();
+    const startedAt = h.manager.listRuns().find((candidate) => candidate.id === run.id)?.startedAt;
+    expect(startedAt).toBeDefined();
+
+    h.setNow(startedAt! + 5 * 60_000);
+    await h.manager.tick();
+
+    expect(h.manager.listRuns().find((candidate) => candidate.id === run.id)).toMatchObject({
+      status: "failed",
+      error: "Stopped after reaching the 5-minute run limit",
+      finishedAt: startedAt! + 5 * 60_000,
+    });
+    expect(h.interruptedTurns).toEqual([
+      { botId: "maus-timeout", threadId: "thread-1", runOn: "maus" },
+    ]);
+  });
+
+  it("keeps legacy duration metadata without imposing a timeout", async () => {
+    const h = harness();
+    const routine = h.manager.create({
+      name: "Unbounded check",
+      prompt: "Keep checking",
+      botId: "maus-unbounded",
+      schedule: { type: "daily", time: "23:59", weekdays: [1] },
+      durationMinutes: 5,
+    });
+    const run = h.manager.runNow(routine.id)!;
+    await h.manager.tick();
+    const startedAt = h.manager.listRuns().find((candidate) => candidate.id === run.id)?.startedAt;
+    h.setNow(startedAt! + 6 * 60_000);
+    await h.manager.tick();
+
+    expect(h.manager.listRuns().find((candidate) => candidate.id === run.id)).toMatchObject({
+      status: "running",
+      durationMinutes: 5,
+    });
+    expect(h.manager.listRuns().find((candidate) => candidate.id === run.id)).not.toHaveProperty("timeoutMinutes");
+    expect(h.interruptedTurns).toEqual([]);
+  });
+
+  it("reports a timed-out room goal as limit-reached", async () => {
+    const h = harness();
+    const routine = h.manager.create({
+      name: "Bounded team goal",
+      prompt: "Coordinate until the limit",
+      target: "room-goal",
+      botId: "chief-1",
+      groupId: "room-1",
+      schedule: { type: "daily", time: "23:59", weekdays: [1] },
+      timeoutMinutes: 5,
+    });
+    const run = h.manager.runNow(routine.id)!;
+    await h.manager.tick();
+    const startedAt = h.manager.listRuns().find((candidate) => candidate.id === run.id)?.startedAt;
+    h.setNow(startedAt! + 5 * 60_000);
+    await h.manager.tick();
+
+    expect(h.manager.listRuns().find((candidate) => candidate.id === run.id)).toMatchObject({
+      status: "failed",
+      goalStatus: "limit-reached",
+      error: "Stopped after reaching the 5-minute run limit",
+    });
+    expect(h.interruptedGoals).toEqual([{
+      groupId: "room-1",
+      threadId: "goal-thread-1",
+      outcome: {
+        status: "limit-reached",
+        detail: "Stopped after reaching the 5-minute run limit",
+      },
+    }]);
   });
 
   it("distinguishes direct bot work from room goals coordinated by the same bot", async () => {

--- a/server/routines.ts
+++ b/server/routines.ts
@@ -12,7 +12,8 @@ import type { RoutineRequestOperation } from "../shared/routine-request.ts";
 
 export type RoutineSchedule =
   | { type: "once"; at: number }
-  | { type: "daily"; time: string; weekdays: number[] };
+  | { type: "daily"; time: string; weekdays: number[] }
+  | { type: "interval"; everyMinutes: number; anchorAt: number };
 
 /** `cloud` runs the agent itself inside the bot's Box VM. `maus` keeps
  * using the provider selected on the MAUS and only borrows its configured
@@ -53,7 +54,10 @@ export interface Routine {
   runOn: RoutineRunOn;
   enabled: boolean;
   schedule: RoutineSchedule;
+  /** Legacy calendar/display length. Kept for persisted-data compatibility. */
   durationMinutes: number;
+  /** Optional safety cap for active work. Missing means no timeout. */
+  timeoutMinutes?: number;
   attachments?: RoutineContextAttachment[];
   /** Conversation that created this routine in chat. Calendar/import-created
    * routines intentionally have no source, and older files migrate in place. */
@@ -69,7 +73,10 @@ export interface RoutineRun {
   routineName: string;
   /** Snapshot the work so an edited/deleted definition cannot rewrite history. */
   prompt?: string;
+  /** Snapshot of the legacy calendar/display length. */
   durationMinutes?: number;
+  /** Snapshot of the optional active-work safety cap. */
+  timeoutMinutes?: number;
   attachments?: RoutineContextAttachment[];
   target: RoutineTarget;
   /** Exact terminal room outcome. `status` remains the scheduler lifecycle
@@ -141,6 +148,8 @@ export interface RoutineInput {
   enabled?: boolean;
   schedule: RoutineSchedule;
   durationMinutes?: number;
+  /** `null` deliberately removes an existing safety cap. */
+  timeoutMinutes?: number | null;
   attachments?: RoutineContextAttachment[];
 }
 
@@ -185,7 +194,11 @@ export interface RoutineManagerOptions {
     onDispatchError: (message: string) => void,
   ) => Promise<void>;
   interruptTurn?: (botId: string, threadId: string, runOn: RoutineRunOn) => Promise<void>;
-  interruptGoal?: (groupId: string, threadId: string) => Promise<void>;
+  interruptGoal?: (
+    groupId: string,
+    threadId: string,
+    outcome?: { status: "stopped" | "limit-reached"; detail: string },
+  ) => Promise<void>;
   /** Projects every durable transition into the source conversation. */
   onRunChanged?: (run: RoutineRun) => void;
   onRunFailed?: (run: RoutineRun) => void;
@@ -193,6 +206,7 @@ export interface RoutineManagerOptions {
 
 const ALL_DAYS = [0, 1, 2, 3, 4, 5, 6];
 const CATCH_UP_MS = 12 * 60 * 60_000;
+const MAX_DATE_MS = 8_640_000_000_000_000;
 const MAX_RUNS = 2_000;
 const MAX_ATTACHMENTS = 50;
 const attachmentSchema = z.object({
@@ -238,6 +252,22 @@ function cleanAttachments(value: unknown): RoutineContextAttachment[] {
   });
 }
 
+function cleanTimeoutMinutes(value: unknown): number | undefined {
+  if (value == null) return undefined;
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 5 || value > 240) {
+    throw new Error("Run limit must be a whole number from 5 to 240 minutes");
+  }
+  return value;
+}
+
+function loadTimeoutMinutes(value: unknown): number | undefined {
+  try {
+    return cleanTimeoutMinutes(value);
+  } catch {
+    return undefined;
+  }
+}
+
 /** A malformed legacy metadata field must not make the scheduler forget the
  * otherwise valid routine or run that owns it. New writes still fail closed. */
 function loadAttachments(value: unknown): RoutineContextAttachment[] {
@@ -249,9 +279,11 @@ function loadAttachments(value: unknown): RoutineContextAttachment[] {
 }
 
 function cloneSchedule(schedule: RoutineSchedule): RoutineSchedule {
-  return schedule.type === "once"
-    ? { type: "once", at: schedule.at }
-    : { type: "daily", time: schedule.time, weekdays: [...schedule.weekdays] };
+  if (schedule.type === "once") return { type: "once", at: schedule.at };
+  if (schedule.type === "interval") {
+    return { type: "interval", everyMinutes: schedule.everyMinutes, anchorAt: schedule.anchorAt };
+  }
+  return { type: "daily", time: schedule.time, weekdays: [...schedule.weekdays] };
 }
 
 function cloneAttachments(attachments: readonly RoutineContextAttachment[] | undefined): RoutineContextAttachment[] {
@@ -331,12 +363,42 @@ function cleanSchedule(schedule: RoutineSchedule): RoutineSchedule {
     if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(time)) throw new Error("Time must use HH:MM");
     return { type: "daily", time, weekdays: cleanDays(schedule.weekdays) };
   }
+  if (schedule?.type === "interval") {
+    const { everyMinutes, anchorAt } = schedule;
+    if (typeof everyMinutes !== "number" || !Number.isInteger(everyMinutes) || everyMinutes < 5 || everyMinutes > 1_440) {
+      throw new Error("Interval must be a whole number from 5 to 1440 minutes");
+    }
+    if (
+      typeof anchorAt !== "number" ||
+      !Number.isSafeInteger(anchorAt) ||
+      anchorAt < 0 ||
+      anchorAt > MAX_DATE_MS
+    ) {
+      throw new Error("Choose a valid interval start time");
+    }
+    return { type: "interval", everyMinutes, anchorAt };
+  }
   throw new Error("Choose a supported schedule");
+}
+
+function loadSchedule(value: unknown): RoutineSchedule | null {
+  try {
+    return cleanSchedule(value as RoutineSchedule);
+  } catch {
+    return null;
+  }
 }
 
 /** Next wall-clock occurrence in this computer's timezone, strictly after `after`. */
 export function nextOccurrence(schedule: RoutineSchedule, after: number): number | null {
   if (schedule.type === "once") return schedule.at > after ? schedule.at : null;
+  if (schedule.type === "interval") {
+    if (schedule.anchorAt > after) return schedule.anchorAt;
+    const intervalMs = schedule.everyMinutes * 60_000;
+    const intervalsElapsed = Math.floor((after - schedule.anchorAt) / intervalMs);
+    const candidate = schedule.anchorAt + (intervalsElapsed + 1) * intervalMs;
+    return Number.isSafeInteger(candidate) && candidate <= MAX_DATE_MS ? candidate : null;
+  }
   const [hour, minute] = schedule.time.split(":").map(Number);
   const weekdays = new Set(cleanDays(schedule.weekdays));
   for (let offset = 0; offset <= 8; offset++) {
@@ -346,6 +408,15 @@ export function nextOccurrence(schedule: RoutineSchedule, after: number): number
     if (d.getTime() > after && weekdays.has(d.getDay())) return d.getTime();
   }
   return null;
+}
+
+function latestIntervalOccurrence(
+  schedule: Extract<RoutineSchedule, { type: "interval" }>,
+  at: number,
+): number | null {
+  if (schedule.anchorAt > at) return null;
+  const intervalMs = schedule.everyMinutes * 60_000;
+  return schedule.anchorAt + Math.floor((at - schedule.anchorAt) / intervalMs) * intervalMs;
 }
 
 function sanitizeInput(input: RoutineInput): Omit<Routine, "id" | "createdAt" | "updatedAt" | "nextRunAt"> {
@@ -362,6 +433,7 @@ function sanitizeInput(input: RoutineInput): Omit<Routine, "id" | "createdAt" | 
   const runOn = input.runOn ?? "maus";
   if (runOn !== "maus" && runOn !== "cloud") throw new Error("Choose where this routine runs");
   const attachments = cleanAttachments(input.attachments);
+  const timeoutMinutes = cleanTimeoutMinutes(input.timeoutMinutes);
   if (target === "room-goal" && runOn === "cloud") {
     throw new Error("Room goals can only run on this computer");
   }
@@ -381,6 +453,7 @@ function sanitizeInput(input: RoutineInput): Omit<Routine, "id" | "createdAt" | 
     enabled: input.enabled !== false,
     schedule: cleanSchedule(input.schedule),
     durationMinutes: Math.min(240, Math.max(5, Math.round(Number(input.durationMinutes) || 30))),
+    ...(timeoutMinutes === undefined ? {} : { timeoutMinutes }),
     attachments,
   };
 }
@@ -402,30 +475,39 @@ export class RoutineManager {
     try {
       const disk = JSON.parse(readFileSync(this.file, "utf8")) as Partial<RoutineFile>;
       this.routines = Array.isArray(disk.routines)
-        ? disk.routines.map((routine) => {
+        ? disk.routines.flatMap((routine) => {
+            const schedule = loadSchedule(routine.schedule);
+            if (!schedule) return [];
             const target = loadTarget(routine.target);
-            return {
+            const loaded: Routine = {
               ...routine,
+              schedule,
               target,
               groupId: loadGroupId(routine.groupId, target),
               runOn: routine.runOn ?? "maus",
+              timeoutMinutes: loadTimeoutMinutes(routine.timeoutMinutes),
               attachments: loadAttachments(routine.attachments),
               sourceThreadId: persistedSourceThreadId.parse(routine.sourceThreadId),
             };
+            if (loaded.timeoutMinutes === undefined) delete loaded.timeoutMinutes;
+            return [loaded];
           })
         : [];
       this.runs = Array.isArray(disk.runs)
         ? disk.runs.map((run) => {
             const target = loadTarget(run.target);
-            return {
+            const loaded: RoutineRun = {
               ...run,
               target,
               goalStatus: loadGoalStatus(run.goalStatus, target),
               groupId: loadGroupId(run.groupId, target),
               runOn: run.runOn ?? "maus",
+              timeoutMinutes: loadTimeoutMinutes(run.timeoutMinutes),
               attachments: loadAttachments(run.attachments),
               sourceThreadId: persistedSourceThreadId.parse(run.sourceThreadId),
             };
+            if (loaded.timeoutMinutes === undefined) delete loaded.timeoutMinutes;
+            return loaded;
           })
         : [];
       this.routineRequestReceipts = Array.isArray(disk.routineRequestReceipts)
@@ -611,6 +693,7 @@ export class RoutineManager {
       enabled: patch.enabled ?? routine.enabled,
       schedule: patch.schedule ?? routine.schedule,
       durationMinutes: patch.durationMinutes ?? routine.durationMinutes,
+      timeoutMinutes: Object.hasOwn(patch, "timeoutMinutes") ? patch.timeoutMinutes : routine.timeoutMinutes,
       attachments: patch.attachments ?? routine.attachments,
     });
     if (this.targetState(clean) === "missing") throw new Error(this.missingTargetMessage(clean.target));
@@ -622,6 +705,9 @@ export class RoutineManager {
         // confirmation cards. Keep it monotonic even for two writes in one ms.
         updatedAt: Math.max(now, routine.updatedAt + 1),
       });
+      if (Object.hasOwn(patch, "timeoutMinutes") && patch.timeoutMinutes == null) {
+        delete routine.timeoutMinutes;
+      }
       if (patch.enabled === false) {
         for (const run of this.runs) {
           if (run.routineId !== routine.id || run.status !== "queued") continue;
@@ -782,7 +868,6 @@ export class RoutineManager {
       createdAt: this.now(),
     };
     this.runs.push(run);
-    if (this.runs.length > MAX_RUNS) this.runs.splice(0, this.runs.length - MAX_RUNS);
     this.save();
     this.emitRun(run);
     queueMicrotask(() => void this.tick());
@@ -857,27 +942,65 @@ export class RoutineManager {
     this.ticking = true;
     try {
       const now = this.now();
+      for (const run of this.runs) {
+        if (
+          !["running", "waiting"].includes(run.status) ||
+          run.startedAt == null ||
+          run.timeoutMinutes == null ||
+          now - run.startedAt < run.timeoutMinutes * 60_000
+        ) continue;
+        const threadId = run.threadId;
+        const detail = `Stopped after reaching the ${run.timeoutMinutes}-minute run limit`;
+        if (run.target === "room-goal") run.goalStatus = "limit-reached";
+        this.failRun(run, detail);
+        if (!threadId) continue;
+        if (run.target === "room-goal" && run.groupId) {
+          await this.options.interruptGoal?.(run.groupId, threadId, {
+            status: "limit-reached",
+            detail,
+          }).catch(() => {});
+        } else {
+          await this.options.interruptTurn?.(run.botId, threadId, run.runOn ?? "maus").catch(() => {});
+        }
+      }
       let changed = false;
       const missedRuns: RoutineRun[] = [];
       for (const routine of this.routines) {
         if (!routine.enabled || routine.nextRunAt == null || routine.nextRunAt > now) continue;
-        const scheduledFor = routine.nextRunAt;
-        const late = now - scheduledFor;
-        if (late > CATCH_UP_MS) {
-          const missed = this.newRun(routine, scheduledFor, false);
-          missed.status = "missed";
-          missed.finishedAt = now;
-          missed.error = "This computer was offline for more than 12 hours after the scheduled time";
-          this.emitRun(missed);
-          missedRuns.push(cloneRun(missed));
-        } else {
-          const run = this.newRun(routine, scheduledFor, false);
-          this.emitRun(run);
+        const pendingAt = routine.nextRunAt;
+        const late = now - pendingAt;
+        const scheduledFor = routine.schedule.type === "interval" && late <= CATCH_UP_MS
+          ? latestIntervalOccurrence(routine.schedule, now) ?? pendingAt
+          : pendingAt;
+        // One slow interval run must not build an unbounded queue of stale
+        // copies behind it. The series still advances on its original phase.
+        const overlapping = routine.schedule.type === "interval" && this.runs.some(
+          (run) => run.routineId === routine.id && ["queued", "running", "waiting"].includes(run.status),
+        );
+        if (!overlapping) {
+          if (late > CATCH_UP_MS) {
+            const missed = this.newRun(routine, scheduledFor, false);
+            missed.status = "missed";
+            missed.finishedAt = now;
+            missed.error = "This computer was offline for more than 12 hours after the scheduled time";
+            this.emitRun(missed);
+            missedRuns.push(cloneRun(missed));
+          } else {
+            const run = this.newRun(routine, scheduledFor, false);
+            this.emitRun(run);
+          }
         }
         routine.nextRunAt =
           routine.schedule.type === "once" ? null : nextOccurrence(routine.schedule, Math.max(now, scheduledFor));
-        if (routine.schedule.type === "once") routine.enabled = false;
-        routine.updatedAt = Math.max(now, routine.updatedAt + 1);
+        // `updatedAt` is the optimistic definition revision carried by
+        // routine confirmation cards. Moving the scheduler cursor is runtime
+        // progress, not a definition edit, so recurring ticks must not make a
+        // still-accurate pending confirmation stale. A one-time routine does
+        // mutate its definition by auto-disabling after its occurrence.
+        if (routine.schedule.type === "once") {
+          routine.enabled = false;
+          routine.updatedAt = Math.max(now, routine.updatedAt + 1);
+        }
         this.emitRoutine(routine);
         changed = true;
       }
@@ -886,6 +1009,23 @@ export class RoutineManager {
 
       for (const run of [...this.runs].reverse()) {
         if (run.status !== "queued") continue;
+        // A queued interval represents the latest useful check, not a backlog
+        // item. If the bot stayed busy across later occurrences, align this
+        // scheduled receipt to the newest due point immediately before it can
+        // dispatch. Manual runs and webhook deliveries retain their exact
+        // requested/received timestamps.
+        const triggerSource = run.triggerSource ?? (run.manual ? "manual" : "schedule");
+        const definition = triggerSource === "schedule"
+          ? this.routines.find((routine) => routine.id === run.routineId)
+          : undefined;
+        if (definition?.schedule.type === "interval") {
+          const latest = latestIntervalOccurrence(definition.schedule, now);
+          if (latest !== null && latest > run.scheduledFor) {
+            run.scheduledFor = latest;
+            this.save();
+            this.emitRun(run);
+          }
+        }
         const state = this.targetState(run);
         if (state === "busy") continue;
         if (state === "missing") {
@@ -1082,6 +1222,7 @@ export class RoutineManager {
       routineName: routine.name,
       prompt: routine.prompt,
       durationMinutes: routine.durationMinutes,
+      ...(routine.timeoutMinutes === undefined ? {} : { timeoutMinutes: routine.timeoutMinutes }),
       attachments: cloneAttachments(routine.attachments),
       target: routine.target,
       groupId: routine.groupId,
@@ -1095,7 +1236,6 @@ export class RoutineManager {
       createdAt: this.now(),
     };
     this.runs.push(run);
-    if (this.runs.length > MAX_RUNS) this.runs.splice(0, this.runs.length - MAX_RUNS);
     return run;
   }
 
@@ -1171,6 +1311,19 @@ export class RoutineManager {
   }
 
   private save() {
+    // Active receipts own cancellation, timeout, and provider-event routing;
+    // evicting one would strand live work. Treat MAX_RUNS as a soft history
+    // cap and reclaim only the oldest terminal receipts. An unusually large
+    // active queue may exceed it until work settles.
+    let excess = this.runs.length - MAX_RUNS;
+    for (let index = 0; index < this.runs.length && excess > 0;) {
+      if (["queued", "running", "waiting"].includes(this.runs[index]!.status)) {
+        index += 1;
+        continue;
+      }
+      this.runs.splice(index, 1);
+      excess -= 1;
+    }
     mkdirSync(dirname(this.file), { recursive: true });
     writeFileAtomic(this.file, JSON.stringify({
       version: 1,

--- a/shared/routine-request.ts
+++ b/shared/routine-request.ts
@@ -12,17 +12,23 @@ export type RoutineRequestRunOn = "maus" | "cloud";
 
 export type RoutineRequestSchedule =
   | { type: "once"; at: number }
-  | { type: "daily"; time: string; weekdays: number[] };
+  | { type: "daily"; time: string; weekdays: number[] }
+  | { type: "interval"; everyMinutes: number; anchorAt?: number };
 
 export interface RoutineRequestDefinition {
   name: string;
   instructions: string;
   schedule: RoutineRequestSchedule;
   runOn: RoutineRequestRunOn;
+  /** Legacy calendar/display length. It does not stop an active run. */
   durationMinutes: number;
+  /** Optional safety cap for active work. Missing means no timeout. */
+  timeoutMinutes?: number;
 }
 
-export type RoutineRequestChanges = Partial<RoutineRequestDefinition>;
+export type RoutineRequestChanges =
+  & Omit<Partial<RoutineRequestDefinition>, "timeoutMinutes">
+  & { /** `null` removes an existing safety cap. */ timeoutMinutes?: number | null };
 
 /** Another bot in the proposer's section that the routine is scheduled for.
  * Captured (id + display name) when the card is created so the card stays

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -108,6 +108,9 @@ function routineScheduleLabel(routine: Routine) {
       minute: "2-digit",
     });
   }
+  if (routine.schedule.type === "interval") {
+    return `Every ${routine.schedule.everyMinutes} min`;
+  }
   const days = routine.schedule.weekdays;
   const cadence =
     days.length === 7

--- a/src/components/RoutineCalendarPage.tsx
+++ b/src/components/RoutineCalendarPage.tsx
@@ -83,12 +83,14 @@ const HOUR_HEIGHT = 64;
 const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 const ALL_DAYS = [0, 1, 2, 3, 4, 5, 6];
 const WEEKDAYS = [1, 2, 3, 4, 5];
+const INTERVAL_PRESETS = [5, 10, 15, 30, 60];
 const EVENT_DURATION_OPTIONS = Array.from({ length: 240 / CALENDAR_SLOT_MINUTES }, (_, index) => (index + 1) * CALENDAR_SLOT_MINUTES);
 const BOT_DRAG_TYPE = "application/x-openmaus-bot";
 const EVENT_DRAG_TYPE = "application/x-openmaus-calendar-event";
 
 type EventKind = "routine" | "call";
-type RecurrenceChoice = "none" | "daily" | "weekdays" | "weekly" | "custom";
+type RecurrenceChoice = "none" | "daily" | "weekdays" | "weekly" | "custom" | "interval";
+type CalendarRecurrenceChoice = Exclude<RecurrenceChoice, "interval">;
 
 type CallOccurrence = {
   id: string;
@@ -161,8 +163,18 @@ function durationLabel(minutes: number): string {
   return `${Math.floor(minutes / 60)} hr ${minutes % 60} min`;
 }
 
+function intervalLabel(minutes: number): string {
+  if (minutes < 60) return `Every ${minutes} min`;
+  if (minutes === 60) return "Every hour";
+  if (minutes % 60 === 0) return `Every ${minutes / 60} hr`;
+  return `Every ${Math.floor(minutes / 60)} hr ${minutes % 60} min`;
+}
+
 function scheduleLabel(schedule: RoutineSchedule | CalendarCall["schedule"]): string {
   if (schedule.type === "once") return `${niceDate(schedule.at)}, ${niceTime(schedule.at)}`;
+  if (schedule.type === "interval") {
+    return `${intervalLabel(schedule.everyMinutes)} · aligned from ${niceDate(schedule.anchorAt)}, ${niceTime(schedule.anchorAt)}`;
+  }
   const days = schedule.weekdays;
   const label = days.length === 7
     ? "Every day"
@@ -176,13 +188,14 @@ function scheduleLabel(schedule: RoutineSchedule | CalendarCall["schedule"]): st
 
 function recurrenceFor(schedule: RoutineSchedule | CalendarCall["schedule"], at: number): RecurrenceChoice {
   if (schedule.type === "once") return "none";
+  if (schedule.type === "interval") return "interval";
   if (schedule.weekdays.length === 7) return "daily";
   if (schedule.weekdays.join(",") === "1,2,3,4,5") return "weekdays";
   if (schedule.weekdays.length === 1 && schedule.weekdays[0] === new Date(at).getDay()) return "weekly";
   return "custom";
 }
 
-function makeSchedule(choice: RecurrenceChoice, at: number, weekdays: number[]): RoutineSchedule {
+function makeCalendarSchedule(choice: CalendarRecurrenceChoice, at: number, weekdays: number[]): CalendarCall["schedule"] {
   if (choice === "none") return { type: "once", at };
   const selected = choice === "daily"
     ? ALL_DAYS
@@ -192,6 +205,11 @@ function makeSchedule(choice: RecurrenceChoice, at: number, weekdays: number[]):
         ? [new Date(at).getDay()]
         : weekdays;
   return { type: "daily", time: toLocalTimeInput(at), weekdays: [...selected].sort() };
+}
+
+function makeRoutineSchedule(choice: RecurrenceChoice, at: number, weekdays: number[], everyMinutes: number): RoutineSchedule {
+  if (choice === "interval") return { type: "interval", everyMinutes, anchorAt: at };
+  return makeCalendarSchedule(choice, at, weekdays);
 }
 
 function projectCalls(calls: CalendarCall[], from: number, to: number): CallOccurrence[] {
@@ -330,6 +348,8 @@ function EventEditor({
     ? existingRoutine.schedule.at
     : existingRoutine?.schedule.type === "daily"
       ? atLocalTime(seed.at, existingRoutine.schedule.time)
+      : existingRoutine?.schedule.type === "interval"
+        ? existingRoutine.schedule.anchorAt
       : existingCall?.schedule.type === "once"
         ? existingCall.schedule.at
         : existingCall?.schedule.type === "daily"
@@ -339,8 +359,13 @@ function EventEditor({
   const [date, setDate] = useState(toLocalDateInput(initialAt));
   const [startTime, setStartTime] = useState(toLocalTimeInput(initialAt));
   const [durationMinutes, setDurationMinutes] = useState(existingRoutine?.durationMinutes ?? existingCall?.durationMinutes ?? seed.durationMinutes);
+  const [timeoutMinutes, setTimeoutMinutes] = useState<number | null>(
+    existingRoutine?.timeoutMinutes ?? null,
+  );
+  const [intervalTimeoutDefaultApplied, setIntervalTimeoutDefaultApplied] = useState(Boolean(existingRoutine));
   const [recurrence, setRecurrence] = useState<RecurrenceChoice>(recurrenceFor(schedule, initialAt));
   const [weekdays, setWeekdays] = useState(schedule.type === "daily" ? schedule.weekdays : [new Date(initialAt).getDay()]);
+  const [intervalMinutes, setIntervalMinutes] = useState(schedule.type === "interval" ? schedule.everyMinutes : 15);
   const [botIds, setBotIds] = useState(lockedBotId ? [lockedBotId] : existingRoutine ? [existingRoutine.botId] : existingCall?.botIds ?? seed.botIds);
   const [routineTarget, setRoutineTarget] = useState<RoutineTarget>(existingRoutine?.target ?? "bot");
   const [groupId, setGroupId] = useState(existingRoutine?.groupId ?? "");
@@ -364,6 +389,21 @@ function EventEditor({
   const dialogRef = useRef<HTMLDivElement>(null);
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
+  const intervalInvalid = recurrence === "interval"
+    && (!Number.isInteger(intervalMinutes) || intervalMinutes < 5 || intervalMinutes > 1_440);
+
+  const selectRecurrence = (choice: RecurrenceChoice) => {
+    if (choice === "interval" && recurrence !== "interval" && !existingRoutine) {
+      const firstAt = Date.now() + intervalMinutes * 60_000;
+      setDate(toLocalDateInput(firstAt));
+      setStartTime(toLocalTimeInput(firstAt));
+    }
+    if (choice === "interval" && !intervalTimeoutDefaultApplied) {
+      setTimeoutMinutes((current) => current ?? 30);
+      setIntervalTimeoutDefaultApplied(true);
+    }
+    setRecurrence(choice);
+  };
 
   const selectRoutineTarget = (target: RoutineTarget) => {
     setRoutineTarget(target);
@@ -403,11 +443,11 @@ function EventEditor({
   };
 
   const save = async () => {
-    const nextSchedule = makeSchedule(recurrence, at, weekdays);
     setSaving(true);
     setError("");
     try {
       if (kind === "routine") {
+        const nextSchedule = makeRoutineSchedule(recurrence, at, weekdays, intervalMinutes);
         const input: RoutineInput = {
           name,
           prompt: description,
@@ -418,6 +458,7 @@ function EventEditor({
           enabled: existingRoutine ? undefined : true,
           schedule: nextSchedule,
           durationMinutes,
+          timeoutMinutes,
           attachments: routineTarget === "room-goal" ? [] : attachments as RoutineContextAttachment[],
         };
         const response = await api(existingRoutine ? `/api/routines/${existingRoutine.id}` : "/api/routines", {
@@ -426,6 +467,7 @@ function EventEditor({
         });
         dispatch({ type: "routinePatched", routine: response.routine });
       } else {
+        const nextSchedule = makeCalendarSchedule(recurrence === "interval" ? "none" : recurrence, at, weekdays);
         const input: CalendarCallInput = {
           name,
           description,
@@ -456,7 +498,8 @@ function EventEditor({
       ? botIds.length > 0
       : routineTarget === "room-goal"
         ? groupId && botIds[0] && roomMembers.some((bot) => bot.id === botIds[0])
-        : botIds.length > 0),
+        : botIds.length > 0)
+    && !intervalInvalid,
   );
   const canSwitchKind = !existingRoutine && !existingCall && !lockedBotId;
 
@@ -506,7 +549,7 @@ function EventEditor({
           {canSwitchKind && (
             <div className="ml-10 inline-flex rounded-lg bg-inset p-1">
               <button type="button" onClick={() => { setKind("routine"); setBotIds((ids) => ids.slice(0, 1)); }} className={cn("rounded-md px-4 py-1.5 text-[12.5px] font-medium", kind === "routine" ? "bg-raised text-ink shadow" : "text-ink-secondary")}>Routine</button>
-              <button type="button" onClick={() => setKind("call")} className={cn("rounded-md px-4 py-1.5 text-[12.5px] font-medium", kind === "call" ? "bg-raised text-ink shadow" : "text-ink-secondary")}>Call</button>
+              <button type="button" onClick={() => { setKind("call"); if (recurrence === "interval") setRecurrence("none"); }} className={cn("rounded-md px-4 py-1.5 text-[12.5px] font-medium", kind === "call" ? "bg-raised text-ink shadow" : "text-ink-secondary")}>Call</button>
             </div>
           )}
 
@@ -543,18 +586,23 @@ function EventEditor({
             <Clock3 size={18} className="mt-2.5 shrink-0 text-ink-secondary" />
             <div className="min-w-0 flex-1 space-y-3">
               <div className="flex flex-wrap items-center gap-2">
-                <input type="date" value={date} onChange={(event) => setDate(event.target.value)} className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[13px] text-ink outline-none focus:border-accent [color-scheme:dark]" />
+                {kind === "routine" && (recurrence === "none" || recurrence === "interval") && <span className="text-[12px] font-medium text-ink-secondary">Starts</span>}
+                {kind === "routine" && recurrence === "weekly" && <span className="text-[12px] font-medium text-ink-secondary">On</span>}
+                {(kind === "call" || recurrence === "none" || recurrence === "interval" || recurrence === "weekly") && <input type="date" value={date} onChange={(event) => setDate(event.target.value)} className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[13px] text-ink outline-none focus:border-accent [color-scheme:dark]" />}
                 <input type="time" step={CALENDAR_SLOT_MINUTES * 60} value={startTime} onChange={(event) => setStartTime(event.target.value)} className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[13px] text-ink outline-none focus:border-accent [color-scheme:dark]" />
-                <span className="text-[12px] text-ink-secondary">to</span>
-                <span className="rounded-lg border border-hairline/40 bg-inset/60 px-3 py-2 text-[13px] text-ink">{niceTime(endAt)}</span>
-                <select value={durationMinutes} onChange={(event) => setDurationMinutes(Number(event.target.value))} className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[12px] text-ink outline-none focus:border-accent">
-                  {EVENT_DURATION_OPTIONS.map((minutes) => <option key={minutes} value={minutes}>{durationLabel(minutes)}</option>)}
-                </select>
+                {kind === "call" && <>
+                  <span className="text-[12px] text-ink-secondary">to</span>
+                  <span className="rounded-lg border border-hairline/40 bg-inset/60 px-3 py-2 text-[13px] text-ink">{niceTime(endAt)}</span>
+                  <select aria-label="Call duration" value={durationMinutes} onChange={(event) => setDurationMinutes(Number(event.target.value))} className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[12px] text-ink outline-none focus:border-accent">
+                    {EVENT_DURATION_OPTIONS.map((minutes) => <option key={minutes} value={minutes}>{durationLabel(minutes)}</option>)}
+                  </select>
+                </>}
               </div>
               <div className="flex flex-wrap items-center gap-2">
                 <Repeat2 size={14} className="text-ink-secondary" />
-                <select value={recurrence} onChange={(event) => setRecurrence(event.target.value as RecurrenceChoice)} className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[12.5px] text-ink outline-none focus:border-accent">
+                <select value={recurrence} onChange={(event) => selectRecurrence(event.target.value as RecurrenceChoice)} className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[12.5px] text-ink outline-none focus:border-accent">
                   <option value="none">Does not repeat</option>
+                  {kind === "routine" && <option value="interval">Every few minutes…</option>}
                   <option value="daily">Daily</option>
                   <option value="weekdays">Every weekday (Monday to Friday)</option>
                   <option value="weekly">Weekly on {DAY_NAMES[new Date(at).getDay()]}</option>
@@ -565,6 +613,62 @@ function EventEditor({
                 <div className="flex flex-wrap gap-1.5">
                   {DAY_NAMES.map((label, day) => <button key={label} type="button" onClick={() => setWeekdays((current) => current.includes(day) ? (current.length === 1 ? current : current.filter((value) => value !== day)) : [...current, day].sort())} className={cn("size-8 rounded-full text-[10px] font-semibold", weekdays.includes(day) ? "bg-accent text-white" : "bg-inset text-ink-secondary hover:bg-raised hover:text-ink")}>{label[0]}</button>)}
                 </div>
+              )}
+              {recurrence === "interval" && kind === "routine" && (
+                <div className="rounded-xl border border-accent/30 bg-accent/[0.055] p-3">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-[12.5px] font-medium text-ink">Run every</span>
+                    <input
+                      type="number"
+                      min={5}
+                      max={1_440}
+                      step={1}
+                      value={intervalMinutes || ""}
+                      onChange={(event) => setIntervalMinutes(Number(event.target.value))}
+                      aria-label="Interval in minutes"
+                      aria-invalid={intervalInvalid}
+                      aria-describedby={intervalInvalid ? "routine-interval-error" : "routine-interval-help"}
+                      className={cn("w-20 rounded-lg border bg-inset px-3 py-2 text-[12.5px] tabular-nums text-ink outline-none focus:border-accent", intervalInvalid ? "border-danger/70" : "border-hairline/50")}
+                    />
+                    <span className="text-[12px] text-ink-secondary">minutes</span>
+                  </div>
+                  <div className="mt-2 flex flex-wrap gap-1.5">
+                    {INTERVAL_PRESETS.map((minutes) => (
+                      <button
+                        key={minutes}
+                        type="button"
+                        onClick={() => setIntervalMinutes(minutes)}
+                        aria-pressed={intervalMinutes === minutes}
+                        className={cn("rounded-full px-2.5 py-1 text-[10.5px] font-medium", intervalMinutes === minutes ? "bg-accent text-white" : "bg-inset text-ink-secondary hover:bg-raised hover:text-ink")}
+                      >
+                        {minutes} min
+                      </button>
+                    ))}
+                  </div>
+                  <div id="routine-interval-help" className="mt-2 text-[11px] leading-relaxed text-ink-secondary">
+                    The cadence is aligned from the date and time above; the next future occurrence runs. If the previous run is still active, that occurrence is skipped.
+                  </div>
+                  {intervalInvalid && (
+                    <div id="routine-interval-error" className="mt-2 text-[11px] text-danger">Choose a whole number from 5 to 1,440 minutes.</div>
+                  )}
+                </div>
+              )}
+              {kind === "routine" && (
+                <details className="rounded-xl border border-hairline/40 bg-inset/40 px-3 py-2.5">
+                  <summary className="cursor-pointer select-none text-[11.5px] font-medium text-ink-secondary hover:text-ink">
+                    Advanced · {timeoutMinutes == null ? "no run limit" : `${durationLabel(timeoutMinutes)} run limit`}
+                  </summary>
+                  <div className="mt-3 border-t border-hairline/35 pt-3">
+                    <label className="flex flex-wrap items-center gap-2 text-[12px] text-ink">
+                      <span>Stop if still running after</span>
+                      <select aria-label="Routine safety limit" value={timeoutMinutes ?? ""} onChange={(event) => setTimeoutMinutes(event.target.value ? Number(event.target.value) : null)} className="rounded-lg border border-hairline/50 bg-panel px-3 py-2 text-[12px] text-ink outline-none focus:border-accent">
+                        <option value="">No limit</option>
+                        {EVENT_DURATION_OPTIONS.map((minutes) => <option key={minutes} value={minutes}>{durationLabel(minutes)}</option>)}
+                      </select>
+                    </label>
+                    <div className="mt-1.5 text-[10.5px] leading-relaxed text-ink-secondary">Optional. The clock starts when work actually begins and does not control how often the routine starts.</div>
+                  </div>
+                </details>
               )}
             </div>
           </div>
@@ -698,7 +802,7 @@ function QuickComposer({
   const [error, setError] = useState("");
   const dialogRef = useRef<HTMLDivElement>(null);
   const [dialogPosition, setDialogPosition] = useState<{ left: number; top: number } | null>(null);
-  const durationMinutes = seed.durationMinutes;
+  const durationMinutes = kind === "routine" ? 30 : seed.durationMinutes;
 
   useLayoutEffect(() => {
     if (!seed.anchor) {
@@ -779,7 +883,7 @@ function QuickComposer({
         </div>
         <div className="flex items-start gap-3 text-[12.5px] text-ink">
           <Clock3 size={16} className="mt-0.5 shrink-0 text-ink-secondary" />
-          <div><div>{niceDate(seed.at)}</div><div className="mt-0.5 text-ink-secondary">{niceTime(seed.at)} – {niceTime(seed.at + durationMinutes * 60_000)}</div></div>
+          <div><div>{niceDate(seed.at)}</div><div className="mt-0.5 text-ink-secondary">{niceTime(seed.at)}{kind === "call" ? ` – ${niceTime(seed.at + durationMinutes * 60_000)}` : ""}</div></div>
         </div>
         <div className="flex items-start gap-3">
           <UserRoundPlus size={16} className="mt-2.5 shrink-0 text-ink-secondary" />
@@ -845,7 +949,9 @@ function CalendarEventCard({
   const status = run?.status;
   const statusLabel = run?.goalStatus ? goalStatusLabel(run.goalStatus) : status?.replace("waiting", "needs you");
   const canMove = isCall || Boolean(routine && !run);
-  const recurring = (isCall ? item.call.schedule : routine?.schedule)?.type === "daily";
+  const schedule = isCall ? item.call.schedule : routine?.schedule;
+  const recurring = Boolean(schedule && schedule.type !== "once");
+  const intervalCadence = schedule?.type === "interval" ? intervalLabel(schedule.everyMinutes) : null;
 
   const beginResize = (event: ReactPointerEvent<HTMLDivElement>) => {
     event.preventDefault();
@@ -896,11 +1002,11 @@ function CalendarEventCard({
         {previewDuration >= 30 && (isCall ? <Video size={compact ? 11 : 13} className="mt-0.5 shrink-0" /> : primary ? <BotAvatar bot={primary} state={status ? statusState(status) : "idle"} size={compact ? 22 : 26} animated={status === "running" || status === "waiting"} /> : null)}
         <div className="min-w-0 flex-1">
           <div className={cn("truncate text-[11px] font-semibold", previewDuration < 30 ? "leading-none" : "leading-tight")}>{name}</div>
-          {previewDuration >= 30 && <div className="mt-0.5 truncate text-[9.5px] text-white/75">{niceTime(item.at)} · {isCall ? `${ownerBots.length} bot${ownerBots.length === 1 ? "" : "s"}` : isRoomGoal ? `Team goal · ${room?.name ?? "Room"}${statusLabel ? ` · ${statusLabel}` : ""}` : statusLabel ?? primary?.name}</div>}
+          {previewDuration >= 30 && <div className="mt-0.5 truncate text-[9.5px] text-white/75">{niceTime(item.at)} · {intervalCadence ?? (isCall ? `${ownerBots.length} bot${ownerBots.length === 1 ? "" : "s"}` : isRoomGoal ? `Team goal · ${room?.name ?? "Room"}${statusLabel ? ` · ${statusLabel}` : ""}` : statusLabel ?? primary?.name)}</div>}
         </div>
         {previewDuration >= 30 && ownerBots.length > 1 && <span className="rounded bg-black/20 px-1 py-0.5 text-[8px]">+{ownerBots.length - 1}</span>}
       </div>
-      {canMove && <div onPointerDown={beginResize} className="absolute inset-x-1 bottom-0 h-1.5 cursor-ns-resize rounded-full opacity-0 transition group-hover:opacity-100" aria-label="Resize event"><div className="mx-auto mt-0.5 h-0.5 w-5 rounded-full bg-white/55" /></div>}
+      {isCall && <div onPointerDown={beginResize} className="absolute inset-x-1 bottom-0 h-1.5 cursor-ns-resize rounded-full opacity-0 transition group-hover:opacity-100" aria-label="Resize event"><div className="mx-auto mt-0.5 h-0.5 w-5 rounded-full bg-white/55" /></div>}
     </button>
   );
 }
@@ -1059,6 +1165,7 @@ function EventDetails({
   const description = call?.description ?? run?.prompt ?? routine?.prompt ?? "";
   const attachments = call?.attachments ?? run?.attachments ?? routine?.attachments ?? [];
   const roomId = call?.botIds.length === 1 ? primary?.id : undefined;
+  const safetyLimit = run ? run.timeoutMinutes : routine?.timeoutMinutes;
 
   const openRunTask = () => {
     if (!executionThreadId) return;
@@ -1119,7 +1226,9 @@ function EventDetails({
           <span className={cn("mt-1 size-4 shrink-0 rounded", isCall ? "bg-[#6d7cff]" : "bg-accent")} />
           <div className="min-w-0 flex-1">
             <div className="text-[19px] font-semibold text-ink">{title}</div>
-            <div className="mt-1 text-[12.5px] text-ink-secondary">{niceDate(item.at)} · {niceTime(item.at)} – {niceTime(item.at + item.durationMinutes * 60_000)}</div>
+            <div className="mt-1 text-[12.5px] text-ink-secondary">
+              {niceDate(item.at)} · {niceTime(item.at)}{isCall ? ` – ${niceTime(item.at + item.durationMinutes * 60_000)}` : ""}
+            </div>
             {(routine || call) && <div className="mt-1 text-[11.5px] text-ink-secondary">{scheduleLabel((routine ?? call)!.schedule)}</div>}
           </div>
           <button onClick={onClose} className="rounded-full p-2 text-ink-secondary hover:bg-raised hover:text-ink" aria-label="Close"><X size={17} /></button>
@@ -1146,6 +1255,7 @@ function EventDetails({
           )}
           {description && <div className="flex items-start gap-3"><FileText size={17} className="mt-1 shrink-0 text-ink-secondary" /><div className="whitespace-pre-wrap text-[12.5px] leading-relaxed text-ink">{description}</div></div>}
           {attachments.length > 0 && <div className="flex items-start gap-3"><Paperclip size={17} className="mt-1 shrink-0 text-ink-secondary" /><div className="min-w-0 flex-1 space-y-2"><AttachmentChips attachments={attachments} />{call && <div className="text-[11px] leading-relaxed text-ink-secondary">{call.botIds.length > 1 ? "These references will be shared in the room when the event starts." : "These references stay with the event and are available when you join the room."}</div>}</div></div>}
+          {!isCall && <div className="flex items-start gap-3"><Clock3 size={17} className="mt-1 shrink-0 text-ink-secondary" /><div><div className="text-[11px] font-medium uppercase tracking-wider text-ink-secondary">Run limit</div><div className="mt-1 text-[12.5px] text-ink">{safetyLimit == null ? "No time limit" : `Stops if still running after ${durationLabel(safetyLimit)}`}</div></div></div>}
           {run && <div className="rounded-xl border border-hairline/40 bg-inset p-3"><div className="flex items-center gap-2 text-[12px] font-medium capitalize text-ink">{run.status === "running" && <Loader2 size={13} className="animate-spin text-accent" />}{run.goalStatus ? goalStatusLabel(run.goalStatus) : run.status.replace("waiting", "needs you")}</div>{run.output && <div className="mt-2 whitespace-pre-wrap text-[11.5px] leading-relaxed text-ink-secondary">{run.output}</div>}{run.error && <div className="mt-2 text-[11.5px] text-danger">{run.error}</div>}</div>}
           {run?.attention && <div className="flex items-start gap-2 rounded-xl border border-warning/30 bg-warning/10 px-3 py-2.5 text-warning"><CircleAlert size={15} className="mt-0.5 shrink-0" /><div className="min-w-0"><div className="text-[11.5px] font-semibold">Needs your attention</div><div className="mt-1 whitespace-pre-wrap text-[11.5px] leading-relaxed">{run.attention}</div></div></div>}
           {run?.status === "waiting" && !run.attention && <div className="rounded-xl border border-warning/30 bg-warning/10 px-3 py-2.5 text-[11.5px] text-warning">{isRoomGoal ? "This team goal needs your answer. Open its room task to continue the run." : "This bot needs your answer. Open its task to continue the run."}</div>}
@@ -1233,6 +1343,8 @@ export function RoutineEditor({
     ? routine.schedule.at
     : routine?.schedule.type === "daily"
       ? atLocalTime(Date.now(), routine.schedule.time)
+      : routine?.schedule.type === "interval"
+        ? routine.schedule.anchorAt
       : nextHour();
   return <EventEditor seed={{ kind: "routine", at, durationMinutes: routine?.durationMinutes ?? 30, botIds: lockedBotId ? [lockedBotId] : routine ? [routine.botId] : [], routine }} bots={bots} lockedBotId={lockedBotId} defaultRunOn={defaultRunOn} onClose={onClose} onSavedCall={() => {}} />;
 }
@@ -1293,7 +1405,7 @@ export function RoutinesPage({ onBack, onOpenRoom }: { onBack: () => void; onOpe
           run: selected.run ? state.routineRuns.find((run) => run.id === selected.run?.id) ?? selected.run : null,
         }
       : null;
-  const paused = state.routines.filter((routine) => !routine.enabled && (routine.schedule.type === "daily" || routine.schedule.at > Date.now()));
+  const paused = state.routines.filter((routine) => !routine.enabled && (routine.schedule.type !== "once" || routine.schedule.at > Date.now()));
   const running = state.routineRuns.filter((run) => ["queued", "running", "waiting"].includes(run.status)).length;
   const unseenFailures = state.routineRuns.filter((run) => ["failed", "missed"].includes(run.status) && !run.seenAt).length;
   const macInset = capabilities.windowChrome === "mac-inset";
@@ -1338,7 +1450,7 @@ export function RoutinesPage({ onBack, onOpenRoom }: { onBack: () => void; onOpe
       if (dragged.kind === "routine") {
         const routine = state.routines.find((candidate) => candidate.id === dragged.id);
         if (!routine) return;
-        if (routine.schedule.type === "daily" && !window.confirm("Move this entire recurring series?")) return;
+        if (routine.schedule.type !== "once" && !window.confirm("Move this entire recurring series?")) return;
         const response = await api(`/api/routines/${routine.id}`, { method: "PATCH", body: JSON.stringify({ schedule: scheduleAt(routine.schedule, dragged.at, nextAt) }) });
         dispatch({ type: "routinePatched", routine: response.routine });
       } else {
@@ -1437,7 +1549,7 @@ export function RoutinesPage({ onBack, onOpenRoom }: { onBack: () => void; onOpe
       {quick && <><div className="fixed inset-0 z-40 bg-black/25" onMouseDown={() => setQuick(null)} /><QuickComposer seed={quick} bots={visibleBots} onClose={() => setQuick(null)} onMore={(seed) => { setQuick(null); setEditor(seed); }} onSavedRoutine={(routine) => dispatch({ type: "routinePatched", routine })} onSavedCall={upsertCall} /></>}
       {editor && <EventEditor seed={editor} bots={visibleBots} onClose={() => setEditor(null)} onSavedCall={upsertCall} />}
       {liveSelected && <EventDetails item={liveSelected} bots={state.bots} onClose={() => setSelected(null)} onEdit={() => { const seed: EventSeed = liveSelected.kind === "call" ? { kind: "call", at: liveSelected.at, durationMinutes: liveSelected.call.durationMinutes, botIds: liveSelected.call.botIds, call: liveSelected.call } : { kind: "routine", at: liveSelected.at, durationMinutes: liveSelected.routine?.durationMinutes ?? liveSelected.run?.durationMinutes ?? 30, botIds: [liveSelected.routine?.botId ?? liveSelected.run?.botId ?? ""].filter(Boolean), routine: liveSelected.routine ?? undefined }; setSelected(null); setEditor(seed); }} onCallChanged={(id) => { if (id) setCalls((current) => current.filter((call) => call.id !== id)); else void loadCalls(); }} onOpenRoom={onOpenRoom} />}
-      {pausedOpen && <PausedList routines={paused} bots={state.bots} groups={state.groups} onClose={() => setPausedOpen(false)} onEdit={(routine) => { setPausedOpen(false); const at = routine.schedule.type === "once" ? routine.schedule.at : atLocalTime(Date.now(), routine.schedule.time); setEditor({ kind: "routine", at, durationMinutes: routine.durationMinutes, botIds: [routine.botId], routine }); }} onOpenRoom={onOpenRoom} />}
+      {pausedOpen && <PausedList routines={paused} bots={state.bots} groups={state.groups} onClose={() => setPausedOpen(false)} onEdit={(routine) => { setPausedOpen(false); const at = routine.schedule.type === "once" ? routine.schedule.at : routine.schedule.type === "interval" ? routine.schedule.anchorAt : atLocalTime(Date.now(), routine.schedule.time); setEditor({ kind: "routine", at, durationMinutes: routine.durationMinutes, botIds: [routine.botId], routine }); }} onOpenRoom={onOpenRoom} />}
     </main>
   );
 }

--- a/src/components/RoutineCalendarPage.tsx
+++ b/src/components/RoutineCalendarPage.tsx
@@ -173,7 +173,7 @@ function intervalLabel(minutes: number): string {
 function scheduleLabel(schedule: RoutineSchedule | CalendarCall["schedule"]): string {
   if (schedule.type === "once") return `${niceDate(schedule.at)}, ${niceTime(schedule.at)}`;
   if (schedule.type === "interval") {
-    return `${intervalLabel(schedule.everyMinutes)} · aligned from ${niceDate(schedule.anchorAt)}, ${niceTime(schedule.anchorAt)}`;
+    return `${intervalLabel(schedule.everyMinutes)} · starting ${niceDate(schedule.anchorAt)}, ${niceTime(schedule.anchorAt)}`;
   }
   const days = schedule.weekdays;
   const label = days.length === 7
@@ -585,24 +585,26 @@ function EventEditor({
           <div className="flex items-start gap-4">
             <Clock3 size={18} className="mt-2.5 shrink-0 text-ink-secondary" />
             <div className="min-w-0 flex-1 space-y-3">
-              <div className="flex flex-wrap items-center gap-2">
-                {kind === "routine" && (recurrence === "none" || recurrence === "interval") && <span className="text-[12px] font-medium text-ink-secondary">Starts</span>}
-                {kind === "routine" && recurrence === "weekly" && <span className="text-[12px] font-medium text-ink-secondary">On</span>}
-                {(kind === "call" || recurrence === "none" || recurrence === "interval" || recurrence === "weekly") && <input type="date" value={date} onChange={(event) => setDate(event.target.value)} className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[13px] text-ink outline-none focus:border-accent [color-scheme:dark]" />}
-                <input type="time" step={CALENDAR_SLOT_MINUTES * 60} value={startTime} onChange={(event) => setStartTime(event.target.value)} className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[13px] text-ink outline-none focus:border-accent [color-scheme:dark]" />
-                {kind === "call" && <>
-                  <span className="text-[12px] text-ink-secondary">to</span>
-                  <span className="rounded-lg border border-hairline/40 bg-inset/60 px-3 py-2 text-[13px] text-ink">{niceTime(endAt)}</span>
-                  <select aria-label="Call duration" value={durationMinutes} onChange={(event) => setDurationMinutes(Number(event.target.value))} className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[12px] text-ink outline-none focus:border-accent">
-                    {EVENT_DURATION_OPTIONS.map((minutes) => <option key={minutes} value={minutes}>{durationLabel(minutes)}</option>)}
-                  </select>
-                </>}
-              </div>
+              {recurrence !== "interval" && (
+                <div className="flex flex-wrap items-center gap-2">
+                  {kind === "routine" && recurrence === "none" && <span className="text-[12px] font-medium text-ink-secondary">Starts</span>}
+                  {kind === "routine" && recurrence === "weekly" && <span className="text-[12px] font-medium text-ink-secondary">On</span>}
+                  {(kind === "call" || recurrence === "none" || recurrence === "weekly") && <input type="date" value={date} onChange={(event) => setDate(event.target.value)} className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[13px] text-ink outline-none focus:border-accent [color-scheme:dark]" />}
+                  <input type="time" step={CALENDAR_SLOT_MINUTES * 60} value={startTime} onChange={(event) => setStartTime(event.target.value)} className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[13px] text-ink outline-none focus:border-accent [color-scheme:dark]" />
+                  {kind === "call" && <>
+                    <span className="text-[12px] text-ink-secondary">to</span>
+                    <span className="rounded-lg border border-hairline/40 bg-inset/60 px-3 py-2 text-[13px] text-ink">{niceTime(endAt)}</span>
+                    <select aria-label="Call duration" value={durationMinutes} onChange={(event) => setDurationMinutes(Number(event.target.value))} className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[12px] text-ink outline-none focus:border-accent">
+                      {EVENT_DURATION_OPTIONS.map((minutes) => <option key={minutes} value={minutes}>{durationLabel(minutes)}</option>)}
+                    </select>
+                  </>}
+                </div>
+              )}
               <div className="flex flex-wrap items-center gap-2">
                 <Repeat2 size={14} className="text-ink-secondary" />
                 <select value={recurrence} onChange={(event) => selectRecurrence(event.target.value as RecurrenceChoice)} className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[12.5px] text-ink outline-none focus:border-accent">
                   <option value="none">Does not repeat</option>
-                  {kind === "routine" && <option value="interval">Every few minutes…</option>}
+                  {kind === "routine" && <option value="interval">Every X minutes</option>}
                   <option value="daily">Daily</option>
                   <option value="weekdays">Every weekday (Monday to Friday)</option>
                   <option value="weekly">Weekly on {DAY_NAMES[new Date(at).getDay()]}</option>
@@ -615,38 +617,41 @@ function EventEditor({
                 </div>
               )}
               {recurrence === "interval" && kind === "routine" && (
-                <div className="rounded-xl border border-accent/30 bg-accent/[0.055] p-3">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-[12.5px] font-medium text-ink">Run every</span>
-                    <input
-                      type="number"
-                      min={5}
-                      max={1_440}
-                      step={1}
-                      value={intervalMinutes || ""}
-                      onChange={(event) => setIntervalMinutes(Number(event.target.value))}
-                      aria-label="Interval in minutes"
-                      aria-invalid={intervalInvalid}
-                      aria-describedby={intervalInvalid ? "routine-interval-error" : "routine-interval-help"}
-                      className={cn("w-20 rounded-lg border bg-inset px-3 py-2 text-[12.5px] tabular-nums text-ink outline-none focus:border-accent", intervalInvalid ? "border-danger/70" : "border-hairline/50")}
-                    />
-                    <span className="text-[12px] text-ink-secondary">minutes</span>
-                  </div>
-                  <div className="mt-2 flex flex-wrap gap-1.5">
-                    {INTERVAL_PRESETS.map((minutes) => (
-                      <button
-                        key={minutes}
-                        type="button"
-                        onClick={() => setIntervalMinutes(minutes)}
-                        aria-pressed={intervalMinutes === minutes}
-                        className={cn("rounded-full px-2.5 py-1 text-[10.5px] font-medium", intervalMinutes === minutes ? "bg-accent text-white" : "bg-inset text-ink-secondary hover:bg-raised hover:text-ink")}
-                      >
-                        {minutes} min
-                      </button>
-                    ))}
+                <div>
+                  <div className="flex flex-wrap items-center gap-2 text-[12.5px] text-ink">
+                    <span className="font-medium">Runs every</span>
+                    <select
+                      value={INTERVAL_PRESETS.includes(intervalMinutes) ? String(intervalMinutes) : "custom"}
+                      onChange={(event) => setIntervalMinutes(event.target.value === "custom" ? 0 : Number(event.target.value))}
+                      aria-label="How often this routine runs"
+                      className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[12.5px] tabular-nums text-ink outline-none focus:border-accent"
+                    >
+                      {INTERVAL_PRESETS.map((minutes) => <option key={minutes} value={minutes}>{minutes}</option>)}
+                      <option value="custom">Custom…</option>
+                    </select>
+                    {!INTERVAL_PRESETS.includes(intervalMinutes) && (
+                      <input
+                        type="number"
+                        min={5}
+                        max={1_440}
+                        step={1}
+                        value={intervalMinutes || ""}
+                        onChange={(event) => setIntervalMinutes(Number(event.target.value))}
+                        aria-label="Custom interval in minutes"
+                        aria-invalid={intervalInvalid}
+                        aria-describedby={intervalInvalid ? "routine-interval-error" : "routine-interval-help"}
+                        autoFocus
+                        className={cn("w-20 rounded-lg border bg-inset px-3 py-2 text-[12.5px] tabular-nums text-ink outline-none focus:border-accent", intervalInvalid ? "border-danger/70" : "border-hairline/50")}
+                      />
+                    )}
+                    <span>minutes, starting</span>
+                    <input aria-label="Interval start date" type="date" value={date} onChange={(event) => setDate(event.target.value)} className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[13px] text-ink outline-none focus:border-accent [color-scheme:dark]" />
+                    <span>at</span>
+                    <input aria-label="Interval start time" type="time" step={CALENDAR_SLOT_MINUTES * 60} value={startTime} onChange={(event) => setStartTime(event.target.value)} className="rounded-lg border border-hairline/50 bg-inset px-3 py-2 text-[13px] text-ink outline-none focus:border-accent [color-scheme:dark]" />
+                    <span>.</span>
                   </div>
                   <div id="routine-interval-help" className="mt-2 text-[11px] leading-relaxed text-ink-secondary">
-                    The cadence is aligned from the date and time above; the next future occurrence runs. If the previous run is still active, that occurrence is skipped.
+                    The cadence continues from this starting point. If a run is still active, the next occurrence is skipped instead of queued.
                   </div>
                   {intervalInvalid && (
                     <div id="routine-interval-error" className="mt-2 text-[11px] text-danger">Choose a whole number from 5 to 1,440 minutes.</div>

--- a/src/lib/routine-calendar.test.ts
+++ b/src/lib/routine-calendar.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import type { Routine } from "./routines";
+import type { Routine, RoutineRun } from "./routines";
 import {
   atLocalTime,
   formatGmtOffset,
@@ -37,6 +37,17 @@ describe("routine calendar geometry", () => {
       type: "daily",
       time: "14:30",
       weekdays: [2, 4],
+    });
+  });
+
+  it("shifts an interval series without changing its cadence", () => {
+    const anchor = new Date(2026, 7, 31, 9).getTime();
+    const occurrence = anchor + 15 * 60_000;
+    const moved = new Date(2026, 7, 31, 10, 5).getTime();
+    expect(scheduleAt({ type: "interval", everyMinutes: 15, anchorAt: anchor }, occurrence, moved)).toEqual({
+      type: "interval",
+      everyMinutes: 15,
+      anchorAt: new Date(2026, 7, 31, 9, 50).getTime(),
     });
   });
 
@@ -120,5 +131,124 @@ describe("routine calendar projection", () => {
     expect(items).toHaveLength(2);
     expect(items.map((item) => new Date(item.at).getDay())).toEqual([1, 2]);
     expect(items[0]?.run?.id).toBe("run1");
+  });
+
+  it("shows one next interval occurrence instead of filling the calendar", () => {
+    const from = new Date(2026, 7, 31, 9).getTime();
+    const receiptAt = from;
+    const routine: Routine = {
+      id: "interval-routine",
+      name: "Pulse",
+      prompt: "Check status",
+      target: "bot",
+      botId: "b1",
+      runOn: "maus",
+      enabled: true,
+      schedule: { type: "interval", everyMinutes: 5, anchorAt: from },
+      durationMinutes: 30,
+      nextRunAt: from + 5 * 60_000,
+      createdAt: from,
+      updatedAt: from,
+    };
+    const items = projectedRoutineItems(
+      [routine],
+      [{
+        id: "interval-run",
+        routineId: routine.id,
+        routineName: routine.name,
+        target: "bot",
+        botId: routine.botId,
+        runOn: "maus",
+        scheduledFor: receiptAt,
+        status: "completed",
+        manual: false,
+        createdAt: receiptAt,
+      }],
+      from,
+      from + 60 * 60_000,
+    );
+
+    expect(items).toHaveLength(2);
+    expect(items[0]?.run?.id).toBe("interval-run");
+    expect(items[1]?.at).toBe(from + 5 * 60_000);
+    expect(items[1]?.run).toBeNull();
+  });
+
+  it("does not resurrect an interval occurrence the scheduler skipped", () => {
+    const from = new Date(2026, 7, 31, 9).getTime();
+    const routine: Routine = {
+      id: "interval-routine",
+      name: "Pulse",
+      prompt: "Check status",
+      target: "bot",
+      botId: "b1",
+      runOn: "maus",
+      enabled: true,
+      schedule: { type: "interval", everyMinutes: 5, anchorAt: from },
+      durationMinutes: 30,
+      nextRunAt: from + 15 * 60_000,
+      createdAt: from,
+      updatedAt: from,
+    };
+
+    const items = projectedRoutineItems([routine], [], from, from + 60 * 60_000);
+
+    expect(items.map((item) => item.at)).toEqual([from + 15 * 60_000]);
+  });
+
+  it("caps dense interval receipts so a week view stays responsive", () => {
+    const from = new Date(2026, 7, 31, 9).getTime();
+    const routine: Routine = {
+      id: "interval-routine",
+      name: "Pulse",
+      prompt: "Check status",
+      target: "bot",
+      botId: "b1",
+      runOn: "maus",
+      enabled: false,
+      schedule: { type: "interval", everyMinutes: 5, anchorAt: from },
+      durationMinutes: 30,
+      nextRunAt: null,
+      createdAt: from,
+      updatedAt: from,
+    };
+    const runs: RoutineRun[] = Array.from({ length: 100 }, (_, index) => ({
+      id: `run-${index}`,
+      routineId: routine.id,
+      routineName: routine.name,
+      target: "bot",
+      botId: routine.botId,
+      runOn: "maus",
+      scheduledFor: from + index * 5 * 60_000,
+      status: "completed",
+      manual: false,
+      createdAt: from + index * 5 * 60_000,
+    }));
+
+    const items = projectedRoutineItems([routine], runs, from, from + 24 * 60 * 60_000);
+
+    expect(items).toHaveLength(12);
+    expect(items.at(-1)?.at).toBe(from + 99 * 5 * 60_000);
+  });
+
+  it("keeps dense history bounded after its routine is deleted", () => {
+    const from = new Date(2026, 7, 31, 9).getTime();
+    const runs: RoutineRun[] = Array.from({ length: 100 }, (_, index) => ({
+      id: `orphaned-run-${index}`,
+      routineId: "deleted-interval-routine",
+      routineName: "Deleted pulse",
+      target: "bot",
+      botId: "b1",
+      runOn: "maus",
+      scheduledFor: from + index * 5 * 60_000,
+      status: "completed",
+      manual: false,
+      createdAt: from + index * 5 * 60_000,
+    }));
+
+    const items = projectedRoutineItems([], runs, from, from + 24 * 60 * 60_000);
+
+    expect(items).toHaveLength(12);
+    expect(items.at(-1)?.at).toBe(from + 99 * 5 * 60_000);
   });
 });

--- a/src/lib/routine-calendar.ts
+++ b/src/lib/routine-calendar.ts
@@ -1,6 +1,8 @@
 import type { Routine, RoutineRun, RoutineSchedule } from "./routines";
 
 export const CALENDAR_SLOT_MINUTES = 5;
+const ROUTINE_MARKER_MINUTES = 30;
+const MAX_RECEIPTS_PER_ROUTINE_PER_RANGE = 12;
 
 export type RoutineCalendarItem = {
   id: string;
@@ -129,6 +131,13 @@ export function slotAt(day: number, clientY: number, top: number, hourHeight: nu
 
 export function scheduleAt(schedule: RoutineSchedule, occurrenceAt: number, nextAt: number): RoutineSchedule {
   if (schedule.type === "once") return { type: "once", at: nextAt };
+  if (schedule.type === "interval") {
+    return {
+      type: "interval",
+      everyMinutes: schedule.everyMinutes,
+      anchorAt: schedule.anchorAt + (nextAt - occurrenceAt),
+    };
+  }
   const dayDelta = Math.round((startOfDay(nextAt) - startOfDay(occurrenceAt)) / 86_400_000);
   return {
     type: "daily",
@@ -143,13 +152,25 @@ export function projectedRoutineItems(
   from: number,
   to: number,
 ): RoutineCalendarItem[] {
-  const items: RoutineCalendarItem[] = runs
+  const routineById = new Map(routines.map((routine) => [routine.id, routine]));
+  const receiptCounts = new Map<string, number>();
+  const visibleRuns = runs
     .filter((run) => run.scheduledFor >= from && run.scheduledFor < to)
+    .sort((left, right) => right.scheduledFor - left.scheduledFor)
+    .filter((run) => {
+      // A routine may later be edited or deleted, so the current definition
+      // cannot safely tell us whether its history came from a dense interval.
+      const count = receiptCounts.get(run.routineId) ?? 0;
+      if (count >= MAX_RECEIPTS_PER_ROUTINE_PER_RANGE) return false;
+      receiptCounts.set(run.routineId, count + 1);
+      return true;
+    });
+  const items: RoutineCalendarItem[] = visibleRuns
     .map((run) => ({
       id: `run-${run.id}`,
       at: run.scheduledFor,
-      durationMinutes: run.durationMinutes ?? 30,
-      routine: routines.find((routine) => routine.id === run.routineId) ?? null,
+      durationMinutes: ROUTINE_MARKER_MINUTES,
+      routine: routineById.get(run.routineId) ?? null,
       run,
     }));
 
@@ -164,7 +185,23 @@ export function projectedRoutineItems(
         items.push({
           id: `next-${routine.id}-${at}`,
           at,
-          durationMinutes: routine.durationMinutes,
+          durationMinutes: ROUTINE_MARKER_MINUTES,
+          routine,
+          run: null,
+        });
+      }
+      continue;
+    }
+    if (routine.schedule.type === "interval") {
+      // The scheduler deliberately skips overlapping and stale interval ticks.
+      // Its persisted nextRunAt is the only future occurrence users can act on;
+      // reconstructing an unreceipted tick would resurrect work it skipped.
+      const at = routine.nextRunAt;
+      if (at != null && at >= from && at < to && !hasReceipt(routine.id, at)) {
+        items.push({
+          id: `next-${routine.id}-${at}`,
+          at,
+          durationMinutes: ROUTINE_MARKER_MINUTES,
           routine,
           run: null,
         });
@@ -178,7 +215,7 @@ export function projectedRoutineItems(
         items.push({
           id: `next-${routine.id}-${at}`,
           at,
-          durationMinutes: routine.durationMinutes,
+          durationMinutes: ROUTINE_MARKER_MINUTES,
           routine,
           run: null,
         });

--- a/src/lib/routines.ts
+++ b/src/lib/routines.ts
@@ -1,6 +1,7 @@
 export type RoutineSchedule =
   | { type: "once"; at: number }
-  | { type: "daily"; time: string; weekdays: number[] };
+  | { type: "daily"; time: string; weekdays: number[] }
+  | { type: "interval"; everyMinutes: number; anchorAt: number };
 
 export type RoutineRunOn = "maus" | "cloud";
 
@@ -44,6 +45,8 @@ export interface Routine {
   enabled: boolean;
   schedule: RoutineSchedule;
   durationMinutes: number;
+  /** Optional wall-clock safety limit. Missing means the run is unlimited. */
+  timeoutMinutes?: number;
   attachments?: RoutineContextAttachment[];
   nextRunAt: number | null;
   createdAt: number;
@@ -56,6 +59,7 @@ export interface RoutineRun {
   routineName: string;
   prompt?: string;
   durationMinutes?: number;
+  timeoutMinutes?: number;
   attachments?: RoutineContextAttachment[];
   target: RoutineTarget;
   goalStatus?: RoutineGoalStatus;
@@ -93,5 +97,7 @@ export interface RoutineInput {
   enabled?: boolean;
   schedule: RoutineSchedule;
   durationMinutes?: number;
+  /** `null` explicitly removes the limit; omission preserves it on updates. */
+  timeoutMinutes?: number | null;
   attachments?: RoutineContextAttachment[];
 }

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -12,6 +12,7 @@ import {
   type Message,
 } from "./store";
 import { openLiveEvents, type LiveEventSourceLike, type LiveEventsPlatform } from "../lib/live-events";
+import type { RoutineRun } from "../lib/routines";
 
 type SnapshotFrame =
   | { kind: "hello"; resumed: boolean; cursor: string }
@@ -366,6 +367,51 @@ describe("cross-client bot creation", () => {
     });
 
     expect(greeted.bots[0]?.messages).toEqual([greeting]);
+  });
+});
+
+describe("routine receipt retention", () => {
+  const run = (id: string, scheduledFor: number, status: RoutineRun["status"]): RoutineRun => ({
+    id,
+    routineId: "routine",
+    routineName: "Check inbox",
+    target: "bot",
+    botId: "echo",
+    runOn: "maus",
+    scheduledFor,
+    status,
+    manual: false,
+    createdAt: scheduledFor,
+  });
+
+  it("trims finished history without hiding older active work", () => {
+    const waiting = run("waiting", 0, "waiting");
+    const history = Array.from({ length: 2_000 }, (_, index) =>
+      run(`finished-${index}`, index + 1, "completed"),
+    );
+
+    const hydrated = reducer(initialState, {
+      type: "routinesHydrated",
+      routines: [],
+      runs: [waiting, ...history],
+    });
+    expect(hydrated.routineRuns).toHaveLength(2_000);
+    expect(hydrated.routineRuns).toContainEqual(waiting);
+
+    const running = { ...waiting, status: "running" as const, startedAt: 2_000 };
+    const activePatched = reducer(hydrated, {
+      type: "routineRunPatched",
+      run: running,
+    });
+    expect(activePatched.routineRuns).toContainEqual(running);
+
+    const next = reducer(activePatched, {
+      type: "routineRunPatched",
+      run: run("newest", 2_001, "completed"),
+    });
+    expect(next.routineRuns).toHaveLength(2_000);
+    expect(next.routineRuns).toContainEqual(running);
+    expect(next.routineRuns[0]?.id).toBe("newest");
   });
 });
 

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -34,6 +34,25 @@ import { createBotPatchQueue, type BotUpdatePatch } from "./bot-patch-queue";
 import { skillRecorderEnabled } from "@/lib/feature-flags";
 import { openLiveEvents } from "@/lib/live-events";
 
+const MAX_ROUTINE_RUNS = 2_000;
+const ACTIVE_ROUTINE_RUN_STATUSES = new Set<RoutineRun["status"]>(["queued", "running", "waiting"]);
+
+function trimRoutineRuns(runs: readonly RoutineRun[]): RoutineRun[] {
+  const sorted = [...runs].sort((a, b) => b.scheduledFor - a.scheduledFor);
+  if (sorted.length <= MAX_ROUTINE_RUNS) return sorted;
+  const activeCount = sorted.reduce(
+    (count, run) => count + (ACTIVE_ROUTINE_RUN_STATUSES.has(run.status) ? 1 : 0),
+    0,
+  );
+  let terminalSlots = Math.max(0, MAX_ROUTINE_RUNS - activeCount);
+  return sorted.filter((run) => {
+    if (ACTIVE_ROUTINE_RUN_STATUSES.has(run.status)) return true;
+    if (terminalSlots === 0) return false;
+    terminalSlots -= 1;
+    return true;
+  });
+}
+
 export type { MausColor } from "@/lib/mascot";
 export type { RoutineRunCardData } from "../../shared/routine-run";
 
@@ -780,7 +799,7 @@ export function reducer(state: AppState, action: Action): AppState {
         pluginsOpen: false,
       };
     case "routinesHydrated":
-      return { ...state, routines: action.routines, routineRuns: action.runs };
+      return { ...state, routines: action.routines, routineRuns: trimRoutineRuns(action.runs) };
     case "routinePatched": {
       const exists = state.routines.some((routine) => routine.id === action.routine.id);
       return {
@@ -797,7 +816,10 @@ export function reducer(state: AppState, action: Action): AppState {
       const runs = exists
         ? state.routineRuns.map((run) => (run.id === action.run.id ? action.run : run))
         : [action.run, ...state.routineRuns];
-      return { ...state, routineRuns: runs.sort((a, b) => b.scheduledFor - a.scheduledFor) };
+      return {
+        ...state,
+        routineRuns: trimRoutineRuns(runs),
+      };
     }
     case "webhooksHydrated":
       return { ...state, webhooks: action.webhooks, webhookAttempts: action.attempts, webhookIngress: action.ingress };


### PR DESCRIPTION
## What changed

- adds recurring routines that run every 5–1,440 minutes
- keeps the cadence anchored to the chosen starting date and time
- presents interval setup as one clear sentence: `Runs every [15] minutes, starting [date] at [time].`
- offers common interval choices directly, with a custom value only when requested
- supports the same interval flow on desktop, iOS/iPadOS, and Android
- keeps run limits optional and separate from scheduling
- prevents overlapping interval runs and skips missed occurrences instead of creating a backlog
- exposes interval schedules through the routine APIs and agent tools

## Verification

- 3,121 TypeScript tests passed (20 skipped, 1 todo)
- focused routine and state suite: 152 tests passed
- TypeScript typecheck and lint passed
- production build passed
- iOS: 291 Swift tests passed and simulator app build succeeded
- Android: debug Kotlin compilation and routine unit tests passed
- isolated companion fixture passed its health checks



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interval-based routine scheduling, from 5 to 1,440 minutes, with configurable start times.
  * Added optional per-run time limits from 5 to 240 minutes.
  * Updated routine editors, calendars, imports, exports, and summaries to support interval schedules and run limits.
* **Bug Fixes**
  * Improved handling of missed and overlapping interval runs.
  * Preserved active run records while limiting stored routine history.
* **Documentation**
  * Updated the README with interval scheduling, alignment, skipped runs, and run-limit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->