### PR TITLE
fix: preserve routine limits and active history

### DIFF
--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/RoutineRules.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/RoutineRules.kt
@@ -344,6 +344,7 @@ object RoutineRules {
             schedule = schedule,
             durationMinutes = durationMinutes,
             timeoutMinutes = timeoutMinutes,
+            clearTimeout = timeoutMinutes == null,
         )
     }
 }

--- a/android/app/src/test/kotlin/com/openmausbot/companion/ui/RoutineRulesTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/ui/RoutineRulesTest.kt
@@ -372,6 +372,7 @@ class RoutineRulesTest {
         assertEquals(false, input.enabled)
         assertEquals(5, input.durationMinutes)
         assertEquals(45, input.timeoutMinutes)
+        assertFalse(input.clearTimeout)
     }
 
     @Test
@@ -389,6 +390,7 @@ class RoutineRulesTest {
         assertNull(input.enabled)
         assertEquals(30, input.durationMinutes)
         assertNull(input.timeoutMinutes)
+        assertTrue(input.clearTimeout)
     }
 
     @Test

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Client.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Client.kt
@@ -766,10 +766,8 @@ class CompanionClient(
                 input.schedule.anchorAt?.let { put("anchorAt", it) }
             })
             put("durationMinutes", input.durationMinutes)
-            put(
-                "timeoutMinutes",
-                input.timeoutMinutes?.let(::JsonPrimitive) ?: JsonNull,
-            )
+            if (input.timeoutMinutes != null) put("timeoutMinutes", input.timeoutMinutes)
+            else if (input.clearTimeout) put("timeoutMinutes", JsonNull)
         }
 
         suspend fun pair(

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Models.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Models.kt
@@ -879,8 +879,10 @@ data class RoutineInput(
     val schedule: RoutineSchedule,
     /** Still required by older paired desktops; it is not the execution timeout. */
     val durationMinutes: Int = 30,
-    /** `null` deliberately removes an existing execution timeout. */
+    /** A value replaces the stored limit; null leaves it unchanged on PATCH. */
     val timeoutMinutes: Int? = null,
+    /** Interpreted by CompanionClient as an explicit JSON null. */
+    @kotlinx.serialization.Transient val clearTimeout: Boolean = false,
 )
 
 @Serializable

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/RoutineClientTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/RoutineClientTest.kt
@@ -85,7 +85,7 @@ class RoutineClientTest {
                     everyMinutes = 15,
                     anchorAtMillis = 2_500_000L,
                 ),
-                timeoutMinutes = 30,
+                clearTimeout = true,
             ),
         )
         client.setRoutineEnabled("routine-1", true)
@@ -116,7 +116,6 @@ class RoutineClientTest {
                 "runOn",
                 "schedule",
                 "durationMinutes",
-                "timeoutMinutes",
             ),
             create.keys,
         )
@@ -124,7 +123,7 @@ class RoutineClientTest {
         assertEquals(exactPrompt, create.getValue("prompt").jsonPrimitive.content)
         assertEquals("maus", create.getValue("runOn").jsonPrimitive.content)
         assertEquals(5, create.getValue("durationMinutes").jsonPrimitive.content.toInt())
-        assertEquals(JsonNull, create.getValue("timeoutMinutes"))
+        assertFalse("timeoutMinutes" in create)
         assertEquals(
             mapOf("type" to "once", "at" to "2000000.0"),
             create.getValue("schedule").jsonObject.mapValues { it.value.jsonPrimitive.content },
@@ -153,7 +152,7 @@ class RoutineClientTest {
             ),
             interval.mapValues { it.value.jsonPrimitive.content },
         )
-        assertEquals(30, intervalUpdate.getValue("timeoutMinutes").jsonPrimitive.content.toInt())
+        assertEquals(JsonNull, intervalUpdate.getValue("timeoutMinutes"))
 
         assertEquals(
             mapOf("enabled" to "true"),

--- a/ios/App/TasksRoutinesView.swift
+++ b/ios/App/TasksRoutinesView.swift
@@ -462,7 +462,8 @@ private struct RoutineEditorView: View {
             name: String(name.trimmingCharacters(in: .whitespacesAndNewlines).prefix(80)),
             prompt: String(prompt.trimmingCharacters(in: .whitespacesAndNewlines).prefix(20_000)),
             botId: botId, runOn: runOn.rawValue, enabled: routine?.enabled,
-            schedule: schedule, durationMinutes: duration, timeoutMinutes: timeoutMinutes
+            schedule: schedule, durationMinutes: duration,
+            timeoutMinutes: timeoutMinutes, clearTimeout: timeoutMinutes == nil
         )
         if await session.saveRoutine(input, id: routine?.id) != nil {
             await onSaved()

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -1103,8 +1103,9 @@ public struct CompanionClient: Sendable {
         var body: [String: Any] = [
             "name": input.name, "prompt": input.prompt, "botId": input.botId,
             "runOn": input.runOn, "schedule": schedule, "durationMinutes": input.durationMinutes,
-            "timeoutMinutes": input.timeoutMinutes ?? NSNull(),
         ]
+        if let timeoutMinutes = input.timeoutMinutes { body["timeoutMinutes"] = timeoutMinutes }
+        else if input.clearTimeout { body["timeoutMinutes"] = NSNull() }
         if let enabled = input.enabled { body["enabled"] = enabled }
         return body
     }

--- a/ios/Sources/CompanionCore/Models.swift
+++ b/ios/Sources/CompanionCore/Models.swift
@@ -742,12 +742,15 @@ public struct RoutineInput: Encodable, Sendable {
     public var enabled: Bool?
     public var schedule: RoutineSchedule
     public var durationMinutes: Int
+    /// A value replaces the stored limit; nil leaves it unchanged on PATCH.
     public var timeoutMinutes: Int?
+    /// Explicitly writes JSON null when `timeoutMinutes` is nil.
+    public var clearTimeout: Bool
 
     public init(
         name: String, prompt: String, botId: String, runOn: String = "maus",
         enabled: Bool? = nil, schedule: RoutineSchedule, durationMinutes: Int = 30,
-        timeoutMinutes: Int? = nil
+        timeoutMinutes: Int? = nil, clearTimeout: Bool = false
     ) {
         self.name = name
         self.prompt = prompt
@@ -757,6 +760,24 @@ public struct RoutineInput: Encodable, Sendable {
         self.schedule = schedule
         self.durationMinutes = durationMinutes
         self.timeoutMinutes = timeoutMinutes
+        self.clearTimeout = clearTimeout
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name, prompt, botId, runOn, enabled, schedule, durationMinutes, timeoutMinutes
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var values = encoder.container(keyedBy: CodingKeys.self)
+        try values.encode(name, forKey: .name)
+        try values.encode(prompt, forKey: .prompt)
+        try values.encode(botId, forKey: .botId)
+        try values.encode(runOn, forKey: .runOn)
+        try values.encodeIfPresent(enabled, forKey: .enabled)
+        try values.encode(schedule, forKey: .schedule)
+        try values.encode(durationMinutes, forKey: .durationMinutes)
+        if let timeoutMinutes { try values.encode(timeoutMinutes, forKey: .timeoutMinutes) }
+        else if clearTimeout { try values.encodeNil(forKey: .timeoutMinutes) }
     }
 }
 

--- a/ios/Tests/CompanionCoreTests/RoutineClientTests.swift
+++ b/ios/Tests/CompanionCoreTests/RoutineClientTests.swift
@@ -108,13 +108,28 @@ final class RoutineClientTests: XCTestCase {
         XCTAssertEqual(created.schedule.type, .interval)
     }
 
-    func testSendsNullToRemoveAnOptionalRunLimit() async throws {
-        _ = try await client.createRoutine(RoutineInput(
+    func testOmitsAnUnchangedRunLimitFromPatch() async throws {
+        let unchangedTimeout: Int? = nil
+        _ = try await client.updateRoutine(id: "routine-1", input: RoutineInput(
             name: "Pulse",
             prompt: "Check status",
             botId: "bot-1",
             schedule: .interval(everyMinutes: 15, anchorAt: Date()),
-            timeoutMinutes: nil
+            timeoutMinutes: unchangedTimeout
+        ))
+
+        let data = try XCTUnwrap(RoutineRequestStub.capturedBody)
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertNil(body["timeoutMinutes"])
+    }
+
+    func testSendsNullToRemoveAnOptionalRunLimit() async throws {
+        _ = try await client.updateRoutine(id: "routine-1", input: RoutineInput(
+            name: "Pulse",
+            prompt: "Check status",
+            botId: "bot-1",
+            schedule: .interval(everyMinutes: 15, anchorAt: Date()),
+            clearTimeout: true
         ))
 
         let data = try XCTUnwrap(RoutineRequestStub.capturedBody)

--- a/src/lib/routine-calendar.test.ts
+++ b/src/lib/routine-calendar.test.ts
@@ -231,6 +231,46 @@ describe("routine calendar projection", () => {
     expect(items.at(-1)?.at).toBe(from + 99 * 5 * 60_000);
   });
 
+  it("keeps queued, running, and waiting receipts outside the terminal history cap", () => {
+    const from = new Date(2026, 7, 31, 9).getTime();
+    const terminalRuns: RoutineRun[] = Array.from({ length: 20 }, (_, index) => ({
+      id: `completed-run-${index}`,
+      routineId: "interval-routine",
+      routineName: "Pulse",
+      target: "bot",
+      botId: "b1",
+      runOn: "maus",
+      scheduledFor: from + (index + 3) * 5 * 60_000,
+      status: "completed",
+      manual: false,
+      createdAt: from + (index + 3) * 5 * 60_000,
+    }));
+    const activeRuns: RoutineRun[] = (["queued", "running", "waiting"] as const).map((status, index) => ({
+      id: `${status}-run`,
+      routineId: "interval-routine",
+      routineName: "Pulse",
+      target: "bot",
+      botId: "b1",
+      runOn: "maus",
+      scheduledFor: from + index * 5 * 60_000,
+      status,
+      manual: false,
+      createdAt: from + index * 5 * 60_000,
+    }));
+
+    const items = projectedRoutineItems(
+      [],
+      [...activeRuns, ...terminalRuns],
+      from,
+      from + 24 * 60 * 60_000,
+    );
+
+    expect(items.filter((item) => item.run?.status === "completed")).toHaveLength(12);
+    expect(items.filter((item) => item.run?.status === "queued")).toHaveLength(1);
+    expect(items.filter((item) => item.run?.status === "running")).toHaveLength(1);
+    expect(items.filter((item) => item.run?.status === "waiting")).toHaveLength(1);
+  });
+
   it("keeps dense history bounded after its routine is deleted", () => {
     const from = new Date(2026, 7, 31, 9).getTime();
     const runs: RoutineRun[] = Array.from({ length: 100 }, (_, index) => ({

--- a/src/lib/routine-calendar.ts
+++ b/src/lib/routine-calendar.ts
@@ -158,8 +158,12 @@ export function projectedRoutineItems(
     .filter((run) => run.scheduledFor >= from && run.scheduledFor < to)
     .sort((left, right) => right.scheduledFor - left.scheduledFor)
     .filter((run) => {
+      if (run.status === "queued" || run.status === "running" || run.status === "waiting") {
+        return true;
+      }
       // A routine may later be edited or deleted, so the current definition
       // cannot safely tell us whether its history came from a dense interval.
+      // Keep active receipts unbounded above, while trimming terminal history.
       const count = receiptCounts.get(run.routineId) ?? 0;
       if (count >= MAX_RECEIPTS_PER_ROUTINE_PER_RANGE) return false;
       receiptCounts.set(run.routineId, count + 1);


### PR DESCRIPTION
## Summary

- preserve an existing routine run limit when mobile sends an unrelated update
- let the iOS and Android editors explicitly clear the limit when “No limit” is selected
- keep queued, running, and waiting receipts visible outside the terminal history cap
- retain the existing public mobile model shape and Android serialization

## Verification

- `pnpm exec vitest run src/lib/routine-calendar.test.ts` — 14 passed
- `pnpm typecheck`
- `swift test` — 301 passed
- unsigned iOS simulator app build
- Android routine core and UI tests
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit control for clearing routine execution timeouts.
  * Routine updates now preserve an existing timeout when no new value is provided, while allowing users to remove it intentionally.
  * Active routine runs—including queued, running, and waiting states—remain visible in projected calendars.

* **Bug Fixes**
  * Improved routine request handling to distinguish between unchanged, updated, and cleared timeout settings.
  * Prevented active runs from being hidden when projected calendar history reaches its display limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->