### PR TITLE
feat(composer): add slash command menu for goals

### DIFF
--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -1,6 +1,6 @@
 import { track } from "@/lib/analytics";
 import { useCallback, useEffect, useMemo, useRef, useState, type SetStateAction } from "react";
-import { ArrowUp, Check, Clock, Hand, Mic, Paperclip, ShieldCheck, Square, Target, Users, X } from "lucide-react";
+import { ArrowUp, BookOpen, Check, Clock, Hand, Mic, Paperclip, ShieldCheck, Square, Target, Users, X } from "lucide-react";
 import { useStore, visibleMessages, type Bot, type Group, type Message } from "@/state/store";
 import { cn } from "@/lib/cn";
 import {
@@ -36,6 +36,13 @@ import { useDesktopCapabilities } from "./DesktopCapabilities";
 import { ReplyQuote } from "./ReplyQuote";
 import { ComposerInjectNow, composerCanInjectNow } from "./ComposerInjectNow";
 import { QueuedComposerMessages } from "./ComposerQueuedMessages";
+import { skillRecorderEnabled } from "@/lib/feature-flags";
+import {
+  composerSlashTrigger,
+  goalTextFromComposer,
+  replaceComposerSlashTrigger,
+  type ComposerSlashCommand,
+} from "@/lib/composer-commands";
 
 /** The active @mention query at the caret: the text between an `@` that
  * starts a word and the caret. null = no mention being typed. */
@@ -50,6 +57,18 @@ function mentionQueryAt(text: string, caret: number): { start: number; query: st
 }
 
 type MentionChoice = { id: string; name: string; bot?: Bot };
+
+const GOAL_COMMAND: ComposerSlashCommand = {
+  id: "goal",
+  label: "/goal",
+  description: "Keep a team working until the goal is complete",
+};
+
+const LEARN_COMMAND: ComposerSlashCommand = {
+  id: "learn",
+  label: "/learn",
+  description: "Teach a reusable workflow from this conversation",
+};
 
 interface ComposerDraftSnapshot extends ComposerSendSnapshot {
   reply: Message | null;
@@ -265,6 +284,7 @@ export function Composer({
   const [caret, setCaret] = useState(0);
   const [highlight, setHighlight] = useState(0);
   const [dismissedAt, setDismissedAt] = useState<number | null>(null); // Esc'd this @
+  const [dismissedSlashAt, setDismissedSlashAt] = useState<number | null>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   // what was typed before the mic went on — partials append after it
   const baseText = useRef("");
@@ -285,9 +305,41 @@ export function Composer({
     const responders = roomRespondersForComposer(message, members ?? [], group);
     return responders.length > 0 && responders.every(botSupportsImages);
   };
-  const engineSupportsImages = imageTargetsSupport(text, channelMode);
+  const typedGoalText = group && !group.dm ? goalTextFromComposer(text) : null;
+  const effectiveText = typedGoalText ?? text;
+  const effectiveChannelMode = typedGoalText !== null ? "goal" : channelMode;
+  const engineSupportsImages = imageTargetsSupport(effectiveText, effectiveChannelMode);
 
-  // ── @mention picker (tag another bot; the agent reaches it via ask_bot) ──
+  // ── Slash commands and @mentions ─────────────────────────────────────
+  const slash = composerSlashTrigger(text, caret);
+  const commandCandidates = useMemo(() => {
+    if (!slash || slash.start === dismissedSlashAt) return [];
+    const supportsAgents = (candidate?: Bot) =>
+      Boolean(
+        candidate &&
+          state.instances.find(
+            (instance) => instance.instanceId === candidate.modelSelection.instanceId,
+          )?.capabilities?.agentsMcp,
+      );
+    const available: ComposerSlashCommand[] = [];
+    if (group && !group.dm) available.push(GOAL_COMMAND);
+    if (
+      skillRecorderEnabled(state.config) &&
+      (group ? (members ?? []).some(supportsAgents) : supportsAgents(bot))
+    ) {
+      available.push(LEARN_COMMAND);
+    }
+    const query = slash.query.toLowerCase();
+    return available.filter(
+      (command) =>
+        !query ||
+        command.id.startsWith(query) ||
+        command.description.toLowerCase().includes(query),
+    );
+  }, [slash, dismissedSlashAt, group, members, bot, state.config, state.instances]);
+  const commandPickerOpen = commandCandidates.length > 0;
+
+  // Tag another bot; the agent reaches it via ask_bot.
   const mention = mentionQueryAt(text, caret);
   const candidates = useMemo(() => {
     if (!mention || mention.start === dismissedAt) return [];
@@ -305,9 +357,12 @@ export function Composer({
     if (mention.query.endsWith(" ") && pool.some((b) => b.name.toLowerCase() === q)) return [];
     return pool.filter((b) => !q || b.name.toLowerCase().includes(q)).slice(0, 6);
   }, [mention, dismissedAt, state.bots, bot?.id, group, members]);
-  const pickerOpen = candidates.length > 0;
+  const mentionPickerOpen = candidates.length > 0;
 
-  useEffect(() => setHighlight(0), [mention?.start, mention?.query]);
+  useEffect(
+    () => setHighlight(0),
+    [mention?.start, mention?.query, slash?.start, slash?.query],
+  );
 
   // one line at rest, then grow with the draft — hard cap at six lines
   useEffect(() => {
@@ -331,6 +386,20 @@ export function Composer({
     requestAnimationFrame(() => {
       inputRef.current?.focus();
       inputRef.current?.setSelectionRange(newCaret, newCaret);
+    });
+  };
+
+  const pickCommand = (command: ComposerSlashCommand) => {
+    if (!slash) return;
+    const replacement = command.id === "learn" ? "/learn " : "";
+    const next = replaceComposerSlashTrigger(text, slash, replacement);
+    editText(next.text);
+    setCaret(next.caret);
+    setDismissedSlashAt(slash.start);
+    setChannelMode(command.id === "goal" ? "goal" : "chat");
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(next.caret, next.caret);
     });
   };
 
@@ -374,7 +443,7 @@ export function Composer({
     dispatch({ type: "updateBot", botId: autoBot.id, patch: { autoApprove: auto } });
   };
 
-  const hasContent = Boolean(text.trim()) || attachments.length > 0;
+  const hasContent = Boolean(effectiveText.trim()) || attachments.length > 0;
   const retryFailedSend = (failed: FailedComposerSend) => {
     const failedMode = failed.channelMode ?? "chat";
     if (failed.requestText.includes("<attached-image ") && !imageTargetsSupport(failed.requestText, failedMode)) {
@@ -406,11 +475,14 @@ export function Composer({
   };
   const send = () => {
     if (locked) return;
-    if (attachments.some((attachment) => attachment.kind === "image") && !imageTargetsSupport(text, channelMode)) {
+    if (
+      attachments.some((attachment) => attachment.kind === "image") &&
+      !imageTargetsSupport(effectiveText, effectiveChannelMode)
+    ) {
       dispatch({ type: "error", message: "The selected responder does not support image attachments." });
       return;
     }
-    const t = composeMessage(text, attachments);
+    const t = composeMessage(effectiveText, attachments);
     if (!t) return;
     const sentDraft: ComposerDraftSnapshot = {
       draftId,
@@ -422,7 +494,7 @@ export function Composer({
       reply: replyTo ?? null,
       replyToId: replyTo?.id,
       threadId,
-      channelMode: group ? channelMode : undefined,
+      channelMode: group ? effectiveChannelMode : undefined,
     };
     if (group) {
       dispatch({
@@ -432,10 +504,10 @@ export function Composer({
         sendId: sentDraft.sendId,
         replyToId: replyTo?.id,
         threadId,
-        mode: channelMode,
+        mode: effectiveChannelMode,
         onError: () => restoreDraft(sentDraft),
       });
-      track("message_sent", { room: true, mode: channelMode, queued: busy });
+      track("message_sent", { room: true, mode: effectiveChannelMode, queued: busy });
     } else if (bot) {
       dispatch({
         type: "send",
@@ -533,7 +605,47 @@ export function Composer({
             </button>
           </div>
         ))}
-        {pickerOpen && (
+        {commandPickerOpen && (
+          <div
+            role="listbox"
+            aria-label="Composer commands"
+            className="absolute bottom-full left-2 z-20 mb-2 w-80 overflow-hidden rounded-xl border border-hairline/40 bg-raised shadow-lg"
+          >
+            <div className="border-b border-hairline/20 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.08em] text-ink-secondary">
+              Commands
+            </div>
+            {commandCandidates.map((command, index) => (
+              <button
+                key={command.id}
+                type="button"
+                role="option"
+                aria-selected={index === highlight}
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => pickCommand(command)}
+                onMouseEnter={() => setHighlight(index)}
+                className={cn(
+                  "flex w-full items-center gap-3 px-3 py-2.5 text-left",
+                  index === highlight ? "bg-raised-hover" : "",
+                )}
+              >
+                <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-accent/10 text-accent">
+                  {command.id === "goal" ? (
+                    <Target size={15} aria-hidden="true" />
+                  ) : (
+                    <BookOpen size={15} aria-hidden="true" />
+                  )}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-[14px] font-medium text-accent">{command.label}</span>
+                  <span className="block truncate text-xs text-ink-secondary">
+                    {command.description}
+                  </span>
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+        {mentionPickerOpen && (
           <div
             role="listbox"
             aria-label="Tag a bot"
@@ -656,7 +768,7 @@ export function Composer({
                   )}
                 >
                   <Target size={14} aria-hidden="true" />
-                  Goal
+                  {channelMode === "goal" ? "/goal" : "Goal"}
                 </button>
               )}
               {autoBot && <PermissionModeSelector bot={autoBot} onSetAuto={setAuto} />}
@@ -670,6 +782,7 @@ export function Composer({
             editText(e.target.value);
             setCaret(e.target.selectionStart ?? e.target.value.length);
             setDismissedAt(null);
+            setDismissedSlashAt(null);
           }}
           onPaste={(e) => {
             // an image from the clipboard becomes an uploaded attachment —
@@ -710,7 +823,27 @@ export function Composer({
           onKeyUp={(e) => setCaret((e.target as HTMLTextAreaElement).selectionStart ?? 0)}
           onClick={(e) => setCaret((e.target as HTMLTextAreaElement).selectionStart ?? 0)}
           onKeyDown={(e) => {
-            if (pickerOpen) {
+            if (commandPickerOpen) {
+              if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+                e.preventDefault();
+                const delta = e.key === "ArrowDown" ? 1 : -1;
+                setHighlight((current) =>
+                  (current + delta + commandCandidates.length) % commandCandidates.length,
+                );
+                return;
+              }
+              if (e.key === "Enter" || e.key === "Tab") {
+                e.preventDefault();
+                pickCommand(commandCandidates[highlight]);
+                return;
+              }
+              if (e.key === "Escape") {
+                e.preventDefault();
+                setDismissedSlashAt(slash?.start ?? null);
+                return;
+              }
+            }
+            if (mentionPickerOpen) {
               if (e.key === "ArrowDown" || e.key === "ArrowUp") {
                 e.preventDefault();
                 const delta = e.key === "ArrowDown" ? 1 : -1;

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -753,22 +753,33 @@ export function Composer({
               {group && !group.dm && (
                 <button
                   type="button"
-                  aria-pressed={channelMode === "goal"}
+                  aria-pressed={effectiveChannelMode === "goal"}
                   aria-label="Finish together"
                   title="Finish together — the team keeps working until the goal is complete"
                   onClick={() => {
                     markDraftEdited(draftId);
+                    if (typedGoalText !== null) {
+                      const nextCaret = Math.max(0, caret - (text.length - typedGoalText.length));
+                      editText(typedGoalText);
+                      setCaret(nextCaret);
+                      setChannelMode("chat");
+                      requestAnimationFrame(() => {
+                        inputRef.current?.focus();
+                        inputRef.current?.setSelectionRange(nextCaret, nextCaret);
+                      });
+                      return;
+                    }
                     setChannelMode((current) => current === "goal" ? "chat" : "goal");
                   }}
                   className={cn(
                     "flex h-8 items-center gap-1.5 whitespace-nowrap rounded-full border px-3 text-[13px] transition-colors",
-                    channelMode === "goal"
+                    effectiveChannelMode === "goal"
                       ? "border-accent/35 bg-accent/10 text-accent"
                       : "border-hairline/20 bg-transparent text-ink-secondary hover:bg-raised hover:text-ink",
                   )}
                 >
                   <Target size={14} aria-hidden="true" />
-                  {channelMode === "goal" ? "/goal" : "Goal"}
+                  {effectiveChannelMode === "goal" ? "/goal" : "Goal"}
                 </button>
               )}
               {autoBot && <PermissionModeSelector bot={autoBot} onSetAuto={setAuto} />}

--- a/src/lib/composer-commands.test.ts
+++ b/src/lib/composer-commands.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  composerSlashTrigger,
+  goalTextFromComposer,
+  replaceComposerSlashTrigger,
+} from "./composer-commands";
+
+describe("composer slash commands", () => {
+  it("opens command search only for the first unfinished token", () => {
+    expect(composerSlashTrigger("/", 1)).toEqual({ query: "", start: 0, end: 1 });
+    expect(composerSlashTrigger("/go", 3)).toEqual({ query: "go", start: 0, end: 3 });
+    expect(composerSlashTrigger("hello /go", 9)).toBeNull();
+    expect(composerSlashTrigger("/goal write", 11)).toBeNull();
+  });
+
+  it("replaces the active token without losing text after the caret", () => {
+    expect(
+      replaceComposerSlashTrigger("/go later", { query: "go", start: 0, end: 3 }, ""),
+    ).toEqual({ text: " later", caret: 0 });
+    expect(
+      replaceComposerSlashTrigger("/le", { query: "le", start: 0, end: 3 }, "/learn "),
+    ).toEqual({ text: "/learn ", caret: 7 });
+  });
+
+  it("turns a manually typed goal command into a goal request", () => {
+    expect(goalTextFromComposer("/goal ship the release")).toBe("ship the release");
+    expect(goalTextFromComposer("/GOAL\n  investigate the failure")).toBe(
+      "investigate the failure",
+    );
+    expect(goalTextFromComposer("/goalie says hello")).toBeNull();
+    expect(goalTextFromComposer("discuss /goal later")).toBeNull();
+  });
+});

--- a/src/lib/composer-commands.ts
+++ b/src/lib/composer-commands.ts
@@ -1,0 +1,40 @@
+export type ComposerSlashCommandId = "goal" | "learn";
+
+export interface ComposerSlashCommand {
+  id: ComposerSlashCommandId;
+  label: `/${ComposerSlashCommandId}`;
+  description: string;
+}
+
+export interface ComposerSlashTrigger {
+  query: string;
+  start: number;
+  end: number;
+}
+
+/** Slash commands configure the whole send, so they are offered only at the
+ * beginning of a draft and only while the first token is being typed. */
+export function composerSlashTrigger(text: string, caretInput: number): ComposerSlashTrigger | null {
+  const caret = Math.max(0, Math.min(text.length, Math.floor(caretInput)));
+  const prefix = text.slice(0, caret);
+  const match = /^\/([a-z-]*)$/i.exec(prefix);
+  if (!match) return null;
+  return { query: match[1] ?? "", start: 0, end: caret };
+}
+
+/** A typed `/goal …` is equivalent to selecting Goal mode from the menu.
+ * null means this is an ordinary chat message; an empty string means the
+ * command is present but still needs a goal description or attachment. */
+export function goalTextFromComposer(text: string): string | null {
+  const match = /^\/goal(?:\s+([\s\S]*))?$/i.exec(text);
+  return match ? (match[1] ?? "").trimStart() : null;
+}
+
+export function replaceComposerSlashTrigger(
+  text: string,
+  trigger: ComposerSlashTrigger,
+  replacement: string,
+): { text: string; caret: number } {
+  const next = `${text.slice(0, trigger.start)}${replacement}${text.slice(trigger.end)}`;
+  return { text: next, caret: trigger.start + replacement.length };
+}

--- a/src/lib/composer-commands.ts
+++ b/src/lib/composer-commands.ts
@@ -30,6 +30,8 @@ export function goalTextFromComposer(text: string): string | null {
   return match ? (match[1] ?? "").trimStart() : null;
 }
 
+/** Replace the active slash token and return the caret position immediately
+ * after the inserted text. */
 export function replaceComposerSlashTrigger(
   text: string,
   trigger: ComposerSlashTrigger,


### PR DESCRIPTION
## What this fixes

The goal runner shipped in #702, but its planned `/goal` composer command did not. Users had to discover and click the small Goal control, and typing `/goal …` sent ordinary chat text.

## What changed

- typing `/` at the start of the composer opens a filtered, keyboard-navigable command menu
- `/goal` is offered only in team channels, where goal mode actually exists
- selecting it activates goal mode, removes the command text, and shows an accent-colored `/goal` pill
- manually typing `/goal describe the work` also sends the description through the real durable goal path
- `/learn` appears in the same menu only when the experimental Teach feature is enabled and a capable agent is available

The interaction follows T3 Code's simple built-in-command pattern: commands change composer state, while provider-style commands remain text.

## Verification

- `pnpm exec vitest run src/lib/composer-commands.test.ts`
- `pnpm exec oxlint src/components/Composer.tsx src/lib/composer-commands.ts src/lib/composer-commands.test.ts`
- `pnpm typecheck`
- `pnpm build`
- isolated fixture: created two bots and a channel, posted a `mode: goal` message, waited for settlement, and confirmed the stored user message had `channelMode: goal` plus a `goal.run` receipt

Generated with Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/goal` and `/learn` slash commands in the composer.
  * Added command suggestions with keyboard navigation, selection, and dismissal.
  * Goal text in non-direct-message groups now automatically activates goal mode.
  * The goal toggle now displays `/goal` and recognizes manually entered goal commands.
  * Editing composer text resets slash-command dismissal.

* **Bug Fixes**
  * Composer validation, drafts, analytics, and content detection now consistently reflect the active goal or chat mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->