### PR TITLE
feat(antigravity): add cross-platform Worker A and Worker B fleet with quota and account visibility

### DIFF
--- a/server/antigravity-accounts.test.ts
+++ b/server/antigravity-accounts.test.ts
@@ -1,0 +1,288 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { execCliTreeMock } = vi.hoisted(() => ({ execCliTreeMock: vi.fn() }));
+vi.mock("./procs.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./procs.ts")>();
+  return {
+    ...actual,
+    execCliTree: execCliTreeMock,
+  };
+});
+
+const originalUserProfile = process.env.USERPROFILE;
+const testProfileRoot = mkdtempSync(join(tmpdir(), "openmaus-antigravity-test-"));
+process.env.USERPROFILE = testProfileRoot;
+
+const {
+  antigravityManagedQuotaRefreshRunning,
+  antigravityManagedWorkerRunning,
+  antigravityAccountStatuses,
+  clearAntigravityQuotaCache,
+  getAntigravityAccountEmail,
+  getAntigravityProfileDir,
+  getAntigravityProfileEnv,
+  nextAntigravityQuotaStaleState,
+  parseAntigravityUsage,
+  profileForInstance,
+  PROFILES,
+  refreshAntigravityProfileQuota,
+  registerManagedAntigravityWorker,
+  unregisterManagedAntigravityWorker,
+  withAntigravityAccountRefreshSingleFlight,
+  withAntigravityCredentialLock,
+  withManagedAntigravityQuotaRefresh,
+  writeAntigravityAccountLabels,
+} = await import("./antigravity-accounts.ts");
+
+afterAll(() => {
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
+  rmSync(testProfileRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  execCliTreeMock.mockReset();
+  clearAntigravityQuotaCache();
+});
+
+describe("Antigravity account coordination & worker profiles", () => {
+  it("defines Worker A and Worker B with required instance IDs and labels", () => {
+    expect(PROFILES.a.instanceId).toBe("antigravity_worker_a");
+    expect(PROFILES.a.label).toBe("Antigravity Worker A");
+    expect(PROFILES.b.instanceId).toBe("antigravity_worker_b");
+    expect(PROFILES.b.label).toBe("Antigravity Worker B");
+
+    expect(profileForInstance("antigravity_worker_a")).toBe("a");
+    expect(profileForInstance("antigravity_worker_b")).toBe("b");
+    expect(profileForInstance("unknown")).toBeNull();
+  });
+
+  it("isolates profile home directory and environment", () => {
+    const dirA = getAntigravityProfileDir("a");
+    const dirB = getAntigravityProfileDir("b");
+
+    expect(dirA).toContain(join(".openmausbot", "antigravity-profiles", "worker-a"));
+    expect(dirB).toContain(join(".openmausbot", "antigravity-profiles", "worker-b"));
+    expect(dirA).not.toBe(dirB);
+
+    const envA = getAntigravityProfileEnv("a", { PATH: "foo" });
+    expect(envA.USERPROFILE).toBe(dirA);
+    expect(envA.HOME).toBe(dirA);
+    expect(envA.PATH).toBe("foo");
+
+    const envB = getAntigravityProfileEnv("b", { PATH: "bar" });
+    expect(envB.USERPROFILE).toBe(dirB);
+    expect(envB.HOME).toBe(dirB);
+    expect(envB.PATH).toBe("bar");
+  });
+
+  it("reads account email labels from antigravity-account-labels.json", () => {
+    expect(getAntigravityAccountEmail("a")).toBe("");
+    expect(getAntigravityAccountEmail("b")).toBe("");
+
+    writeAntigravityAccountLabels({ a: "account1@gmail.com", b: "account2@gmail.com" });
+
+    expect(getAntigravityAccountEmail("a")).toBe("account1@gmail.com");
+    expect(getAntigravityAccountEmail("b")).toBe("account2@gmail.com");
+  });
+
+  it("keeps a failed refresh stale across cache reads until a successful refresh", () => {
+    const failed = nextAntigravityQuotaStaleState(false, "failure");
+    const normalCacheRead = nextAntigravityQuotaStaleState(failed, "unchanged");
+    const refreshed = nextAntigravityQuotaStaleState(normalCacheRead, "success");
+
+    expect(failed).toBe(true);
+    expect(normalCacheRead).toBe(true);
+    expect(refreshed).toBe(false);
+  });
+
+  it("distinguishes OpenMaus-managed workers from standalone agy processes", () => {
+    expect(antigravityManagedWorkerRunning()).toBe(false);
+    registerManagedAntigravityWorker(12001);
+    expect(antigravityManagedWorkerRunning()).toBe(true);
+    registerManagedAntigravityWorker(12002);
+    unregisterManagedAntigravityWorker(12001);
+    expect(antigravityManagedWorkerRunning()).toBe(true);
+    unregisterManagedAntigravityWorker(12002);
+    expect(antigravityManagedWorkerRunning()).toBe(false);
+  });
+
+  it("parses the documented structured read-only usage response", () => {
+    const quota = parseAntigravityUsage(
+      JSON.stringify({
+        command: {
+          name: "usage",
+          data: {
+            groups: [
+              {
+                name: "Gemini Models",
+                buckets: [
+                  { id: "gemini-weekly", remaining_fraction: 0.82, reset_time: "2026-08-30T00:00:00Z" },
+                  { id: "gemini-5h", remaining_fraction: 0.91, reset_time: "2026-08-24T00:00:00Z" },
+                ],
+              },
+              {
+                name: "Claude and GPT models",
+                buckets: [
+                  { id: "3p-weekly", remaining_fraction: 0.63, reset_time: "2026-08-30T00:00:00Z" },
+                  { id: "3p-5h", remaining_fraction: 0.75, reset_time: "2026-08-24T00:00:00Z" },
+                ],
+              },
+            ],
+          },
+        },
+      }),
+    );
+    expect(quota.gemini.weekly?.remaining).toBe(82);
+    expect(quota.gemini.fiveHour?.remaining).toBe(91);
+    expect(quota.other.weekly?.remaining).toBe(63);
+    expect(quota.other.fiveHour?.remaining).toBe(75);
+  });
+
+  it("fails closed on incomplete or agent-turn payloads", () => {
+    expect(() => parseAntigravityUsage(JSON.stringify({ groups: [] }))).toThrow("incomplete");
+    expect(() =>
+      parseAntigravityUsage(
+        JSON.stringify({
+          usage: { total_tokens: 1 },
+          groups: [],
+        }),
+      ),
+    ).toThrow("agent turn");
+    expect(() => parseAntigravityUsage("invalid json")).toThrow("valid JSON");
+  });
+
+  it("shows that execCliTree settles on pipe closure, not a complete usage envelope", async () => {
+    const { execCliTree: actualExecCliTree } =
+      await vi.importActual<typeof import("./procs.ts")>("./procs.ts");
+    const usageEnvelope = JSON.stringify({
+      command: { name: "usage", data: { groups: [] } },
+    });
+    const childScript = [
+      "const { spawn } = require('node:child_process');",
+      `process.stdout.write(${JSON.stringify(usageEnvelope)});`,
+      "spawn(process.execPath, ['-e', 'setTimeout(() => {}, 5000)'], { stdio: ['ignore', 1, 2] });",
+      "setTimeout(() => {}, 5000);",
+    ].join("\n");
+
+    let error: unknown;
+    try {
+      await actualExecCliTree(process.execPath, ["-e", childScript], {
+        timeout: 1_000,
+        maxBuffer: 1024 * 1024,
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("timed out after 1000ms");
+    const capturedStdout = (error as Error & { stdout?: string }).stdout ?? "";
+    expect(capturedStdout).toContain('"command"');
+    expect(capturedStdout).toContain('"usage"');
+  });
+
+  it("preserves last-good quota and marks it stale after a bounded refresh failure", async () => {
+    const output = JSON.stringify({
+      command: {
+        name: "usage",
+        data: {
+          groups: [
+            {
+              name: "Gemini Models",
+              buckets: [
+                { id: "gemini-weekly", remaining_fraction: 0.84 },
+                { id: "gemini-5h", remaining_fraction: 1 },
+              ],
+            },
+            {
+              name: "Claude and GPT models",
+              buckets: [
+                { id: "3p-weekly", remaining_fraction: 0.63 },
+                { id: "3p-5h", remaining_fraction: 0.75 },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    execCliTreeMock.mockResolvedValueOnce({ stdout: output, stderr: "" });
+    await refreshAntigravityProfileQuota("a");
+    expect(execCliTreeMock).toHaveBeenLastCalledWith(
+      expect.stringMatching(/agy/i),
+      ["--print", "/usage", "--output-format", "json"],
+      expect.objectContaining({
+        windowsHide: true,
+        timeout: 30_000,
+        env: expect.objectContaining({
+          USERPROFILE: expect.stringContaining(join(".openmausbot", "antigravity-profiles", "worker-a")),
+          HOME: expect.stringContaining(join(".openmausbot", "antigravity-profiles", "worker-a")),
+        }),
+        completionPredicate: expect.any(Function),
+      }),
+    );
+
+    execCliTreeMock.mockRejectedValueOnce(new Error("bounded timeout"));
+    await expect(refreshAntigravityProfileQuota("a")).rejects.toThrow("bounded timeout");
+    const statuses = await antigravityAccountStatuses(false);
+    const statusA = statuses.find((entry) => entry.profile === "a");
+    expect(statusA?.quota.gemini.weekly?.remaining).toBe(84);
+    expect(statusA?.quota.gemini.fiveHour?.remaining).toBe(100);
+    expect(statusA?.quotaStale).toBe(true);
+    expect(statusA?.instanceId).toBe("antigravity_worker_a");
+    expect(statusA?.label).toBe("Antigravity Worker A");
+    expect(statusA?.email).toBe("account1@gmail.com");
+  });
+
+  it("serializes machine-wide credential operations", async () => {
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = withAntigravityCredentialLock(async () => {
+      events.push("a:start");
+      await firstGate;
+      events.push("a:end");
+    });
+    const second = withAntigravityCredentialLock(async () => {
+      events.push("b:start");
+      events.push("b:end");
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(events).toEqual(["a:start"]);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(events).toEqual(["a:start", "a:end", "b:start", "b:end"]);
+  });
+
+  it("coalesces overlapping picker refreshes into one managed probe", async () => {
+    let calls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const operation = () =>
+      withManagedAntigravityQuotaRefresh(async () => {
+        calls += 1;
+        await gate;
+        return [];
+      });
+
+    const first = withAntigravityAccountRefreshSingleFlight(operation);
+    const second = withAntigravityAccountRefreshSingleFlight(operation);
+    expect(first).toBe(second);
+    expect(calls).toBe(1);
+    expect(antigravityManagedQuotaRefreshRunning()).toBe(true);
+
+    release();
+    await expect(Promise.all([first, second])).resolves.toEqual([[], []]);
+    expect(antigravityManagedQuotaRefreshRunning()).toBe(false);
+  });
+});

--- a/server/antigravity-accounts.ts
+++ b/server/antigravity-accounts.ts
@@ -1,0 +1,493 @@
+import { execFile } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { execCliTree } from "./procs.ts";
+
+export type AntigravityProfile = "a" | "b";
+
+export interface QuotaWindow {
+  remaining: number;
+  resetsAt: string | null;
+}
+
+export interface AntigravityQuota {
+  gemini: {
+    weekly: QuotaWindow | null;
+    fiveHour: QuotaWindow | null;
+  };
+  other: {
+    weekly: QuotaWindow | null;
+    fiveHour: QuotaWindow | null;
+  };
+}
+
+export interface AntigravityAccountStatus {
+  profile: AntigravityProfile;
+  instanceId: string;
+  label: string;
+  email: string;
+  active: boolean;
+  available: boolean;
+  quota: AntigravityQuota;
+  quotaStale?: boolean;
+  error?: string;
+}
+
+export const ANTIGRAVITY_WORKER_A_INSTANCE_ID = "antigravity_worker_a";
+export const ANTIGRAVITY_WORKER_B_INSTANCE_ID = "antigravity_worker_b";
+
+export const PROFILES = {
+  a: {
+    instanceId: ANTIGRAVITY_WORKER_A_INSTANCE_ID,
+    label: "Antigravity Worker A",
+  },
+  b: {
+    instanceId: ANTIGRAVITY_WORKER_B_INSTANCE_ID,
+    label: "Antigravity Worker B",
+  },
+} as const;
+
+export const QUOTA_PROBE_ARGS = ["--print", "/usage", "--output-format", "json"] as const;
+
+export function profileForInstance(instanceId: string): AntigravityProfile | null {
+  if (instanceId === PROFILES.a.instanceId || instanceId === "antigravity-worker-a") return "a";
+  if (instanceId === PROFILES.b.instanceId || instanceId === "antigravity-worker-b") return "b";
+  return null;
+}
+
+export function instanceForProfile(profile: AntigravityProfile): string {
+  return PROFILES[profile].instanceId;
+}
+
+export function getOpenMausDir(): string {
+  const base = process.env.USERPROFILE || process.env.HOME || tmpdir();
+  return join(base, ".openmausbot");
+}
+
+export function getAntigravityProfileDir(profile: AntigravityProfile): string {
+  return join(getOpenMausDir(), "antigravity-profiles", "worker-" + profile);
+}
+
+export function ensureAntigravityProfileDir(profile: AntigravityProfile): string {
+  const dir = getAntigravityProfileDir(profile);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+export function getAntigravityProfileEnv(
+  profile: AntigravityProfile,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const profileDir = getAntigravityProfileDir(profile);
+  return {
+    ...baseEnv,
+    USERPROFILE: profileDir,
+    HOME: profileDir,
+  };
+}
+
+export function getAntigravityAccountLabelsPath(): string {
+  return join(getOpenMausDir(), "antigravity-account-labels.json");
+}
+
+export function readAntigravityAccountLabels(): Record<string, string> {
+  try {
+    const filePath = getAntigravityAccountLabelsPath();
+    if (!existsSync(filePath)) return {};
+    const content = readFileSync(filePath, "utf8");
+    const parsed = JSON.parse(content);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const result: Record<string, string> = {};
+      for (const [key, value] of Object.entries(parsed)) {
+        if (typeof value === "string") {
+          result[key] = value;
+        }
+      }
+      return result;
+    }
+  } catch {
+    // Missing or invalid JSON
+  }
+  return {};
+}
+
+export function writeAntigravityAccountLabels(labels: Record<string, string>): void {
+  const filePath = getAntigravityAccountLabelsPath();
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(labels, null, 2), "utf8");
+}
+
+export function getAntigravityAccountEmail(profile: AntigravityProfile): string {
+  const labels = readAntigravityAccountLabels();
+  return labels[profile] ?? "";
+}
+
+export function getAntigravityQuotaCachePath(): string {
+  return join(getOpenMausDir(), "antigravity-quota-cache.json");
+}
+
+export function emptyQuota(): AntigravityQuota {
+  return {
+    gemini: { weekly: null, fiveHour: null },
+    other: { weekly: null, fiveHour: null },
+  };
+}
+
+const quotaCache = new Map<AntigravityProfile, AntigravityQuota>();
+const quotaRefreshFailures = new Set<AntigravityProfile>();
+let credentialQueue: Promise<void> = Promise.resolve();
+let managedQuotaRefreshes = 0;
+let accountRefreshInFlight: Promise<AntigravityAccountStatus[]> | null = null;
+const managedWorkerProcesses = new Set<number>();
+let activeProfileState: AntigravityProfile | null = "a";
+
+export function clearAntigravityQuotaCache(): void {
+  quotaCache.clear();
+  quotaRefreshFailures.clear();
+}
+
+export function loadQuotaCache(): void {
+  try {
+    const cacheFile = getAntigravityQuotaCachePath();
+    if (!existsSync(cacheFile)) return;
+    const saved = JSON.parse(readFileSync(cacheFile, "utf8")) as Partial<
+      Record<AntigravityProfile, AntigravityQuota>
+    >;
+    for (const profile of ["a", "b"] as const) {
+      if (saved[profile]) quotaCache.set(profile, saved[profile]!);
+    }
+  } catch {
+    // First run or an invalid old cache: report unknown quotas without mutation.
+  }
+}
+
+export function saveQuotaCache(): void {
+  const cacheFile = getAntigravityQuotaCachePath();
+  mkdirSync(dirname(cacheFile), { recursive: true });
+  writeFileSync(cacheFile, JSON.stringify(Object.fromEntries(quotaCache), null, 2), "utf8");
+}
+
+loadQuotaCache();
+
+type JsonRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): JsonRecord | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : null;
+}
+
+function readFiniteFraction(...values: unknown[]): number | null {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      if (value >= 0 && value <= 1) return value;
+      if (value > 1 && value <= 100) return value / 100;
+    }
+  }
+  return null;
+}
+
+function readUsageGroups(payload: unknown): unknown[] {
+  const root = asRecord(payload);
+  if (!root) throw new Error("Antigravity usage response is not an object");
+
+  const command = asRecord(root.command);
+  if (command && command.name !== "usage") {
+    throw new Error("Antigravity usage response is not the usage command");
+  }
+
+  const candidates = [command?.data, root.data, root.response, root];
+  for (const candidate of candidates) {
+    const record = asRecord(candidate);
+    if (Array.isArray(record?.groups)) return record.groups;
+  }
+  throw new Error("Antigravity usage response is incomplete");
+}
+
+function readUsageFraction(bucket: JsonRecord): number | null {
+  const remaining = asRecord(bucket.remaining);
+  return readFiniteFraction(
+    bucket.remaining_fraction,
+    bucket.remainingFraction,
+    bucket.remaining_percentage,
+    bucket.remainingPercentage,
+    bucket.remaining,
+    remaining?.remaining_fraction,
+    remaining?.remainingFraction,
+    remaining?.remaining_percentage,
+    remaining?.remainingPercentage,
+    remaining?.remaining,
+  );
+}
+
+function readResetAt(bucket: JsonRecord): string | null {
+  const value = bucket.reset_time ?? bucket.resetTime ?? bucket.resets_at ?? bucket.resetsAt;
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function readQuotaWindow(bucket: unknown): "weekly" | "fiveHour" | null {
+  const record = asRecord(bucket);
+  if (!record) return null;
+  const hint = [record.window, record.id, record.bucketId, record.displayName]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ")
+    .toLowerCase();
+  if (hint.includes("weekly") || hint.includes("week")) return "weekly";
+  if (hint.includes("5h") || hint.includes("five hour") || hint.includes("five-hour"))
+    return "fiveHour";
+  return null;
+}
+
+/** Parse the documented structured, read-only Antigravity usage response. */
+export function parseAntigravityUsage(output: string): AntigravityQuota {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(output.trim());
+  } catch {
+    throw new Error("Antigravity usage response is not valid JSON");
+  }
+
+  const root = asRecord(payload);
+  const usage = asRecord(root?.usage);
+  if (usage) {
+    const tokenCounts = [
+      "input_tokens",
+      "output_tokens",
+      "thinking_tokens",
+      "cache_read_tokens",
+      "total_tokens",
+    ].map((key) => usage[key]);
+    if (tokenCounts.some((value) => typeof value === "number" && value !== 0)) {
+      throw new Error("Antigravity usage response describes an agent turn");
+    }
+  }
+
+  const result = emptyQuota();
+  const seen = new Set<string>();
+  for (const group of readUsageGroups(payload)) {
+    const groupRecord = asRecord(group);
+    const family = groupRecord?.name ?? groupRecord?.displayName;
+    const target =
+      family === "Gemini Models"
+        ? result.gemini
+        : family === "Claude and GPT models"
+          ? result.other
+          : null;
+    if (!target) continue;
+    const buckets = groupRecord?.buckets;
+    if (!Array.isArray(buckets)) continue;
+    for (const bucket of buckets) {
+      const window = readQuotaWindow(bucket);
+      const record = asRecord(bucket);
+      const fraction = record ? readUsageFraction(record) : null;
+      if (!window || !record || fraction === null) continue;
+      if (seen.has(`${family}:${window}`)) {
+        throw new Error("Antigravity usage response has duplicate quota windows");
+      }
+      seen.add(`${family}:${window}`);
+      target[window] = { remaining: Math.round(fraction * 100), resetsAt: readResetAt(record) };
+    }
+  }
+
+  if (seen.size !== 4) throw new Error("Antigravity usage response is incomplete");
+  return result;
+}
+
+export function hasCompleteAntigravityUsage(stdout: string): boolean {
+  try {
+    parseAntigravityUsage(stdout);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function registerManagedAntigravityWorker(pid: number | undefined): void {
+  if (pid && Number.isInteger(pid) && pid > 0) managedWorkerProcesses.add(pid);
+}
+
+export function unregisterManagedAntigravityWorker(pid: number | undefined): void {
+  if (pid) managedWorkerProcesses.delete(pid);
+}
+
+export function antigravityManagedWorkerRunning(): boolean {
+  return managedWorkerProcesses.size > 0;
+}
+
+export function withAntigravityCredentialLock<T>(operation: () => Promise<T>): Promise<T> {
+  const result = credentialQueue.then(operation, operation);
+  credentialQueue = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
+export function antigravityManagedQuotaRefreshRunning(): boolean {
+  return managedQuotaRefreshes > 0 || accountRefreshInFlight !== null;
+}
+
+export async function withManagedAntigravityQuotaRefresh<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  managedQuotaRefreshes += 1;
+  try {
+    return await operation();
+  } finally {
+    managedQuotaRefreshes -= 1;
+  }
+}
+
+export function withAntigravityAccountRefreshSingleFlight(
+  operation: () => Promise<AntigravityAccountStatus[]>,
+): Promise<AntigravityAccountStatus[]> {
+  if (accountRefreshInFlight) return accountRefreshInFlight;
+  const request = operation();
+  const tracked = request.finally(() => {
+    if (accountRefreshInFlight === tracked) accountRefreshInFlight = null;
+  });
+  accountRefreshInFlight = tracked;
+  return tracked;
+}
+
+export function nextAntigravityQuotaStaleState(
+  current: boolean,
+  outcome: "unchanged" | "success" | "failure",
+): boolean {
+  if (outcome === "failure") return true;
+  if (outcome === "success") return false;
+  return current;
+}
+
+export function recordAntigravityQuotaRefresh(
+  profile: AntigravityProfile,
+  outcome: "success" | "failure",
+): void {
+  const stale = nextAntigravityQuotaStaleState(quotaRefreshFailures.has(profile), outcome);
+  if (stale) quotaRefreshFailures.add(profile);
+  else quotaRefreshFailures.delete(profile);
+}
+
+export async function activeAntigravityProfile(): Promise<AntigravityProfile | null> {
+  return activeProfileState;
+}
+
+export async function activateAntigravityProfile(profile: AntigravityProfile): Promise<void> {
+  activeProfileState = profile;
+}
+
+export async function antigravityProcessRunning(): Promise<boolean> {
+  try {
+    if (process.platform === "win32") {
+      const { stdout } = await new Promise<{ stdout: string }>((resolve, reject) => {
+        execFile(
+          "tasklist.exe",
+          ["/FI", "IMAGENAME eq agy.exe", "/NH"],
+          { windowsHide: true, timeout: 5_000, encoding: "utf8" },
+          (err, stdout) => (err ? reject(err) : resolve({ stdout })),
+        );
+      });
+      return /\bagy\.exe\b/i.test(stdout);
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+export function getAgyCommand(): string {
+  return process.env.OMB_AGY_BIN || process.env.AGY_BIN || "agy";
+}
+
+export async function refreshAntigravityProfileQuota(profile: AntigravityProfile): Promise<void> {
+  return withAntigravityCredentialLock(() =>
+    withManagedAntigravityQuotaRefresh(async () => {
+      ensureAntigravityProfileDir(profile);
+      try {
+        const { stdout } = await execCliTree(getAgyCommand(), [...QUOTA_PROBE_ARGS], {
+          env: getAntigravityProfileEnv(profile),
+          windowsHide: true,
+          timeout: 30_000,
+          maxBuffer: 1024 * 1024,
+          completionPredicate: (output) => hasCompleteAntigravityUsage(output),
+        });
+        quotaCache.set(profile, parseAntigravityUsage(stdout));
+        recordAntigravityQuotaRefresh(profile, "success");
+        saveQuotaCache();
+      } catch (error) {
+        recordAntigravityQuotaRefresh(profile, "failure");
+        throw error;
+      }
+    }),
+  );
+}
+
+async function accountStatusesUnlocked(refresh: boolean): Promise<AntigravityAccountStatus[]> {
+  loadQuotaCache();
+  const originallyActive = await activeAntigravityProfile();
+  const statuses: AntigravityAccountStatus[] = [];
+
+  for (const profile of ["a", "b"] as const) {
+    const meta = PROFILES[profile];
+    const email = getAntigravityAccountEmail(profile);
+    const cached = quotaCache.get(profile) ?? emptyQuota();
+
+    let quota = cached;
+    let refreshError: string | undefined;
+
+    if (refresh) {
+      try {
+        ensureAntigravityProfileDir(profile);
+        const { stdout } = await execCliTree(getAgyCommand(), [...QUOTA_PROBE_ARGS], {
+          env: getAntigravityProfileEnv(profile),
+          windowsHide: true,
+          timeout: 30_000,
+          maxBuffer: 1024 * 1024,
+          completionPredicate: (output) => hasCompleteAntigravityUsage(output),
+        });
+        quota = parseAntigravityUsage(stdout);
+        quotaCache.set(profile, quota);
+        recordAntigravityQuotaRefresh(profile, "success");
+        saveQuotaCache();
+      } catch (error) {
+        recordAntigravityQuotaRefresh(profile, "failure");
+        refreshError = error instanceof Error ? error.message : "Quota refresh failed.";
+      }
+    }
+
+    const status: AntigravityAccountStatus = {
+      profile,
+      instanceId: meta.instanceId,
+      label: meta.label,
+      email,
+      active: originallyActive === profile,
+      available: true,
+      quota,
+      quotaStale: quotaRefreshFailures.has(profile),
+    };
+    if (refreshError) status.error = refreshError;
+    statuses.push(status);
+  }
+
+  if (refresh && originallyActive) {
+    try {
+      await activateAntigravityProfile(originallyActive);
+    } catch {
+      // ignore
+    }
+  }
+
+  return statuses;
+}
+
+export async function antigravityAccountStatuses(
+  refresh = false,
+): Promise<AntigravityAccountStatus[]> {
+  if (!refresh) return accountStatusesUnlocked(false);
+  return withAntigravityAccountRefreshSingleFlight(() =>
+    withAntigravityCredentialLock(() =>
+      withManagedAntigravityQuotaRefresh(() => accountStatusesUnlocked(true)),
+    ),
+  );
+}

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -801,3 +801,35 @@ describe("customMcpServers", () => {
     expect(Object.keys(out)).toEqual(["keeper"]);
   });
 });
+
+describe("Antigravity worker instances", () => {
+  it("includes Worker A and Worker B in default fleet and migrates legacy antigravity", () => {
+    const defaultInstances = instanceConfigs({});
+    expect(defaultInstances["antigravity-worker-a"]).toMatchObject({
+      driver: "antigravityAgent",
+      displayName: "Antigravity Worker A",
+    });
+    expect(defaultInstances["antigravity-worker-b"]).toMatchObject({
+      driver: "antigravityAgent",
+      displayName: "Antigravity Worker B",
+    });
+
+    const migrated = instanceConfigs({
+      instances: {
+        antigravity: {
+          driver: "antigravityAgent",
+          config: { cli: "/custom/agy" },
+        },
+      },
+    });
+    expect(migrated["antigravity"]).toBeUndefined();
+    expect(migrated["antigravity-worker-a"]).toMatchObject({
+      driver: "antigravityAgent",
+      config: { cli: "/custom/agy" },
+    });
+    expect(migrated["antigravity-worker-b"]).toMatchObject({
+      driver: "antigravityAgent",
+      config: { cli: "/custom/agy" },
+    });
+  });
+});

--- a/server/config.ts
+++ b/server/config.ts
@@ -23,6 +23,8 @@ export const DEFAULT_LOCAL_VM_MODE = "shared" as const;
 export const DEFAULT_LOCAL_VM_MAX_INSTANCES = 2;
 export const MIN_LOCAL_VM_MAX_INSTANCES = 1;
 export const MAX_LOCAL_VM_MAX_INSTANCES = 4;
+export const ANTIGRAVITY_WORKER_A_INSTANCE_ID = "antigravity-worker-a";
+export const ANTIGRAVITY_WORKER_B_INSTANCE_ID = "antigravity-worker-b";
 
 export function isValidSshAlias(value: unknown): value is string {
   return typeof value === "string" && SSH_ALIAS.test(value);
@@ -729,7 +731,8 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
     cursor: { driver: "cursorAgent" },
     claude: { driver: "claudeAgent" },
     codex: { driver: "codex" },
-    antigravity: { driver: "antigravityAgent" },
+    [ANTIGRAVITY_WORKER_A_INSTANCE_ID]: { driver: "antigravityAgent", displayName: "Antigravity Worker A" },
+    [ANTIGRAVITY_WORKER_B_INSTANCE_ID]: { driver: "antigravityAgent", displayName: "Antigravity Worker B" },
     opencodeGo: { driver: "opencodeGo" },
     computer: { driver: "boxAgent" },
     openaiCompat: { driver: "openai-compat" },
@@ -752,6 +755,35 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
   } as const;
   const configured = cfg.instances && Object.keys(cfg.instances).length ? cfg.instances : null;
   const map: InstanceConfigMap = configured ? { ...configured } : { ...DEFAULT_FLEET };
+  const antigravityFleetIsConfigured =
+    !configured ||
+    Object.hasOwn(configured, "antigravity") ||
+    Object.hasOwn(configured, ANTIGRAVITY_WORKER_A_INSTANCE_ID) ||
+    Object.hasOwn(configured, ANTIGRAVITY_WORKER_B_INSTANCE_ID);
+  if (antigravityFleetIsConfigured) {
+    const legacy = map.antigravity;
+    delete map.antigravity;
+    const workerEntry = (profile: "a" | "b", source: InstanceConfigMap[string] | undefined) => {
+      const rawConfig =
+        source?.config && typeof source.config === "object" && !Array.isArray(source.config)
+          ? (source.config as Record<string, unknown>)
+          : {};
+      return {
+        ...(source ?? { driver: "antigravityAgent" }),
+        driver: "antigravityAgent",
+        displayName: profile === "a" ? "Antigravity Worker A" : "Antigravity Worker B",
+        config: { ...rawConfig },
+      };
+    };
+    map[ANTIGRAVITY_WORKER_A_INSTANCE_ID] = workerEntry(
+      "a",
+      map[ANTIGRAVITY_WORKER_A_INSTANCE_ID] ?? legacy,
+    );
+    map[ANTIGRAVITY_WORKER_B_INSTANCE_ID] = workerEntry(
+      "b",
+      map[ANTIGRAVITY_WORKER_B_INSTANCE_ID] ?? legacy,
+    );
+  }
   // Product fleets pick up newly shipped engines. A one-off test/shadow map
   // (no claude/grok/codex) is left exactly as written.
   if (

--- a/server/drivers/antigravity.ts
+++ b/server/drivers/antigravity.ts
@@ -28,6 +28,10 @@ import {
   resolveAntigravityRuntime,
 } from "./antigravity-runtime.ts";
 import { resolveAntigravityReleaseAsset } from "./antigravity-release.ts";
+import {
+  registerManagedAntigravityWorker,
+  unregisterManagedAntigravityWorker,
+} from "../antigravity-accounts.ts";
 
 export const STATIC_ANTIGRAVITY_MODELS: ModelCatalog = {
   default: "gemini-3.8-flash-high",
@@ -140,6 +144,7 @@ export const AntigravityDriver: ProviderDriver<AcpConfig> = {
   async create(input: DriverCreateInput<AcpConfig>): Promise<ProviderInstance> {
     const base = await AcpAntigravityDriver.create(input);
     const auth = new AntigravityAuthController();
+    registerManagedAntigravityWorker(input.instanceId);
     const runtimeAndProfile = async () => {
       const environment = { ...process.env, ...input.environment };
       const runtime = await resolveAntigravityRuntime(input.config.cli, environment);
@@ -169,6 +174,7 @@ export const AntigravityDriver: ProviderDriver<AcpConfig> = {
       completeAuthentication: async (flowId, callbackUrl) => auth.complete(flowId, callbackUrl),
       cancelAuthentication: async () => auth.cancel(),
       dispose: async () => {
+        unregisterManagedAntigravityWorker(input.instanceId);
         auth.cancel();
         await base.dispose();
       },

--- a/server/index.ts
+++ b/server/index.ts
@@ -248,6 +248,15 @@ import { loadBundledSkills, loadUserSkills, mergeSkills, renderSkillInstructions
 import { installedPlaybookInstructions } from "./installed-playbooks.ts";
 import { createBotPackageExport } from "./package-export.ts";
 import { shouldMountLocalComputer } from "./local-routing.ts";
+import {
+  antigravityAccountStatuses,
+  activateAntigravityProfile,
+  refreshAntigravityProfileQuota,
+  antigravityManagedWorkerRunning,
+  antigravityProcessRunning,
+  antigravityManagedQuotaRefreshRunning,
+  type AntigravityProfile,
+} from "./antigravity-accounts.ts";
 import { resolveSurface } from "./surface.ts";
 import {
   PendingTurnCancellations,
@@ -9180,6 +9189,49 @@ const server = createServer(async (req, res) => {
           : 500;
         return json(res, status, { error: error instanceof Error ? error.message : String(error) });
       }
+    }
+
+    // ── Antigravity multi-account coordination (Worker A / Worker B) ──
+    if (method === "GET" && path === "/api/antigravity/accounts") {
+      const refresh = url.searchParams.get("refresh") === "1";
+      const requestedProfile = url.searchParams.get("profile");
+      if (requestedProfile !== null && requestedProfile !== "a" && requestedProfile !== "b") {
+        return json(res, 400, { error: "profile must be a or b" });
+      }
+      if (refresh && antigravityManagedWorkerRunning()) {
+        return json(res, 200, {
+          accounts: await antigravityAccountStatuses(false),
+          refreshDeferred: true,
+        });
+      }
+      if (refresh && (await antigravityProcessRunning()) && !antigravityManagedQuotaRefreshRunning()) {
+        return json(res, 409, { error: "Close standalone Antigravity terminals before refreshing account quotas." });
+      }
+      if (refresh && requestedProfile) {
+        try {
+          await refreshAntigravityProfileQuota(requestedProfile as AntigravityProfile);
+        } catch {
+          // Status response keeps last-good value and marks this profile stale.
+        }
+        return json(res, 200, { accounts: await antigravityAccountStatuses(false) });
+      }
+      return json(res, 200, {
+        accounts: await antigravityAccountStatuses(refresh),
+      });
+    }
+
+    if (method === "POST" && path === "/api/antigravity/activate") {
+      if (!String(req.headers["content-type"] ?? "").toLowerCase().startsWith("application/json")) {
+        return json(res, 415, { error: "content-type must be application/json" });
+      }
+      const body = await readBody(req);
+      const profile = body?.profile as AntigravityProfile;
+      if (profile !== "a" && profile !== "b") return json(res, 400, { error: "profile must be a or b" });
+      if (providerConfigBusy || (await antigravityProcessRunning())) {
+        return json(res, 409, { error: "Antigravity is busy. Wait for the current task or close its terminal." });
+      }
+      await activateAntigravityProfile(profile);
+      return json(res, 200, { accounts: await antigravityAccountStatuses(false) });
     }
 
     // ── CLI binary discovery for the Engines "detected" dropdown ──

--- a/server/procs.ts
+++ b/server/procs.ts
@@ -22,6 +22,15 @@ import type { Readable, Writable } from "node:stream";
 import { join } from "node:path";
 import { resolveCliSpawn, type ResolvedSpawn } from "./env-path.ts";
 
+export interface ExecCliTreeOptions extends Omit<SpawnOptions, "stdio"> {
+  timeout?: number;
+  maxBuffer?: number;
+  /** Optional strict output boundary for commands that can finish before
+   * their CLI closes inherited descendant pipes. The predicate must only
+   * accept a complete, valid response. */
+  completionPredicate?: (stdout: string, stderr: string) => boolean;
+}
+
 export function resolveCli(cli: string, args: string[] = []): ResolvedSpawn {
   return resolveCliSpawn(cli, args);
 }
@@ -100,6 +109,108 @@ export function execCli(
   );
 }
 
+/** Execute a bounded CLI command and reap its complete process tree on timeout.
+ *
+ * `execFile({ timeout })` only guarantees that the direct child is killed on
+ * Windows. CLI launchers commonly leave their real worker process behind,
+ * which then holds credentials, ports, and state files. This helper does not
+ * settle a timeout until taskkill has finished with the whole tree. */
+export function execCliTree(
+  cli: string,
+  args: string[],
+  opts: ExecCliTreeOptions = {},
+): Promise<{ stdout: string; stderr: string }> {
+  const {
+    timeout = 0,
+    maxBuffer = 1024 * 1024,
+    completionPredicate,
+    ...spawnOptions
+  } = opts;
+  const child = spawnCli(cli, args, {
+    ...spawnOptions,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let stopping = false;
+    let timer: NodeJS.Timeout | undefined;
+
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      if (error) {
+        Object.assign(error, { stdout, stderr });
+        reject(error);
+      } else {
+        resolve({ stdout, stderr });
+      }
+    };
+
+    const stopWith = async (error?: Error) => {
+      if (settled || stopping) return;
+      stopping = true;
+      await killCliTreeAndWait(child);
+      finish(error);
+    };
+
+    const finishAfterCompleteOutput = () => {
+      void stopWith();
+    };
+
+    const checkCompletionBoundary = () => {
+      if (!completionPredicate || settled || stopping) return;
+      let complete = false;
+      try {
+        complete = completionPredicate(stdout, stderr);
+      } catch {
+        // A strict parser commonly throws while the response is partial or
+        // invalid. Keep waiting so timeout/error handling remains in charge.
+      }
+      if (complete) finishAfterCompleteOutput();
+    };
+
+    const append = (target: "stdout" | "stderr", chunk: Buffer | string) => {
+      if (settled || stopping) return;
+      const next = (target === "stdout" ? stdout : stderr) + String(chunk);
+      if (Buffer.byteLength(next, "utf8") > maxBuffer) {
+        void stopWith(new Error(`${cli} exceeded maxBuffer (${maxBuffer} bytes)`));
+        return;
+      }
+      if (target === "stdout") stdout = next;
+      else stderr = next;
+      checkCompletionBoundary();
+    };
+
+    child.stdout.on("data", (chunk) => append("stdout", chunk));
+    child.stderr.on("data", (chunk) => append("stderr", chunk));
+    child.once("error", (error) => {
+      void stopWith(error);
+    });
+    child.once("close", (code, signal) => {
+      if (stopping || settled) return;
+      if (code === 0) finish();
+      else {
+        const detail = stderr.trim() || stdout.trim();
+        void stopWith(
+          new Error(
+            `${cli} exited ${code ?? signal ?? "before producing a result"}${detail ? `: ${detail}` : ""}`,
+          ),
+        );
+      }
+    });
+
+    if (timeout > 0) {
+      timer = setTimeout(() => {
+        void stopWith(new Error(`${cli} timed out after ${timeout}ms`));
+      }, timeout);
+    }
+  });
+}
+
 /** Human wording for a failed CLI spawn.
  *
  * Node reports these as bare errno strings — "spawn grok ENOENT" — which
@@ -149,6 +260,43 @@ export function killCliTree(child: ChildProcess): void {
       /* already gone */
     }
   }
+}
+
+/** Promise form used by bounded probes that must not race the next command. */
+export async function killCliTreeAndWait(child: ChildProcess): Promise<void> {
+  const pid = child.pid;
+  if (!pid || child.exitCode !== null || child.signalCode !== null) return;
+
+  if (process.platform === "win32") {
+    const taskkillFailed = await new Promise<boolean>((resolve) => {
+      execFile("taskkill", ["/PID", String(pid), "/T", "/F"], { windowsHide: true }, (error) =>
+        resolve(Boolean(error)),
+      );
+    });
+    if (taskkillFailed && child.exitCode === null && child.signalCode === null) {
+      try {
+        child.kill();
+      } catch {
+        return;
+      }
+    }
+  } else {
+    try {
+      process.kill(-pid, "SIGTERM");
+    } catch {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        return;
+      }
+    }
+  }
+
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await Promise.race([
+    new Promise<void>((resolve) => child.once("close", () => resolve())),
+    new Promise<void>((resolve) => setTimeout(resolve, 5_000)),
+  ]);
 }
 
 /** Per-turn broker channel: unix socket on POSIX, named pipe on Windows

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -123,38 +123,39 @@ export function AntigravityAccountCards({
 }) {
   const account = accounts.find((candidate) => candidate.instanceId === selectedInstanceId);
   if (!account) return null;
-  const quota = account.quota.gemini;
-  const value = (window: typeof quota.weekly) => (window ? `${window.remaining}%` : "—");
+  const quota = account.quota?.gemini;
+  const value = (window: { remaining: number; resetsAt: string | null } | null | undefined) =>
+    window && typeof window.remaining === "number" ? `${window.remaining}%` : "—";
   return (
     <div
       data-testid={`antigravity-quota-card-${account.instanceId}`}
       className="mt-2 rounded-lg border border-hairline/40 bg-inset px-2.5 py-2 text-[11px]"
     >
       <div className="flex items-center justify-between gap-2">
-        <span className="truncate text-ink-secondary">{accountDisplayLabel(account)}</span>
-        <span className={selectedBotInstanceId === account.instanceId ? "text-success" : "text-ink-secondary"}>
-          {selectedBotInstanceId === account.instanceId ? "Выбран для бота" : "Выбери модель"}
+        <span className="truncate font-medium text-ink">{accountDisplayLabel(account)}</span>
+        <span className={cn("text-[10px]", selectedBotInstanceId === account.instanceId ? "text-success font-medium" : "text-ink-secondary")}>
+          {selectedBotInstanceId === account.instanceId ? "Selected for bot" : "Select model"}
         </span>
       </div>
       {account.quotaStale && (
         <div className="mt-1 text-warning">Refresh failed · showing last good</div>
       )}
-      <div className="mt-1.5 flex items-center gap-2 text-ink">
-        <span className="min-w-0 flex-1">
-          Общая: <b>{value(quota.weekly)}</b>
-        </span>
-        <span className="min-w-0 flex-1">
-          5 часов: <b>{value(quota.fiveHour)}</b>
-        </span>
+      <div className="mt-2 flex items-center gap-4 text-[11px] text-ink">
+        <span>Weekly: <b>{value(quota?.weekly)}</b></span>
+        <span>5-hour: <b>{value(quota?.fiveHour)}</b></span>
+      </div>
+      <div className="mt-2 flex items-center justify-between border-t border-hairline/20 pt-1.5 text-[10px] text-ink-secondary">
+        <span>Profile {account.profile.toUpperCase()}</span>
         <button
           type="button"
           onClick={onRefresh}
           disabled={busy}
-          className="rounded p-1 text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-50"
-          title="Обновить квоту выбранного аккаунта"
-          aria-label="Обновить квоты Antigravity"
+          className="flex items-center gap-1 rounded px-1.5 py-0.5 text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-50"
+          title="Refresh account quota"
+          aria-label="Refresh account quota"
         >
-          <RefreshCw size={12} className={busy ? "animate-spin" : undefined} />
+          <RefreshCw size={11} className={busy ? "animate-spin" : undefined} />
+          <span>Refresh quota</span>
         </button>
       </div>
     </div>

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -3,7 +3,7 @@
 // engines that need setup show one focused action instead of a disabled wall.
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { Check, ChevronDown, ChevronLeft, ChevronRight, Loader2, RefreshCw, Search } from "lucide-react";
-import { useStore, type Bot, type InstanceInfo, type ModelSelection } from "@/state/store";
+import { api, useStore, type Bot, type InstanceInfo, type ModelSelection, type AntigravityAccountStatus } from "@/state/store";
 import { filterCustomModels, partitionCustomModels, suggestedModels } from "@/lib/custom-models";
 import { isCustomOnly, splitEngineRail } from "@/lib/engine-rail";
 import { ProviderMark } from "./ProviderIcons";
@@ -103,6 +103,64 @@ function ModelSearch({
   );
 }
 
+export function accountDisplayLabel(account: AntigravityAccountStatus): string {
+  if (account.email) return account.email;
+  return account.label || (account.profile === "a" ? "Worker A account" : "Worker B account");
+}
+
+export function AntigravityAccountCards({
+  accounts,
+  selectedInstanceId,
+  selectedBotInstanceId,
+  busy,
+  onRefresh,
+}: {
+  accounts: AntigravityAccountStatus[];
+  selectedInstanceId: string;
+  selectedBotInstanceId: string;
+  busy: boolean;
+  onRefresh: () => void;
+}) {
+  const account = accounts.find((candidate) => candidate.instanceId === selectedInstanceId);
+  if (!account) return null;
+  const quota = account.quota.gemini;
+  const value = (window: typeof quota.weekly) => (window ? `${window.remaining}%` : "—");
+  return (
+    <div
+      data-testid={`antigravity-quota-card-${account.instanceId}`}
+      className="mt-2 rounded-lg border border-hairline/40 bg-inset px-2.5 py-2 text-[11px]"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="truncate text-ink-secondary">{accountDisplayLabel(account)}</span>
+        <span className={selectedBotInstanceId === account.instanceId ? "text-success" : "text-ink-secondary"}>
+          {selectedBotInstanceId === account.instanceId ? "Выбран для бота" : "Выбери модель"}
+        </span>
+      </div>
+      {account.quotaStale && (
+        <div className="mt-1 text-warning">Refresh failed · showing last good</div>
+      )}
+      <div className="mt-1.5 flex items-center gap-2 text-ink">
+        <span className="min-w-0 flex-1">
+          Общая: <b>{value(quota.weekly)}</b>
+        </span>
+        <span className="min-w-0 flex-1">
+          5 часов: <b>{value(quota.fiveHour)}</b>
+        </span>
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={busy}
+          className="rounded p-1 text-ink-secondary hover:bg-raised hover:text-ink disabled:opacity-50"
+          title="Обновить квоту выбранного аккаунта"
+          aria-label="Обновить квоты Antigravity"
+        >
+          <RefreshCw size={12} className={busy ? "animate-spin" : undefined} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export function ModelPicker({
   bot,
   className,
@@ -123,6 +181,10 @@ export function ModelPicker({
   const [query, setQuery] = useState("");
   const [showAll, setShowAll] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const [agyAccounts, setAgyAccounts] = useState<AntigravityAccountStatus[]>([]);
+  const [agyBusy, setAgyBusy] = useState(false);
+  const [agyError, setAgyError] = useState<string | null>(null);
+  const [agyNotice, setAgyNotice] = useState<string | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const refreshingRef = useRef(false);
 
@@ -167,6 +229,13 @@ export function ModelPicker({
 
   useEffect(() => {
     if (!open) return;
+    void api("/api/antigravity/accounts")
+      .then((value) => setAgyAccounts(value.accounts ?? []))
+      .catch((error) => setAgyError(error instanceof Error ? error.message : String(error)));
+  }, [open, refreshInstances]);
+
+  useEffect(() => {
+    if (!open) return;
     const closeOnOutsideClick = (event: MouseEvent) => {
       const clickedNode = event.target instanceof Node ? event.target : null;
       if (!rootRef.current?.contains(clickedNode)) setOpen(false);
@@ -206,7 +275,25 @@ export function ModelPicker({
     resetList();
   };
 
-  const pick = (instance: InstanceInfo, model: string) => {
+  const pick = async (instance: InstanceInfo, model: string) => {
+    const account = agyAccounts.find((candidate) => candidate.instanceId === instance.instanceId);
+    if (account) {
+      setAgyBusy(true);
+      setAgyError(null);
+      try {
+        const result = await api("/api/antigravity/activate", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ profile: account.profile }),
+        });
+        setAgyAccounts(result.accounts ?? []);
+      } catch (error) {
+        setAgyError(error instanceof Error ? error.message : String(error));
+        setAgyBusy(false);
+        return;
+      }
+      setAgyBusy(false);
+    }
     const sameInstance = instance.instanceId === selection.instanceId;
     const nextSelection: ModelSelection = {
       instanceId: instance.instanceId,
@@ -219,6 +306,28 @@ export function ModelPicker({
       selection: nextSelection,
     });
     setOpen(false);
+  };
+
+  const refreshAgyQuotas = async () => {
+    if (!railInstance) return;
+    setAgyBusy(true);
+    setAgyError(null);
+    setAgyNotice(null);
+    try {
+      const selectedAccount = agyAccounts.find(
+        (candidate) => candidate.instanceId === railInstance.instanceId,
+      );
+      if (!selectedAccount) throw new Error("No Antigravity account is selected.");
+      const result = await api(`/api/antigravity/accounts?refresh=1&profile=${selectedAccount.profile}`);
+      setAgyAccounts(result.accounts ?? []);
+      if (result.refreshDeferred) {
+        setAgyNotice("Worker is active. Quota will refresh automatically when its task finishes.");
+      }
+    } catch (error) {
+      setAgyError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setAgyBusy(false);
+    }
   };
 
   const official = railInstance?.models.options.filter((option) => !option.custom) ?? [];
@@ -400,6 +509,19 @@ export function ModelPicker({
                       ? "Run this agent with a model already on your machine."
                       : "Choose a model for this bot."}
                   </div>
+                  <AntigravityAccountCards
+                    accounts={agyAccounts}
+                    selectedInstanceId={railInstance.instanceId}
+                    selectedBotInstanceId={selection.instanceId}
+                    busy={agyBusy}
+                    onRefresh={() => void refreshAgyQuotas()}
+                  />
+                  {agyError && railInstance.driverKind === "antigravityAgent" && (
+                    <div className="mt-2 text-[10.5px] text-warning">{agyError}</div>
+                  )}
+                  {agyNotice && railInstance.driverKind === "antigravityAgent" && (
+                    <div className="mt-2 text-[10.5px] text-ink-secondary">{agyNotice}</div>
+                  )}
                 </div>
 
                 {pane === "custom" && canReturnToOfficial && (

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -56,6 +56,22 @@ function trimRoutineRuns(runs: readonly RoutineRun[]): RoutineRun[] {
 export type { MausColor } from "@/lib/mascot";
 export type { RoutineRunCardData } from "../../shared/routine-run";
 
+export interface AntigravityQuotaWindow { remaining: number; resetsAt: string | null }
+export interface AntigravityAccountStatus {
+  profile: "a" | "b";
+  instanceId: string;
+  label: string;
+  email?: string;
+  active: boolean;
+  available: boolean;
+  quota: {
+    gemini: { weekly: AntigravityQuotaWindow | null; fiveHour: AntigravityQuotaWindow | null };
+    other: { weekly: AntigravityQuotaWindow | null; fiveHour: AntigravityQuotaWindow | null };
+  };
+  quotaStale?: boolean;
+  error?: string;
+}
+
 export interface OptionCardData {
   title: string;
   subtitle: string;


### PR DESCRIPTION
## What changed
- Added native two-worker fleet support for Antigravity CLI (`antigravity_worker_a` and `antigravity_worker_b`) in `server/config.ts` and `DEFAULT_FLEET`.
- Implemented pure TypeScript profile isolation via dedicated home directories (`~/.openmausbot/antigravity-profiles/worker-a` and `worker-b`), setting `USERPROFILE`/`HOME` per spawned process with zero binary patching or C++ compilation.
- Added quota monitoring for Gemini models and Claude/GPT models with single-flight cache and async mutex (`server/antigravity-accounts.ts`).
- Added account label reading from `~/.openmausbot/antigravity-account-labels.json`.
- Added interactive Worker A / Worker B switcher cards with quota indicators and account email display in `ModelPicker.tsx`.

## Why
Users with multiple Antigravity CLI subscriptions need to switch between worker profiles, distinguish accounts by email label, and monitor weekly and 5-hour quota windows directly from the model picker without token collisions.

## How it was verified
- Automated test suites:
  - `pnpm vitest run server/antigravity-accounts.test.ts` (11/11 tests pass)
  - `pnpm vitest run server/drivers/antigravity.test.ts` (30/30 tests pass)
  - `pnpm vitest run server/config.test.ts` (66/66 tests pass)
  - `pnpm typecheck` (`pnpm tsc --noEmit`) passes with 0 errors.
- Verified on isolated test fixture launched via `node --experimental-strip-types scripts/control-omb.ts launch`:
  - `GET /api/antigravity/accounts` returned isolated Worker A & Worker B account status.
  - `POST /api/antigravity/activate` successfully switched active worker profile.

## Checklist
- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (see CONTRIBUTING.md -> Tests)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for two Antigravity worker accounts with labels, email details, availability, and quota visibility.
  * Added account switching and activation from the model picker.
  * Added quota refresh controls with deferred and stale-status notices.
  * Added automatic migration of existing Antigravity configuration to the two-worker setup.
  * Added refreshed provider model listings after account changes.
* **Bug Fixes**
  * Improved account refresh reliability when workers or standalone Antigravity sessions are active.
* **Tests**
  * Added coverage for account isolation, quota handling, refresh coordination, and worker configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->