### PR TITLE
fix(release): retry Windows helper cleanup

### DIFF
--- a/scripts/prepare-cloudflared.mjs
+++ b/scripts/prepare-cloudflared.mjs
@@ -262,11 +262,13 @@ async function stageTarget(root, target) {
       `${JSON.stringify(expectedManifest(target), null, 2)}\n`,
       { mode: 0o600 },
     );
-    rmSync(finalDirectory, { recursive: true, force: true });
+    rmSync(finalDirectory, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 });
     renameSync(stagedDirectory, finalDirectory);
     console.log(`staged cloudflared ${CLOUDFLARED_VERSION} for ${target}`);
   } finally {
-    rmSync(scratch, { recursive: true, force: true });
+    // Windows Defender can briefly retain the executable after the version
+    // probe exits. Node retries EPERM for recursive removals when asked.
+    rmSync(scratch, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 });
   }
 }
 


### PR DESCRIPTION
## What failed

The `0.1.50` release reached Windows packaging, staged and verified cloudflared, then Windows Defender briefly retained the probed executable. The temporary-directory cleanup failed with `EPERM`, stopping the release before assembly.

## Fix

Use Node’s built-in retry behavior for recursive removals. This handles transient Windows `EPERM`/file-lock races without weakening binary verification or leaving cleanup disabled.

## Validation

- targeted cloudflared tests: 8/8
- typecheck
- oxlint
- diff check

After merge I will rerun the existing `0.1.50` release from the new merge commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of cloudflared updates on Windows by retrying temporary directory cleanup when files are briefly locked by security software.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->