### PR TITLE
fix(acp): longer configurable handshake timeouts and guard session/load null result

### DIFF
--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -219,6 +219,7 @@ describe("ACP turns (fake CLI)", () => {
     delete process.env.FAKE_ACP_MODELS;
     delete process.env.FAKE_ACP_MODEL_STICKS;
     delete process.env.FAKE_ACP_USAGE_ROOT;
+    delete process.env.FAKE_ACP_LOAD_NULL;
     recorder?.stop();
     await instance?.dispose();
     await removeTempDir(scratch);
@@ -673,6 +674,35 @@ describe("ACP turns (fake CLI)", () => {
     // hook must fire on a resumed thread as well
     const started = await recorder.until((e) => e.type === "session.started");
     expect(started).toMatchObject({ sessionId: "resumed-thread-1", model: "m-two" });
+    const done = await recorder.until((e) => e.type === "turn.completed");
+    expect(done).toMatchObject({ ok: true });
+  });
+
+  it("reuses a resume cursor when session/load returns a session", async () => {
+    await create(GrokAgentDriver);
+    await instance.adapter.sendTurn({
+      threadId: "t-resume-truthy",
+      text: "go",
+      resumeCursor: "resumed-cursor-1",
+    });
+
+    const started = await recorder.until((e) => e.type === "session.started");
+    expect(started).toMatchObject({ sessionId: "resumed-cursor-1" });
+    const done = await recorder.until((e) => e.type === "turn.completed");
+    expect(done).toMatchObject({ ok: true });
+  });
+
+  it("falls through to session/new when session/load returns null", async () => {
+    process.env.FAKE_ACP_LOAD_NULL = "1";
+    await create(GrokAgentDriver);
+    await instance.adapter.sendTurn({
+      threadId: "t-resume-null",
+      text: "go",
+      resumeCursor: "gone-cursor",
+    });
+
+    const started = await recorder.until((e) => e.type === "session.started");
+    expect(started).toMatchObject({ sessionId: "fake-acp-session" });
     const done = await recorder.until((e) => e.type === "turn.completed");
     expect(done).toMatchObject({ ok: true });
   });

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -148,10 +148,11 @@ export interface AcpSupport {
   }): Promise<void>;
 }
 
-const INIT_TIMEOUT = 20_000;
-const SESSION_CONFIG_TIMEOUT = 20_000; // configureSession's per-request default
-const NEW_SESSION_TIMEOUT = 30_000;
-const LOAD_SESSION_TIMEOUT = 120_000; // history replay on a long thread is slow
+const envOr = (key: string, fallback: number): number => Number(process.env[key] ?? fallback);
+const INIT_TIMEOUT = envOr("OPENMAUS_ACP_INIT_TIMEOUT_MS", 300_000);
+const SESSION_CONFIG_TIMEOUT = envOr("OPENMAUS_ACP_SESSION_CONFIG_TIMEOUT_MS", 300_000); // configureSession's per-request default
+const NEW_SESSION_TIMEOUT = envOr("OPENMAUS_ACP_NEW_SESSION_TIMEOUT_MS", 300_000);
+const LOAD_SESSION_TIMEOUT = envOr("OPENMAUS_ACP_LOAD_SESSION_TIMEOUT_MS", 120_000); // history replay on a long thread is slow
 
 function decodeAcpConfig(defaultCli: string) {
   return (raw: unknown): AcpConfig => {
@@ -636,7 +637,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
                   { sessionId: cursor, cwd, mcpServers },
                   LOAD_SESSION_TIMEOUT,
                 );
-                sessionId = cursor;
+                if (sessionResult) sessionId = cursor;
               } catch {
                 /* session gone, load unsupported, or too slow — start fresh */
               }

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -5,6 +5,8 @@
 // session/prompt, and streams session/update notifications for a scripted
 // turn. Failure modes mirror how real ACP agents misbehave:
 //
+//   FAKE_ACP_LOAD_NULL  return null for session/load so the resume cursor is
+//                       ignored and the driver falls through to session/new
 //   FAKE_ACP_MODE   happy (default) | image | empty-reply | exit-early | fail-after-text | hang | no-auth | auth-required | permission
 //                   | interleave (message → tool → message → tool → message)
 //                   | no-session-config (reject session/set_mode + set_model
@@ -336,6 +338,10 @@ function handle(msg: any) {
       break;
     }
     case "session/load": {
+      if (process.env.FAKE_ACP_LOAD_NULL) {
+        result(msg.id, null);
+        break;
+      }
       const opts = configOptions();
       const mdls = sessionModels();
       result(msg.id, { ...(opts ? { configOptions: opts } : {}), ...(mdls ? { models: mdls } : {}) });


### PR DESCRIPTION
## Problem

ACP handshake timeouts (`initialize`, `session/set_config_option`, and `session/new`) were hardcoded at 20–30 s. When spawning a cold local Hermes ACP against a slow llama.cpp `llama-server`, these routinely time out even though `session/prompt` would have worked, killing the first turn.

In the same code path, `session/load` can return `null` (JSON-RPC success with `result: null`) when the session id is gone. The driver unconditionally assigned `sessionId = cursor`, so the stale cursor was preserved and the following `session/prompt` failed with a confusing "Model turn failed: refusal" in 1–2 s.

## Triage

The `session/load` bug is the minimal correctness issue; the timeout hardcoding is the higher-impact user-facing failure. There was no env/config knob for the timeouts, so users had to patch `resources/server/index.js` after every auto-update.

## Fix

- Make the four ACP handshake timeouts env-configurable:
  - `OPENMAUS_ACP_INIT_TIMEOUT_MS`
  - `OPENMAUS_ACP_SESSION_CONFIG_TIMEOUT_MS`
  - `OPENMAUS_ACP_NEW_SESSION_TIMEOUT_MS`
  - `OPENMAUS_ACP_LOAD_SESSION_TIMEOUT_MS`
- Default `initialize`, `session/set_config_option`, and `session/new` to 300 s (the reporter's working value), keeping `session/load` at 120 s.
- Only reuse the resume cursor when `session/load` returns a truthy result.
- Extend `server/testing/fake-acp-cli.ts` with `FAKE_ACP_LOAD_NULL=1`.
- Add regression tests covering both the truthy and null `session/load` responses.

## Verification

- `pnpm typecheck` passes.
- `pnpm lint` passes (existing warnings only).
- `pnpm vitest run server/drivers/acp/acp.test.ts` passes (47/47).
- `pnpm vitest run` passes except for 3 unrelated pre-existing environment failures:
  - `scripts/linux-after-install.test.mjs` (path under `/tmp`)
  - `server/control-omb.test.ts` (verification fixture `doctor` returns not ok)
  - `server/drivers/codex-catalog.test.ts` (catalog lookup)

## Notes

Fixes #715


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session resumption by falling back to a new session when an existing session cannot be loaded.
  * Increased default time limits for session initialization and creation to support longer-running operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->