### PR TITLE
feat(android): add file previews and chat attachments

### DIFF
--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/ChatPolicy.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/ChatPolicy.kt
@@ -187,7 +187,7 @@ object SearchPolicy {
  * with a task list get the same task controls as an agent. Exporting is not a
  * bot idea — a room has a transcript like anything else.
  */
-enum class ChatActionId { NEW_TASK, TASKS, WATCH_COMPUTER, SHARE_MARKDOWN, SHARE_JSON, INTERRUPT }
+enum class ChatActionId { PHOTOS, FILES, NEW_TASK, TASKS, WATCH_COMPUTER, SHARE_MARKDOWN, SHARE_JSON, INTERRUPT }
 
 data class ChatAction(
     val id: ChatActionId,
@@ -207,9 +207,24 @@ object ChatActions {
      * fresh thread over the one question on screen that only a person can
      * answer.
      */
-    fun sheet(chat: Chat, hasPendingApproval: Boolean): List<ChatAction> {
+    fun sheet(chat: Chat, hasPendingApproval: Boolean, canAddAttachment: Boolean): List<ChatAction> {
         val bot = (chat as? Chat.BotChat)?.bot
         val out = mutableListOf<ChatAction>()
+        // Attachments first, for a bot and a room alike — the order of iOS's
+        // `plusActions`. [canAddAttachment] is false at the four-item cap and
+        // while a send or an import is in flight.
+        out += ChatAction(
+            id = ChatActionId.PHOTOS,
+            title = "Photo Library",
+            subtitle = "Add a photo to this message",
+            enabled = canAddAttachment,
+        )
+        out += ChatAction(
+            id = ChatActionId.FILES,
+            title = "Choose File",
+            subtitle = "Add a document from Files",
+            enabled = canAddAttachment,
+        )
         if (bot != null) {
             out += ChatAction(
                 id = ChatActionId.NEW_TASK,
@@ -662,9 +677,11 @@ object ComposerAccessories {
         busy: Boolean,
         pendingApproval: Boolean,
         hasQuickReplies: Boolean,
+        /** A pending attachment is half a message too; a chip would send without it. */
+        hasAttachments: Boolean,
     ): ComposerAccessory = when {
         hudOpen -> ComposerAccessory.HUD
-        draft.isEmpty() && !busy && !pendingApproval && hasQuickReplies -> ComposerAccessory.CHIPS
+        draft.isEmpty() && !hasAttachments && !busy && !pendingApproval && hasQuickReplies -> ComposerAccessory.CHIPS
         else -> ComposerAccessory.NONE
     }
 }

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/ChatScreen.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/ChatScreen.kt
@@ -1,6 +1,12 @@
 package com.openmausbot.companion.ui
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.horizontalScroll
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
@@ -52,6 +58,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -71,7 +78,9 @@ import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
@@ -86,8 +95,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.openmausbot.companion.R
+import com.openmausbot.companion.core.AttachmentPolicy
 import com.openmausbot.companion.core.Chat
 import com.openmausbot.companion.core.ChatTarget
+import com.openmausbot.companion.core.LocalMessageLink
+import com.openmausbot.companion.core.PendingMessageAttachment
 import com.openmausbot.companion.core.CompanionState
 import com.openmausbot.companion.core.Dictation
 import com.openmausbot.companion.core.Message
@@ -95,7 +107,10 @@ import com.openmausbot.companion.core.TranscriptRow
 import com.openmausbot.companion.core.target
 import com.openmausbot.companion.core.transcriptRows
 import java.util.Locale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * One conversation: the transcript, the approval cards, and the composer — the
@@ -195,6 +210,107 @@ private fun LoadedChat(
     var showingProfile by rememberSaveable { mutableStateOf(false) }
     var showingPlus by remember(threadId) { mutableStateOf(false) }
     val focusManager = LocalFocusManager.current
+    val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
+
+    // Attachments waiting above the composer, and the flags iOS keeps beside
+    // them. Keyed on the conversation like the draft: a task switch inside the
+    // same chat keeps them, leaving the chat drops them.
+    val attachments = remember(chatId) { mutableStateListOf<PendingMessageAttachment>() }
+    var preparingAttachments by remember(chatId) { mutableStateOf(false) }
+    var sendingMessage by remember(chatId) { mutableStateOf(false) }
+    var attachmentError by remember(chatId) { mutableStateOf<String?>(null) }
+    // A bot-linked file on its way from the computer, and where it landed.
+    var openingFileName by remember { mutableStateOf<String?>(null) }
+    var fileOpenError by remember { mutableStateOf<String?>(null) }
+    var filePreview by remember { mutableStateOf<FilePreviewItem?>(null) }
+    var fileDownloadJob by remember { mutableStateOf<Job?>(null) }
+    val filePreviews = remember(context) { FilePreviews(context) }
+    DisposableEffect(filePreviews) {
+        onDispose {
+            fileDownloadJob?.cancel()
+            filePreviews.clear()
+        }
+    }
+    val canAddAttachment = AttachmentImportRules.canAdd(attachments.size, preparingAttachments, sendingMessage)
+
+    suspend fun importInto(count: Int, read: suspend (Int, Int) -> PendingMessageAttachment) {
+        if (preparingAttachments || sendingMessage) return
+        if (count > AttachmentPolicy.MAXIMUM_ITEMS - attachments.size) {
+            attachmentError = AttachmentImportRules.TOO_MANY
+            return
+        }
+        preparingAttachments = true
+        attachmentError = null
+        try {
+            val imported = mutableListOf<PendingMessageAttachment>()
+            for (index in 0 until count) {
+                val remaining = AttachmentImportRules.remainingBytes(attachments + imported)
+                val candidate = withContext(Dispatchers.IO) { read(index, remaining) }
+                AttachmentPolicy.validate(attachments + imported + candidate)
+                imported += candidate
+            }
+            attachments += imported
+            haptics.play(HapticCue.SELECT)
+        } catch (error: Exception) {
+            if (error is kotlinx.coroutines.CancellationException) throw error
+            attachmentError = error.message ?: "Couldn't add that attachment."
+        } finally {
+            preparingAttachments = false
+        }
+    }
+
+    val pickPhotos = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickMultipleVisualMedia(AttachmentPolicy.MAXIMUM_ITEMS),
+    ) { uris ->
+        if (uris.isEmpty()) return@rememberLauncherForActivityResult
+        scope.launch {
+            importInto(uris.size) { index, remaining ->
+                AttachmentImport.readPhoto(context.contentResolver, uris[index], index, uris.size, remaining)
+            }
+        }
+    }
+    val pickFiles = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
+        if (uris.isEmpty()) return@rememberLauncherForActivityResult
+        scope.launch {
+            importInto(uris.size) { index, remaining ->
+                AttachmentImport.readDocument(context.contentResolver, uris[index], remaining)
+            }
+        }
+    }
+
+    // A tapped link in a bot reply: the web goes to the system, a desktop path
+    // comes back through the computer, anything else is refused out loud.
+    fun openLink(url: String, message: Message) {
+        when (val target = LocalMessageLink.resolve(url)) {
+            is LocalMessageLink.Web -> runCatching { uriHandler.openUri(target.url) }
+                .onFailure { fileOpenError = "This link can't be opened on this phone." }
+            is LocalMessageLink.DesktopFile -> {
+                fileDownloadJob?.cancel()
+                fileOpenError = null
+                openingFileName = FilePreviewRules.nameForOpening(target.path)
+                fileDownloadJob = scope.launch {
+                    val downloaded = session.downloadFile(threadId, message.id, target.path)
+                    openingFileName = null
+                    if (downloaded == null) {
+                        fileOpenError = session.actionError ?: "Couldn't open that file. Try again."
+                        session.actionError = null
+                        return@launch
+                    }
+                    val item = runCatching { withContext(Dispatchers.IO) { filePreviews.store(downloaded) } }
+                        .getOrElse {
+                            fileOpenError = "The downloaded file couldn't be previewed."
+                            return@launch
+                        }
+                    when (item.kind) {
+                        FilePreviewKind.MARKDOWN, FilePreviewKind.TEXT -> filePreview = item
+                        FilePreviewKind.OTHER -> filePreviews.openWithSystem(item)?.let { fileOpenError = it }
+                    }
+                }
+            }
+            null -> fileOpenError = "This link can't be opened securely."
+        }
+    }
     val focusedMessageId by session.focusedMessageId.collectAsState()
 
     val dictationListening by dictation.isListening.collectAsState()
@@ -384,6 +500,12 @@ private fun LoadedChat(
     // there is — including both export formats.
     val onAction: (ChatActionId) -> Unit = { action ->
         when (action) {
+            ChatActionId.PHOTOS -> pickPhotos.launch(
+                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+            )
+            ChatActionId.FILES -> pickFiles.launch(
+                (AttachmentPolicy.IMAGE_MIME_TYPES + AttachmentPolicy.DOCUMENT_MIME_TYPES).toTypedArray(),
+            )
             ChatActionId.NEW_TASK -> scope.launch {
                 when (chat) {
                     is Chat.BotChat -> session.createTask(chat.bot, null)
@@ -423,6 +545,34 @@ private fun LoadedChat(
         // microphone after the message has already been sent.
         dictation.stop()
         val text = (explicitText ?: draft).trim()
+        // With attachments waiting, the message is the attachments plus
+        // whatever was typed; the draft is cleared only once they are sent.
+        if (attachments.isNotEmpty()) {
+            if (preparingAttachments || sendingMessage) return
+            val outgoing = attachments.toList()
+            val draftAtSend = draft
+            sendingMessage = true
+            attachmentError = null
+            showingPlus = false
+            scope.launch {
+                val sent = session.send(text, outgoing, chat)
+                sendingMessage = false
+                if (!sent) {
+                    attachmentError = session.actionError ?: "Couldn't send this message. Try again."
+                    session.actionError = null
+                    return@launch
+                }
+                // Compare with what was in the field at tap time, so a newer
+                // edit made while uploading survives the clear.
+                if (draft == draftAtSend) {
+                    composer.onSend()
+                    publishFrom(composer)
+                }
+                if (attachments.map { it.id } == outgoing.map { it.id }) attachments.clear()
+                haptics.play(HapticCue.SEND)
+            }
+            return
+        }
         if (text.isEmpty()) return
         composer.onSend()
         // Clearing the draft closes the HUD through the rule above, which is
@@ -574,6 +724,7 @@ private fun LoadedChat(
                                     // One tail per run of bubbles from the same author,
                                     // not one per bubble.
                                     endsRun = TranscriptLayout.endsRowRun(transcript, index),
+                                    openLink = ::openLink,
                                 )
                                 is TranscriptRow.ActivityRun -> ActivityRunChip(message.items)
                             }
@@ -628,6 +779,7 @@ private fun LoadedChat(
                     busy = chat.busy,
                     pendingApproval = pendingApproval,
                     hasQuickReplies = predictiveChips.isNotEmpty(),
+                    hasAttachments = attachments.isNotEmpty(),
                 ),
                 commands = commands,
                 chips = predictiveChips,
@@ -635,6 +787,21 @@ private fun LoadedChat(
                 dictationListening = dictationListening,
                 dictationLocked = dictationLocked,
                 dictationError = dictationError,
+                attachments = attachments,
+                sending = sendingMessage,
+                preparing = preparingAttachments,
+                openingFileName = openingFileName,
+                attachmentError = fileOpenError ?: attachmentError,
+                onRemoveAttachment = { attachment ->
+                    if (!preparingAttachments && !sendingMessage) {
+                        attachments.removeAll { it.id == attachment.id }
+                        attachmentError = null
+                    }
+                },
+                onDismissError = {
+                    fileOpenError = null
+                    attachmentError = null
+                },
                 onTogglePlus = {
                     // iOS drops the composer's focus before the sheet rises; a
                     // keyboard under it would leave the sheet nowhere to go.
@@ -671,8 +838,8 @@ private fun LoadedChat(
 
         PlusSheet(
             open = showingPlus,
-            actions = remember(chat, pendingApproval) {
-                ChatActions.sheet(chat, hasPendingApproval = pendingApproval)
+            actions = remember(chat, pendingApproval, canAddAttachment) {
+                ChatActions.sheet(chat, hasPendingApproval = pendingApproval, canAddAttachment = canAddAttachment)
             },
             onDismiss = { showingPlus = false },
             onAction = {
@@ -688,6 +855,10 @@ private fun LoadedChat(
 
     if (showingProfile && bot != null) {
         AgentProfileSheet(bot = bot, onDismiss = { showingProfile = false })
+    }
+
+    filePreview?.let { item ->
+        FilePreviewSheet(item = item, onDismiss = { filePreview = null })
     }
 }
 
@@ -997,6 +1168,22 @@ private val PLUS_SHEET_RADIUS = 28.dp
 /** The + becomes an ×. */
 private const val PLUS_TURN_DEGREES = 45f
 
+/** A quiet progress line above the field — `ProgressView` plus a caption on iOS. */
+@Composable
+private fun ComposerStatusLine(text: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp)
+            .semantics(mergeDescendants = true) { },
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        CircularProgressIndicator(modifier = Modifier.size(14.dp), strokeWidth = 2.dp)
+        Text(text = text, fontSize = 13.sp, fontWeight = FontWeight.Medium, color = secondaryTint, maxLines = 1)
+    }
+}
+
 /**
  * The glyph beside an action. Decorative: the row's own text is the label, and
  * TalkBack reading the icon too would say everything twice.
@@ -1005,6 +1192,10 @@ private const val PLUS_TURN_DEGREES = 45f
 private fun ChatActionIcon(id: ChatActionId, tint: Color) {
     val modifier = Modifier.size(22.dp)
     when (id) {
+        ChatActionId.PHOTOS ->
+            Icon(painterResource(R.drawable.ic_photo), null, tint = tint, modifier = modifier)
+        ChatActionId.FILES ->
+            Icon(painterResource(R.drawable.ic_attach_file), null, tint = tint, modifier = modifier)
         ChatActionId.NEW_TASK ->
             Icon(Icons.Filled.Add, null, tint = tint, modifier = modifier)
         ChatActionId.TASKS ->
@@ -1038,8 +1229,16 @@ private fun Composer(
     onSelectCommand: (SlashCommand) -> Unit,
     chips: List<PredictiveChip>,
     onSelectChip: (PredictiveChip) -> Unit,
+    attachments: List<PendingMessageAttachment>,
+    sending: Boolean,
+    preparing: Boolean,
+    openingFileName: String?,
+    attachmentError: String?,
+    onRemoveAttachment: (PendingMessageAttachment) -> Unit,
+    onDismissError: () -> Unit,
 ) {
-    val canSend = draft.isNotBlank()
+    val canSend = AttachmentImportRules.canSend(draft, attachments.size, preparing, sending)
+    val inFlight = preparing || sending
     // Held as the state rather than unwrapped with `by`: read inside the layer
     // block, the turn is a new frame, not a new composition of the composer.
     val turn = animateFloatAsState(
@@ -1060,6 +1259,60 @@ private fun Composer(
                 color = Color(0xFFFF9800),
                 modifier = Modifier.padding(horizontal = 4.dp),
             )
+        }
+        // What is in flight, in the order iOS stacks them: the send or the
+        // import, then a file on its way, then whatever went wrong.
+        if (inFlight) {
+            ComposerStatusLine(if (preparing) "Preparing attachments…" else "Sending…")
+        }
+        if (openingFileName != null) {
+            ComposerStatusLine("Opening $openingFileName…")
+        }
+        if (attachmentError != null) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color(0xFFFF9800).copy(alpha = 0.12f), RoundedCornerShape(12.dp))
+                    .padding(horizontal = 12.dp, vertical = 9.dp)
+                    .semantics(mergeDescendants = true) { },
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Warning,
+                    contentDescription = null,
+                    tint = Color(0xFFFF9800),
+                    modifier = Modifier.size(18.dp),
+                )
+                Text(text = attachmentError, fontSize = 13.sp, modifier = Modifier.weight(1f))
+                Text(
+                    text = "Dismiss",
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(8.dp))
+                        .clickable(role = Role.Button, onClick = onDismissError)
+                        .padding(horizontal = 6.dp, vertical = 4.dp),
+                )
+            }
+        }
+        if (attachments.isNotEmpty()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+                    .padding(horizontal = 2.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                attachments.forEach { attachment ->
+                    PendingAttachmentChip(
+                        attachment = attachment,
+                        enabled = !inFlight,
+                        onRemove = { onRemoveAttachment(attachment) },
+                    )
+                }
+            }
         }
         // One or the other, never both: the HUD is what the composer is doing
         // right now, and a row of send-immediately chips under it would be a
@@ -1156,7 +1409,11 @@ private fun Composer(
                 ) {
                     if (draft.isEmpty()) {
                         Text(
-                            text = if (dictationListening) "Listening…" else "Ask $name",
+                            text = when {
+                                sending -> "Sending…"
+                                dictationListening -> "Listening…"
+                                else -> "Ask $name"
+                            },
                             fontSize = 17.sp,
                             color = secondaryTint,
                         )

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/ComposerAttachments.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/ComposerAttachments.kt
@@ -1,0 +1,324 @@
+package com.openmausbot.companion.ui
+
+import android.content.ContentResolver
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.provider.OpenableColumns
+import android.webkit.MimeTypeMap
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.openmausbot.companion.R
+import com.openmausbot.companion.core.AttachmentPolicy
+import com.openmausbot.companion.core.PendingMessageAttachment
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.util.Locale
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * What the composer decides about attachments, with no Android in it — the
+ * rules half of the attachment code `ios/App/ChatView.swift` gained in #695.
+ */
+object AttachmentImportRules {
+    const val TOO_MANY: String = "Send up to ${AttachmentPolicy.MAXIMUM_ITEMS} items at a time."
+
+    fun unreadable(name: String): String = "OpenMausBot couldn't read $name. Try exporting it to Files first."
+
+    fun unsupported(name: String): String =
+        "$name isn't a supported attachment. Try an image, PDF, text, Word, Excel, or PowerPoint file."
+
+    fun tooLarge(name: String, limitBytes: Int): String =
+        "$name is larger than the ${formatBytes(limitBytes.toLong())} remaining attachment limit."
+
+    /** `Photo.jpg` for one, `Photo 2.jpg` for the second of several. */
+    fun photoName(index: Int, count: Int, extension: String): String =
+        if (count == 1) "Photo.$extension" else "Photo ${index + 1}.$extension"
+
+    fun extensionForImageMime(mime: String): String = when (AttachmentPolicy.normalizedMime(mime)) {
+        "image/png" -> "png"
+        "image/gif" -> "gif"
+        "image/webp" -> "webp"
+        else -> "jpg"
+    }
+
+    /** Whatever the 50 MB total has left after what is already attached. */
+    fun remainingBytes(attached: List<PendingMessageAttachment>): Int =
+        max(0, AttachmentPolicy.MAXIMUM_TOTAL_BYTES - attached.sumOf { it.data.size })
+
+    /** The most one more item of this kind may read: its own cap, or the total's remainder. */
+    fun readLimit(kind: PendingMessageAttachment.Kind, remainingBytes: Int): Int {
+        val itemLimit = when (kind) {
+            PendingMessageAttachment.Kind.IMAGE -> AttachmentPolicy.MAXIMUM_IMAGE_BYTES
+            PendingMessageAttachment.Kind.FILE -> AttachmentPolicy.MAXIMUM_FILE_BYTES
+        }
+        return min(itemLimit, remainingBytes)
+    }
+
+    fun canAdd(attached: Int, preparing: Boolean, sending: Boolean): Boolean =
+        attached < AttachmentPolicy.MAXIMUM_ITEMS && !preparing && !sending
+
+    /** `canSend` in the Swift: text or an attachment, and nothing in flight. */
+    fun canSend(draft: String, attached: Int, preparing: Boolean, sending: Boolean): Boolean =
+        (draft.isNotBlank() || attached > 0) && !preparing && !sending
+
+    /** `ByteCountFormatter` with `.file`: KB/MB with one decimal, bytes below a kilobyte. */
+    fun formatBytes(bytes: Long): String = when {
+        bytes < 1_000 -> "$bytes bytes"
+        bytes < 1_000_000 -> String.format(Locale.ROOT, "%.0f KB", bytes / 1_000.0)
+        bytes < 1_000_000_000 -> String.format(Locale.ROOT, "%.1f MB", bytes / 1_000_000.0)
+        else -> String.format(Locale.ROOT, "%.2f GB", bytes / 1_000_000_000.0)
+    }
+}
+
+class AttachmentImportException(message: String) : Exception(message)
+
+/**
+ * Reading what the pickers hand back into app-owned bytes. Every read is
+ * bounded by what the policy has room for: a provider can lie about a size, so
+ * the stream is read one byte past the allowance and refused, never trusted.
+ */
+object AttachmentImport {
+    private const val PHOTO_MAX_PIXELS = 3_072
+
+    /** A document (or an image) from the system file picker. */
+    fun readDocument(resolver: ContentResolver, uri: Uri, remainingBytes: Int): PendingMessageAttachment {
+        val name = safeName(displayName(resolver, uri) ?: "that file")
+        val mime = AttachmentPolicy.normalizedMime(
+            resolver.getType(uri)?.takeIf { it.isNotBlank() && it != "*/*" }
+                ?: mimeForName(name)
+                ?: "application/octet-stream",
+        )
+        val kind = AttachmentPolicy.kindForMime(mime) ?: throw AttachmentImportException(AttachmentImportRules.unsupported(name))
+        val limit = AttachmentImportRules.readLimit(kind, remainingBytes)
+        val data = readBounded(resolver, uri, limit)
+            ?: throw AttachmentImportException(AttachmentImportRules.tooLarge(name, limit))
+        if (data.isEmpty()) throw AttachmentImportException(AttachmentImportRules.unreadable(name))
+        return PendingMessageAttachment(data = data, name = name, mime = mime, kind = kind)
+    }
+
+    /**
+     * A picture from the photo picker. A supported type within its limit
+     * travels as it is; anything else — HEIC, a 40 MB PNG — is re-encoded as
+     * JPEG the way the Share target does, so the picker never refuses a photo
+     * the computer could have shown.
+     */
+    fun readPhoto(
+        resolver: ContentResolver,
+        uri: Uri,
+        index: Int,
+        count: Int,
+        remainingBytes: Int,
+    ): PendingMessageAttachment {
+        val label = if (count == 1) "that photo" else "photo ${index + 1}"
+        val declared = AttachmentPolicy.normalizedMime(resolver.getType(uri).orEmpty())
+        val limit = AttachmentImportRules.readLimit(PendingMessageAttachment.Kind.IMAGE, remainingBytes)
+        val raw = readBounded(resolver, uri, limit)
+        if (raw != null && raw.isNotEmpty() && declared in AttachmentPolicy.IMAGE_MIME_TYPES) {
+            val extension = AttachmentImportRules.extensionForImageMime(declared)
+            return PendingMessageAttachment(
+                data = raw,
+                name = AttachmentImportRules.photoName(index, count, extension),
+                mime = declared,
+                kind = PendingMessageAttachment.Kind.IMAGE,
+            )
+        }
+        val jpeg = transcodeJpeg(resolver, uri)
+            ?: throw AttachmentImportException(AttachmentImportRules.unsupported(label))
+        if (jpeg.size > limit) throw AttachmentImportException(AttachmentImportRules.tooLarge(label, limit))
+        return PendingMessageAttachment(
+            data = jpeg,
+            name = AttachmentImportRules.photoName(index, count, "jpg"),
+            mime = "image/jpeg",
+            kind = PendingMessageAttachment.Kind.IMAGE,
+        )
+    }
+
+    /** The bytes, or null when the stream runs past [limit]. */
+    private fun readBounded(resolver: ContentResolver, uri: Uri, limit: Int): ByteArray? {
+        val input = runCatching { resolver.openInputStream(uri) }.getOrNull() ?: return ByteArray(0)
+        input.use { source ->
+            val out = ByteArrayOutputStream()
+            val buffer = ByteArray(64 * 1_024)
+            var copied = 0
+            while (true) {
+                val read = source.read(buffer)
+                if (read < 0) break
+                if (copied + read > limit) return null
+                out.write(buffer, 0, read)
+                copied += read
+            }
+            return out.toByteArray()
+        }
+    }
+
+    private fun transcodeJpeg(resolver: ContentResolver, uri: Uri): ByteArray? {
+        fun open(): InputStream? = runCatching { resolver.openInputStream(uri) }.getOrNull()
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        open()?.use { BitmapFactory.decodeStream(it, null, bounds) } ?: return null
+        if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
+        var sample = 1
+        while (max(bounds.outWidth, bounds.outHeight) / sample > PHOTO_MAX_PIXELS) sample *= 2
+        val bitmap = open()?.use {
+            BitmapFactory.decodeStream(it, null, BitmapFactory.Options().apply { inSampleSize = sample })
+        } ?: return null
+        val out = ByteArrayOutputStream()
+        val written = bitmap.compress(Bitmap.CompressFormat.JPEG, 90, out)
+        bitmap.recycle()
+        return if (written) out.toByteArray() else null
+    }
+
+    private fun displayName(resolver: ContentResolver, uri: Uri): String? {
+        if (uri.scheme == ContentResolver.SCHEME_FILE) return uri.lastPathSegment
+        val cursor = runCatching {
+            resolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+        }.getOrNull()
+        cursor?.use {
+            if (it.moveToFirst()) {
+                val column = it.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (column >= 0) it.getString(column)?.let { name -> return name }
+            }
+        }
+        return uri.lastPathSegment
+    }
+
+    private fun mimeForName(name: String): String? {
+        val extension = name.substringAfterLast('.', "").lowercase()
+        if (extension.isEmpty()) return null
+        return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+            ?: SharePolicy.mimeForExtension(extension)
+    }
+
+    private fun safeName(raw: String): String {
+        val trimmed = raw.substringAfterLast('/').substringAfterLast('\\').trim()
+        val cleaned = trimmed.map { if (it.isISOControl()) ' ' else it }.joinToString("").ifBlank { "file" }
+        return cleaned.take(180)
+    }
+}
+
+/** One attachment waiting above the composer — `PendingAttachmentChip` in `AttachmentViews.swift`. */
+@Composable
+internal fun PendingAttachmentChip(
+    attachment: PendingMessageAttachment,
+    enabled: Boolean,
+    onRemove: () -> Unit,
+) {
+    val outline = secondaryTint.copy(alpha = 0.10f)
+    Row(
+        modifier = Modifier
+            .widthIn(max = 280.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(outline)
+            .border(1.dp, outline, RoundedCornerShape(14.dp))
+            .padding(start = 7.dp, end = 6.dp, top = 6.dp, bottom = 6.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AttachmentThumbnail(attachment)
+        Column(modifier = Modifier.weight(1f, fill = false), verticalArrangement = Arrangement.spacedBy(1.dp)) {
+            Text(
+                text = attachment.name,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = AttachmentImportRules.formatBytes(attachment.data.size.toLong()),
+                fontSize = 11.sp,
+                color = secondaryTint,
+            )
+        }
+        TouchTarget(
+            onClick = onRemove,
+            enabled = enabled,
+            contentDescription = "Remove ${attachment.name}",
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(24.dp)
+                    .background(secondaryTint.copy(alpha = 0.12f), CircleShape),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Close,
+                    contentDescription = null,
+                    tint = secondaryTint,
+                    modifier = Modifier.size(12.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AttachmentThumbnail(attachment: PendingMessageAttachment) {
+    val shape = RoundedCornerShape(8.dp)
+    val bitmap = remember(attachment.id) {
+        if (attachment.kind != PendingMessageAttachment.Kind.IMAGE) return@remember null
+        runCatching {
+            val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            BitmapFactory.decodeByteArray(attachment.data, 0, attachment.data.size, bounds)
+            var sample = 1
+            while (max(bounds.outWidth, bounds.outHeight) / sample > 256) sample *= 2
+            BitmapFactory.decodeByteArray(
+                attachment.data,
+                0,
+                attachment.data.size,
+                BitmapFactory.Options().apply { inSampleSize = sample },
+            )?.asImageBitmap()
+        }.getOrNull()
+    }
+    if (bitmap != null) {
+        Image(
+            bitmap = bitmap,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.size(34.dp).clip(shape).semantics { contentDescription = "" },
+        )
+    } else {
+        Box(
+            modifier = Modifier
+                .size(34.dp)
+                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f), shape),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_attach_file),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/FilePreview.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/FilePreview.kt
@@ -1,0 +1,176 @@
+package com.openmausbot.companion.ui
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.content.FileProvider
+import com.openmausbot.companion.core.DownloadedFile
+import java.io.File
+import java.util.UUID
+
+/** How a downloaded file is shown — `FilePreviewItem.Kind` in `AttachmentViews.swift`. */
+enum class FilePreviewKind {
+    /** Rendered in the app, the way a bot reply is. */
+    MARKDOWN,
+    /** Monospace, in the app. */
+    TEXT,
+    /** Handed to whatever app opens it — Android's Quick Look. */
+    OTHER,
+}
+
+object FilePreviewRules {
+    /** iOS reads 2 MB of a text file into the preview and says so. */
+    const val TEXT_LIMIT_BYTES: Int = 2 * 1_024 * 1_024
+    const val TRUNCATED_NOTE: String = "\n\n— Preview truncated. Share or open the file to read the rest. —"
+
+    fun kind(contentType: String, filename: String): FilePreviewKind {
+        val mime = contentType.lowercase()
+        val suffix = filename.substringAfterLast('.', "").lowercase()
+        if (mime == "text/markdown" || suffix == "md" || suffix == "markdown") return FilePreviewKind.MARKDOWN
+        if (mime.startsWith("text/") || mime == "application/json") return FilePreviewKind.TEXT
+        return FilePreviewKind.OTHER
+    }
+
+    fun text(data: ByteArray): String {
+        val visible = if (data.size > TEXT_LIMIT_BYTES) data.copyOf(TEXT_LIMIT_BYTES) else data
+        val decoded = visible.toString(Charsets.UTF_8)
+        return if (data.size > TEXT_LIMIT_BYTES) decoded + TRUNCATED_NOTE else decoded
+    }
+
+    /** The name a bot's link points at, for the "Opening…" line. */
+    fun nameForOpening(path: String): String =
+        path.split('/', '\\').lastOrNull { it.isNotEmpty() }?.take(180) ?: "file"
+
+    fun noViewer(filename: String): String = "No app on this phone can open $filename."
+}
+
+/** A downloaded file, on disk and in memory, ready to show. */
+class FilePreviewItem(
+    val file: File,
+    val filename: String,
+    val contentType: String,
+    val data: ByteArray,
+) {
+    val kind: FilePreviewKind get() = FilePreviewRules.kind(contentType, filename)
+}
+
+/**
+ * Where downloaded files live while they are on screen: one directory per
+ * download under the app's cache, reachable through the FileProvider so a
+ * viewer app can read exactly that file and nothing else. Only the most recent
+ * is kept, and a replacement is written completely before the previous one is
+ * removed, so a failed download cannot invalidate the file currently shown.
+ */
+class FilePreviews(private val context: Context) {
+    private val root: File get() = File(context.cacheDir, ROOT)
+    private var current: File? = null
+
+    /** Called once at launch: whatever a previous process left behind goes. */
+    fun removeStale() {
+        root.deleteRecursively()
+    }
+
+    fun store(download: DownloadedFile): FilePreviewItem {
+        val directory = File(root, UUID.randomUUID().toString()).apply { mkdirs() }
+        val file = File(directory, download.filename)
+        try {
+            file.writeBytes(download.data)
+        } catch (error: Throwable) {
+            directory.deleteRecursively()
+            throw error
+        }
+        current?.deleteRecursively()
+        current = directory
+        return FilePreviewItem(file, download.filename, download.contentType, download.data)
+    }
+
+    fun clear() {
+        current?.deleteRecursively()
+        current = null
+    }
+
+    /** Hand the file to the system. Returns the sentence to show when nothing will take it. */
+    fun openWithSystem(item: FilePreviewItem): String? {
+        val uri = FileProvider.getUriForFile(context, "${context.packageName}.$AUTHORITY_SUFFIX", item.file)
+        val intent = Intent(Intent.ACTION_VIEW)
+            .setDataAndType(uri, item.contentType)
+            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        val chooser = Intent.createChooser(intent, item.filename).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        return try {
+            context.startActivity(chooser)
+            null
+        } catch (_: ActivityNotFoundException) {
+            FilePreviewRules.noViewer(item.filename)
+        }
+    }
+
+    companion object {
+        const val ROOT = "file-previews"
+        const val AUTHORITY_SUFFIX = "transcripts"
+    }
+}
+
+/** Markdown and text, shown in the app — `FilePreviewView`'s two in-app arms. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun FilePreviewSheet(item: FilePreviewItem, onDismiss: () -> Unit) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp)) {
+                TextButton(onClick = onDismiss, modifier = Modifier.align(Alignment.CenterStart)) { Text("Done") }
+                Text(
+                    text = item.filename,
+                    fontSize = 17.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.align(Alignment.Center).padding(horizontal = 72.dp),
+                )
+            }
+            val text = FilePreviewRules.text(item.data)
+            SelectionContainer {
+                when (item.kind) {
+                    FilePreviewKind.MARKDOWN -> MarkdownText(
+                        source = text,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .verticalScroll(rememberScrollState())
+                            .padding(20.dp),
+                    )
+                    else -> Text(
+                        text = text,
+                        fontSize = 14.sp,
+                        fontFamily = FontFamily.Monospace,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .verticalScroll(rememberScrollState())
+                            .horizontalScroll(rememberScrollState())
+                            .padding(20.dp),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/MarkdownText.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/MarkdownText.kt
@@ -19,11 +19,14 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.LinkInteractionListener
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.buildAnnotatedString
@@ -61,14 +64,25 @@ fun MarkdownText(
      * in a list item.
      */
     caret: Boolean = false,
+    /**
+     * Where a tapped link goes. Null hands every link to the system; a chat
+     * supplies this so a bot's desktop path is fetched through the computer
+     * instead of handed to a browser that cannot reach it.
+     */
+    openLink: ((String) -> Unit)? = null,
 ) {
     val blocks = Markdown.blocks(source)
-    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        blocks.forEachIndexed { index, block ->
-            MarkdownBlockView(block, tail = caret && index == blocks.lastIndex)
+    CompositionLocalProvider(LocalLinkOpener provides openLink) {
+        Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            blocks.forEachIndexed { index, block ->
+                MarkdownBlockView(block, tail = caret && index == blocks.lastIndex)
+            }
         }
     }
 }
+
+/** The opener [MarkdownText] was given, reachable from every block's inline run. */
+private val LocalLinkOpener = compositionLocalOf<((String) -> Unit)?> { null }
 
 @Composable
 private fun MarkdownBlockView(block: MarkdownBlock, tail: Boolean) {
@@ -166,6 +180,7 @@ private fun MarkerRow(symbol: String, indent: Int, text: String, tail: Boolean, 
 @Composable
 private fun inline(text: String, tail: Boolean, muted: Color): AnnotatedString {
     val linkColor = MaterialTheme.colorScheme.primary
+    val opener = LocalLinkOpener.current
     return buildAnnotatedString {
         for (span in InlineMarkdown.parse(text)) {
             val style = SpanStyle(
@@ -190,6 +205,8 @@ private fun inline(text: String, tail: Boolean, muted: Color): AnnotatedString {
                                 textDecoration = TextDecoration.Underline,
                             ),
                         ),
+                        // With an opener the UriHandler is never consulted.
+                        linkInteractionListener = opener?.let { open -> LinkInteractionListener { open(url) } },
                     ),
                 ) { append(span.text) }
             }

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/MessageRow.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/MessageRow.kt
@@ -94,7 +94,13 @@ private const val MESSAGE_CLIP_LABEL = "OpenMausMobile message"
  * never has to look at its neighbours.
  */
 @Composable
-fun MessageRow(chat: Chat, message: Message, endsRun: Boolean = true) {
+fun MessageRow(
+    chat: Chat,
+    message: Message,
+    endsRun: Boolean = true,
+    /** Where a tapped link in a bot reply goes; null leaves it to the system. */
+    openLink: ((String, Message) -> Unit)? = null,
+) {
     val session = LocalCompanion.current.session
     val scope = rememberCoroutineScope()
     val haptics = rememberHaptics()
@@ -127,7 +133,7 @@ fun MessageRow(chat: Chat, message: Message, endsRun: Boolean = true) {
             horizontalAlignment = if (mine) Alignment.End else Alignment.Start,
             verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
-            MessageContent(chat = chat, message = message, endsRun = endsRun, haptics = haptics)
+            MessageContent(chat = chat, message = message, endsRun = endsRun, haptics = haptics, openLink = openLink)
 
             message.comm?.let {
                 Text(
@@ -357,9 +363,15 @@ private fun SelectableTextDialog(text: String, onDismiss: () -> Unit) {
 }
 
 @Composable
-private fun MessageContent(chat: Chat, message: Message, endsRun: Boolean, haptics: Haptics) {
+private fun MessageContent(
+    chat: Chat,
+    message: Message,
+    endsRun: Boolean,
+    haptics: Haptics,
+    openLink: ((String, Message) -> Unit)?,
+) {
     when (message.kind) {
-        Message.Kind.TEXT -> TextBubble(message, endsRun)
+        Message.Kind.TEXT -> TextBubble(message, endsRun, openLink)
         Message.Kind.OPTIONS -> CardView(chat, message, haptics)
         Message.Kind.ACTIVITY -> ActivityChip(message.tool)
         Message.Kind.SCREEN -> ScreenShot(chat.threadId, message)
@@ -368,12 +380,12 @@ private fun MessageContent(chat: Chat, message: Message, endsRun: Boolean, hapti
         // always better than a gap in the transcript. When there is nothing to
         // show, show nothing — a placeholder saying "unsupported" is a worse gap
         // than the gap.
-        Message.Kind.UNKNOWN -> if (!message.text.isNullOrEmpty()) TextBubble(message, endsRun)
+        Message.Kind.UNKNOWN -> if (!message.text.isNullOrEmpty()) TextBubble(message, endsRun, openLink)
     }
 }
 
 @Composable
-private fun TextBubble(message: Message, endsRun: Boolean) {
+private fun TextBubble(message: Message, endsRun: Boolean, openLink: ((String, Message) -> Unit)?) {
     val mine = message.role == Message.Role.USER
     val tail = TranscriptLayout.tail(message, endsRun)
     // A reply that is *entirely* a patch or a table is drawn as one. The gate is
@@ -451,7 +463,10 @@ private fun TextBubble(message: Message, endsRun: Boolean) {
                             }
                         }
                     } else {
-                        MarkdownText(source = message.text.orEmpty())
+                        MarkdownText(
+                            source = message.text.orEmpty(),
+                            openLink = openLink?.let { open -> { url -> open(url, message) } },
+                        )
                     }
                 }
             }

--- a/android/app/src/main/res/drawable/ic_attach_file.xml
+++ b/android/app/src/main/res/drawable/ic_attach_file.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- A paperclip, for the composer's "Choose File" action and the pending-file chip. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M16.5,6v11.5c0,2.21 -1.79,4 -4,4s-4,-1.79 -4,-4V5c0,-1.38 1.12,-2.5 2.5,-2.5s2.5,1.12 2.5,2.5v10.5c0,0.55 -0.45,1 -1,1s-1,-0.45 -1,-1V6H10v9.5c0,1.38 1.12,2.5 2.5,2.5s2.5,-1.12 2.5,-2.5V5c0,-2.21 -1.79,-4 -4,-4S7,2.79 7,5v12.5c0,3.04 2.46,5.5 5.5,5.5s5.5,-2.46 5.5,-5.5V6h-1.5z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_photo.xml
+++ b/android/app/src/main/res/drawable/ic_photo.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  A photo, for the composer's "Photo Library" action. Drawn here for the same
+  reason `ic_mic.xml` is: the core icon set has no image glyph.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z" />
+</vector>

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -9,4 +9,11 @@
     <cache-path
         name="shared-transcripts"
         path="shared-transcripts/" />
+    <!--
+      Files a bot linked, downloaded for viewing. FilePreviews keeps at most
+      the most recent one, in its own directory, and empties the rest.
+    -->
+    <cache-path
+        name="file-previews"
+        path="file-previews/" />
 </paths>

--- a/android/app/src/test/kotlin/com/openmausbot/companion/ui/AttachmentRulesTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/ui/AttachmentRulesTest.kt
@@ -1,0 +1,101 @@
+package com.openmausbot.companion.ui
+
+import com.openmausbot.companion.core.AttachmentPolicy
+import com.openmausbot.companion.core.PendingMessageAttachment
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * What the composer decides about attachments and downloaded files, read off
+ * `ios/App/ChatView.swift` (#695) and `AttachmentViews.swift`.
+ */
+class AttachmentRulesTest {
+    private fun pending(bytes: Int, kind: PendingMessageAttachment.Kind = PendingMessageAttachment.Kind.FILE) =
+        PendingMessageAttachment(data = ByteArray(bytes), name = "a.txt", mime = "text/plain", kind = kind)
+
+    @Test
+    fun `photos are named for their count`() {
+        assertEquals("Photo.jpg", AttachmentImportRules.photoName(0, 1, "jpg"))
+        assertEquals("Photo 1.png", AttachmentImportRules.photoName(0, 2, "png"))
+        assertEquals("Photo 2.png", AttachmentImportRules.photoName(1, 2, "png"))
+        assertEquals("webp", AttachmentImportRules.extensionForImageMime("image/webp"))
+        assertEquals("jpg", AttachmentImportRules.extensionForImageMime("image/heic"))
+    }
+
+    @Test
+    fun `a read is bounded by the item cap or the total's remainder, whichever is smaller`() {
+        assertEquals(AttachmentPolicy.MAXIMUM_TOTAL_BYTES, AttachmentImportRules.remainingBytes(emptyList()))
+        assertEquals(AttachmentPolicy.MAXIMUM_TOTAL_BYTES - 1_000, AttachmentImportRules.remainingBytes(listOf(pending(1_000))))
+        assertEquals(AttachmentPolicy.MAXIMUM_IMAGE_BYTES, AttachmentImportRules.readLimit(PendingMessageAttachment.Kind.IMAGE, Int.MAX_VALUE))
+        assertEquals(AttachmentPolicy.MAXIMUM_FILE_BYTES, AttachmentImportRules.readLimit(PendingMessageAttachment.Kind.FILE, Int.MAX_VALUE))
+        assertEquals(500, AttachmentImportRules.readLimit(PendingMessageAttachment.Kind.FILE, 500))
+    }
+
+    @Test
+    fun `adding stops at four and while anything is in flight`() {
+        assertTrue(AttachmentImportRules.canAdd(3, preparing = false, sending = false))
+        assertFalse(AttachmentImportRules.canAdd(4, preparing = false, sending = false))
+        assertFalse(AttachmentImportRules.canAdd(0, preparing = true, sending = false))
+        assertFalse(AttachmentImportRules.canAdd(0, preparing = false, sending = true))
+    }
+
+    @Test
+    fun `sending needs text or an attachment, and nothing in flight`() {
+        assertFalse(AttachmentImportRules.canSend("  ", 0, preparing = false, sending = false))
+        assertTrue(AttachmentImportRules.canSend("hi", 0, preparing = false, sending = false))
+        assertTrue(AttachmentImportRules.canSend("", 1, preparing = false, sending = false))
+        assertFalse(AttachmentImportRules.canSend("hi", 1, preparing = true, sending = false))
+        assertFalse(AttachmentImportRules.canSend("hi", 1, preparing = false, sending = true))
+    }
+
+    @Test
+    fun `sizes read the way the Swift's byte formatter prints them`() {
+        assertEquals("512 bytes", AttachmentImportRules.formatBytes(512))
+        assertEquals("48 KB", AttachmentImportRules.formatBytes(48_000))
+        assertEquals("1.2 MB", AttachmentImportRules.formatBytes(1_200_000))
+        assertEquals("a.txt is larger than the 25.0 MB remaining attachment limit.", AttachmentImportRules.tooLarge("a.txt", 25_000_000))
+    }
+
+    @Test
+    fun `a downloaded file is shown by its type, then its suffix`() {
+        assertEquals(FilePreviewKind.MARKDOWN, FilePreviewRules.kind("text/markdown", "x.bin"))
+        assertEquals(FilePreviewKind.MARKDOWN, FilePreviewRules.kind("application/octet-stream", "README.md"))
+        assertEquals(FilePreviewKind.TEXT, FilePreviewRules.kind("text/plain", "notes"))
+        assertEquals(FilePreviewKind.TEXT, FilePreviewRules.kind("application/json", "data.json"))
+        assertEquals(FilePreviewKind.OTHER, FilePreviewRules.kind("application/pdf", "report.pdf"))
+        assertEquals("report.pdf", FilePreviewRules.nameForOpening("/Users/x/report.pdf"))
+        assertEquals("report.pdf", FilePreviewRules.nameForOpening("""C:\Users\x\report.pdf"""))
+    }
+
+    @Test
+    fun `a text preview is cut at two megabytes and says so`() {
+        val small = "hello".toByteArray()
+        assertEquals("hello", FilePreviewRules.text(small))
+        val large = ByteArray(FilePreviewRules.TEXT_LIMIT_BYTES + 1) { 'a'.code.toByte() }
+        val text = FilePreviewRules.text(large)
+        assertTrue(text.endsWith(FilePreviewRules.TRUNCATED_NOTE))
+        assertEquals(FilePreviewRules.TEXT_LIMIT_BYTES, text.length - FilePreviewRules.TRUNCATED_NOTE.length)
+    }
+
+    @Test
+    fun `a pending attachment hides the chips the way a draft does`() {
+        assertEquals(
+            ComposerAccessory.NONE,
+            ComposerAccessories.accessory(hudOpen = false, draft = "", busy = false, pendingApproval = false, hasQuickReplies = true, hasAttachments = true),
+        )
+        assertEquals(
+            ComposerAccessory.CHIPS,
+            ComposerAccessories.accessory(hudOpen = false, draft = "", busy = false, pendingApproval = false, hasQuickReplies = true, hasAttachments = false),
+        )
+    }
+
+    @Test
+    fun `the sheet greys the attachment rows at the cap`() {
+        val actions = ChatActions.sheet(com.openmausbot.companion.core.Chat.BotChat(bot()), hasPendingApproval = false, canAddAttachment = false)
+        assertFalse(actions.single { it.id == ChatActionId.PHOTOS }.enabled)
+        assertFalse(actions.single { it.id == ChatActionId.FILES }.enabled)
+        assertTrue(actions.single { it.id == ChatActionId.TASKS }.enabled)
+    }
+}

--- a/android/app/src/test/kotlin/com/openmausbot/companion/ui/ChatPreferencesUiPolicyTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/ui/ChatPreferencesUiPolicyTest.kt
@@ -14,6 +14,7 @@ class ChatPreferencesUiPolicyTest {
                 busy = false,
                 pendingApproval = false,
                 hasQuickReplies = false,
+                hasAttachments = false,
             ),
         )
         assertEquals(
@@ -24,6 +25,7 @@ class ChatPreferencesUiPolicyTest {
                 busy = false,
                 pendingApproval = false,
                 hasQuickReplies = false,
+                hasAttachments = false,
             ),
         )
     }

--- a/android/app/src/test/kotlin/com/openmausbot/companion/ui/SlashCommandTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/ui/SlashCommandTest.kt
@@ -261,6 +261,7 @@ class ComposerAccessoriesTest {
                 busy = false,
                 pendingApproval = false,
                 hasQuickReplies = true,
+                hasAttachments = false,
             ),
         )
     }
@@ -294,6 +295,7 @@ class ComposerAccessoriesTest {
                 busy = true,
                 pendingApproval = true,
                 hasQuickReplies = true,
+                hasAttachments = false,
             ),
         )
     }
@@ -316,7 +318,8 @@ class ComposerAccessoriesTest {
         busy: Boolean = false,
         pendingApproval: Boolean = false,
         hasQuickReplies: Boolean = true,
-    ) = ComposerAccessories.accessory(hudOpen, draft, busy, pendingApproval, hasQuickReplies)
+        hasAttachments: Boolean = false,
+    ) = ComposerAccessories.accessory(hudOpen, draft, busy, pendingApproval, hasQuickReplies, hasAttachments)
 
     private fun card(pending: Boolean): Message = Message(
         id = if (pending) "pending" else "answered",

--- a/android/app/src/test/kotlin/com/openmausbot/companion/ui/TranscriptRunTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/ui/TranscriptRunTest.kt
@@ -110,6 +110,8 @@ class ChatActionsTest {
         val actions = sheet(Chat.BotChat(bot(name = "Scout")))
         assertEquals(
             listOf(
+                ChatActionId.PHOTOS,
+                ChatActionId.FILES,
                 ChatActionId.NEW_TASK,
                 ChatActionId.TASKS,
                 ChatActionId.WATCH_COMPUTER,
@@ -118,16 +120,20 @@ class ChatActionsTest {
             ),
             actions.map { it.id },
         )
-        assertEquals("New task", actions[0].title)
-        assertEquals("Start a fresh thread with Scout", actions[0].subtitle)
-        assertEquals("Tasks", actions[1].title)
-        assertEquals("Switch, rename or remove one", actions[1].subtitle)
-        assertEquals("Watch computer", actions[2].title)
-        assertEquals("Live view of what Scout is doing", actions[2].subtitle)
-        assertEquals("Share transcript", actions[3].title)
-        assertEquals("This chat as Markdown", actions[3].subtitle)
-        assertEquals("Share as JSON", actions[4].title)
-        assertEquals("Structured transcript data", actions[4].subtitle)
+        assertEquals("Photo Library", actions[0].title)
+        assertEquals("Add a photo to this message", actions[0].subtitle)
+        assertEquals("Choose File", actions[1].title)
+        assertEquals("Add a document from Files", actions[1].subtitle)
+        assertEquals("New task", actions[2].title)
+        assertEquals("Start a fresh thread with Scout", actions[2].subtitle)
+        assertEquals("Tasks", actions[3].title)
+        assertEquals("Switch, rename or remove one", actions[3].subtitle)
+        assertEquals("Watch computer", actions[4].title)
+        assertEquals("Live view of what Scout is doing", actions[4].subtitle)
+        assertEquals("Share transcript", actions[5].title)
+        assertEquals("This chat as Markdown", actions[5].subtitle)
+        assertEquals("Share as JSON", actions[6].title)
+        assertEquals("Structured transcript data", actions[6].subtitle)
     }
 
     @Test
@@ -157,24 +163,26 @@ class ChatActionsTest {
         // above it asks only `bot.busy == true`.
         val channel = Chat.RoomChat(taskCapableRoom())
         assertFalse(
-            ChatActions.sheet(channel, hasPendingApproval = true)
+            ChatActions.sheet(channel, hasPendingApproval = true, canAddAttachment = true)
                 .single { it.id == ChatActionId.NEW_TASK }.enabled,
         )
         assertTrue(
-            ChatActions.sheet(channel, hasPendingApproval = false)
+            ChatActions.sheet(channel, hasPendingApproval = false, canAddAttachment = true)
                 .single { it.id == ChatActionId.NEW_TASK }.enabled,
         )
         assertTrue(
-            ChatActions.sheet(Chat.BotChat(bot()), hasPendingApproval = true)
+            ChatActions.sheet(Chat.BotChat(bot()), hasPendingApproval = true, canAddAttachment = true)
                 .single { it.id == ChatActionId.NEW_TASK }.enabled,
         )
     }
 
     @Test
     fun `a pending approval leaves the rest of a channel's sheet alone`() {
-        val actions = ChatActions.sheet(Chat.RoomChat(taskCapableRoom()), hasPendingApproval = true)
+        val actions = ChatActions.sheet(Chat.RoomChat(taskCapableRoom()), hasPendingApproval = true, canAddAttachment = true)
         assertEquals(
             listOf(
+                ChatActionId.PHOTOS,
+                ChatActionId.FILES,
                 ChatActionId.NEW_TASK,
                 ChatActionId.TASKS,
                 ChatActionId.SHARE_MARKDOWN,
@@ -191,7 +199,7 @@ class ChatActionsTest {
         // channel branch is the only one that adds them.
         val dm = Chat.RoomChat(taskCapableRoom().copy(dm = true))
         assertEquals(
-            listOf(ChatActionId.SHARE_MARKDOWN, ChatActionId.SHARE_JSON),
+            listOf(ChatActionId.PHOTOS, ChatActionId.FILES, ChatActionId.SHARE_MARKDOWN, ChatActionId.SHARE_JSON),
             sheet(dm).map { it.id },
         )
     }
@@ -200,7 +208,7 @@ class ChatActionsTest {
     fun `a legacy room has no tasks, no computer and nothing to interrupt`() {
         val busyRoom = Chat.RoomChat(room().copy(busyBotId = "bot-1"))
         assertEquals(
-            listOf(ChatActionId.SHARE_MARKDOWN, ChatActionId.SHARE_JSON),
+            listOf(ChatActionId.PHOTOS, ChatActionId.FILES, ChatActionId.SHARE_MARKDOWN, ChatActionId.SHARE_JSON),
             sheet(busyRoom).map { it.id },
         )
     }
@@ -211,6 +219,8 @@ class ChatActionsTest {
         val actions = sheet(room)
         assertEquals(
             listOf(
+                ChatActionId.PHOTOS,
+                ChatActionId.FILES,
                 ChatActionId.NEW_TASK,
                 ChatActionId.TASKS,
                 ChatActionId.SHARE_MARKDOWN,
@@ -238,7 +248,7 @@ class ChatActionsTest {
     }
 
     /** The sheet with nothing waiting on an answer, which is most of these cases. */
-    private fun sheet(chat: Chat) = ChatActions.sheet(chat, hasPendingApproval = false)
+    private fun sheet(chat: Chat) = ChatActions.sheet(chat, hasPendingApproval = false, canAddAttachment = true)
 
     private fun taskCapableRoom(): Room =
         room().copy(tasks = listOf(BotTask("thread-room-1", "Plan", 0.0)))

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Client.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Client.kt
@@ -237,6 +237,39 @@ class CompanionClient(
         return raw.data
     }
 
+    /**
+     * Fetch an app-owned file mentioned by one transcript message. The path
+     * still names the file on the paired computer, so it is sent in an
+     * authenticated JSON body rather than placed in the URL. The server
+     * verifies both message provenance and its attachment roots.
+     */
+    suspend fun downloadFile(threadId: String, messageId: String, path: String): DownloadedFile {
+        val link = LocalMessageLink.resolve(path) as? LocalMessageLink.DesktopFile ?: throw APIError.BadUrl
+        val raw = perform(
+            makeRequest(
+                "POST",
+                "/api/threads/${safeRouteId(threadId)}/messages/${safeRouteId(messageId)}/file",
+                body = jsonBody("path" to link.path),
+            ),
+        )
+        check(raw)
+        val declared = raw.headers["Content-Length"]?.trim()?.toLongOrNull() ?: -1L
+        if (declared > MAXIMUM_FILE_DOWNLOAD_BYTES || raw.data.size > MAXIMUM_FILE_DOWNLOAD_BYTES) {
+            throw APIError.Transport("That file is larger than 25 MB.")
+        }
+        val rawContentType = raw.headers["Content-Type"].orEmpty()
+        val contentType = if (AttachmentPolicy.validMime(rawContentType)) {
+            AttachmentPolicy.normalizedMime(rawContentType)
+        } else {
+            "application/octet-stream"
+        }
+        return DownloadedFile(
+            data = raw.data,
+            filename = downloadFilename(raw.headers["Content-Disposition"], link.path),
+            contentType = contentType,
+        )
+    }
+
     suspend fun avatar(path: String): ByteArray {
         if (!validAvatarPath(path)) throw APIError.BadUrl
         val raw = perform(makeRequest("GET", path))
@@ -646,6 +679,39 @@ class CompanionClient(
         private const val STREAM_IDLE_TIMEOUT_SECONDS = 90L
         private const val AVATAR_MAX_BYTES = 10 * 1_024 * 1_024
         const val SHARE_FILE_MAX_BYTES = 25 * 1_024 * 1_024
+        const val MAXIMUM_FILE_DOWNLOAD_BYTES = AttachmentPolicy.MAXIMUM_FILE_BYTES
+
+        /**
+         * The name to show a downloaded file under: `filename*=` first, then
+         * `filename=`, then the last segment of the requested path — reduced to
+         * a basename, with control and bidi-override characters blanked so a
+         * server-chosen name cannot disguise itself.
+         */
+        internal fun downloadFilename(disposition: String?, fallbackPath: String): String {
+            val parameters = disposition.orEmpty().split(';').map(String::trim)
+            val encoded = parameters.firstOrNull { it.startsWith("filename*=", ignoreCase = true) }
+                ?.drop("filename*=".length)
+            val ordinary = parameters.firstOrNull { it.startsWith("filename=", ignoreCase = true) }
+                ?.drop("filename=".length)
+            val decodedEncoded = encoded?.let { value ->
+                val unquoted = value.trim('"')
+                val payload = unquoted.split('\'', limit = 3)
+                val encodedValue = if (payload.size == 3) payload[2] else unquoted
+                runCatching { java.net.URLDecoder.decode(encodedValue.replace("+", "%2B"), "UTF-8") }.getOrNull()
+            }
+            val candidate = decodedEncoded
+                ?: ordinary?.trim('"')
+                ?: fallbackPath.split('/', '\\').lastOrNull { it.isNotEmpty() }
+                ?: "file"
+            val basename = candidate.split('/', '\\').lastOrNull { it.isNotEmpty() } ?: "file"
+            val cleaned = basename.map { character ->
+                val code = character.code
+                val bidiControl = code in 0x202A..0x202E || code in 0x2066..0x2069
+                if (character.isISOControl() || bidiControl) ' ' else character
+            }.joinToString("").trim()
+            val shortened = cleaned.take(180)
+            return if (shortened.isEmpty() || shortened == "." || shortened == "..") "file" else shortened
+        }
         private val AVATAR_MIME_TYPES = setOf("image/png", "image/jpeg", "image/gif", "image/webp")
         private val JSON_MEDIA_TYPE = "application/json".toMediaType()
         private val EMPTY_BODY: RequestBody = ByteArray(0).toRequestBody(null)

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/MessageAttachments.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/MessageAttachments.kt
@@ -1,0 +1,163 @@
+package com.openmausbot.companion.core
+
+import java.net.URI
+import java.net.URLDecoder
+import java.util.UUID
+
+/**
+ * One attachment waiting in the composer — the port of
+ * `ios/Sources/CompanionCore/MessageAttachments.swift`.
+ *
+ * The bytes are app-owned: picker URIs are copied before this value is created,
+ * so a later send never depends on a content provider still granting access.
+ */
+class PendingMessageAttachment(
+    val id: String = UUID.randomUUID().toString(),
+    val data: ByteArray,
+    val name: String,
+    val mime: String,
+    val kind: Kind,
+) {
+    enum class Kind { IMAGE, FILE }
+
+    val bytes: Int get() = data.size
+}
+
+class AttachmentPolicyException(message: String) : Exception(message)
+
+/**
+ * The same limits apply to the in-app composer and the Share target. Keeping
+ * the policy in `:core` prevents either entry point from accepting an
+ * attachment that the authenticated upload route will reject.
+ */
+object AttachmentPolicy {
+    const val MAXIMUM_ITEMS: Int = 4
+    const val MAXIMUM_TOTAL_BYTES: Int = 50 * 1_024 * 1_024
+    const val MAXIMUM_IMAGE_BYTES: Int = 10 * 1_024 * 1_024
+    const val MAXIMUM_FILE_BYTES: Int = 25 * 1_024 * 1_024
+
+    val IMAGE_MIME_TYPES: Set<String> = setOf("image/png", "image/jpeg", "image/gif", "image/webp")
+
+    val DOCUMENT_MIME_TYPES: Set<String> = setOf(
+        "text/plain", "text/markdown", "text/csv", "text/tab-separated-values",
+        "application/json", "application/pdf", "application/rtf", "text/rtf",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.ms-excel",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.ms-powerpoint",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/vnd.oasis.opendocument.text",
+        "application/vnd.oasis.opendocument.spreadsheet",
+        "application/vnd.oasis.opendocument.presentation",
+    )
+
+    const val TOO_MANY_ITEMS: String = "Attach up to 4 items at a time."
+    const val TOTAL_TOO_LARGE: String = "Those attachments are larger than 50 MB together."
+    const val INVALID_NAME: String = "That file doesn't have a valid filename."
+
+    fun unsupportedType(name: String): String =
+        "$name isn't a supported file. Try PDF, text, Word, Excel, or PowerPoint."
+
+    fun itemTooLarge(name: String, limitMB: Int): String = "$name is larger than $limitMB MB."
+
+    /** `type/subtype` only, lowercased — a `; charset=` parameter is not part of the type. */
+    fun normalizedMime(value: String): String =
+        value.substringBefore(';').trim().lowercase()
+
+    fun kindForMime(value: String): PendingMessageAttachment.Kind? {
+        val mime = normalizedMime(value)
+        if (mime in IMAGE_MIME_TYPES) return PendingMessageAttachment.Kind.IMAGE
+        if (mime in DOCUMENT_MIME_TYPES) return PendingMessageAttachment.Kind.FILE
+        return null
+    }
+
+    /** Throws [AttachmentPolicyException] with the sentence the composer shows. */
+    fun validate(attachments: List<PendingMessageAttachment>) {
+        if (attachments.size > MAXIMUM_ITEMS) throw AttachmentPolicyException(TOO_MANY_ITEMS)
+        if (attachments.sumOf { it.data.size.toLong() } > MAXIMUM_TOTAL_BYTES) {
+            throw AttachmentPolicyException(TOTAL_TOO_LARGE)
+        }
+        for (attachment in attachments) {
+            val name = attachment.name.trim()
+            if (!validDisplayName(name)) throw AttachmentPolicyException(INVALID_NAME)
+            val mime = normalizedMime(attachment.mime)
+            when (attachment.kind) {
+                PendingMessageAttachment.Kind.IMAGE -> {
+                    if (mime !in IMAGE_MIME_TYPES) throw AttachmentPolicyException(unsupportedType(name))
+                    if (attachment.data.size > MAXIMUM_IMAGE_BYTES) {
+                        throw AttachmentPolicyException(itemTooLarge(name, 10))
+                    }
+                }
+                PendingMessageAttachment.Kind.FILE -> {
+                    if (mime !in DOCUMENT_MIME_TYPES) throw AttachmentPolicyException(unsupportedType(name))
+                    if (attachment.data.size > MAXIMUM_FILE_BYTES) {
+                        throw AttachmentPolicyException(itemTooLarge(name, 25))
+                    }
+                }
+            }
+        }
+    }
+
+    /** A syntactically plausible media type, so a server header cannot smuggle anything odd. */
+    fun validMime(value: String): Boolean {
+        val mime = normalizedMime(value)
+        if (mime.isEmpty() || mime.toByteArray().size > 127 || '/' !in mime) return false
+        return mime.all { it in '0'..'9' || it in 'a'..'z' || it in 'A'..'Z' || it in "!#$&+-./^_" }
+    }
+
+    private fun validDisplayName(value: String): Boolean =
+        value.isNotEmpty() && value.toByteArray().size <= 255 &&
+            '/' !in value && '\\' !in value && value.none(Char::isISOControl)
+}
+
+/**
+ * What tapping a Markdown link in a message is allowed to do. Web links go to
+ * the system. Absolute desktop paths go back through the authenticated
+ * companion file route. Relative and custom-scheme links do nothing.
+ */
+sealed class LocalMessageLink {
+    data class Web(val url: String) : LocalMessageLink()
+    data class DesktopFile(val path: String) : LocalMessageLink()
+
+    companion object {
+        fun resolve(rawValue: String): LocalMessageLink? {
+            val value = rawValue.trim()
+            if (value.isEmpty() || value.toByteArray().size > 8_192 || value.any(Char::isISOControl)) return null
+            if (isWindowsAbsolutePath(value) || isUncPath(value)) return DesktopFile(value)
+            if (value.startsWith("/")) return DesktopFile(value)
+            val uri = runCatching { URI(value) }.getOrNull() ?: return null
+            val scheme = uri.scheme?.lowercase() ?: return null
+            if (scheme == "http" || scheme == "https") {
+                if (uri.host.isNullOrEmpty()) return null
+                return Web(value)
+            }
+            if (scheme == "file") {
+                if (uri.rawQuery != null || uri.rawFragment != null) return null
+                var path = uri.rawPath?.let { decode(it) } ?: return null
+                if (path.startsWith("/") && isWindowsAbsolutePath(path.drop(1))) path = path.drop(1)
+                val host = uri.host
+                if (!host.isNullOrEmpty() && host.lowercase() != "localhost") path = "//$host$path"
+                if (!(path.startsWith("/") || isWindowsAbsolutePath(path) || isUncPath(path))) return null
+                return DesktopFile(path)
+            }
+            return null
+        }
+
+        private fun decode(value: String): String =
+            runCatching { URLDecoder.decode(value.replace("+", "%2B"), "UTF-8") }.getOrDefault(value)
+
+        private fun isWindowsAbsolutePath(value: String): Boolean =
+            value.length >= 3 && value[0].isLetter() && value[0].code < 128 && value[1] == ':' &&
+                (value[2] == '/' || value[2] == '\\')
+
+        private fun isUncPath(value: String): Boolean = value.startsWith("\\\\") || value.startsWith("//")
+    }
+}
+
+/** Bytes returned by the authenticated file route, with the sanitised name and type to show them under. */
+class DownloadedFile(
+    val data: ByteArray,
+    val filename: String,
+    val contentType: String,
+)

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Session.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Session.kt
@@ -398,6 +398,7 @@ class Session(
     }
 
     fun signOut() {
+        attachmentSendIds.clear()
         streamJob?.cancel()
         streamJob = null
         scope.launch {
@@ -1033,6 +1034,151 @@ class Session(
                 is Chat.BotChat -> it.sendToBot(to.bot.id, text)
                 is Chat.RoomChat -> it.sendToRoom(to.room.id, text)
             }
+        }
+    }
+
+    /**
+     * An ambiguous network failure may happen after the server accepted a
+     * message. Reusing the id for the exact same retained draft makes Retry
+     * idempotent instead of sending the attachment twice.
+     */
+    private data class AttachmentDraftKey(
+        val destination: MessageDestination,
+        val text: String,
+        val attachmentIds: List<String>,
+    )
+
+    private val attachmentSendIds = LinkedHashMap<AttachmentDraftKey, String>()
+
+    /**
+     * Send a composer draft with app-owned attachments — the port of
+     * `Session.send(text:attachments:to:)`. The destination includes the exact
+     * active thread at tap time, so neither a desktop task switch nor an upload
+     * delay can move the message elsewhere. Callers only clear their draft when
+     * this returns true.
+     */
+    suspend fun send(text: String, attachments: List<PendingMessageAttachment>, to: Chat): Boolean {
+        val activeClient = client ?: run {
+            _actionError.value = "This computer is offline."
+            return false
+        }
+        val connectionId = _connection.value?.id
+        _actionError.value = null
+        return try {
+            AttachmentPolicy.validate(attachments)
+            if (text.isBlank() && attachments.isEmpty()) {
+                _actionError.value = "Write a message or attach a file first."
+                return false
+            }
+            if (attachments.any { it.kind == PendingMessageAttachment.Kind.IMAGE }) {
+                val capable = try {
+                    activeClient.imageCapableInstanceIds()
+                } catch (error: APIError.Status) {
+                    if (error.code != 404) throw error
+                    _actionError.value = "Update OpenMausBot on this computer before sending images."
+                    return false
+                }
+                if (!imageSupported(to, capable)) {
+                    _actionError.value = imageCompatibilityMessage(to)
+                    return false
+                }
+            }
+            val destination = when (to) {
+                is Chat.BotChat -> MessageDestination.Bot(to.bot.id, to.bot.threadId)
+                is Chat.RoomChat -> MessageDestination.Room(to.room.id, to.room.threadId)
+            }
+            val key = AttachmentDraftKey(destination, text, attachments.map { it.id })
+            if (attachmentSendIds.size >= 20 && key !in attachmentSendIds) attachmentSendIds.clear()
+            val sendId = attachmentSendIds.getOrPut(key) { UUID.randomUUID().toString() }
+
+            val uploaded = attachments.map { attachment ->
+                currentCoroutineContext().ensureActive()
+                val mime = AttachmentPolicy.normalizedMime(attachment.mime)
+                when (attachment.kind) {
+                    PendingMessageAttachment.Kind.IMAGE -> SharedAttachmentReference(
+                        path = activeClient.uploadImage(attachment.data, mime, attachment.id),
+                        kind = SharedAttachmentKind.IMAGE,
+                    )
+                    PendingMessageAttachment.Kind.FILE -> {
+                        val file = activeClient.uploadFile(attachment.data, attachment.name, mime, attachment.id)
+                        SharedAttachmentReference(file.path, SharedAttachmentKind.FILE, file.name)
+                    }
+                }
+            }
+            val message = SharedMessageComposer.compose(
+                instruction = text,
+                text = emptyList(),
+                urls = emptyList(),
+                attachments = uploaded,
+            )
+            activeClient.send(message, destination, sendId)
+            attachmentSendIds.remove(key)
+            _actionError.value = null
+            true
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: APIError) {
+            if (error.isUnauthorized) {
+                gate.withLock {
+                    if (connectionId != null && _connection.value?.id == connectionId) {
+                        _status.value = Status.Unauthorized
+                    }
+                }
+            }
+            _actionError.value = error.message
+            false
+        } catch (error: Throwable) {
+            _actionError.value = error.message
+            false
+        }
+    }
+
+    private fun imageSupported(chat: Chat, capableInstances: Set<String>): Boolean = when (chat) {
+        is Chat.BotChat -> chat.bot.modelSelection.instanceId in capableInstances
+        is Chat.RoomChat -> chat.room.memberIds.isNotEmpty() && chat.room.memberIds.all { id ->
+            val bot = _state.value.bot(id) ?: return@all false
+            bot.modelSelection.instanceId in capableInstances
+        }
+    }
+
+    private fun imageCompatibilityMessage(chat: Chat): String = when (chat) {
+        is Chat.BotChat ->
+            "${chat.bot.name}'s current model doesn't support images. Choose another model or remove the image."
+        is Chat.RoomChat ->
+            "Every bot that may answer in this channel must use a model that supports images."
+    }
+
+    /**
+     * Download one desktop path through its originating transcript message.
+     * Where the bytes are kept for viewing is the app's business (it owns a
+     * cache directory); this only fetches and reports.
+     */
+    suspend fun downloadFile(threadId: String, messageId: String, path: String): DownloadedFile? {
+        val activeClient = client ?: run {
+            _actionError.value = "This computer is offline."
+            return null
+        }
+        val connectionId = _connection.value?.id
+        _actionError.value = null
+        return try {
+            val download = activeClient.downloadFile(threadId, messageId, path)
+            currentCoroutineContext().ensureActive()
+            download
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: APIError) {
+            if (error.isUnauthorized) {
+                gate.withLock {
+                    if (connectionId != null && _connection.value?.id == connectionId) {
+                        _status.value = Status.Unauthorized
+                    }
+                }
+            }
+            _actionError.value = error.message
+            null
+        } catch (error: Throwable) {
+            _actionError.value = error.message
+            null
         }
     }
 

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/FileDownloadClientTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/FileDownloadClientTest.kt
@@ -1,0 +1,114 @@
+package com.openmausbot.companion.core
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okio.Buffer
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/** The authenticated file route — the download half of `ShareClientTests.swift`. */
+class FileDownloadClientTest {
+    private lateinit var server: MockWebServer
+    private lateinit var client: CompanionClient
+
+    @BeforeTest
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        client = CompanionClient(requireNotNull(Connection.parse(server.url("/").toString())), "paired-token")
+    }
+
+    @AfterTest
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun postsThePathAndSanitisesResponseMetadata() = runBlocking {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "Text/Markdown; charset=utf-8")
+                .setHeader("Content-Disposition", "attachment; filename*=UTF-8''Quarter%20Report.md")
+                .setBody("# Report"),
+        )
+
+        val file = client.downloadFile("thread-1", "message-1", "/Users/test/Documents/report.md")
+
+        val request = server.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/api/threads/thread-1/messages/message-1/file", request.path)
+        assertEquals("Bearer paired-token", request.getHeader("Authorization"))
+        val body = CompanionJson.parseToJsonElement(request.body.readUtf8()).jsonObject
+        assertEquals(setOf("path"), body.keys)
+        assertEquals("/Users/test/Documents/report.md", body.getValue("path").jsonPrimitive.content)
+        assertContentEquals("# Report".toByteArray(), file.data)
+        assertEquals("Quarter Report.md", file.filename)
+        assertEquals("text/markdown", file.contentType)
+    }
+
+    @Test
+    fun stripsPathAndControlsFromTheResponseFilename() = runBlocking {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "not a mime")
+                .setHeader("Content-Disposition", "attachment; filename=\"../secret.txt\"")
+                .setBody(Buffer().write(byteArrayOf(1))),
+        )
+
+        val file = client.downloadFile("thread-1", "message-1", "/Users/test/fallback.txt")
+
+        assertEquals("secret.txt", file.filename)
+        assertEquals("application/octet-stream", file.contentType)
+    }
+
+    @Test
+    fun blanksControlAndBidiOverrideCharactersInAServerChosenName() {
+        // OkHttp refuses to carry the raw header, so the sanitiser is exercised directly.
+        assertEquals("secret .txt", CompanionClient.downloadFilename("attachment; filename=\"../secret\u202E.txt\"", "/x"))
+        assertEquals("file", CompanionClient.downloadFilename("attachment; filename=\"..\"", "/"))
+        assertEquals("a b.txt", CompanionClient.downloadFilename("attachment; filename=\"a\tb.txt\"", "/x"))
+    }
+
+    @Test
+    fun fallsBackToTheRequestedPathsBasename() = runBlocking {
+        server.enqueue(MockResponse().setHeader("Content-Type", "text/plain").setBody("x"))
+        val file = client.downloadFile("thread-1", "message-1", "/Users/test/notes/todo.txt")
+        assertEquals("todo.txt", file.filename)
+    }
+
+    @Test
+    fun rejectsAnUnsafeRequestBeforeNetworking() = runBlocking {
+        assertFailsWith<APIError.BadUrl> { client.downloadFile("../thread", "message-1", "relative/report.md") }
+        assertFailsWith<APIError.BadUrl> { client.downloadFile("thread-1", "message-1", "relative/report.md") }
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun rejectsAnOversizedDeclaredResponse() = runBlocking {
+        server.enqueue(
+            MockResponse()
+                .setBody("x")
+                .setHeader("Content-Type", "text/plain")
+                // After setBody, so the declared length is the oversized one.
+                .setHeader("Content-Length", (CompanionClient.MAXIMUM_FILE_DOWNLOAD_BYTES + 1).toString())
+                .setSocketPolicy(okhttp3.mockwebserver.SocketPolicy.DISCONNECT_AT_END),
+        )
+        assertFailsWith<APIError> { client.downloadFile("thread-1", "message-1", "/Users/test/large.txt") }
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun aServerErrorSurfacesItsMessage() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(403).setHeader("Content-Type", "application/json").setBody("""{"error":"that file is outside this conversation"}"""))
+        val error = assertFailsWith<APIError.Status> { client.downloadFile("thread-1", "message-1", "/Users/test/x.txt") }
+        assertEquals(403, error.code)
+        assertEquals("that file is outside this conversation", error.message)
+    }
+}

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/MessageAttachmentsTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/MessageAttachmentsTest.kt
@@ -1,0 +1,89 @@
+package com.openmausbot.companion.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+/** The port of `ios/Tests/CompanionCoreTests/MessageAttachmentsTests.swift`. */
+class MessageAttachmentsTest {
+
+    @Test
+    fun classifiesWebAndAbsoluteDesktopLinks() {
+        assertEquals(
+            LocalMessageLink.Web("https://example.com/report.md?q=1"),
+            LocalMessageLink.resolve("https://example.com/report.md?q=1"),
+        )
+        assertEquals(
+            LocalMessageLink.DesktopFile("/Users/milind/Documents/report.md"),
+            LocalMessageLink.resolve("/Users/milind/Documents/report.md"),
+        )
+        assertEquals(
+            LocalMessageLink.DesktopFile("/Users/milind/My Report.md"),
+            LocalMessageLink.resolve("file:///Users/milind/My%20Report.md"),
+        )
+        assertEquals(
+            LocalMessageLink.DesktopFile("""C:\Users\Milind\report.md"""),
+            LocalMessageLink.resolve("""C:\Users\Milind\report.md"""),
+        )
+        assertEquals(
+            LocalMessageLink.DesktopFile("C:/Users/Milind/report.md"),
+            LocalMessageLink.resolve("file:///C:/Users/Milind/report.md"),
+        )
+        assertEquals(
+            LocalMessageLink.DesktopFile("""\\server\share\report.md"""),
+            LocalMessageLink.resolve("""\\server\share\report.md"""),
+        )
+    }
+
+    @Test
+    fun rejectsRelativeMalformedAndCustomSchemeLinks() {
+        assertNull(LocalMessageLink.resolve("notes/report.md"))
+        assertNull(LocalMessageLink.resolve("openmausbot://pair?token=secret"))
+        assertNull(LocalMessageLink.resolve("javascript:alert(1)"))
+        assertNull(LocalMessageLink.resolve("https:///missing-host.md"))
+        assertNull(LocalMessageLink.resolve("file:///tmp/report.md?replace=1"))
+        assertNull(LocalMessageLink.resolve("/tmp/bad\u0000name.md"))
+        assertNull(LocalMessageLink.resolve(""))
+    }
+
+    @Test
+    fun attachmentPolicyAcceptsSupportedImageAndMarkdown() {
+        AttachmentPolicy.validate(
+            listOf(
+                PendingMessageAttachment(data = byteArrayOf(0x89.toByte(), 0x50), name = "photo.png", mime = "IMAGE/PNG; charset=binary", kind = PendingMessageAttachment.Kind.IMAGE),
+                PendingMessageAttachment(data = "# Notes".toByteArray(), name = "notes.md", mime = "text/markdown", kind = PendingMessageAttachment.Kind.FILE),
+            ),
+        )
+        assertEquals(PendingMessageAttachment.Kind.IMAGE, AttachmentPolicy.kindForMime(" IMAGE/JPEG "))
+        assertEquals(PendingMessageAttachment.Kind.FILE, AttachmentPolicy.kindForMime("application/pdf"))
+        assertNull(AttachmentPolicy.kindForMime("application/zip"))
+    }
+
+    @Test
+    fun attachmentPolicyRejectsCountTypeNameAndSize() {
+        val valid = PendingMessageAttachment(data = byteArrayOf(1), name = "notes.txt", mime = "text/plain", kind = PendingMessageAttachment.Kind.FILE)
+        assertEquals(
+            AttachmentPolicy.TOO_MANY_ITEMS,
+            assertFailsWith<AttachmentPolicyException> { AttachmentPolicy.validate(List(5) { valid }) }.message,
+        )
+        assertEquals(
+            "archive.zip isn't a supported file. Try PDF, text, Word, Excel, or PowerPoint.",
+            assertFailsWith<AttachmentPolicyException> {
+                AttachmentPolicy.validate(listOf(PendingMessageAttachment(data = byteArrayOf(1), name = "archive.zip", mime = "application/zip", kind = PendingMessageAttachment.Kind.FILE)))
+            }.message,
+        )
+        assertEquals(
+            AttachmentPolicy.INVALID_NAME,
+            assertFailsWith<AttachmentPolicyException> {
+                AttachmentPolicy.validate(listOf(PendingMessageAttachment(data = byteArrayOf(1), name = "../notes.txt", mime = "text/plain", kind = PendingMessageAttachment.Kind.FILE)))
+            }.message,
+        )
+        assertEquals(
+            "huge.png is larger than 10 MB.",
+            assertFailsWith<AttachmentPolicyException> {
+                AttachmentPolicy.validate(listOf(PendingMessageAttachment(data = ByteArray(AttachmentPolicy.MAXIMUM_IMAGE_BYTES + 1), name = "huge.png", mime = "image/png", kind = PendingMessageAttachment.Kind.IMAGE)))
+            }.message,
+        )
+    }
+}


### PR DESCRIPTION
The Android port of #695.

**Attachments.** The composer's + gains Photo Library and Choose File: up to four items, 50 MB together, images to 10 MB and documents to 25 MB — the policy the Share target already enforces, now in `:core` (`AttachmentPolicy`) where both entry points read it. Pending items sit as chips above the field and travel through the existing image and file upload routes, composed into the same message the Share sheet sends. The send id is reused for an identical retained draft so a retry after an ambiguous failure cannot post the attachment twice. Sending an image checks the bot's model can read one first.

**File previews.** A link in a bot reply now resolves before it goes anywhere (`LocalMessageLink`): web links open in the browser; an absolute desktop path is fetched through the authenticated per-message file route (`POST /api/threads/:t/messages/:m/file`) and shown — Markdown and text in the app, everything else handed to whatever app opens it through the FileProvider. Relative and custom-scheme links are refused out loud. The downloaded name and type are sanitised the way iOS does, and only the most recent download is kept on disk.

Tests: `MessageAttachmentsTest`, `FileDownloadClientTest`, `AttachmentRulesTest`, plus the action-sheet expectations.

Verified: Android suite 1267 tests, 0 failures; debug APK builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added photo and file attachments to chat messages, including previews, removal controls, upload status, and validation.
  * Added support for opening linked web pages and downloading linked files for preview or system viewing.
  * Added in-chat previews for Markdown and text files.
* **Improvements**
  * Attachment actions are available from the composer and respect size and item limits.
  * Predictive reply suggestions are hidden while attachments are pending.
* **Bug Fixes**
  * Improved handling of attachment upload errors, unsupported files, and unavailable viewers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->