### PR TITLE
chore(release): bump version to 0.1.50

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.49",
+  "version": "0.1.50",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {


### PR DESCRIPTION
Bumps OpenMausBot to `0.1.50`. Merging this PR starts the automated release workflow and assembles the draft from the exact merge commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version from 0.1.49 to 0.1.50.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->