### PR TITLE
feat(android): call a bot, and set the ElevenLabs key from the phone

### DIFF
--- a/android/app/src/main/kotlin/com/openmausbot/companion/audio/CallSpeaker.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/audio/CallSpeaker.kt
@@ -1,0 +1,97 @@
+package com.openmausbot.companion.audio
+
+import android.content.Context
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Sequential playback of the utterances a call fetched from the computer —
+ * `CallSpeaker` in `ios/App/CallView.swift`.
+ *
+ * One clip at a time, each awaited to its end, over the same MediaPlayer
+ * engine and audio-focus gate the voice preview uses. [stop] — an interrupt
+ * or a hang-up — bumps the generation so a `speak` in flight returns false
+ * and whatever it was about to play never starts.
+ */
+class CallSpeaker internal constructor(
+    private val engineFactory: () -> PreviewAudioEngine,
+    private val focus: PreviewAudioFocus,
+) {
+    constructor(context: Context) : this(
+        engineFactory = { MediaPlayerPreviewEngine() },
+        focus = AudioFocusGate(context.applicationContext),
+    )
+
+    private val lock = Any()
+    private var generation = 0
+    private var engine: PreviewAudioEngine? = null
+    private var finished: CompletableDeferred<Boolean>? = null
+
+    private val _isSpeaking = MutableStateFlow(false)
+    val isSpeaking: StateFlow<Boolean> = _isSpeaking.asStateFlow()
+
+    /** Speak every clip in order. Returns false when stopped early. */
+    suspend fun speak(clips: List<ByteArray>): Boolean {
+        val mine = synchronized(lock) {
+            stopLocked()
+            generation += 1
+            _isSpeaking.value = true
+            generation
+        }
+        try {
+            focus.request(onInterrupted = { stop() })
+            for (clip in clips) {
+                val done = CompletableDeferred<Boolean>()
+                val started = synchronized(lock) {
+                    if (generation != mine) return false
+                    val next = engineFactory()
+                    next.onCompletion = { done.complete(true) }
+                    next.onError = { done.complete(false) }
+                    engine = next
+                    finished = done
+                    runCatching { next.start(clip) }.getOrDefault(false)
+                }
+                if (!started) {
+                    synchronized(lock) { releaseCurrentLocked() }
+                    continue
+                }
+                done.await()
+                synchronized(lock) {
+                    if (generation != mine) return false
+                    releaseCurrentLocked()
+                }
+            }
+            return synchronized(lock) { generation == mine }
+        } finally {
+            synchronized(lock) {
+                if (generation == mine) {
+                    _isSpeaking.value = false
+                    focus.abandon()
+                }
+            }
+        }
+    }
+
+    fun stop() {
+        synchronized(lock) {
+            generation += 1
+            stopLocked()
+            _isSpeaking.value = false
+            focus.abandon()
+        }
+    }
+
+    private fun stopLocked() {
+        engine?.stop()
+        releaseCurrentLocked()
+        finished?.complete(false)
+        finished = null
+    }
+
+    private fun releaseCurrentLocked() {
+        engine?.release()
+        engine = null
+    }
+}

--- a/android/app/src/main/kotlin/com/openmausbot/companion/dictation/SpeechDictation.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/dictation/SpeechDictation.kt
@@ -54,6 +54,12 @@ class SpeechDictation internal constructor(
     private val postMain: (() -> Unit) -> Unit = { block ->
         Handler(Looper.getMainLooper()).post(block)
     },
+    /** Runs [block] after a delay; the call endpointer below is a chain of these. */
+    private val postDelayed: (delayMillis: Long, block: () -> Unit) -> Unit = { delayMillis, block ->
+        Handler(Looper.getMainLooper()).postDelayed(block, delayMillis)
+    },
+    /** Milliseconds from any fixed origin; only differences are read. */
+    private val clock: () -> Long = { System.nanoTime() / 1_000_000 },
 ) : DefaultLifecycleObserver {
 
     constructor(
@@ -79,6 +85,18 @@ class SpeechDictation internal constructor(
     private var attempt: Int = 0
     private var stopping: Boolean = false
 
+    // Call mode. Composer dictation runs until the person taps stop; a call
+    // has to notice when they have finished a sentence. The same silence
+    // endpointer as the desktop helper: the turn ends [turnGapMillis] after the
+    // transcript last *changed* — a recognizer may re-emit an unchanged
+    // partial, and only a change counts. An empty turn never ends on the
+    // timer: a call may be quiet for as long as the person needs before they
+    // begin. (The platform recognizer does give up on prolonged silence; that
+    // ends the turn empty, and the call listens again.)
+    private var turnGapMillis: Long? = null
+    private var onTurnEnded: ((String) -> Unit)? = null
+    private var lastTranscriptChange: Long = 0L
+
     private val _isListening = MutableStateFlow(false)
     private val _isStarting = MutableStateFlow(false)
     private val _transcript = MutableStateFlow("")
@@ -100,6 +118,9 @@ class SpeechDictation internal constructor(
             if (_isListening.value || _isStarting.value) {
                 stopLocked()
             } else {
+                // Composer dictation, not a call: no endpointer, no callback.
+                turnGapMillis = null
+                onTurnEnded = null
                 startLocked(capturing)
             }
         }
@@ -107,6 +128,43 @@ class SpeechDictation internal constructor(
 
     fun stop() {
         synchronized(lock) { stopLocked() }
+    }
+
+    /**
+     * One turn of a call: listen until [endpointGapMillis] of silence follows
+     * speech, then stop and hand the transcript to [onTurn]. A final result
+     * from the recognizer ends the turn too. Stopping any other way — hang up,
+     * an interruption — ends the turn without a callback.
+     */
+    fun listenForTurn(endpointGapMillis: Long, onTurn: (String) -> Unit) {
+        synchronized(lock) {
+            if (_isListening.value || _isStarting.value) return
+            turnGapMillis = endpointGapMillis
+            onTurnEnded = onTurn
+            startLocked("")
+            // A start that failed outright has already cleared the callback.
+            if (onTurnEnded != null) scheduleEndpointCheckLocked(generation)
+        }
+    }
+
+    private fun scheduleEndpointCheckLocked(gen: Int) {
+        postDelayed(ENDPOINT_POLL_MILLIS) {
+            synchronized(lock) {
+                if (gen != generation || stopping) return@synchronized
+                val gap = turnGapMillis ?: return@synchronized
+                val heard = _transcript.value.isNotEmpty() && clock() - lastTranscriptChange >= gap
+                if (_isListening.value && heard) endTurnLocked() else scheduleEndpointCheckLocked(gen)
+            }
+        }
+    }
+
+    /** Take the callback first — [stopLocked] clears it — and deliver it off the lock. */
+    private fun endTurnLocked() {
+        val callback = onTurnEnded ?: return
+        val heard = _transcript.value
+        onTurnEnded = null
+        stopLocked()
+        postMain { callback(heard) }
     }
 
     /** True while starting or listening — the composer must not accept edits. */
@@ -167,6 +225,7 @@ class SpeechDictation internal constructor(
         _error.value = null
         base = capturing.trim()
         _transcript.value = ""
+        lastTranscriptChange = clock()
         _isStarting.value = true
         stopping = false
         generation += 1
@@ -289,6 +348,8 @@ class SpeechDictation internal constructor(
 
     private fun stopLocked() {
         generation += 1
+        turnGapMillis = null
+        onTurnEnded = null
         attempt += 1
         _isStarting.value = false
         stopping = true
@@ -332,7 +393,12 @@ class SpeechDictation internal constructor(
         override fun onPartial(text: String) {
             synchronized(lock) {
                 if (!live() || !_isListening.value) return
-                _transcript.value = text
+                // Only a change restarts the silence clock: a recognizer may
+                // re-emit the same partial while the person is quiet.
+                if (text != _transcript.value) {
+                    _transcript.value = text
+                    lastTranscriptChange = clock()
+                }
             }
         }
 
@@ -341,8 +407,9 @@ class SpeechDictation internal constructor(
                 if (!live() || !_isListening.value) return
                 if (text.isNotEmpty()) _transcript.value = text
                 // Composer dictation does not wait for a later final beyond
-                // this — matching iOS stopping when the recognizer finalizes.
-                stopLocked()
+                // this — matching iOS stopping when the recognizer finalizes;
+                // on a call, that is the turn ending.
+                if (onTurnEnded != null) endTurnLocked() else stopLocked()
             }
         }
 
@@ -376,6 +443,10 @@ class SpeechDictation internal constructor(
                                 localeIndex = 0,
                                 gen = gen,
                             )
+                        } else if (onTurnEnded != null) {
+                            // On a call, silence the recognizer gave up on is an
+                            // empty turn, not a failure: the call listens again.
+                            endTurnLocked()
                         } else {
                             _error.value = TRANSCRIBE_FAILED_MESSAGE
                             stopLocked()
@@ -394,6 +465,7 @@ class SpeechDictation internal constructor(
             "Dictation isn't available for this language."
         const val START_FAILED_MESSAGE: String = "Couldn't start the microphone."
         const val TRANSCRIBE_FAILED_MESSAGE: String = "Couldn't transcribe that."
+        private const val ENDPOINT_POLL_MILLIS: Long = 100L
     }
 }
 

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/CallRules.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/CallRules.kt
@@ -1,0 +1,91 @@
+package com.openmausbot.companion.ui
+
+import com.openmausbot.companion.core.Message
+
+/** Where a call is — `CallView.Phase` on iOS. */
+enum class CallPhase { LISTENING, SENDING, WORKING, SPEAKING }
+
+/** What the call does next, decided from what just changed. */
+sealed class CallAction {
+    /** A pending approval or question: announce it, then listen. */
+    data class Announce(val text: String) : CallAction()
+
+    /** A reply landed: read it, then listen. */
+    data class SayReply(val text: String) : CallAction()
+
+    /** An activity chip the harness phrased for a voice: read it, then keep working. */
+    data class SayChip(val text: String) : CallAction()
+
+    /** The bot went busy while the mic was open: close it and wait. */
+    data object StopListeningAndWork : CallAction()
+
+    /** The bot went idle with nothing to say: open the mic. */
+    data object Listen : CallAction()
+
+    data object None : CallAction()
+}
+
+/**
+ * The call loop's decisions, with no audio in them — the rules half of
+ * `ios/App/CallView.swift`.
+ *
+ * Half-duplex on purpose: the microphone is live only while the bot is not
+ * speaking. A recognizer that hears even a little of the bot's own voice
+ * sends it back as a message, and the two of them talk forever.
+ */
+object CallRules {
+    /** The turn ends this long after the transcript last changed — the desktop's endpointer. */
+    const val ENDPOINT_GAP_MILLIS: Long = 850L
+
+    fun phaseText(phase: CallPhase, name: String): String = when (phase) {
+        CallPhase.LISTENING -> "Listening…"
+        CallPhase.SENDING -> "Sending…"
+        CallPhase.WORKING -> "$name is working…"
+        CallPhase.SPEAKING -> "Speaking"
+    }
+
+    fun noVoiceNote(name: String): String = "Set up a voice in Settings → Voice to hear $name."
+
+    /**
+     * Approvals and questions are announced, not answered by voice: saying
+     * "yes" to a permission is not the kind of thing to infer from a sentence
+     * that happened to contain the word.
+     */
+    fun announcement(name: String, isPermission: Boolean): String =
+        "$name ${if (isPermission) "is asking for permission" else "has a question"}. Open the chat to answer it."
+
+    /**
+     * `react()` in the Swift. [fresh] are the messages that arrived since the
+     * last look; [pendingCard] the newest unanswered card; [announced] the
+     * request ids already spoken.
+     */
+    fun react(
+        name: String,
+        fresh: List<Message>,
+        pendingCard: Message?,
+        announced: Set<String>,
+        phase: CallPhase,
+        busy: Boolean,
+        speakerSpeaking: Boolean,
+    ): CallAction {
+        val request = pendingCard?.card?.requestId
+        if (pendingCard != null && request != null && request !in announced && phase != CallPhase.SPEAKING) {
+            return CallAction.Announce(announcement(name, pendingCard.card?.tool != null))
+        }
+        val reply = fresh.lastOrNull {
+            it.role == Message.Role.BOT && it.kind == Message.Kind.TEXT && !it.text.isNullOrBlank()
+        }
+        if (reply != null) return CallAction.SayReply(reply.text.orEmpty())
+        val chip = fresh.lastOrNull { it.kind == Message.Kind.ACTIVITY && it.tool?.spoken != null }
+        if (chip != null && phase == CallPhase.WORKING) return CallAction.SayChip(chip.tool?.spoken.orEmpty())
+        if (busy) {
+            return if (phase == CallPhase.LISTENING || phase == CallPhase.SENDING) {
+                CallAction.StopListeningAndWork
+            } else {
+                CallAction.None
+            }
+        }
+        if ((phase == CallPhase.WORKING || phase == CallPhase.SENDING) && !speakerSpeaking) return CallAction.Listen
+        return CallAction.None
+    }
+}

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/CallScreen.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/CallScreen.kt
@@ -1,0 +1,304 @@
+package com.openmausbot.companion.ui
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.openmausbot.companion.R
+import com.openmausbot.companion.audio.CallSpeaker
+import com.openmausbot.companion.core.Bot
+import com.openmausbot.companion.core.Chat
+import com.openmausbot.companion.core.Message
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+
+/**
+ * Call mode — the bot on the line, on the phone. The port of
+ * `ios/App/CallView.swift`, and deliberately HALF-DUPLEX for the same reason:
+ * the microphone is live only while the bot is not speaking. Interrupting is
+ * a tap instead.
+ *
+ * Turn-taking is the silence endpointer in [com.openmausbot.companion.dictation.SpeechDictation.listenForTurn]:
+ * the turn ends [CallRules.ENDPOINT_GAP_MILLIS] after the transcript last
+ * changed. Waiting is narrated — every activity chip the harness phrases for
+ * a voice is read as it lands — so an agent turn of tool calls sounds like
+ * someone working rather than a dropped call. Approvals and questions are
+ * announced, not answered by voice; answering them happens in the chat.
+ */
+@Composable
+internal fun CallScreen(bot: Bot, onDismiss: () -> Unit) {
+    val environment = LocalCompanion.current
+    val session = environment.session
+    val microphone = environment.dictation
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val speaker = remember { CallSpeaker(context) }
+    val state by session.state.collectAsState()
+    val current = state.bot(bot.id) ?: bot
+    val messages = remember(state, current.threadId) { state.visibleTranscript(current.threadId) }
+    val transcript by microphone.transcript.collectAsState()
+    val microphoneError by microphone.error.collectAsState()
+    val speaking by speaker.isSpeaking.collectAsState()
+
+    var phase by remember { mutableStateOf(CallPhase.LISTENING) }
+    var note by remember { mutableStateOf<String?>(null) }
+    // Everything already on screen when the call starts has been read or
+    // ignored — a call must not open by reciting the backlog.
+    val spokenIds = remember { mutableSetOf<String>() }
+    val announcedRequests = remember { mutableSetOf<String>() }
+    var started by remember { mutableStateOf(false) }
+    var sayGeneration by remember { mutableStateOf(0) }
+
+    fun listen() {
+        phase = CallPhase.LISTENING
+        note = null
+        microphone.listenForTurn(CallRules.ENDPOINT_GAP_MILLIS) { heard ->
+            val said = heard.trim()
+            if (said.isEmpty()) {
+                listen()
+            } else {
+                phase = CallPhase.SENDING
+                scope.launch { session.send(said, Chat.BotChat(current)) }
+            }
+        }
+    }
+
+    /**
+     * Speak with the microphone closed, then return whether this call is
+     * still the one that asked (an interrupt or hang-up bumps the generation).
+     */
+    suspend fun say(text: String): Boolean {
+        sayGeneration += 1
+        val mine = sayGeneration
+        phase = CallPhase.SPEAKING
+        microphone.stop()
+        return try {
+            val prepared = session.prepareSpeech(text, current.voice)
+            if (!prepared.ready) {
+                note = CallRules.noVoiceNote(current.name)
+                return sayGeneration == mine
+            }
+            val clips = ArrayList<ByteArray>(prepared.utterances.size)
+            for (utterance in prepared.utterances) {
+                if (sayGeneration != mine) return false
+                clips += session.speak(utterance, current.voice)
+            }
+            if (sayGeneration != mine) return false
+            speaker.speak(clips) && sayGeneration == mine
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            note = error.message ?: "Couldn't speak that."
+            sayGeneration == mine
+        }
+    }
+
+    fun sayThenListen(text: String) {
+        scope.launch {
+            val stillMine = say(text)
+            if (stillMine && phase == CallPhase.SPEAKING) listen()
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        if (started) return@LaunchedEffect
+        started = true
+        spokenIds += messages.map { it.id }
+        if (current.busy == true) phase = CallPhase.WORKING else listen()
+    }
+
+    LaunchedEffect(messages, current.busy) {
+        if (!started) return@LaunchedEffect
+        val fresh = messages.filter { it.id !in spokenIds }
+        spokenIds += fresh.map { it.id }
+        val pendingCard = messages.lastOrNull { it.card?.isPending == true }
+        when (val action = CallRules.react(
+            name = current.name,
+            fresh = fresh,
+            pendingCard = pendingCard,
+            announced = announcedRequests,
+            phase = phase,
+            busy = current.busy == true,
+            speakerSpeaking = speaking,
+        )) {
+            is CallAction.Announce -> {
+                pendingCard?.card?.requestId?.let { announcedRequests += it }
+                sayThenListen(action.text)
+            }
+            is CallAction.SayReply -> sayThenListen(action.text)
+            is CallAction.SayChip -> scope.launch {
+                val stillMine = say(action.text)
+                if (stillMine && phase == CallPhase.SPEAKING) phase = CallPhase.WORKING
+            }
+            CallAction.StopListeningAndWork -> {
+                microphone.stop()
+                phase = CallPhase.WORKING
+            }
+            CallAction.Listen -> listen()
+            CallAction.None -> Unit
+        }
+    }
+
+    LaunchedEffect(microphoneError) { microphoneError?.let { note = it } }
+
+    fun hangUp() {
+        sayGeneration += 1
+        microphone.stop()
+        speaker.stop()
+        onDismiss()
+    }
+
+    fun interrupt() {
+        if (phase != CallPhase.SPEAKING) return
+        sayGeneration += 1
+        speaker.stop()
+        listen()
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            microphone.stop()
+            speaker.stop()
+        }
+    }
+
+    Dialog(
+        onDismissRequest = ::hangUp,
+        properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false),
+    ) {
+        BackHandler { hangUp() }
+        val tint = Color(MausPalette.argb(current.color))
+        val pulse = rememberInfiniteTransition(label = "speaking")
+        val breathe by pulse.animateFloat(
+            initialValue = 1f,
+            targetValue = 1.06f,
+            animationSpec = infiniteRepeatable(tween(600), RepeatMode.Reverse),
+            label = "breathe",
+        )
+        val (leftIcon, leftLabel, leftEnabled) = Triple(R.drawable.ic_pan_tool, "Interrupt and speak", phase == CallPhase.SPEAKING)
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.surface)
+                .background(tint.copy(alpha = 0.18f))
+                .systemBarsPadding(),
+        ) {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(24.dp),
+            ) {
+                Spacer(Modifier.weight(1f))
+                BotAvatar(
+                    bot = current,
+                    size = 160.dp,
+                    state = if (phase == CallPhase.SPEAKING) MausState.HAPPY else MausState.forChat(Chat.BotChat(current), messages.lastOrNull()),
+                    contentDescription = "${current.name} avatar",
+                    modifier = Modifier.graphicsLayer {
+                        val scale = if (phase == CallPhase.SPEAKING) breathe else 1f
+                        scaleX = scale
+                        scaleY = scale
+                    },
+                )
+                Text(text = current.name, fontSize = 28.sp, fontWeight = FontWeight.SemiBold)
+                Text(text = CallRules.phaseText(phase, current.name), fontSize = 17.sp, color = secondaryTint)
+                if (transcript.isNotEmpty() && phase == CallPhase.LISTENING) {
+                    Text(
+                        text = transcript,
+                        fontSize = 17.sp,
+                        textAlign = TextAlign.Center,
+                        maxLines = 4,
+                        modifier = Modifier.padding(horizontal = 28.dp),
+                    )
+                }
+                note?.let {
+                    Text(
+                        text = it,
+                        fontSize = 14.sp,
+                        color = Color(0xFFFF9800),
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(horizontal = 28.dp),
+                    )
+                }
+                Spacer(Modifier.weight(1f))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(40.dp),
+                    modifier = Modifier.padding(bottom = 36.dp),
+                ) {
+                    TouchTarget(
+                        onClick = ::interrupt,
+                        enabled = leftEnabled,
+                        size = 68.dp,
+                        contentDescription = leftLabel,
+                        modifier = Modifier.graphicsLayer { alpha = if (leftEnabled) 1f else 0.35f },
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(68.dp)
+                                .background(secondaryTint.copy(alpha = 0.18f), CircleShape),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                painter = painterResource(leftIcon),
+                                contentDescription = null,
+                                modifier = Modifier.size(26.dp),
+                            )
+                        }
+                    }
+                    TouchTarget(onClick = ::hangUp, size = 68.dp, contentDescription = "End call") {
+                        Box(
+                            modifier = Modifier
+                                .size(68.dp)
+                                .background(Color(0xFFD94B52), CircleShape),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_call_end),
+                                contentDescription = null,
+                                tint = Color.White,
+                                modifier = Modifier.size(28.dp),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/ChatScreen.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/ChatScreen.kt
@@ -194,6 +194,9 @@ private fun LoadedChat(
     // what was typed into it — the sheet has to come back for that to matter.
     var showingProfile by rememberSaveable { mutableStateOf(false) }
     var showingPlus by remember(threadId) { mutableStateOf(false) }
+    // The bot on the line. Not saveable: a call does not survive a rotation's
+    // teardown of the audio session any better than a phone call would.
+    var showingCall by remember { mutableStateOf(false) }
     val focusManager = LocalFocusManager.current
     val focusedMessageId by session.focusedMessageId.collectAsState()
 
@@ -325,6 +328,7 @@ private fun LoadedChat(
     LaunchedEffect(showingPlus) { if (showingPlus) dictation.stop() }
     LaunchedEffect(showingTasks) { if (showingTasks) dictation.stop() }
     LaunchedEffect(showingProfile) { if (showingProfile) dictation.stop() }
+    LaunchedEffect(showingCall) { if (showingCall) dictation.stop() }
 
     // Opening a chat is what marks it read, exactly as on the desktop — and a
     // message can arrive while it is already on screen, so this keys on the bit
@@ -604,6 +608,10 @@ private fun LoadedChat(
                         dictation.stop()
                         if (bot != null) onOpenComputer(bot.id)
                     },
+                    onCall = {
+                        focusManager.clearFocus()
+                        showingCall = true
+                    },
                     // A bot's face and its name pill are both the door to its
                     // profile; a room has no profile, so its pill opens the same
                     // sheet the + does.
@@ -689,6 +697,10 @@ private fun LoadedChat(
     if (showingProfile && bot != null) {
         AgentProfileSheet(bot = bot, onDismiss = { showingProfile = false })
     }
+
+    if (showingCall && bot != null) {
+        CallScreen(bot = bot, onDismiss = { showingCall = false })
+    }
 }
 
 private fun share(
@@ -740,6 +752,7 @@ private fun ChatHeader(
     unreadElsewhere: Int,
     onBack: () -> Unit,
     onWatchComputer: () -> Unit,
+    onCall: () -> Unit,
     onOpenProfile: () -> Unit,
 ) {
     val surface = MaterialTheme.colorScheme.surface
@@ -767,8 +780,14 @@ private fun ChatHeader(
         ) {
             BackPill(unreadElsewhere = unreadElsewhere, onBack = onBack)
             Spacer(Modifier.weight(1f))
-            // The computer is a bot idea; a room has none (§12).
+            // The computer is a bot idea; a room has none (§12). So is a call.
             if (chat is Chat.BotChat) {
+                ChromeButton(
+                    painter = painterResource(R.drawable.ic_phone),
+                    contentDescription = "Call ${chat.name}",
+                    onClick = onCall,
+                )
+                Spacer(Modifier.size(8.dp))
                 ChromeButton(
                     painter = painterResource(R.drawable.ic_display),
                     contentDescription = "Watch ${chat.name}'s computer",

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/Navigation.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/Navigation.kt
@@ -34,6 +34,8 @@ sealed interface Destination {
 
     /** Settings → Workspace → Connected Apps. */
     data object ConnectedApps : Destination
+    /** Settings → Voice: the computer's voice key, set from the phone. */
+    data object Voice : Destination
 
     /** A bot's computer, watch-only. Addressed by bot id for the same reason. */
     data class Computer(val botId: String) : Destination
@@ -127,6 +129,7 @@ class CompanionNavigator(initial: List<Destination> = listOf(Destination.Roster)
         private const val SETTINGS = "settings"
         private const val ROUTINES = "routines"
         private const val CONNECTED_APPS = "connected-apps"
+        private const val VOICE = "voice"
         private const val THREAD = "thread:"
         private const val COMPUTER = "computer:"
         private const val BOT_CHAT = "botchat:"
@@ -138,6 +141,7 @@ class CompanionNavigator(initial: List<Destination> = listOf(Destination.Roster)
                 Destination.Settings -> SETTINGS
                 Destination.Routines -> ROUTINES
                 Destination.ConnectedApps -> CONNECTED_APPS
+                Destination.Voice -> VOICE
                 is Destination.Thread -> THREAD + it.threadId
                 is Destination.Computer -> COMPUTER + it.botId
                 is Destination.Chat -> when (val target = it.target) {
@@ -153,6 +157,7 @@ class CompanionNavigator(initial: List<Destination> = listOf(Destination.Roster)
                 it == SETTINGS -> Destination.Settings
                 it == ROUTINES -> Destination.Routines
                 it == CONNECTED_APPS -> Destination.ConnectedApps
+                it == VOICE -> Destination.Voice
                 it.startsWith(THREAD) -> Destination.Thread(it.removePrefix(THREAD))
                 it.startsWith(COMPUTER) -> Destination.Computer(it.removePrefix(COMPUTER))
                 it.startsWith(BOT_CHAT) -> split(it.removePrefix(BOT_CHAT))

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/RootScreen.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/RootScreen.kt
@@ -366,6 +366,7 @@ private fun PairedScreen(
             onBack = navigator::pop,
             onOpenRoutines = { navigator.push(Destination.Routines) },
             onOpenConnectedApps = { navigator.push(Destination.ConnectedApps) },
+            onOpenVoice = { navigator.push(Destination.Voice) },
         )
         Destination.Routines -> TasksRoutinesScreen(
             onBack = navigator::pop,
@@ -374,6 +375,7 @@ private fun PairedScreen(
             onOpenChat = navigator::open,
         )
         Destination.ConnectedApps -> ConnectedAppsScreen(onBack = navigator::pop)
+        Destination.Voice -> VoiceSettingsScreen(onBack = navigator::pop)
         // One branch for both shapes of chat address, so a notification's thread
         // becoming an addressed chat re-reads the same screen instead of
         // rebuilding it.

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/SettingsScreen.kt
@@ -70,6 +70,7 @@ fun SettingsScreen(
     onBack: () -> Unit,
     onOpenRoutines: (() -> Unit)? = null,
     onOpenConnectedApps: (() -> Unit)? = null,
+    onOpenVoice: (() -> Unit)? = null,
     /** Offered instead of the computer's details when there is no pairing. */
     onConnect: (() -> Unit)? = null,
 ) {
@@ -219,7 +220,7 @@ fun SettingsScreen(
             // Routine schedules live on the computer this phone is bound to.
             // With no binding there is nothing to schedule against, so the row
             // is absent rather than present and dead.
-            if (onOpenRoutines != null || onOpenConnectedApps != null) {
+            if (onOpenRoutines != null || onOpenConnectedApps != null || onOpenVoice != null) {
                 SettingsSection("Workspace") {
                     onOpenRoutines?.let { openRoutines ->
                         SettingsButton(
@@ -232,6 +233,13 @@ fun SettingsScreen(
                         SettingsButton(
                             text = "Connected Apps",
                             onClick = openConnectedApps,
+                        )
+                    }
+                    onOpenVoice?.let { openVoice ->
+                        SettingsButton(
+                            text = "Voice",
+                            icon = R.drawable.ic_phone,
+                            onClick = openVoice,
                         )
                     }
                     Footnote(SettingsPolicy.WORKSPACE_FOOTER)

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/VoiceSettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/VoiceSettingsScreen.kt
@@ -1,0 +1,206 @@
+package com.openmausbot.companion.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.openmausbot.companion.core.ConfigStatus
+import com.openmausbot.companion.core.VoiceProvider
+import kotlinx.coroutines.launch
+
+/** What Settings → Voice says and offers — the decisions of `ios/App/VoiceSettingsView.swift`. */
+object VoiceSettingsRules {
+    const val HEADER: String = "Calls and spoken replies"
+    const val HEADER_FOOTER: String = "Calls use the voice set up on your computer. Each bot's voice is chosen on its profile."
+    const val SYSTEM_NOTE: String = "This computer is using its built-in voices. Switch to ElevenLabs to use a key from here."
+    const val KEY_FOOTER: String =
+        "The key is checked and stored on your computer, never on this phone. Get one at elevenlabs.io → Settings → API Keys."
+    const val SAVED: String = "Key saved. Calls are ready."
+    const val REMOVED: String = "Key removed."
+
+    fun statusText(status: ConfigStatus?): String? = status?.let { if (it.isTTSConfigured) "Ready" else "Not set up" }
+
+    fun usesSystemVoices(status: ConfigStatus?): Boolean = status?.voiceProvider == VoiceProvider.SYSTEM
+
+    /** The key section is drawn only under ElevenLabs; the built-in engine has no key to enter. */
+    fun showsKeyField(status: ConfigStatus?): Boolean = !usesSystemVoices(status)
+
+    fun saveLabel(status: ConfigStatus?): String = if (status?.isTTSConfigured == true) "Replace key" else "Save key"
+
+    fun canSave(key: String, saving: Boolean): Boolean = !saving && key.isNotBlank()
+
+    fun canRemove(status: ConfigStatus?, saving: Boolean): Boolean = !saving && status?.isTTSConfigured == true
+}
+
+/**
+ * Voice: the key that lets a bot talk, set from the phone — the port of
+ * `ios/App/VoiceSettingsView.swift`.
+ *
+ * The desktop has this under App Settings → Voice. The credential lives on
+ * the computer, in the same config the desktop writes, so entering it here is
+ * the same as entering it there: one PUT, the server checks the key against
+ * ElevenLabs before saving, and the key never comes back in any response.
+ * What the phone shows afterwards is only whether one is on file.
+ */
+@Composable
+fun VoiceSettingsScreen(onBack: () -> Unit) {
+    val session = LocalCompanion.current.session
+    val scope = rememberCoroutineScope()
+    var status by remember { mutableStateOf<ConfigStatus?>(null) }
+    var key by rememberSaveable { mutableStateOf("") }
+    var saving by remember { mutableStateOf(false) }
+    var message by remember { mutableStateOf<String?>(null) }
+    var messageIsError by remember { mutableStateOf(false) }
+
+    suspend fun refresh() {
+        status = session.configStatus()
+    }
+
+    LaunchedEffect(Unit) { refresh() }
+
+    fun run(action: suspend () -> String?, success: String?) {
+        scope.launch {
+            saving = true
+            message = null
+            try {
+                val error = action()
+                if (error != null) {
+                    message = error
+                    messageIsError = true
+                    return@launch
+                }
+                message = success
+                messageIsError = false
+                refresh()
+            } finally {
+                saving = false
+            }
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+            }
+            Text("Voice", fontSize = 17.sp, fontWeight = FontWeight.SemiBold)
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(18.dp),
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Text(VoiceSettingsRules.HEADER.uppercase(), fontSize = 12.sp, fontWeight = FontWeight.SemiBold, color = secondaryTint)
+                HorizontalDivider()
+                Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                    Text("Status", fontSize = 15.sp, color = secondaryTint, modifier = Modifier.weight(1f))
+                    val text = VoiceSettingsRules.statusText(status)
+                    if (text == null) {
+                        CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                    } else {
+                        Text(
+                            text = text,
+                            fontSize = 15.sp,
+                            color = if (status?.isTTSConfigured == true) Color(0xFF009957) else secondaryTint,
+                        )
+                    }
+                }
+                if (VoiceSettingsRules.usesSystemVoices(status)) {
+                    Text(VoiceSettingsRules.SYSTEM_NOTE, fontSize = 13.sp, color = secondaryTint)
+                    ActionRow(text = "Use ElevenLabs", enabled = !saving) {
+                        run({ session.updateVoiceProvider("elevenlabs") }, success = null)
+                    }
+                }
+                Text(VoiceSettingsRules.HEADER_FOOTER, fontSize = 13.sp, color = secondaryTint)
+            }
+
+            if (VoiceSettingsRules.showsKeyField(status)) {
+                Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                    Text("ELEVENLABS", fontSize = 12.sp, fontWeight = FontWeight.SemiBold, color = secondaryTint)
+                    HorizontalDivider()
+                    OutlinedTextField(
+                        value = key,
+                        onValueChange = { key = it },
+                        label = { Text("ElevenLabs API key") },
+                        singleLine = true,
+                        visualTransformation = PasswordVisualTransformation(),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false),
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                        Box(modifier = Modifier.weight(1f)) {
+                            ActionRow(
+                                text = VoiceSettingsRules.saveLabel(status),
+                                enabled = VoiceSettingsRules.canSave(key, saving),
+                            ) {
+                                val entered = key
+                                run(
+                                    {
+                                        val error = session.updateVoiceKey(entered)
+                                        if (error == null) key = ""
+                                        error
+                                    },
+                                    success = VoiceSettingsRules.SAVED,
+                                )
+                            }
+                        }
+                        if (saving) CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                    }
+                    if (VoiceSettingsRules.canRemove(status, saving = false)) {
+                        ActionRow(text = "Remove key", enabled = !saving, destructive = true) {
+                            run({ session.updateVoiceKey("") }, success = VoiceSettingsRules.REMOVED)
+                        }
+                    }
+                    message?.let {
+                        Text(
+                            text = it,
+                            fontSize = 13.sp,
+                            color = if (messageIsError) Color(0xFFFF9800) else Color(0xFF009957),
+                        )
+                    }
+                    Text(VoiceSettingsRules.KEY_FOOTER, fontSize = 13.sp, color = secondaryTint)
+                }
+            } else {
+                message?.let { Text(text = it, fontSize = 13.sp, color = Color(0xFFFF9800)) }
+            }
+        }
+    }
+}

--- a/android/app/src/main/res/drawable/ic_call_end.xml
+++ b/android/app/src/main/res/drawable/ic_call_end.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- A handset going down: the end-call button. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,9c-1.6,0 -3.15,0.25 -4.6,0.72v3.1c0,0.39 -0.23,0.74 -0.56,0.9 -0.98,0.49 -1.87,1.12 -2.66,1.85 -0.18,0.18 -0.43,0.28 -0.7,0.28 -0.28,0 -0.53,-0.11 -0.71,-0.29L0.29,13.08c-0.18,-0.17 -0.29,-0.42 -0.29,-0.7 0,-0.28 0.11,-0.53 0.29,-0.71C3.34,8.78 7.46,7 12,7s8.66,1.78 11.71,4.67c0.18,0.18 0.29,0.43 0.29,0.71 0,0.28 -0.11,0.53 -0.29,0.71l-2.48,2.48c-0.18,0.18 -0.43,0.29 -0.71,0.29 -0.27,0 -0.52,-0.11 -0.7,-0.28 -0.79,-0.74 -1.69,-1.36 -2.67,-1.85 -0.33,-0.16 -0.56,-0.5 -0.56,-0.9v-3.1C15.15,9.25 13.6,9 12,9z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_phone.xml
+++ b/android/app/src/main/res/drawable/ic_phone.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- A handset, for calling a bot and for Settings → Voice. Drawn here: the core icon set's Call glyph is not in this app's icon artifact. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6.62,10.79c1.44,2.83 3.76,5.14 6.59,6.59l2.2,-2.2c0.27,-0.27 0.67,-0.36 1.02,-0.24 1.12,0.37 2.33,0.57 3.57,0.57 0.55,0 1,0.45 1,1V20c0,0.55 -0.45,1 -1,1 -9.39,0 -17,-7.61 -17,-17 0,-0.55 0.45,-1 1,-1h3.5c0.55,0 1,0.45 1,1 0,1.25 0.2,2.45 0.57,3.57 0.11,0.35 0.03,0.74 -0.25,1.02l-2.2,2.2z" />
+</vector>

--- a/android/app/src/test/kotlin/com/openmausbot/companion/dictation/SpeechDictationTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/dictation/SpeechDictationTest.kt
@@ -524,3 +524,127 @@ class SpeechDictationTest {
         }
     }
 }
+
+/**
+ * Call mode — `listenForTurn` on the call-mode branch of
+ * `ios/App/SpeechDictation.swift`: the turn ends a gap after the transcript
+ * last changed, or on the recognizer's final; an empty turn never ends on the
+ * timer; stopping any other way ends it without a callback.
+ */
+class SpeechDictationTurnTest {
+    private var now = 0L
+    private val scheduled = ArrayDeque<() -> Unit>()
+
+    private fun newDictation(fake: TurnFakeFactory): SpeechDictation = SpeechDictation(
+        engineFactory = fake,
+        hasRecordAudio = { true },
+        requestRecordAudio = { it(true) },
+        focus = object : DictationAudioFocus {
+            override fun request(onInterrupted: () -> Unit): Boolean = true
+            override fun abandon() = Unit
+        },
+        preferredLanguages = { listOf("en-US") },
+        currentLocale = { Locale.US },
+        postMain = { it() },
+        postDelayed = { _, block -> scheduled.addLast(block) },
+        clock = { now },
+    )
+
+    /** Advance the clock and run every endpoint check that was queued. */
+    private fun tick(millis: Long) {
+        now += millis
+        val due = scheduled.toList()
+        scheduled.clear()
+        due.forEach { it() }
+    }
+
+    @Test
+    fun theTurnEndsAGapAfterTheTranscriptLastChanged() {
+        val fake = TurnFakeFactory()
+        val dictation = newDictation(fake)
+        val turns = mutableListOf<String>()
+        dictation.listenForTurn(850) { turns += it }
+        assertTrue(dictation.isListening.value)
+
+        fake.listener!!.onPartial("read the")
+        tick(500)
+        fake.listener!!.onPartial("read the logs")
+        tick(500)
+        // 500 ms since the last change: not yet.
+        assertTrue(turns.isEmpty())
+        // The recognizer re-emits the same partial; that is not a change.
+        fake.listener!!.onPartial("read the logs")
+        tick(400)
+        assertEquals(listOf("read the logs"), turns)
+        assertFalse(dictation.isListening.value)
+    }
+
+    @Test
+    fun anEmptyTurnNeverEndsOnTheTimer() {
+        val fake = TurnFakeFactory()
+        val dictation = newDictation(fake)
+        val turns = mutableListOf<String>()
+        dictation.listenForTurn(850) { turns += it }
+        tick(5_000)
+        tick(5_000)
+        assertTrue(turns.isEmpty())
+        assertTrue(dictation.isListening.value)
+    }
+
+    @Test
+    fun theRecognizersFinalEndsTheTurnAtOnce() {
+        val fake = TurnFakeFactory()
+        val dictation = newDictation(fake)
+        val turns = mutableListOf<String>()
+        dictation.listenForTurn(850) { turns += it }
+        fake.listener!!.onPartial("hello")
+        fake.listener!!.onFinal("hello there")
+        assertEquals(listOf("hello there"), turns)
+        assertFalse(dictation.isListening.value)
+    }
+
+    @Test
+    fun silenceTheRecognizerGaveUpOnIsAnEmptyTurnNotAFailure() {
+        val fake = TurnFakeFactory()
+        val dictation = newDictation(fake)
+        val turns = mutableListOf<String>()
+        dictation.listenForTurn(850) { turns += it }
+        fake.listener!!.onError(SpeechEngine.ErrorKind.FAILED)
+        assertEquals(listOf(""), turns)
+        assertNull(dictation.error.value)
+    }
+
+    @Test
+    fun stoppingAnyOtherWayEndsTheTurnWithoutACallback() {
+        val fake = TurnFakeFactory()
+        val dictation = newDictation(fake)
+        val turns = mutableListOf<String>()
+        dictation.listenForTurn(850) { turns += it }
+        fake.listener!!.onPartial("hello")
+        dictation.stop()
+        tick(2_000)
+        assertTrue(turns.isEmpty())
+        // A later composer session is not a call: no endpointer applies.
+        dictation.toggle(capturing = "")
+        fake.listener!!.onPartial("typed")
+        tick(2_000)
+        assertTrue(turns.isEmpty())
+        assertTrue(dictation.isListening.value)
+    }
+
+    private class TurnFakeFactory : SpeechEngineFactory {
+        var listener: SpeechEngine.Listener? = null
+        override fun openers(): List<EngineOpener> = listOf(
+            EngineOpener(isOnDevice = false) {
+                object : SpeechEngine {
+                    override val isOnDevice: Boolean = false
+                    override fun start(request: RecognitionRequest, listener: SpeechEngine.Listener) {
+                        this@TurnFakeFactory.listener = listener
+                    }
+                    override fun cancel() = Unit
+                    override fun destroy() = Unit
+                }
+            },
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/openmausbot/companion/ui/CallRulesTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/ui/CallRulesTest.kt
@@ -1,0 +1,100 @@
+package com.openmausbot.companion.ui
+
+import com.openmausbot.companion.core.ConfigFlag
+import com.openmausbot.companion.core.ConfigStatus
+import com.openmausbot.companion.core.Message
+import com.openmausbot.companion.core.OptionCard
+import com.openmausbot.companion.core.ToolActivity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/** The call loop's decisions, read off `react()` in `ios/App/CallView.swift`. */
+class CallRulesTest {
+    private fun text(id: String, role: Message.Role = Message.Role.BOT, body: String = "Done.") =
+        Message(id = id, role = role, kind = Message.Kind.TEXT, at = 1.0, text = body)
+
+    private fun chip(id: String, spoken: String?) =
+        Message(id = id, role = Message.Role.BOT, kind = Message.Kind.ACTIVITY, at = 1.0, tool = ToolActivity("read", spoken = spoken))
+
+    private fun card(id: String, requestId: String, tool: String?) =
+        Message(id = id, role = Message.Role.BOT, kind = Message.Kind.OPTIONS, at = 1.0, card = OptionCard("Allow?", "", listOf("Allow", "Deny"), requestId = requestId, tool = tool))
+
+    private fun react(
+        fresh: List<Message> = emptyList(),
+        pendingCard: Message? = null,
+        announced: Set<String> = emptySet(),
+        phase: CallPhase = CallPhase.WORKING,
+        busy: Boolean = false,
+        speakerSpeaking: Boolean = false,
+    ) = CallRules.react("Scout", fresh, pendingCard, announced, phase, busy, speakerSpeaking)
+
+    @Test
+    fun `a pending card is announced once, and never over the bot's own voice`() {
+        val permission = card("m1", "req-1", tool = "bash")
+        assertEquals(
+            CallAction.Announce("Scout is asking for permission. Open the chat to answer it."),
+            react(pendingCard = permission, phase = CallPhase.LISTENING),
+        )
+        assertEquals(
+            CallAction.Announce("Scout has a question. Open the chat to answer it."),
+            react(pendingCard = card("m2", "req-2", tool = null), phase = CallPhase.WORKING),
+        )
+        assertEquals(CallAction.None, react(pendingCard = permission, announced = setOf("req-1"), phase = CallPhase.LISTENING))
+        assertEquals(CallAction.None, react(pendingCard = permission, phase = CallPhase.SPEAKING))
+    }
+
+    @Test
+    fun `a reply is read, the newest one, and never the person's own words`() {
+        assertEquals(CallAction.SayReply("Second."), react(fresh = listOf(text("a", body = "First."), text("b", body = "Second."))))
+        assertEquals(CallAction.None, react(fresh = listOf(text("u", role = Message.Role.USER, body = "hi")), busy = false, phase = CallPhase.LISTENING))
+        assertEquals(CallAction.Listen, react(fresh = listOf(text("e", body = "   ")), phase = CallPhase.WORKING))
+    }
+
+    @Test
+    fun `a spoken chip is narrated only while waiting`() {
+        assertEquals(CallAction.SayChip("Reading the logs"), react(fresh = listOf(chip("c", "Reading the logs")), phase = CallPhase.WORKING, busy = true))
+        assertEquals(CallAction.None, react(fresh = listOf(chip("c", null)), phase = CallPhase.WORKING, busy = true))
+        assertEquals(CallAction.StopListeningAndWork, react(fresh = listOf(chip("c", "Reading")), phase = CallPhase.LISTENING, busy = true))
+    }
+
+    @Test
+    fun `busy closes the microphone, idle reopens it once the speaker is quiet`() {
+        assertEquals(CallAction.StopListeningAndWork, react(phase = CallPhase.LISTENING, busy = true))
+        assertEquals(CallAction.StopListeningAndWork, react(phase = CallPhase.SENDING, busy = true))
+        assertEquals(CallAction.None, react(phase = CallPhase.WORKING, busy = true))
+        assertEquals(CallAction.Listen, react(phase = CallPhase.WORKING, busy = false))
+        assertEquals(CallAction.Listen, react(phase = CallPhase.SENDING, busy = false))
+        assertEquals(CallAction.None, react(phase = CallPhase.WORKING, busy = false, speakerSpeaking = true))
+        assertEquals(CallAction.None, react(phase = CallPhase.LISTENING, busy = false))
+    }
+
+    @Test
+    fun `the phase line and the notes read as the Swift's`() {
+        assertEquals("Listening…", CallRules.phaseText(CallPhase.LISTENING, "Scout"))
+        assertEquals("Scout is working…", CallRules.phaseText(CallPhase.WORKING, "Scout"))
+        assertEquals("Set up a voice in Settings → Voice to hear Scout.", CallRules.noVoiceNote("Scout"))
+        assertEquals(850L, CallRules.ENDPOINT_GAP_MILLIS)
+    }
+
+    @Test
+    fun `voice settings offer the key only under ElevenLabs`() {
+        val ready = ConfigStatus(tts = ConfigFlag(configured = true))
+        val system = ConfigStatus(tts = ConfigFlag(configured = true, provider = "system"))
+        assertEquals("Ready", VoiceSettingsRules.statusText(ready))
+        assertEquals("Not set up", VoiceSettingsRules.statusText(ConfigStatus(tts = ConfigFlag(configured = false))))
+        assertNull(VoiceSettingsRules.statusText(null))
+        assertTrue(VoiceSettingsRules.showsKeyField(ready))
+        assertTrue(VoiceSettingsRules.showsKeyField(null))
+        assertFalse(VoiceSettingsRules.showsKeyField(system))
+        assertEquals("Replace key", VoiceSettingsRules.saveLabel(ready))
+        assertEquals("Save key", VoiceSettingsRules.saveLabel(null))
+        assertTrue(VoiceSettingsRules.canSave("sk", saving = false))
+        assertFalse(VoiceSettingsRules.canSave("  ", saving = false))
+        assertFalse(VoiceSettingsRules.canSave("sk", saving = true))
+        assertTrue(VoiceSettingsRules.canRemove(ready, saving = false))
+        assertFalse(VoiceSettingsRules.canRemove(null, saving = false))
+    }
+}

--- a/android/app/src/test/kotlin/com/openmausbot/companion/ui/NavigationTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/ui/NavigationTest.kt
@@ -108,6 +108,7 @@ class NavigationTest {
             Destination.Settings,
             Destination.Routines,
             Destination.ConnectedApps,
+            Destination.Voice,
             Destination.Thread("thread:with:colons"),
             Destination.Computer("bot:with:colons"),
             Destination.Chat(ChatTarget.Bot("bot:1:x", "thread:1:y")),

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Client.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Client.kt
@@ -342,14 +342,63 @@ class CompanionClient(
             avatarGenerationClient,
         ).bot
 
-    suspend fun previewVoice(text: String, voiceId: String): ByteArray {
+    suspend fun previewVoice(text: String, voiceId: String): ByteArray = speak(text, voiceId)
+
+    /**
+     * One utterance, synthesized on the paired computer. The server caps this
+     * at 500 characters; [prepareSpeech] splits a reply into pieces that fit.
+     * An empty [voiceId] means the workspace default.
+     */
+    suspend fun speak(text: String, voiceId: String?): ByteArray {
         val raw = perform(makeRequest(
             "POST",
             "/api/tts/speak",
-            body = jsonBody("text" to text.take(500), "voiceId" to voiceId),
+            body = buildJsonObject {
+                put("text", text.take(500))
+                if (!voiceId.isNullOrEmpty()) put("voiceId", voiceId)
+            },
         ))
         check(raw)
         return raw.data
+    }
+
+    /**
+     * Split a reply into utterances the way the desktop does — on the server,
+     * next to the transform that shapes replies — and learn whether the
+     * computer can voice them at all.
+     */
+    suspend fun prepareSpeech(text: String, voiceId: String?): PreparedSpeech = send(
+        makeRequest(
+            "POST",
+            "/api/tts/prepare",
+            body = buildJsonObject {
+                put("text", text)
+                if (!voiceId.isNullOrEmpty()) put("voiceId", voiceId)
+            },
+        ),
+    )
+
+    /**
+     * Store (or, with an empty string, remove) the workspace's ElevenLabs key.
+     * The companion forwards only this shape, and the server checks a
+     * non-empty key against the provider before saving it; the key itself
+     * never comes back in any response.
+     */
+    suspend fun updateVoiceKey(key: String) {
+        val trimmed = key.trim()
+        if (trimmed.toByteArray().size > 512 || trimmed.any(Char::isISOControl)) {
+            throw APIError.Transport("That doesn't look like an API key.")
+        }
+        sendUnit(makeRequest("PUT", "/api/config", body = buildJsonObject {
+            put("tts", buildJsonObject { put("key", trimmed) })
+        }))
+    }
+
+    /** Pick the voice engine: "elevenlabs" or "system". */
+    suspend fun updateVoiceProvider(provider: String) {
+        sendUnit(makeRequest("PUT", "/api/config", body = buildJsonObject {
+            put("tts", buildJsonObject { put("provider", provider) })
+        }))
     }
 
     suspend fun createRoutine(input: RoutineInput): Routine {

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Models.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Models.kt
@@ -518,6 +518,13 @@ data class InstanceCapabilities(val images: Boolean? = null)
 @Serializable
 data class InstanceList(val instances: List<Instance>)
 
+/**
+ * A reply split into utterances the computer can voice, and whether it can
+ * voice them at all — `POST /api/tts/prepare`.
+ */
+@Serializable
+data class PreparedSpeech(val ready: Boolean, val utterances: List<String>)
+
 /** Which engine actually speaks. `VoiceProvider` in `server/tts/index.ts`. */
 enum class VoiceProvider { ELEVENLABS, SYSTEM }
 

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Session.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Session.kt
@@ -1559,6 +1559,46 @@ class Session(
         }
     }
 
+    /**
+     * A reply as utterances the computer can voice, or `ready = false` when it
+     * has no voice set up — so a call can say so rather than fall silent.
+     * Throws: a call reads the failure itself instead of an action banner.
+     */
+    suspend fun prepareSpeech(text: String, voiceId: String?): PreparedSpeech {
+        val activeClient = client ?: throw APIError.Transport("This computer is offline.")
+        return activeClient.prepareSpeech(text, voiceId)
+    }
+
+    suspend fun speak(text: String, voiceId: String?): ByteArray {
+        val activeClient = client ?: throw APIError.Transport("This computer is offline.")
+        return activeClient.speak(text, voiceId)
+    }
+
+    /** Save the ElevenLabs key on the computer. The server's reason when it refuses, null on success. */
+    suspend fun updateVoiceKey(key: String): String? {
+        val activeClient = client ?: return "This computer is offline."
+        return try {
+            activeClient.updateVoiceKey(key)
+            null
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            error.message ?: "Couldn't save the key."
+        }
+    }
+
+    suspend fun updateVoiceProvider(provider: String): String? {
+        val activeClient = client ?: return "This computer is offline."
+        return try {
+            activeClient.updateVoiceProvider(provider)
+            null
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            error.message ?: "Couldn't change the voice engine."
+        }
+    }
+
     suspend fun configStatus(): ConfigStatus? = try {
         client?.config()
     } catch (error: Throwable) {

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/VoiceClientTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/VoiceClientTest.kt
@@ -1,0 +1,117 @@
+package com.openmausbot.companion.core
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** The calls a call makes — the voice half of `Client.swift` on the call-mode branch. */
+class VoiceClientTest {
+    private lateinit var server: MockWebServer
+    private lateinit var client: CompanionClient
+
+    @BeforeTest
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        client = CompanionClient(requireNotNull(Connection.parse(server.url("/").toString())), "paired-token")
+    }
+
+    @AfterTest
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun prepareSendsTheWholeReplyAndTheBotsVoice() = runBlocking {
+        server.enqueue(json("""{"ready":true,"utterances":["One.","Two."]}"""))
+        val prepared = client.prepareSpeech("One. Two.", "rachel")
+        val request = server.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/api/tts/prepare", request.path)
+        val body = CompanionJson.parseToJsonElement(request.body.readUtf8()).jsonObject
+        assertEquals("One. Two.", body.getValue("text").jsonPrimitive.content)
+        assertEquals("rachel", body.getValue("voiceId").jsonPrimitive.content)
+        assertTrue(prepared.ready)
+        assertEquals(listOf("One.", "Two."), prepared.utterances)
+    }
+
+    @Test
+    fun aMissingVoiceMeansTheWorkspaceDefaultAndIsNotSentAsAnEmptyString() = runBlocking {
+        server.enqueue(json("""{"ready":false,"utterances":[]}"""))
+        val prepared = client.prepareSpeech("Hello", null)
+        val body = CompanionJson.parseToJsonElement(server.takeRequest().body.readUtf8()).jsonObject
+        assertEquals(setOf("text"), body.keys)
+        assertFalse(prepared.ready)
+
+        server.enqueue(MockResponse().setHeader("Content-Type", "audio/mpeg").setBody("mp3"))
+        client.speak("Hello", "")
+        val speak = CompanionJson.parseToJsonElement(server.takeRequest().body.readUtf8()).jsonObject
+        assertEquals(setOf("text"), speak.keys)
+    }
+
+    @Test
+    fun speakCapsOneUtteranceAtTheServersFiveHundredCharacters() = runBlocking {
+        server.enqueue(MockResponse().setHeader("Content-Type", "audio/mpeg").setBody("mp3"))
+        val audio = client.speak("a".repeat(600), "rachel")
+        val request = server.takeRequest()
+        assertEquals("/api/tts/speak", request.path)
+        val body = CompanionJson.parseToJsonElement(request.body.readUtf8()).jsonObject
+        assertEquals(500, body.getValue("text").jsonPrimitive.content.length)
+        assertEquals("rachel", body.getValue("voiceId").jsonPrimitive.content)
+        assertContentEquals("mp3".toByteArray(), audio)
+    }
+
+    @Test
+    fun theKeyTravelsAsExactlyTheVoiceShapeTheCompanionForwards() = runBlocking {
+        server.enqueue(json("{}"))
+        client.updateVoiceKey("  sk_live_abc  ")
+        val request = server.takeRequest()
+        assertEquals("PUT", request.method)
+        assertEquals("/api/config", request.path)
+        val body = CompanionJson.parseToJsonElement(request.body.readUtf8()).jsonObject
+        assertEquals(setOf("tts"), body.keys)
+        val tts = body.getValue("tts").jsonObject
+        assertEquals(setOf("key"), tts.keys)
+        assertEquals("sk_live_abc", tts.getValue("key").jsonPrimitive.content)
+
+        server.enqueue(json("{}"))
+        client.updateVoiceProvider("system")
+        val provider = CompanionJson.parseToJsonElement(server.takeRequest().body.readUtf8()).jsonObject
+        assertEquals("system", provider.getValue("tts").jsonObject.getValue("provider").jsonPrimitive.content)
+    }
+
+    @Test
+    fun anEmptyKeyRemovesIt() = runBlocking {
+        server.enqueue(json("{}"))
+        client.updateVoiceKey("")
+        val tts = CompanionJson.parseToJsonElement(server.takeRequest().body.readUtf8()).jsonObject.getValue("tts").jsonObject
+        assertEquals("", tts.getValue("key").jsonPrimitive.content)
+    }
+
+    @Test
+    fun somethingThatIsNotAKeyNeverLeavesThePhone() = runBlocking {
+        assertFailsWith<APIError.Transport> { client.updateVoiceKey("a\nb") }
+        assertFailsWith<APIError.Transport> { client.updateVoiceKey("k".repeat(513)) }
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun theServersRefusalReadsAsItsOwnSentence() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(400).setHeader("Content-Type", "application/json").setBody("""{"error":"ElevenLabs rejected that key"}"""))
+        val error = assertFailsWith<APIError.Status> { client.updateVoiceKey("bad") }
+        assertEquals("ElevenLabs rejected that key", error.message)
+    }
+
+    private fun json(body: String): MockResponse =
+        MockResponse().setResponseCode(200).setHeader("Content-Type", "application/json").setBody(body)
+}

--- a/companion/src/proxy.ts
+++ b/companion/src/proxy.ts
@@ -19,7 +19,7 @@ import {
   MAX_COMPANION_ENDPOINTS,
   type CompanionEndpoint,
 } from "./endpoints.ts";
-import { denyReason, isCloudDesktopJoin, isMessageFileDownload } from "./routes.ts";
+import { denyReason, isCloudDesktopJoin, isMessageFileDownload, isVoiceConfigWrite, voiceConfigDenial } from "./routes.ts";
 import { createSseScrubber, isJson, scrub } from "./wire.ts";
 
 /** What the forwarding handler needs from the process around it. */
@@ -307,13 +307,22 @@ export function createProxyHandler(options: ProxyOptions) {
       return sendJson(res, 200, endpointSnapshot(options));
     }
 
+    // The one route whose body the sidecar reads before forwarding: a voice
+    // config write. Everything else streams straight through. `payload` is
+    // that re-serialised body; absent, the request is piped as it arrived.
+    const forward = (payload?: Buffer): void => {
+    const headers = forwardHeaders(req);
+    if (payload) {
+      headers["content-type"] = "application/json";
+      headers["content-length"] = String(payload.length);
+    }
     const upstream = httpRequest(
       {
         hostname: "127.0.0.1",
         port: options.harnessPort,
         path: req.url,
         method,
-        headers: forwardHeaders(req),
+        headers,
       },
       (harness) => {
         clearTimeout(headersDeadline);
@@ -593,6 +602,21 @@ export function createProxyHandler(options: ProxyOptions) {
           : { error: "OpenMausBot is not running on this computer" },
       );
     });
-    req.pipe(upstream);
+    if (payload) upstream.end(payload);
+    else req.pipe(upstream);
+    };
+
+    if (isVoiceConfigWrite(method, path)) {
+      readJson(req).then(
+        (body) => {
+          const denial = voiceConfigDenial(body);
+          if (denial) return sendJson(res, 403, { error: denial });
+          forward(Buffer.from(JSON.stringify(body)));
+        },
+        (error: Error) => sendJson(res, 400, { error: error.message }),
+      );
+      return;
+    }
+    forward();
   };
 }

--- a/companion/src/routes.ts
+++ b/companion/src/routes.ts
@@ -56,6 +56,48 @@ export function isMessageFileDownload(method: string, path: string): boolean {
   return method === MESSAGE_FILE_ROUTE.method && MESSAGE_FILE_ROUTE.path.test(path);
 }
 
+/** The one host-configuration write a phone may make: the workspace voice
+ * key and engine, so a call can be set up from the phone. The route itself
+ * is the desktop's general config PUT, which also carries every other
+ * provider key — so the proxy reads the body first and forwards only the
+ * shape `voiceConfigDenial` accepts. */
+export const VOICE_CONFIG_ROUTE = {
+  method: "PUT",
+  path: /^\/api\/config$/,
+} as const;
+
+export function isVoiceConfigWrite(method: string, path: string): boolean {
+  return method === VOICE_CONFIG_ROUTE.method && VOICE_CONFIG_ROUTE.path.test(path);
+}
+
+const VOICE_PROVIDERS = new Set(["elevenlabs", "system"]);
+
+/** Why a config write from a phone is refused, or null when it is exactly a
+ * voice-key or voice-engine change: `{ tts: { key?, provider? } }` and nothing
+ * else at either level. The key is bounded and free of control characters;
+ * the server still verifies it against the provider before saving. */
+export function voiceConfigDenial(body: unknown): string | null {
+  const refusal = "only the voice key and engine can be changed from a phone; other API keys are set on your computer";
+  if (!body || typeof body !== "object" || Array.isArray(body)) return refusal;
+  const top = body as Record<string, unknown>;
+  const keys = Object.keys(top);
+  if (keys.length !== 1 || keys[0] !== "tts") return refusal;
+  const tts = top.tts;
+  if (!tts || typeof tts !== "object" || Array.isArray(tts)) return refusal;
+  const fields = Object.keys(tts as Record<string, unknown>);
+  if (fields.length === 0 || fields.some((field) => field !== "key" && field !== "provider")) return refusal;
+  const { key, provider } = tts as { key?: unknown; provider?: unknown };
+  if (key !== undefined) {
+    if (typeof key !== "string" || Buffer.byteLength(key) > 512 || /[\u0000-\u001f\u007f]/.test(key)) {
+      return "that doesn't look like an API key";
+    }
+  }
+  if (provider !== undefined && (typeof provider !== "string" || !VOICE_PROVIDERS.has(provider))) {
+    return "unknown voice engine";
+  }
+  return null;
+}
+
 /** Every request the iOS app makes, and nothing else.
  *
  * Ids are `[\w-]+`, matching the harness's own route patterns. The paths
@@ -128,8 +170,13 @@ const ALLOWED: ReadonlyArray<{ method: string; path: RegExp }> = [
 
   // Renderer-neutral voice operations. Neither route reads or writes the
   // workspace ElevenLabs key; the phone receives labels or audio only.
+  // `prepare` splits a reply into utterances the way the desktop does and
+  // says whether the computer can voice them at all; it reads no key.
+  { method: "POST", path: /^\/api\/tts\/prepare$/ },
   { method: "GET", path: /^\/api\/tts\/voices$/ },
   { method: "POST", path: /^\/api\/tts\/speak$/ },
+  // The voice key and engine, and nothing else: the proxy gates the body.
+  VOICE_CONFIG_ROUTE,
 
   // Routines create ordinary tasks using an existing agent configuration.
   // Webhook management remains explicitly denied below.
@@ -161,7 +208,7 @@ const EXPLAINED: ReadonlyArray<{ path: RegExp; error: string }> = [
     // Losing the phone must not mean losing the ability to lock it out.
     error: "Phone settings are managed on your computer",
   },
-  { path: /^\/api\/config$/, error: "API keys can only be changed on your computer" },
+  { path: /^\/api\/config$/, error: "API keys other than the voice key can only be changed on your computer" },
   { path: /^\/api\/local-computer(\/|$)/, error: "the Local VM is set up on your computer" },
   {
     // Creating one exposes an endpoint to the internet, and rotating a

--- a/companion/test/proxy.test.ts
+++ b/companion/test/proxy.test.ts
@@ -300,6 +300,9 @@ describe("the sidecar in front of an unmodified harness", () => {
   it("refuses what a device has no business doing, by default", async () => {
     // settings and credentials stay on the machine
     expect((await device("PUT", "/api/config", { body: { xai: { apiKey: "x" } } })).status).toBe(403);
+    // …even riding along with the one write a phone may make
+    expect((await device("PUT", "/api/config", { body: { tts: { provider: "system" }, xai: { apiKey: "x" } } })).status).toBe(403);
+    expect((await device("PATCH", "/api/config", { body: { tts: { provider: "system" } } })).status).toBe(403);
     expect((await device("GET", "/api/devices")).status).toBe(403);
     expect((await device("GET", "/api/companion")).status).toBe(403);
     expect((await device("POST", "/api/local-computer/start")).status).toBe(403);
@@ -1009,5 +1012,23 @@ describe("pairing, end to end", () => {
     } finally {
       await new Promise<void>((r) => control.close(() => r()));
     }
+  });
+});
+
+describe("the voice config write", () => {
+  it("forwards a voice engine change to the harness, and nothing rides along", async () => {
+    const changed = await device("PUT", "/api/config", { body: { tts: { provider: "system" } } });
+    expect(changed.status, JSON.stringify(changed.body)).toBe(200);
+    const config = await device("GET", "/api/config");
+    expect(config.status).toBe(200);
+    expect(config.body.tts?.provider).toBe("system");
+    const back = await device("PUT", "/api/config", { body: { tts: { provider: "elevenlabs" } } });
+    expect(back.status, JSON.stringify(back.body)).toBe(200);
+  });
+
+  it("refuses a malformed key before the harness sees it", async () => {
+    const refused = await device("PUT", "/api/config", { body: { tts: { key: "bad\nkey" } } });
+    expect(refused.status).toBe(403);
+    expect(refused.body.error).toMatch(/API key/);
   });
 });

--- a/companion/test/routes.test.ts
+++ b/companion/test/routes.test.ts
@@ -7,7 +7,7 @@
 // and the one that quietly stopped being true once before.
 import { describe, expect, it } from "vitest";
 
-import { denyReason } from "../src/routes.ts";
+import { denyReason, voiceConfigDenial } from "../src/routes.ts";
 
 const ask = (method: string, path: string, authenticated = true) =>
   denyReason({ method, path, authenticated });
@@ -75,7 +75,9 @@ describe("what the app may do", () => {
     ["GET", "/api/attachments/avatar-123.webp"],
     ["POST", "/api/files"],
     ["GET", "/api/tts/voices"],
+    ["POST", "/api/tts/prepare"],
     ["POST", "/api/tts/speak"],
+    ["PUT", "/api/config"],
     ["GET", "/api/routines"],
     ["POST", "/api/routines"],
     ["PATCH", "/api/routines/routine_1"],
@@ -95,7 +97,6 @@ describe("what the app may do", () => {
 describe("what it may not", () => {
   it("refuses host configuration, and says where it happens", () => {
     for (const [method, path] of [
-      ["PUT", "/api/config"],
       ["PATCH", "/api/config"],
       ["GET", "/api/devices"],
       ["GET", "/api/companion"],
@@ -178,7 +179,9 @@ describe("what it may not", () => {
     expect(allowed("GET", "/api/sidebar-sections")).toBe(false);
     expect(allowed("PATCH", "/api/sidebar-sections")).toBe(false);
     expect(allowed("POST", "/api/sidebar-sections/extra")).toBe(false);
-    expect(allowed("PUT", "/api/config")).toBe(false);
+    // Allowed by path; the proxy reads the body and forwards only a voice change.
+    expect(allowed("PUT", "/api/config")).toBe(true);
+    expect(allowed("PATCH", "/api/config")).toBe(false);
     expect(allowed("GET", "/api/attachments/../config.json")).toBe(false);
     expect(allowed("GET", "/api/files")).toBe(false);
     expect(allowed("POST", "/api/files/anything")).toBe(false);
@@ -214,5 +217,38 @@ describe("what it may not", () => {
       expect(allowed("POST", path), path).toBe(false);
       expect(allowed("DELETE", path), path).toBe(false);
     }
+  });
+});
+
+describe("the voice config write", () => {
+  it("forwards exactly a voice key or engine change", () => {
+    expect(voiceConfigDenial({ tts: { key: "sk_live_abc" } })).toBeNull();
+    expect(voiceConfigDenial({ tts: { key: "" } })).toBeNull();
+    expect(voiceConfigDenial({ tts: { provider: "system" } })).toBeNull();
+    expect(voiceConfigDenial({ tts: { provider: "elevenlabs", key: "k" } })).toBeNull();
+  });
+
+  it("refuses every other key, and any other field beside the voice ones", () => {
+    for (const body of [
+      { xai: { apiKey: "x" } },
+      { tts: { key: "k" }, xai: { apiKey: "x" } },
+      { tts: { voice: "rachel" } },
+      { tts: { key: "k", voice: "rachel" } },
+      { tts: {} },
+      { tts: "k" },
+      {},
+      [],
+      null,
+      "tts",
+    ]) {
+      expect(voiceConfigDenial(body), JSON.stringify(body)).toMatch(/on your computer/);
+    }
+  });
+
+  it("refuses a key that is not a key", () => {
+    expect(voiceConfigDenial({ tts: { key: 42 } })).toMatch(/API key/);
+    expect(voiceConfigDenial({ tts: { key: "a\nb" } })).toMatch(/API key/);
+    expect(voiceConfigDenial({ tts: { key: "k".repeat(513) } })).toMatch(/API key/);
+    expect(voiceConfigDenial({ tts: { provider: "cartesia" } })).toMatch(/voice engine/);
   });
 });


### PR DESCRIPTION
The Android port of the iOS call mode (`fix/ios-file-links-send-attach`, a0baba4), plus the companion change both platforms need.

**Call mode.** A phone button in a bot's chat opens a half-duplex loop: listen until 850 ms of silence, send, narrate the bot's spoken activity chips while it works, read the reply through the computer's voice, listen again. Utterances are split and synthesized by the computer (`/api/tts/prepare`, `/api/tts/speak`), so the voice and the key are the workspace's. Approvals and questions are announced, not answered by voice. `SpeechDictation` gains the silence endpointer (`listenForTurn`); `CallRules` holds the loop's decisions, tested against the Swift; `CallSpeaker` plays the clips in order.

**Settings → Voice** saves the ElevenLabs key with the same `PUT /api/config` the desktop uses; the server verifies it before storing, and it never reaches the phone.

**Companion.** Neither route crossed the sidecar before: the allowlist answered 404 to `prepare` and refused every config write — which is also why the iOS build's call mode cannot work through it today. The sidecar now allows `POST /api/tts/prepare`, and forwards `PUT /api/config` only after reading the body and finding exactly a voice key or engine change (`{ tts: { key?, provider? } }` and nothing else at either level — `voiceConfigDenial`). Every other config write, and `PATCH`, is still refused with the same sentence. Covered in `routes.test.ts` and the end-to-end `proxy.test.ts`.

Verified: Android suite 1265 tests, 0 failures; companion vitest 88 passed; `tsc -p tsconfig.companion.build.json` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added voice calling for bot chats, including turn-based listening, spoken replies, activity announcements, interruption, and hang-up controls.
  * Added Voice settings for choosing the speech provider and managing an ElevenLabs API key.
  * Added navigation from Settings to Voice configuration.
  * Improved speech playback and handling of microphone, speaker, and connection errors.
* **Bug Fixes**
  * Voice configuration changes now validate supported fields and reject malformed or unauthorized updates.
* **Tests**
  * Added coverage for voice calls, speech turn detection, navigation, voice settings, and configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->