### PR TITLE
ci: automate release version preparation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,125 @@
+name: Prepare next release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump"
+        required: true
+        type: choice
+        default: patch
+        options:
+          - patch
+          - minor
+          - custom
+      version:
+        description: "Custom version (only used when Version bump is custom)"
+        required: false
+        type: string
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: prepare-release
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Open the version-bump PR
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Choose the next version
+        id: version
+        env:
+          BUMP: ${{ inputs.bump }}
+          CUSTOM_VERSION: ${{ inputs.version }}
+        run: |
+          current=$(node -p "require('./package.json').version")
+          next=$(node --input-type=module - "$current" "$BUMP" "$CUSTOM_VERSION" <<'EOF'
+          const [current, bump, requested] = process.argv.slice(2);
+          const parse = (value) => {
+            const match = value.replace(/^v/, "").match(/^(\d+)\.(\d+)\.(\d+)$/);
+            if (!match) throw new Error(`expected a stable X.Y.Z version, got: ${value || "(empty)"}`);
+            return match.slice(1).map(Number);
+          };
+          const before = parse(current);
+          let after;
+          if (bump === "patch") after = [before[0], before[1], before[2] + 1];
+          else if (bump === "minor") after = [before[0], before[1] + 1, 0];
+          else if (bump === "custom") after = parse(requested);
+          else throw new Error(`unknown bump: ${bump}`);
+          if (after[0] < before[0]
+            || (after[0] === before[0] && after[1] < before[1])
+            || (after[0] === before[0] && after[1] === before[1] && after[2] <= before[2])) {
+            throw new Error(`${after.join(".")} must be newer than ${current}`);
+          }
+          console.log(after.join("."));
+          EOF
+          )
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          echo "next=$next" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse an existing release or release branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.next }}
+        run: |
+          if gh release view "v$VERSION" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            echo "::error::v$VERSION already exists in $GITHUB_REPOSITORY"
+            exit 1
+          fi
+          if gh release view "v$VERSION" --repo milind-soni/openmausbot-releases > /dev/null 2>&1; then
+            echo "::error::v$VERSION already exists in the legacy updater mirror"
+            exit 1
+          fi
+          if git ls-remote --exit-code --heads origin "release/v$VERSION" > /dev/null 2>&1; then
+            echo "::error::release/v$VERSION already exists — use its existing PR"
+            exit 1
+          fi
+
+      - name: Commit the version bump
+        env:
+          VERSION: ${{ steps.version.outputs.next }}
+        run: |
+          npm pkg set "version=$VERSION"
+          test "$(node -p "require('./package.json').version")" = "$VERSION"
+          git diff --check
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "release/v$VERSION"
+          git add package.json
+          git commit -m "chore(release): bump version to $VERSION"
+          git push --set-upstream origin "release/v$VERSION"
+
+      - name: Open the release PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.next }}
+        run: |
+          url=$(gh pr create \
+            --base main \
+            --head "release/v$VERSION" \
+            --title "chore(release): bump version to $VERSION" \
+            --body "Bumps OpenMausBot to \`$VERSION\`. Merging this PR automatically starts the existing release workflow and assembles a draft release from the exact merge commit.")
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "### Release PR" >> "$GITHUB_STEP_SUMMARY"
+          echo "$url" >> "$GITHUB_STEP_SUMMARY"
+
+      # GITHUB_TOKEN-created branches do not emit another push/pull_request
+      # workflow event. Dispatch CI explicitly so the normal required checks
+      # still gate the release PR.
+      - name: Start CI for the release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.next }}
+        run: gh workflow run ci.yml --ref "release/v$VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
-          fetch-depth: 2
+          fetch-depth: 0
       - id: pin
         env:
           BEFORE: ${{ github.event.before }}
@@ -64,7 +64,11 @@ jobs:
           current=$(node -p "require('./package.json').version")
           echo "version=$current" >> "$GITHUB_OUTPUT"
           should_release=true
-          if [ "$GITHUB_EVENT_NAME" = push ] && git cat-file -e "$BEFORE:package.json" 2>/dev/null; then
+          if [ "$GITHUB_EVENT_NAME" = push ]; then
+            git cat-file -e "$BEFORE:package.json" 2>/dev/null || {
+              echo "::error::cannot verify the version before this push; refusing to start a release"
+              exit 1
+            }
             previous=$(git show "$BEFORE:package.json" | node -e 'let s=""; process.stdin.on("data", d => s += d).on("end", () => console.log(JSON.parse(s).version))')
             if [ "$previous" = "$current" ]; then
               echo "package.json changed without a version bump; skipping the release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: boolean
         default: false
+  push:
+    branches:
+      - main
+    paths:
+      - package.json
 
 permissions:
   contents: read
@@ -44,16 +49,31 @@ jobs:
     outputs:
       sha: ${{ steps.pin.outputs.sha }}
       version: ${{ steps.pin.outputs.version }}
+      should_release: ${{ steps.pin.outputs.should_release }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
+          fetch-depth: 2
       - id: pin
+        env:
+          BEFORE: ${{ github.event.before }}
         run: |
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+          current=$(node -p "require('./package.json').version")
+          echo "version=$current" >> "$GITHUB_OUTPUT"
+          should_release=true
+          if [ "$GITHUB_EVENT_NAME" = push ] && git cat-file -e "$BEFORE:package.json" 2>/dev/null; then
+            previous=$(git show "$BEFORE:package.json" | node -e 'let s=""; process.stdin.on("data", d => s += d).on("end", () => console.log(JSON.parse(s).version))')
+            if [ "$previous" = "$current" ]; then
+              echo "package.json changed without a version bump; skipping the release"
+              should_release=false
+            fi
+          fi
+          echo "should_release=$should_release" >> "$GITHUB_OUTPUT"
       - name: Refuse to overwrite a published canonical release
+        if: steps.pin.outputs.should_release == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -63,6 +83,7 @@ jobs:
             exit 1
           fi
       - name: Refuse to overwrite a published legacy mirror
+        if: steps.pin.outputs.should_release == 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASES_PAT }}
         run: |
@@ -76,6 +97,7 @@ jobs:
   mac:
     name: macOS arm64 + x64 (sign, notarize, staple)
     needs: prepare
+    if: needs.prepare.outputs.should_release == 'true'
     runs-on: macos-14
     timeout-minutes: 90
     steps:
@@ -229,6 +251,7 @@ jobs:
   windows:
     name: Windows x64
     needs: prepare
+    if: needs.prepare.outputs.should_release == 'true'
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
@@ -295,6 +318,7 @@ jobs:
   linux:
     name: Ubuntu 24.04 x64
     needs: prepare
+    if: needs.prepare.outputs.should_release == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
@@ -375,6 +399,7 @@ jobs:
   assemble:
     name: Assemble the draft and verify every feed
     needs: [prepare, mac, windows, linux]
+    if: needs.prepare.outputs.should_release == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     concurrency:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,6 +1,12 @@
 # Releasing
 
-One workflow builds everything: **Actions → Release → Run workflow**. It
+For a normal release, run **Actions → Prepare next release → Run workflow** and
+choose a patch, minor, or custom version. It opens a tiny version-bump PR;
+merging that PR automatically starts **Release** and assembles a draft from the
+exact merge commit. Review and publish the draft when it is ready.
+
+The existing **Actions → Release → Run workflow** button remains available for
+reruns and recovery. It
 builds macOS (arm64 + x64, signed, notarized, stapled), Windows, and Ubuntu
 from a single pinned commit, verifies every artifact the way a user would
 receive it, and assembles the canonical draft in
@@ -16,9 +22,9 @@ published release** workflow
 verifies and publishes its legacy mirror automatically. Never publish only the
 legacy draft.
 
-The workflow refuses to overwrite an already-published version, so the only
-prerequisite per release is that `package.json`'s version is bumped on the
-ref you run it against. A release is rejected if any installer, stable download
+The workflow refuses to overwrite an already-published version. Manual Release
+runs still require `package.json`'s version to be bumped on the selected ref.
+A release is rejected if any installer, stable download
 name, updater feed, blockmap, size, or digest is absent or inconsistent.
 
 GitHub generates the release body from pull requests since the previous
@@ -54,6 +60,11 @@ above it.
 ## One-time setup: release secrets
 
 Set these in **OpenMausBot → Settings → Secrets and variables → Actions**.
+
+The **Prepare next release** workflow also needs
+**Settings → Actions → General → Workflow permissions → Allow GitHub Actions
+to create and approve pull requests** enabled. The workflow only creates the
+version PR; it never approves or merges it.
 
 ### 1. `MAC_CERT_P12_BASE64` + `MAC_CERT_PASSWORD`
 


### PR DESCRIPTION
## What this does

- adds **Actions → Prepare next release** with patch, minor, and custom choices
- opens a one-file version-bump PR and explicitly starts normal CI for it
- starts the existing safe Release workflow after that PR reaches `main`
- keeps manual Release runs available for recovery

The release still assembles a draft by default; publishing remains a human decision.

## One-time repository setting

Enable **Settings → Actions → General → Workflow permissions → Allow GitHub Actions to create and approve pull requests**. The workflow only creates the version PR; it never approves or merges it.

## Validation

- actionlint
- YAML parse
- Prettier check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered workflow for preparing patch, minor, or custom releases.
  * Release preparation now validates versions, prevents duplicate release branches or tags, and opens a version-update pull request.
  * Releases now start automatically when a version update reaches the main branch.
  * Added the ability to manually run CI workflows.

* **Bug Fixes**
  * Release processing now skips changes that do not include a version bump.

* **Documentation**
  * Updated release instructions with the new preparation workflow and required setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->