### PR TITLE
fix(ios): show secure credential requests

### DIFF
--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -1258,6 +1258,12 @@ struct MessageRow: View {
             TextBubble(message: message, chat: chat, tailed: endsRun, openLink: openLink)
         case .options:
             CardView(chat: chat, message: message)
+        case .secret:
+            if let secret = message.secret {
+                CredentialRequestCardView(chat: chat, message: message, secret: secret)
+            } else if let text = message.text, !text.isEmpty {
+                TextBubble(message: message, chat: chat, tailed: endsRun, openLink: openLink)
+            }
         case .activity:
             ActivityChip(tool: message.tool)
         case .screen:
@@ -1471,6 +1477,121 @@ struct ActivityChip: View {
             )
             .padding(.leading, 2)
         }
+    }
+}
+
+/// A host credential is intentionally entered on the computer, where
+/// Electron can commit it through the operating system's encrypted store.
+/// The phone still needs a real row: an invisible blocker makes the bot look
+/// confused and encourages people to paste a key into ordinary chat.
+struct CredentialRequestCardView: View {
+    let chat: Chat
+    let message: Message
+    let secret: SecretRequestCardData
+
+    private var tint: Color { MausPalette.color(message.from?.color ?? chat.color) }
+    private var requester: String { message.from?.name ?? chat.name }
+    private var label: String { visible(secret.label) ?? "API credential" }
+    private var accessibilityStatus: String {
+        if secret.provided == true {
+            return secret.resumed == true ? "Saved securely. The task resumed." : "Saved securely on your computer."
+        }
+        if secret.dismissed == true { return "Not provided." }
+        return "Finish this credential request on your computer."
+    }
+
+    private func visible(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private var helpURL: URL? {
+        guard let raw = secret.helpUrl,
+              let url = URL(string: raw),
+              url.scheme?.lowercased() == "https",
+              url.host != nil,
+              url.user == nil,
+              url.password == nil
+        else { return nil }
+        return url
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 11) {
+                Image(systemName: "key.fill")
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundStyle(tint)
+                    .frame(width: 38, height: 38)
+                    .background(tint.opacity(0.13), in: RoundedRectangle(cornerRadius: 11, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(label)
+                        .font(.system(size: 16, weight: .semibold))
+                    Text("Requested by \(requester)")
+                        .font(.system(size: 12.5))
+                        .foregroundStyle(Color.secondary)
+                }
+                Spacer(minLength: 0)
+            }
+
+            if let description = visible(secret.description) {
+                Text(description)
+                    .font(.system(size: 14.5))
+                    .foregroundStyle(Color.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if secret.provided == true {
+                Label(
+                    secret.resumed == true ? "Saved securely. The task resumed." : "Saved securely on your computer.",
+                    systemImage: "checkmark.shield.fill"
+                )
+                .foregroundStyle(.green)
+            } else if secret.dismissed == true {
+                Label("Not provided", systemImage: "xmark.circle")
+                    .foregroundStyle(Color.secondary)
+            } else {
+                VStack(alignment: .leading, spacing: 5) {
+                    Label("Finish on your computer", systemImage: "desktopcomputer")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(tint)
+                    Text("Open this chat in OpenMausBot on your computer to enter the key. It is stored there securely and is never added to chat.")
+                        .font(.system(size: 13))
+                        .foregroundStyle(Color.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(11)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 13, style: .continuous))
+            }
+
+            if let error = visible(secret.error) {
+                Label(error, systemImage: "exclamationmark.triangle.fill")
+                    .font(.system(size: 12.5))
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if let helpURL {
+                Link(destination: helpURL) {
+                    Label("Where to get this key", systemImage: "arrow.up.right")
+                        .font(.system(size: 13, weight: .medium))
+                }
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .fill(Color.secondary.opacity(0.09))
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .strokeBorder(secret.isPending ? tint.opacity(0.65) : Color.clear, lineWidth: 1.25)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label). \(accessibilityStatus)")
     }
 }
 

--- a/ios/App/Updates.swift
+++ b/ios/App/Updates.swift
@@ -82,6 +82,7 @@ extension CompanionState {
         switch last.kind {
         case .text, .unknown: return last.text ?? ""
         case .options: return last.card?.title ?? ""
+        case .secret: return last.secret?.label ?? last.text ?? "Credential required"
         case .activity: return last.tool?.name ?? ""
         case .screen: return "Screenshot"
         }

--- a/ios/Sources/CompanionCore/ChatPreferences.swift
+++ b/ios/Sources/CompanionCore/ChatPreferences.swift
@@ -157,6 +157,8 @@ func previewText(of message: Message) -> String {
     case .options:
         guard let card = message.card else { return "" }
         return card.isPending && !card.subtitle.isEmpty ? card.subtitle : card.title
+    case .secret:
+        return message.secret?.label ?? message.text ?? "Credential required"
     case .activity: return message.tool?.name ?? ""
     case .screen: return "Screenshot"
     case .unknown: return message.text ?? ""

--- a/ios/Sources/CompanionCore/Models.swift
+++ b/ios/Sources/CompanionCore/Models.swift
@@ -106,6 +106,26 @@ public struct ToolActivity: Codable, Hashable, Sendable {
     public var setup: Bool?
 }
 
+/// A credential request created by the desktop for one paused task.
+///
+/// Paired phones deliberately cannot write host credentials. Keeping the
+/// payload lets the companion render an honest handoff card instead of
+/// turning this newer message kind into an invisible row.
+public struct SecretRequestCardData: Codable, Hashable, Sendable {
+    public var target: String?
+    public var label: String?
+    public var description: String?
+    public var placeholder: String?
+    public var helpUrl: String?
+    public var requestKey: String?
+    public var provided: Bool?
+    public var dismissed: Bool?
+    public var resumed: Bool?
+    public var error: String?
+
+    public var isPending: Bool { provided != true && dismissed != true }
+}
+
 public struct Sender: Codable, Hashable, Sendable {
     public var botId: String
     public var name: String
@@ -126,7 +146,7 @@ public struct CommChip: Codable, Hashable, Sendable {
 
 public struct Message: Codable, Hashable, Identifiable, Sendable {
     public enum Kind: String, Codable, Sendable {
-        case text, options, activity, screen
+        case text, options, activity, screen, secret
         /// A kind this build has never heard of.
         ///
         /// Not decorative. `kind` is not optional, so without this a single
@@ -163,6 +183,7 @@ public struct Message: Codable, Hashable, Identifiable, Sendable {
     public var at: Double
     public var text: String?
     public var card: OptionCard?
+    public var secret: SecretRequestCardData?
     public var tool: ToolActivity?
     /// The message this one follows; nil at the thread root. Two messages
     /// sharing a parent are a fork.

--- a/ios/Tests/CompanionCoreTests/DecodingTests.swift
+++ b/ios/Tests/CompanionCoreTests/DecodingTests.swift
@@ -307,6 +307,54 @@ final class DecodingTests: XCTestCase {
         XCTAssertFalse(card.isPermission)
     }
 
+    func testDecodesADirectCredentialRequestWithoutSenderMetadata() throws {
+        let json = """
+        {
+          "id": "secret-1", "role": "bot", "kind": "secret", "at": 1786742413762,
+          "text": "Complete this credential request securely on your computer.",
+          "secret": {
+            "target": "ttsKey", "label": "ElevenLabs API key",
+            "description": "Enables text-to-speech voices in calls.",
+            "placeholder": "Paste your ElevenLabs API key",
+            "helpUrl": "https://elevenlabs.io/app/settings/api-keys",
+            "requestKey": "request-key-1"
+          }
+        }
+        """
+        let message = try JSONDecoder().decode(Message.self, from: Data(json.utf8))
+
+        XCTAssertEqual(message.kind, .secret)
+        XCTAssertNil(message.from, "a direct chat gets its bot identity from the enclosing chat")
+        XCTAssertEqual(message.secret?.target, "ttsKey")
+        XCTAssertEqual(message.secret?.label, "ElevenLabs API key")
+        XCTAssertEqual(message.secret?.requestKey, "request-key-1")
+        XCTAssertTrue(try XCTUnwrap(message.secret).isPending)
+        XCTAssertEqual(previewText(of: message), "ElevenLabs API key")
+    }
+
+    func testDecodesAChannelCredentialRequestWithItsSender() throws {
+        let json = """
+        {
+          "id": "secret-2", "role": "bot", "kind": "secret", "at": 1786742413762,
+          "from": {"botId": "bot-2", "name": "Robyn", "color": "purple"},
+          "secret": {
+            "target": "ttsKey", "label": "ElevenLabs API key",
+            "description": "Enables voices.", "placeholder": "Paste key",
+            "helpUrl": "https://elevenlabs.io/app/settings/api-keys",
+            "requestKey": "request-key-2", "provided": true, "resumed": true
+          }
+        }
+        """
+        let message = try JSONDecoder().decode(Message.self, from: Data(json.utf8))
+
+        XCTAssertEqual(message.kind, .secret)
+        XCTAssertEqual(message.from?.botId, "bot-2")
+        XCTAssertEqual(message.from?.name, "Robyn")
+        XCTAssertFalse(try XCTUnwrap(message.secret).isPending)
+        XCTAssertEqual(message.secret?.provided, true)
+        XCTAssertEqual(message.secret?.resumed, true)
+    }
+
     func testAPendingApprovalIsActionableAndAnAnsweredOneIsNot() throws {
         // The shape a live permission request takes, which the fixture rig
         // cannot produce without a real provider attached.

--- a/server/drivers/agents-proxy.test.ts
+++ b/server/drivers/agents-proxy.test.ts
@@ -231,11 +231,14 @@ describe("agents-proxy MCP surface", () => {
     const ask = list.result.tools.find((tool: { name: string }) => tool.name === "ask_bot");
     const delegate = list.result.tools.find((tool: { name: string }) => tool.name === "delegate_bot");
     const wait = list.result.tools.find((tool: { name: string }) => tool.name === "wait_delegation");
+    const credential = list.result.tools.find((tool: { name: string }) => tool.name === "request_credential");
     expect(ask.description).toContain("SYNCHRONOUS consultation");
     expect(ask.description).toContain("Do not use for assigning work");
     expect(delegate.description).toContain("DEFAULT FOR ASSIGNING WORK");
     expect(delegate.description).toContain("delivered automatically");
     expect(wait.description).toContain("Never call it in the same turn as delegate_bot");
+    expect(credential.description).toContain("on mobile it only shows a handoff");
+    expect(credential.description).toContain("Never claim a secure field opened on mobile");
   });
 
   it("publishes a flat routine schedule schema that survives provider conversion", async () => {
@@ -391,7 +394,9 @@ describe("agents-proxy MCP surface", () => {
       credential_id: "opencodeGoApiKey",
       reason: "The selected model needs it.",
     });
-    expect(res.result.content[0].text).toContain("secure OpenCode API key card");
+    expect(res.result.content[0].text).toContain("secure OpenCode API key request");
+    expect(res.result.content[0].text).toContain("mobile app only shows a handoff");
+    expect(res.result.content[0].text).toContain("Do not claim a secure field opened on mobile");
     expect(res.result.content[0].text).toContain("End this turn");
     expect(lastCredentialBody).toEqual({
       fromBotId: "bot-asker",

--- a/server/drivers/agents-proxy.ts
+++ b/server/drivers/agents-proxy.ts
@@ -294,7 +294,7 @@ const TOOLS = [
   {
     name: "request_credential",
     description:
-      "Ask the user for a supported API key through OpenMausBot's secure credential card. Use this instead of asking them to paste a secret into chat. The secret is saved by the desktop app and is never returned to you. After calling this tool, end the turn; OpenMausBot resumes the task after the user saves or declines.",
+      "Ask the user for a supported API key through OpenMausBot's secure credential flow. On desktop this shows a secure entry card; on mobile it only shows a handoff telling the user to open the conversation on their computer, because credentials cannot be entered from the mobile app. Never claim a secure field opened on mobile, and never ask the user to paste a secret into chat. The secret is saved by the desktop app and is never returned to you. After calling this tool, end the turn; OpenMausBot resumes the task after the user saves or declines.",
     inputSchema: {
       type: "object",
       properties: {
@@ -611,7 +611,7 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
       return { text: `${r.label ?? CREDENTIAL_TARGETS[credentialId].label} is already configured. Continue the task.` };
     }
     return {
-      text: `A secure ${r.label ?? CREDENTIAL_TARGETS[credentialId].label} card is now visible to the user. End this turn; OpenMausBot will resume the task after they save or decline. Never ask them to paste the key into chat.`,
+      text: `A secure ${r.label ?? CREDENTIAL_TARGETS[credentialId].label} request is ready. The desktop app shows its secure entry card; the mobile app only shows a handoff to open this conversation on the computer and does not accept the credential. End this turn; OpenMausBot will resume the task after the user saves or declines. Do not claim a secure field opened on mobile, and never ask them to paste the key into chat.`,
     };
   }
   if (name === "list_routines") {

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -2599,6 +2599,14 @@ describe("harness HTTP API", () => {
       });
       expect(requested.status).toBe(201);
       const { messageId } = (await requested.json()) as { messageId: string };
+      const directCard = (await api("GET", "/api/bots?messages=20")).body.bots
+        .find((candidate: { id: string }) => candidate.id === bot.id)?.messages
+        .find((message: { id: string }) => message.id === messageId);
+      expect(directCard).toMatchObject({
+        kind: "secret",
+        text: "Open this conversation in OpenMausBot on your computer to securely enter the OpenAI API key. Credential entry is not available in the mobile app.",
+      });
+      expect(directCard).not.toHaveProperty("from");
 
       expect((await api("POST", `/api/bots/${bot.id}/interrupt`)).status).toBe(200);
       expect((await api("PATCH", `/api/bots/${bot.id}`, { computer: "cloud" })).status).toBe(200);
@@ -4576,6 +4584,15 @@ describe("harness HTTP API", () => {
       });
       expect(requested.status).toBe(201);
       const { messageId } = (await requested.json()) as { messageId: string };
+
+      const roomCard = (await api("GET", "/api/bots?messages=20")).body.groups
+        .find((candidate: { id: string }) => candidate.id === room.id)?.messages
+        .find((message: { id: string }) => message.id === messageId);
+      expect(roomCard).toMatchObject({
+        kind: "secret",
+        text: "Open this conversation in OpenMausBot on your computer to securely enter the OpenAI API key. Credential entry is not available in the mobile app.",
+        from: { botId: second.id, name: second.name, color: second.color },
+      });
 
       const resumed = await api("POST", `/api/bots/${second.id}/secret-cards/${messageId}/dismiss`, {
         threadId: room.threadId,

--- a/server/index.ts
+++ b/server/index.ts
@@ -3308,7 +3308,7 @@ async function startTurn(
           ? "You can work with the other bots in your section through the agents tools. list_bots shows who's available. Use delegate_bot for assigned or independent work so you remain available; use ask_bot only for a short consultation whose reply is required in your current answer."
           : "";
       const credentialPrompt = integrations.agents
-        ? " If a supported API key is missing, use request_credential to show the secure in-app card. Never ask the user to paste credentials into chat."
+        ? " If a supported API key is missing, use request_credential to create a secure credential request. The desktop app shows the entry card; the mobile app only shows a handoff to the computer and never accepts the credential. Never claim a secure field opened on mobile, and never ask the user to paste credentials into chat."
         : "";
       const routinePrompt = integrations.agents
         ? " If the user explicitly asks to list or review, schedule, run, or change routines, use list_routines and propose_routine or propose_routine_action. A proposal is not applied until the user confirms its in-app card, so never claim the action completed before that confirmation."
@@ -4175,7 +4175,7 @@ async function runGroupMemberTurn(
     group.bulletin.trim() && `Room bulletin (shared instructions for everyone):\n${group.bulletin.trim()}`,
     `Reply as yourself, briefly and conversationally. To bring a teammate in, mention them like @Name — they'll see the conversation and respond.`,
     integrations.agents &&
-      "If a supported API key is missing, use request_credential to show the secure in-app card. Never ask the user to paste credentials into chat.",
+      "If a supported API key is missing, use request_credential to create a secure credential request. The desktop app shows the entry card; the mobile app only shows a handoff to the computer and never accepts the credential. Never claim a secure field opened on mobile, and never ask the user to paste credentials into chat.",
     integrations.agents &&
       "If the user explicitly asks to list or review, schedule, run, or change routines, use list_routines and propose_routine or propose_routine_action. A proposal is not applied until the user confirms its in-app card, so never claim the action completed before that confirmation.",
     skillAuthoring &&
@@ -5488,6 +5488,10 @@ type SecretResumeEntry = {
 };
 const pendingSecretResumes = new Map<string, SecretResumeEntry>();
 
+function credentialDesktopHandoff(label: string): string {
+  return `Open this conversation in OpenMausBot on your computer to securely enter the ${label}. Credential entry is not available in the mobile app.`;
+}
+
 function secretMessage(botId: string, threadId: string, messageId: string): Message | null {
   if (!connectorThread(botId, threadId)) return null;
   const message = store.messagesFor(threadId).find((candidate) => candidate.id === messageId);
@@ -6460,12 +6464,18 @@ const server = createServer(async (req, res) => {
           isReusableCredentialRequest(message, credentialId, from.id, Boolean(owner.group))
         );
         if (existing) {
+          if (!existing.text?.trim()) {
+            store.patchMessage(fromThreadId, existing.id, {
+              text: credentialDesktopHandoff(target.label),
+            });
+          }
           return json(res, 200, { messageId: existing.id, label: target.label });
         }
         const reason = typeof body.reason === "string" ? body.reason.trim().slice(0, 240) : "";
         const message = store.appendMessage(fromThreadId, {
           role: "bot",
           kind: "secret",
+          text: credentialDesktopHandoff(target.label),
           ...(owner.group ? { from: { botId: from.id, name: from.name, color: from.color } } : {}),
           secret: {
             target: credentialId,


### PR DESCRIPTION
## What changed

- decode and render secure credential-request messages in the iOS companion instead of silently dropping them
- show a native handoff card that directs the user to finish credential entry on the trusted desktop
- add a non-sensitive text fallback so current mobile builds no longer show an invisible row after the desktop updates
- correct agent guidance so bots do not claim that a mobile secure field was opened
- preserve the existing security boundary: mobile cannot write host credentials and no credential value enters the transcript

## Root cause

iOS did not recognize the server secret message kind. It decoded as unknown, and because secret messages had no fallback text, the row rendered nothing. Direct-chat sender metadata was not the cause.

## Verification

- 303 Swift tests
- complete OpenMausCompanion iOS simulator build
- 179 focused server and agent-proxy tests
- TypeScript typecheck
- isolated fixture doctor, bot creation, chat turn, settlement, and transcript verification
- diff validation

## Follow-up

Phone-side secret entry requires a narrow authenticated route into the desktop encrypted store and is intentionally outside this fix. Optional 1Password-backed credentials are tracked separately in #599.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added credential request cards in chat, showing the credential name, requester, description, errors, help links, and request status.
  * Mobile credential requests now provide a handoff to finish securely on a computer; credentials cannot be entered in the mobile app.
  * Credential requests are now represented consistently in conversation previews and update summaries.

* **Bug Fixes**
  * Improved handling and display of direct and channel-based credential requests, including requests without sender information.
  * Updated guidance to prevent credentials from being pasted into chat or incorrectly reported as opened on mobile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->