### PR TITLE
fix: harden Antigravity ACP integration

### DIFF
--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -225,6 +225,29 @@ describe("ACP turns (fake CLI)", () => {
     await removeTempDir(scratch);
   });
 
+  it("names the resolved executable when spawning it fails", async () => {
+    const missing = join(scratch, "resolved-managed-runtime");
+    const driver = createAcpDriver({
+      ...SELECT_MODEL_SUPPORT,
+      selectModel: undefined,
+      resolveCommand: async () => ({ command: missing }),
+    });
+    instance = await driver.create({
+      instanceId: "resolved-spawn-error",
+      displayName: "Resolved spawn error",
+      environment: {},
+      enabled: true,
+      config: { cli: "managed-alias", fullAuto: false },
+    });
+    recorder = recordEvents(instance.adapter);
+
+    await instance.adapter.sendTurn({ threadId: "t-resolved-spawn-error", text: "go" });
+    await recorder.until((event) => event.type === "turn.completed");
+    const error = recorder.events.find((event) => event.type === "runtime.error");
+    expect(error?.message).toContain(missing);
+    expect(error?.message).not.toContain("managed-alias");
+  });
+
   it("normalizes a full turn into the canonical event sequence", async () => {
     await create();
     const { turnId } = await instance.adapter.sendTurn({ threadId: "t-happy", text: "hi", model: "grok-4.5" });

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -609,7 +609,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
             clearTimeout(timer);
             const want = behavior === "allow" ? "allow" : "reject";
             const named = isQuestion && behavior === "answer"
-              ? options.filter((option) => option.optionId === message || option.name === message)
+              ? options.filter((option) => option.optionId === message || option.name?.trim() === message)
               : [];
             const optionId = behavior === "cancel"
               ? null
@@ -755,7 +755,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
           if (stderr.length > 8192) stderr = stderr.slice(-8192);
         });
         child.on("error", (e) => {
-          emit({ ...base(threadId, turnId), type: "runtime.error", ...describeSpawnFailure(e, config.cli) });
+          emit({ ...base(threadId, turnId), type: "runtime.error", ...describeSpawnFailure(e, launch.command) });
           settle(false, "spawn_error");
         });
         child.on("close", (code) => {

--- a/server/drivers/antigravity-acp.ts
+++ b/server/drivers/antigravity-acp.ts
@@ -1,10 +1,11 @@
 import { createHash, randomUUID } from "node:crypto";
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { request as httpRequest } from "node:http";
 import { tmpdir } from "node:os";
 import { delimiter, join, resolve } from "node:path";
 
 import { DATA_DIR, stripWorkspaceCredentialEnv } from "../config.ts";
+import { writeFileAtomic } from "../atomic.ts";
 import { killCliTree, spawnCli } from "../procs.ts";
 import type { ModelCatalog } from "../contracts.ts";
 import type { ChildProcess } from "node:child_process";
@@ -72,7 +73,7 @@ export async function prepareAntigravityProfile(input: {
     await chmod(directory, 0o700);
     await chmod(acpDirectory, 0o700);
   }
-  await writeFile(
+  writeFileAtomic(
     join(acpDirectory, "settings.json"),
     `${JSON.stringify({ auth: { type: "oauth-personal" } })}\n`,
     { mode: 0o600 },

--- a/server/drivers/antigravity-runtime.ts
+++ b/server/drivers/antigravity-runtime.ts
@@ -37,6 +37,15 @@ export interface AntigravityRuntime {
   version: string | null;
 }
 
+export class AntigravitySetupError extends Error {
+  readonly status = 409;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "AntigravitySetupError";
+  }
+}
+
 interface InstallRecord {
   sha256: string;
   version: string;
@@ -129,7 +138,9 @@ export async function resolveAntigravityRuntime(
       const found = await externalRuntime(candidate, "override");
       if (found) return found;
     }
-    throw new Error("The custom Antigravity ACP executable or its localharness_external sibling is missing.");
+    throw new AntigravitySetupError(
+      "The custom Antigravity ACP executable or its localharness_external sibling is missing.",
+    );
   }
 
   const asset = resolveAntigravityReleaseAsset();
@@ -143,9 +154,11 @@ export async function resolveAntigravityRuntime(
     if (found) return found;
   }
   if (!asset) {
-    throw new Error(`Google does not publish an Antigravity runtime for ${process.platform}-${process.arch}. Set a custom executable path.`);
+    throw new AntigravitySetupError(
+      `Google does not publish an Antigravity runtime for ${process.platform}-${process.arch}. Set a custom executable path.`,
+    );
   }
-  throw new Error("Antigravity is not installed. Install the official Google runtime to continue.");
+  throw new AntigravitySetupError("Antigravity is not installed. Install the official Google runtime to continue.");
 }
 
 interface PinnedZipEntry {
@@ -344,7 +357,8 @@ async function installOnce(options: AntigravityInstallOptions): Promise<Antigrav
     try {
       const response = await (options.fetchImpl ?? fetch)(asset.url, { signal: controller.signal, redirect: "follow" });
       if (!response.ok || !response.body) throw new Error(`Google download failed (${response.status}).`);
-      if (new URL(response.url || asset.url).hostname !== "dl.google.com") {
+      const finalUrl = new URL(response.url || asset.url);
+      if (finalUrl.protocol !== "https:" || finalUrl.hostname !== "dl.google.com") {
         throw new Error("The Antigravity download redirected outside dl.google.com.");
       }
       const encoding = response.headers.get("content-encoding")?.trim().toLowerCase();

--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -48,6 +48,7 @@ afterEach(async () => {
   delete process.env.FAKE_ACP_MODELS;
   delete process.env.FAKE_ACP_MODES;
   delete process.env.FAKE_ACP_DUMP;
+  delete process.env.FAKE_ACP_PAD_QUESTION_OPTION;
   while (scratch.length) await removeTempDir(scratch.pop()!);
 });
 
@@ -107,7 +108,47 @@ describe("official Antigravity runtime", () => {
       source: "override",
     });
     rmSync(fake.harness, { force: true });
-    await expect(resolveAntigravityRuntime(fake.executable)).rejects.toThrow(/localharness_external/u);
+    await expect(resolveAntigravityRuntime(fake.executable)).rejects.toMatchObject({
+      message: expect.stringMatching(/localharness_external/u),
+      status: 409,
+    });
+  });
+
+  it("atomically prepares one complete profile for concurrent callers", async () => {
+    const fake = fakeRuntime();
+    const runtime = await resolveAntigravityRuntime(fake.executable);
+    const profileDirectory = join(fake.directory, "profile");
+    await Promise.all(Array.from({ length: 8 }, () => prepareAntigravityProfile({
+      instanceId: "shared",
+      runtime,
+      baseEnv: {},
+      profileDirectory,
+    })));
+    const acpDirectory = join(profileDirectory, "antigravity-acp");
+    expect(JSON.parse(readFileSync(join(acpDirectory, "settings.json"), "utf8"))).toEqual({
+      auth: { type: "oauth-personal" },
+    });
+    expect(readdirSync(acpDirectory).filter((name) => name.endsWith(".tmp"))).toEqual([]);
+  });
+
+  it("rejects a download redirected to insecure HTTP", async () => {
+    const baseDir = mkdtempSync(join(tmpdir(), "omb-antigravity-insecure-"));
+    scratch.push(baseDir);
+    const asset: AntigravityReleaseAsset = {
+      version: "insecure-test",
+      url: "https://dl.google.com/test-antigravity.zip",
+      sha256: "00".repeat(32),
+      archiveBytes: 1,
+      executable: { name: "agy_acp_server.par", bytes: 1 },
+      harness: { name: "localharness_external", bytes: 1 },
+    };
+    const response = new Response(new Uint8Array([0]), { headers: { "content-length": "1" } });
+    Object.defineProperty(response, "url", { value: "http://dl.google.com/test-antigravity.zip" });
+    await expect(installAntigravityRuntime({
+      baseDir,
+      asset,
+      fetchImpl: async () => response,
+    })).rejects.toThrow(/redirected outside/u);
   });
 
   it("coalesces, verifies, extracts, and reuses a pinned managed download", async () => {
@@ -317,6 +358,7 @@ describe("Antigravity driver over shared ACP", () => {
       displayName: undefined,
       environment: {
         FAKE_ACP_MODE: "question",
+        FAKE_ACP_PAD_QUESTION_OPTION: "1",
         FAKE_ACP_AUTH_METHOD: "oauth-personal",
         FAKE_ACP_MODELS: "gemini-3.8-flash-high",
         FAKE_ACP_MODES: "default,yolo",

--- a/server/index.ts
+++ b/server/index.ts
@@ -9175,7 +9175,10 @@ const server = createServer(async (req, res) => {
         }
         return json(res, 200, { ok: true });
       } catch (error) {
-        return json(res, 500, { error: error instanceof Error ? error.message : String(error) });
+        const status = error && typeof error === "object" && (error as { status?: unknown }).status === 409
+          ? 409
+          : 500;
+        return json(res, status, { error: error instanceof Error ? error.message : String(error) });
       }
     }
 

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -713,7 +713,11 @@ function handle(msg: any) {
             toolCall: { toolCallId: "interaction_color", kind: "other", title: "Which color?" },
             options: [
               { optionId: "blue-id", kind: "allow_once", name: "Blue" },
-              { optionId: "green-id", kind: "allow_once", name: "Green" },
+              {
+                optionId: "green-id",
+                kind: "allow_once",
+                name: process.env.FAKE_ACP_PAD_QUESTION_OPTION ? " Green " : "Green",
+              },
             ],
           },
         });


### PR DESCRIPTION
Follow-up to #729 addressing the final CodeRabbit review findings.

- report the actual resolved ACP executable on spawn failure
- match trimmed interactive choice labels
- atomically persist the isolated Antigravity profile settings
- reject non-HTTPS Google download redirects
- distinguish expected setup conflicts (409) from installer failures (500)
- add focused regression coverage

Verification:
- `pnpm exec vitest run server/drivers/antigravity.test.ts server/drivers/acp/acp.test.ts server/atomic.test.ts` (69 passed)
- `pnpm typecheck`
- `pnpm lint` (existing warnings only)
- `pnpm test` (3,143 passed; broker, Electron, and packaged-server checks green)
- isolated `control:omb doctor` fixture connected successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Permission options with surrounding whitespace are now matched correctly.
  * Launch errors provide clearer information about the executable that failed.
  * Setup failures now return a consistent conflict status instead of a generic server error.
  * Runtime downloads now reject insecure HTTP redirects.
  * Concurrent setup requests now produce complete, reliable configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->