### PR TITLE
feat: add secure attachment previews across apps

### DIFF
--- a/android/app/src/main/kotlin/com/openmausbot/companion/OpenMausApp.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/OpenMausApp.kt
@@ -15,6 +15,7 @@ import com.openmausbot.companion.sharing.ShareInbox
 import com.openmausbot.companion.storage.DataStoreConnectionStore
 import com.openmausbot.companion.storage.OnboardingPreferences
 import com.openmausbot.companion.storage.KeystoreTokenStore
+import com.openmausbot.companion.ui.FilePreviews
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -59,6 +60,9 @@ class OpenMausApp : Application() {
         super.onCreate()
         shareInbox = ShareInbox()
         ShareInbox.cleanStale(cacheDir)
+        // Launch stays non-blocking. The preview store awaits the shared
+        // completion barrier on its own IO coroutine before writing anything.
+        FilePreviews.startStaleCleanup(this, appScope)
         notifications = LocalNotificationPoster(this)
         discovery = NsdDiscovery(this)
         permissions = CompanionPermissions(this)

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/ChatPolicy.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/ChatPolicy.kt
@@ -1,5 +1,6 @@
 package com.openmausbot.companion.ui
 
+import com.openmausbot.companion.core.AttachedMessageContent
 import com.openmausbot.companion.core.Bot
 import com.openmausbot.companion.core.Chat
 import com.openmausbot.companion.core.ChatSummary
@@ -476,7 +477,10 @@ object SearchHitRole {
 object MessageActions {
     /** The text worth putting on the clipboard, or null when there is none. */
     fun copyableText(message: Message): String? = when (message.kind) {
-        Message.Kind.TEXT, Message.Kind.UNKNOWN -> message.text?.takeIf { it.isNotBlank() }
+        Message.Kind.TEXT, Message.Kind.UNKNOWN -> message.text
+            ?.let { AttachedMessageContent.parse(it) }
+            ?.text
+            ?.takeIf { it.isNotBlank() }
         // An approval card is worth copying for what it is asking to do.
         Message.Kind.OPTIONS -> message.card
             ?.let { card -> listOf(card.title, card.subtitle).filter { it.isNotBlank() } }
@@ -484,6 +488,18 @@ object MessageActions {
             ?.joinToString("\n\n")
         // A tool chip is context, and a screenshot is pixels.
         Message.Kind.ACTIVITY, Message.Kind.SCREEN -> null
+    }
+
+    /**
+     * Original user text can be retried only when it has no uploaded payload.
+     * Retrying an attachment message would either leak its computer-local path
+     * or silently resend a message without the file.
+     */
+    fun editableText(message: Message): String? {
+        if (message.role != Message.Role.USER || message.kind != Message.Kind.TEXT) return null
+        val raw = message.text ?: return null
+        if (AttachedMessageContent.parse(raw).attachments.isNotEmpty()) return null
+        return raw
     }
 }
 

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/ChatScreen.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/ChatScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
@@ -102,6 +103,8 @@ import com.openmausbot.companion.core.LocalMessageLink
 import com.openmausbot.companion.core.PendingMessageAttachment
 import com.openmausbot.companion.core.CompanionState
 import com.openmausbot.companion.core.Dictation
+import com.openmausbot.companion.core.DisplayedMessageAttachment
+import com.openmausbot.companion.core.DownloadedFile
 import com.openmausbot.companion.core.Message
 import com.openmausbot.companion.core.TranscriptRow
 import com.openmausbot.companion.core.target
@@ -221,15 +224,24 @@ private fun LoadedChat(
     var sendingMessage by remember(chatId) { mutableStateOf(false) }
     var attachmentError by remember(chatId) { mutableStateOf<String?>(null) }
     // A bot-linked file on its way from the computer, and where it landed.
-    var openingFileName by remember { mutableStateOf<String?>(null) }
-    var fileOpenError by remember { mutableStateOf<String?>(null) }
-    var filePreview by remember { mutableStateOf<FilePreviewItem?>(null) }
-    var fileDownloadJob by remember { mutableStateOf<Job?>(null) }
+    var openingFileName by remember(threadId) { mutableStateOf<String?>(null) }
+    var fileOpenError by remember(threadId) { mutableStateOf<String?>(null) }
+    var filePreview by remember(threadId) { mutableStateOf<FilePreviewItem?>(null) }
+    var fileDownloadJob by remember(threadId) { mutableStateOf<Job?>(null) }
     val filePreviews = remember(context) { FilePreviews(context) }
     DisposableEffect(filePreviews) {
         onDispose {
             fileDownloadJob?.cancel()
             filePreviews.clear()
+        }
+    }
+    DisposableEffect(filePreviews, threadId) {
+        onDispose {
+            // LoadedChat follows the bot when its task changes. Invalidate the
+            // old request and its published preview as one lifecycle step; a
+            // late completion can no longer write into the next task's UI.
+            filePreviews.invalidateCurrent()
+            fileDownloadJob?.cancel()
         }
     }
     val canAddAttachment = AttachmentImportRules.canAdd(attachments.size, preparingAttachments, sendingMessage)
@@ -279,38 +291,72 @@ private fun LoadedChat(
         }
     }
 
+    /** Every computer-local attachment takes the authenticated message-file route. */
+    fun openFile(
+        path: String,
+        message: Message,
+        prepared: DownloadedFile? = null,
+        preferredName: String? = null,
+        cacheResult: Boolean = false,
+    ) {
+        val requestGeneration = filePreviews.beginRequest()
+        val requestedThreadId = threadId
+        fileDownloadJob?.cancel()
+        fileOpenError = null
+        openingFileName = preferredName ?: prepared?.filename ?: FilePreviewRules.nameForOpening(path)
+        fileDownloadJob = scope.launch {
+            val fetched = prepared ?: session.downloadFile(
+                requestedThreadId,
+                message.id,
+                path,
+                cacheResult = cacheResult,
+            )
+            if (!filePreviews.isCurrent(requestGeneration)) return@launch
+            openingFileName = null
+            if (fetched == null) {
+                fileOpenError = session.actionError ?: "Couldn't open that file. Try again."
+                session.actionError = null
+                return@launch
+            }
+            val item = try {
+                // The tag's display name labels the card only. Materialising
+                // and sharing must use the canonical Content-Disposition name
+                // returned by the scoped download route.
+                withContext(Dispatchers.IO) { filePreviews.store(fetched, requestGeneration) }
+            } catch (error: kotlinx.coroutines.CancellationException) {
+                throw error
+            } catch (_: Throwable) {
+                if (!filePreviews.isCurrent(requestGeneration)) return@launch
+                fileOpenError = "The downloaded file couldn't be previewed."
+                return@launch
+            } ?: return@launch
+            if (!filePreviews.isCurrent(requestGeneration)) return@launch
+            filePreview = item
+        }
+    }
+
     // A tapped link in a bot reply: the web goes to the system, a desktop path
     // comes back through the computer, anything else is refused out loud.
     fun openLink(url: String, message: Message) {
         when (val target = LocalMessageLink.resolve(url)) {
             is LocalMessageLink.Web -> runCatching { uriHandler.openUri(target.url) }
                 .onFailure { fileOpenError = "This link can't be opened on this phone." }
-            is LocalMessageLink.DesktopFile -> {
-                fileDownloadJob?.cancel()
-                fileOpenError = null
-                openingFileName = FilePreviewRules.nameForOpening(target.path)
-                fileDownloadJob = scope.launch {
-                    val downloaded = session.downloadFile(threadId, message.id, target.path)
-                    openingFileName = null
-                    if (downloaded == null) {
-                        fileOpenError = session.actionError ?: "Couldn't open that file. Try again."
-                        session.actionError = null
-                        return@launch
-                    }
-                    val item = runCatching { withContext(Dispatchers.IO) { filePreviews.store(downloaded) } }
-                        .getOrElse {
-                            fileOpenError = "The downloaded file couldn't be previewed."
-                            return@launch
-                        }
-                    when (item.kind) {
-                        FilePreviewKind.MARKDOWN, FilePreviewKind.TEXT -> filePreview = item
-                        FilePreviewKind.OTHER -> filePreviews.openWithSystem(item)?.let { fileOpenError = it }
-                    }
-                }
-            }
+            is LocalMessageLink.DesktopFile -> openFile(target.path, message)
             null -> fileOpenError = "This link can't be opened securely."
         }
     }
+
+    fun openAttachment(
+        attachment: DisplayedMessageAttachment,
+        message: Message,
+        downloaded: DownloadedFile?,
+    ) = openFile(
+        attachment.path,
+        message,
+        downloaded,
+        preferredName = attachment.name,
+        cacheResult = true,
+    )
     val focusedMessageId by session.focusedMessageId.collectAsState()
 
     val dictationListening by dictation.isListening.collectAsState()
@@ -652,7 +698,10 @@ private fun LoadedChat(
             ) {
                 LazyColumn(
                     state = listState,
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .widthIn(max = CHAT_CONTENT_MAX_WIDTH)
+                        .fillMaxSize(),
                     contentPadding = PaddingValues(
                         start = 16.dp,
                         end = 16.dp,
@@ -725,6 +774,7 @@ private fun LoadedChat(
                                     // not one per bubble.
                                     endsRun = TranscriptLayout.endsRowRun(transcript, index),
                                     openLink = ::openLink,
+                                    openAttachment = ::openAttachment,
                                 )
                                 is TranscriptRow.ActivityRun -> ActivityRunChip(message.items)
                             }
@@ -767,10 +817,16 @@ private fun LoadedChat(
                             showingPlus = true
                         }
                     },
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .widthIn(max = CHAT_CONTENT_MAX_WIDTH),
                 )
             }
 
             Composer(
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .widthIn(max = CHAT_CONTENT_MAX_WIDTH),
                 name = chat.name,
                 draft = draft,
                 accessory = ComposerAccessories.accessory(
@@ -858,7 +914,15 @@ private fun LoadedChat(
     }
 
     filePreview?.let { item ->
-        FilePreviewSheet(item = item, onDismiss = { filePreview = null })
+        FilePreviewSheet(
+            item = item,
+            onDismiss = {
+                filePreview = null
+                scope.launch(Dispatchers.IO) { filePreviews.dismiss(item) }
+            },
+            onShare = { filePreviews.share(item) },
+            onOpen = { filePreviews.openWithSystem(item) },
+        )
     }
 }
 
@@ -877,6 +941,7 @@ private fun share(
 
 private const val LOAD_EARLIER_KEY = "companion.loadEarlier"
 private const val LIVE_BUBBLE_KEY = "companion.live"
+private val CHAT_CONTENT_MAX_WIDTH = 840.dp
 
 /** `itemsIndexed` with the message id as the key — one call site, one helper. */
 private fun androidx.compose.foundation.lazy.LazyListScope.itemsIndexedKeyed(
@@ -912,9 +977,10 @@ private fun ChatHeader(
     onBack: () -> Unit,
     onWatchComputer: () -> Unit,
     onOpenProfile: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val surface = MaterialTheme.colorScheme.surface
-    Box(modifier = Modifier.fillMaxWidth()) {
+    Box(modifier = modifier.fillMaxWidth()) {
         Spacer(
             modifier = Modifier
                 .fillMaxWidth()
@@ -1212,6 +1278,7 @@ private fun ChatActionIcon(id: ChatActionId, tint: Color) {
 /** A round + and a pill with the send button inside it. */
 @Composable
 private fun Composer(
+    modifier: Modifier = Modifier,
     name: String,
     draft: String,
     accessory: ComposerAccessory,
@@ -1247,7 +1314,7 @@ private fun Composer(
         label = "plus",
     )
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(start = 12.dp, end = 12.dp, top = 6.dp, bottom = 8.dp),
         verticalArrangement = Arrangement.spacedBy(6.dp),

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/FilePreview.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/FilePreview.kt
@@ -3,34 +3,81 @@ package com.openmausbot.companion.ui
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import android.graphics.BitmapFactory
+import android.graphics.Matrix
+import android.graphics.ImageDecoder
+import android.os.Build
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.rememberTransformableState
+import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.core.content.FileProvider
+import androidx.exifinterface.media.ExifInterface
 import com.openmausbot.companion.core.DownloadedFile
+import com.openmausbot.companion.core.LocalMessageLink
 import java.io.File
+import java.nio.ByteBuffer
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.math.max
+import kotlin.math.roundToInt
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /** How a downloaded file is shown — `FilePreviewItem.Kind` in `AttachmentViews.swift`. */
 enum class FilePreviewKind {
+    /** Full-window, zoomable image preview. */
+    IMAGE,
     /** Rendered in the app, the way a bot reply is. */
     MARKDOWN,
     /** Monospace, in the app. */
@@ -47,6 +94,9 @@ object FilePreviewRules {
     fun kind(contentType: String, filename: String): FilePreviewKind {
         val mime = contentType.lowercase()
         val suffix = filename.substringAfterLast('.', "").lowercase()
+        if (mime.startsWith("image/") || suffix in setOf("png", "jpg", "jpeg", "gif", "webp")) {
+            return FilePreviewKind.IMAGE
+        }
         if (mime == "text/markdown" || suffix == "md" || suffix == "markdown") return FilePreviewKind.MARKDOWN
         if (mime.startsWith("text/") || mime == "application/json") return FilePreviewKind.TEXT
         return FilePreviewKind.OTHER
@@ -64,6 +114,185 @@ object FilePreviewRules {
 
     fun noViewer(filename: String): String = "No app on this phone can open $filename."
 }
+
+/** Bounds shared by sent-image thumbnails, full-screen previews, and screenshots. */
+object AttachmentImageRules {
+    const val THUMBNAIL_EDGE: Int = 768
+    const val FULL_SCREEN_EDGE: Int = 3_072
+    const val LEGACY_INTERMEDIATE_PIXELS: Long = 12_000_000
+    const val LEGACY_NEAR_TARGET_MAX_PIXELS: Long = 14_000_000
+
+    /** Largest power-of-two sample whose decoded edge still reaches the requested size. */
+    fun sampleSize(width: Int, height: Int, maximumEdge: Int): Int {
+        if (width <= 0 || height <= 0 || maximumEdge <= 0) return 1
+        var sample = 1
+        val sourceEdge = max(width, height)
+        while (sample <= Int.MAX_VALUE / 2) {
+            val next = sample * 2
+            if (sourceEdge / next < maximumEdge) break
+            sample = next
+        }
+        return sample
+    }
+
+    /**
+     * Android 8 must decode through BitmapFactory. Keep its intermediate under
+     * a fixed pixel budget even when that requires one additional power-of-two
+     * sample and a modest undershoot; a bounded sharp bitmap beats an OOM.
+     */
+    fun legacySampleSize(
+        width: Int,
+        height: Int,
+        maximumEdge: Int,
+        maximumPixels: Long = LEGACY_INTERMEDIATE_PIXELS,
+    ): Int {
+        if (width <= 0 || height <= 0 || maximumEdge <= 0 || maximumPixels <= 0) return 1
+        var sample = sampleSize(width, height, maximumEdge)
+        while (sample <= Int.MAX_VALUE / 2) {
+            val pixels = sampledPixels(width, height, sample)
+            val sampledEdge = max(sampledDimension(width, sample), sampledDimension(height, sample))
+            // BitmapFactory's next step halves each dimension. When the current
+            // bitmap is already within 25% of the target, allow a small, hard-
+            // capped allocation tolerance instead of throwing away 75% of its
+            // pixels (for example 3500² -> 1750²).
+            val nearTarget = sampledEdge.toLong() * 4L <= maximumEdge.toLong() * 5L
+            val budget = if (nearTarget) {
+                maxOf(maximumPixels, LEGACY_NEAR_TARGET_MAX_PIXELS)
+            } else {
+                maximumPixels
+            }
+            if (pixels <= budget) break
+            sample *= 2
+        }
+        return sample
+    }
+
+    private fun sampledDimension(value: Int, sample: Int): Int {
+        val divisor = sample.toLong().coerceAtLeast(1)
+        return ((value.toLong() + divisor - 1) / divisor).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+    }
+
+    private fun sampledPixels(width: Int, height: Int, sample: Int): Long {
+        return sampledDimension(width, sample).toLong() * sampledDimension(height, sample).toLong()
+    }
+
+    fun targetSize(width: Int, height: Int, maximumEdge: Int): IntSize {
+        if (width <= 0 || height <= 0 || maximumEdge <= 0) return IntSize.Zero
+        val scale = minOf(1f, maximumEdge.toFloat() / max(width, height).toFloat())
+        return IntSize(
+            (width * scale).roundToInt().coerceAtLeast(1),
+            (height * scale).roundToInt().coerceAtLeast(1),
+        )
+    }
+}
+
+/** Decode budget for a screen frame, derived from its rendered width and aspect. */
+object ScreenShotImageRules {
+    private const val MAXIMUM_EDGE = 4_096
+
+    fun maximumEdge(renderedWidthPixels: Int, sourceWidth: Int, sourceHeight: Int): Int {
+        if (renderedWidthPixels <= 0 || sourceWidth <= 0 || sourceHeight <= 0) return 1
+        val targetWidth = minOf(renderedWidthPixels, sourceWidth)
+        val targetHeight = targetWidth.toFloat() * sourceHeight.toFloat() / sourceWidth.toFloat()
+        return max(targetWidth.toFloat(), targetHeight).roundToInt().coerceIn(1, MAXIMUM_EDGE)
+    }
+}
+
+/** Decode untrusted remote pixels off the main thread, at a bounded display size. */
+internal fun decodeAttachmentImage(data: ByteArray, maximumEdge: Int): ImageBitmap? {
+    if (data.isEmpty()) return null
+    return try {
+        val bitmap = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            ImageDecoder.decodeBitmap(ImageDecoder.createSource(ByteBuffer.wrap(data))) { decoder, info, _ ->
+                decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
+                val target = AttachmentImageRules.targetSize(info.size.width, info.size.height, maximumEdge)
+                decoder.setTargetSize(target.width, target.height)
+            }
+        } else {
+            decodeLegacyOrientedBitmap(data, maximumEdge)
+        }
+        bitmap?.asImageBitmap()
+    } catch (_: OutOfMemoryError) {
+        null
+    } catch (_: Exception) {
+        null
+    }
+}
+
+/** Read the frame's source aspect first, then spend pixels on its actual on-screen width. */
+internal fun decodeScreenShotImage(data: ByteArray, renderedWidthPixels: Int): ImageBitmap? {
+    if (data.isEmpty()) return null
+    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    BitmapFactory.decodeByteArray(data, 0, data.size, bounds)
+    if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
+    val orientation = runCatching {
+        ExifInterface(data.inputStream()).getAttributeInt(
+            ExifInterface.TAG_ORIENTATION,
+            ExifInterface.ORIENTATION_NORMAL,
+        )
+    }.getOrDefault(ExifInterface.ORIENTATION_NORMAL)
+    val swapsAxes = orientation in setOf(
+        ExifInterface.ORIENTATION_TRANSPOSE,
+        ExifInterface.ORIENTATION_ROTATE_90,
+        ExifInterface.ORIENTATION_TRANSVERSE,
+        ExifInterface.ORIENTATION_ROTATE_270,
+    )
+    val displayWidth = if (swapsAxes) bounds.outHeight else bounds.outWidth
+    val displayHeight = if (swapsAxes) bounds.outWidth else bounds.outHeight
+    return decodeAttachmentImage(
+        data,
+        ScreenShotImageRules.maximumEdge(renderedWidthPixels, displayWidth, displayHeight),
+    )
+}
+
+/** BitmapFactory ignores EXIF orientation on Android 8; repair those devices explicitly. */
+private fun decodeLegacyOrientedBitmap(data: ByteArray, maximumEdge: Int): android.graphics.Bitmap? {
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeByteArray(data, 0, data.size, bounds)
+        if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
+        val bitmap = BitmapFactory.decodeByteArray(
+            data,
+            0,
+            data.size,
+            BitmapFactory.Options().apply {
+                inSampleSize = AttachmentImageRules.legacySampleSize(
+                    bounds.outWidth,
+                    bounds.outHeight,
+                    maximumEdge,
+                )
+            },
+        ) ?: return null
+        val orientation = runCatching {
+            ExifInterface(data.inputStream()).getAttributeInt(
+                ExifInterface.TAG_ORIENTATION,
+                ExifInterface.ORIENTATION_NORMAL,
+            )
+        }.getOrDefault(ExifInterface.ORIENTATION_NORMAL)
+        val matrix = Matrix().apply {
+            when (orientation) {
+                ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> setScale(-1f, 1f)
+                ExifInterface.ORIENTATION_ROTATE_180 -> setRotate(180f)
+                ExifInterface.ORIENTATION_FLIP_VERTICAL -> { setRotate(180f); postScale(-1f, 1f) }
+                ExifInterface.ORIENTATION_TRANSPOSE -> { setRotate(90f); postScale(-1f, 1f) }
+                ExifInterface.ORIENTATION_ROTATE_90 -> setRotate(90f)
+                ExifInterface.ORIENTATION_TRANSVERSE -> { setRotate(-90f); postScale(-1f, 1f) }
+                ExifInterface.ORIENTATION_ROTATE_270 -> setRotate(-90f)
+            }
+        }
+        val oriented = if (
+            orientation == ExifInterface.ORIENTATION_NORMAL ||
+            orientation == ExifInterface.ORIENTATION_UNDEFINED
+        ) {
+            bitmap
+        } else {
+            android.graphics.Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+                .also { if (it !== bitmap) bitmap.recycle() }
+        }
+        val target = AttachmentImageRules.targetSize(oriented.width, oriented.height, maximumEdge)
+        if (target.width == oriented.width && target.height == oriented.height) return oriented
+        return android.graphics.Bitmap.createScaledBitmap(oriented, target.width, target.height, true)
+            .also { if (it !== oriented) oriented.recycle() }
+    }
 
 /** A downloaded file, on disk and in memory, ready to show. */
 class FilePreviewItem(
@@ -84,14 +313,20 @@ class FilePreviewItem(
  */
 class FilePreviews(private val context: Context) {
     private val root: File get() = File(context.cacheDir, ROOT)
+    private val lock = Any()
     private var current: File? = null
+    private var generation: Long = 0
 
-    /** Called once at launch: whatever a previous process left behind goes. */
-    fun removeStale() {
-        root.deleteRecursively()
-    }
+    /** Register synchronously before cancelling the previous coroutine. */
+    fun beginRequest(): Long = synchronized(lock) { ++generation }
 
-    fun store(download: DownloadedFile): FilePreviewItem {
+    /**
+     * Serialised with [beginRequest]: a stale request can finish its disk write,
+     * but can never replace or delete the newer request's directory.
+     */
+    suspend fun store(download: DownloadedFile, requestGeneration: Long): FilePreviewItem? {
+        staleCleanupComplete.await()
+        if (!isCurrent(requestGeneration)) return null
         val directory = File(root, UUID.randomUUID().toString()).apply { mkdirs() }
         val file = File(directory, download.filename)
         try {
@@ -100,77 +335,321 @@ class FilePreviews(private val context: Context) {
             directory.deleteRecursively()
             throw error
         }
-        current?.deleteRecursively()
-        current = directory
+        var replaced: File? = null
+        val accepted = synchronized(lock) {
+            if (requestGeneration != generation) return@synchronized false
+            replaced = current
+            current = directory
+            true
+        }
+        if (!accepted) {
+            directory.deleteRecursively()
+            return null
+        }
+        replaced?.deleteRecursively()
         return FilePreviewItem(file, download.filename, download.contentType, download.data)
     }
 
+    fun isCurrent(requestGeneration: Long): Boolean = synchronized(lock) { requestGeneration == generation }
+
+    /**
+     * Invalidate an in-flight request and remove the preview it may already
+     * have published. A request racing this call either loses before publish
+     * and deletes its own directory, or is captured here after publish.
+     */
+    fun invalidateCurrent() {
+        val discarded = synchronized(lock) {
+            ++generation
+            current.also { current = null }
+        }
+        discarded?.deleteRecursively()
+    }
+
+    /** Delete only the dismissed item's directory, never a replacement preview. */
+    fun dismiss(item: FilePreviewItem) {
+        val directory = item.file.parentFile ?: return
+        synchronized(lock) {
+            if (current == directory) current = null
+        }
+        directory.deleteRecursively()
+    }
+
     fun clear() {
-        current?.deleteRecursively()
-        current = null
+        synchronized(lock) {
+            ++generation
+            current = null
+        }
+        root.deleteRecursively()
     }
 
     /** Hand the file to the system. Returns the sentence to show when nothing will take it. */
     fun openWithSystem(item: FilePreviewItem): String? {
-        val uri = FileProvider.getUriForFile(context, "${context.packageName}.$AUTHORITY_SUFFIX", item.file)
         val intent = Intent(Intent.ACTION_VIEW)
-            .setDataAndType(uri, item.contentType)
+            .setDataAndType(contentUri(item), item.contentType)
             .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-        val chooser = Intent.createChooser(intent, item.filename).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        return launchChooser(intent, item.filename, FilePreviewRules.noViewer(item.filename))
+    }
+
+    /** Share only the private content URI; neither the computer path nor its bearer token leaves the app. */
+    fun share(item: FilePreviewItem): String? {
+        val intent = Intent(Intent.ACTION_SEND)
+            .setType(item.contentType)
+            .putExtra(Intent.EXTRA_STREAM, contentUri(item))
+            .putExtra(Intent.EXTRA_TITLE, item.filename)
+            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        return launchChooser(intent, "Share ${item.filename}", "No app on this phone can share ${item.filename}.")
+    }
+
+    private fun contentUri(item: FilePreviewItem) =
+        FileProvider.getUriForFile(context, "${context.packageName}.$AUTHORITY_SUFFIX", item.file)
+
+    private fun launchChooser(intent: Intent, title: String, failure: String): String? {
+        val chooser = Intent.createChooser(intent, title).addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        if (context !is android.app.Activity) chooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         return try {
             context.startActivity(chooser)
             null
         } catch (_: ActivityNotFoundException) {
-            FilePreviewRules.noViewer(item.filename)
+            failure
+        } catch (_: SecurityException) {
+            failure
         }
     }
 
     companion object {
         const val ROOT = "file-previews"
         const val AUTHORITY_SUFFIX = "transcripts"
+        private val staleCleanupStarted = AtomicBoolean(false)
+        private val staleCleanupComplete = CompletableDeferred<Unit>()
+
+        /** One cleanup per process; stores share its barrier across instances. */
+        fun startStaleCleanup(context: Context, scope: CoroutineScope) {
+            if (!staleCleanupStarted.compareAndSet(false, true)) return
+            val job = scope.launch(Dispatchers.IO) {
+                File(context.cacheDir, ROOT).deleteRecursively()
+            }
+            job.invokeOnCompletion { staleCleanupComplete.complete(Unit) }
+        }
     }
 }
 
-/** Markdown and text, shown in the app — `FilePreviewView`'s two in-app arms. */
-@OptIn(ExperimentalMaterial3Api::class)
+/** One native, full-window home for an image, readable document, or downloaded file. */
 @Composable
-internal fun FilePreviewSheet(item: FilePreviewItem, onDismiss: () -> Unit) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
-        Column(modifier = Modifier.fillMaxWidth()) {
-            Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp)) {
-                TextButton(onClick = onDismiss, modifier = Modifier.align(Alignment.CenterStart)) { Text("Done") }
-                Text(
-                    text = item.filename,
-                    fontSize = 17.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.align(Alignment.Center).padding(horizontal = 72.dp),
-                )
-            }
-            val text = FilePreviewRules.text(item.data)
-            SelectionContainer {
+internal fun FilePreviewSheet(
+    item: FilePreviewItem,
+    onDismiss: () -> Unit,
+    onShare: () -> String?,
+    onOpen: () -> String?,
+) {
+    var actionError by remember(item.file.absolutePath) { mutableStateOf<String?>(null) }
+    val uriHandler = LocalUriHandler.current
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false),
+    ) {
+        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surface) {
+            Column(modifier = Modifier.fillMaxSize().systemBarsPadding()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().heightIn(min = 56.dp).padding(horizontal = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    TextButton(onClick = onDismiss) { Text("Done") }
+                    Text(
+                        text = item.filename,
+                        fontSize = 17.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.weight(1f).padding(horizontal = 4.dp),
+                    )
+                    TextButton(onClick = { actionError = onShare() }) { Text("Share") }
+                    TextButton(onClick = { actionError = onOpen() }) { Text("Open") }
+                }
+                HorizontalDivider()
+                actionError?.let { message ->
+                    Text(
+                        text = message,
+                        color = MaterialTheme.colorScheme.error,
+                        fontSize = 13.sp,
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+                    )
+                }
                 when (item.kind) {
-                    FilePreviewKind.MARKDOWN -> MarkdownText(
-                        source = text,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .verticalScroll(rememberScrollState())
-                            .padding(20.dp),
-                    )
-                    else -> Text(
-                        text = text,
-                        fontSize = 14.sp,
-                        fontFamily = FontFamily.Monospace,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .verticalScroll(rememberScrollState())
-                            .horizontalScroll(rememberScrollState())
-                            .padding(20.dp),
-                    )
+                    FilePreviewKind.IMAGE -> FullScreenImage(item)
+                    FilePreviewKind.MARKDOWN -> {
+                        val text = remember(item.file.absolutePath) { FilePreviewRules.text(item.data) }
+                        SelectionContainer(modifier = Modifier.weight(1f)) {
+                            MarkdownText(
+                                source = text,
+                                openLink = { raw ->
+                                    val web = LocalMessageLink.resolve(raw) as? LocalMessageLink.Web
+                                    if (web == null) {
+                                        actionError = "Open links to other computer files from the original message."
+                                    } else {
+                                        runCatching { uriHandler.openUri(web.url) }
+                                            .onFailure { actionError = "That link couldn't be opened on this phone." }
+                                    }
+                                },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .verticalScroll(rememberScrollState())
+                                    .padding(20.dp),
+                            )
+                        }
+                    }
+                    FilePreviewKind.TEXT -> {
+                        val text = remember(item.file.absolutePath) { FilePreviewRules.text(item.data) }
+                        SelectionContainer(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = text,
+                                fontSize = 14.sp,
+                                fontFamily = FontFamily.Monospace,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .verticalScroll(rememberScrollState())
+                                    .horizontalScroll(rememberScrollState())
+                                    .padding(20.dp),
+                            )
+                        }
+                    }
+                    FilePreviewKind.OTHER -> GenericFilePreview(item)
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun FullScreenImage(item: FilePreviewItem) {
+    var bitmap by remember(item.file.absolutePath) { mutableStateOf<ImageBitmap?>(null) }
+    var finished by remember(item.file.absolutePath) { mutableStateOf(false) }
+    LaunchedEffect(item.file.absolutePath) {
+        bitmap = withContext(Dispatchers.Default) {
+            decodeAttachmentImage(item.data, AttachmentImageRules.FULL_SCREEN_EDGE)
+        }
+        finished = true
+    }
+
+    Box(
+        modifier = Modifier.fillMaxSize().background(Color.Black).clipToBounds(),
+        contentAlignment = Alignment.Center,
+    ) {
+        val image = bitmap
+        when {
+            image != null -> ZoomableImage(image, item.filename)
+            !finished -> CircularProgressIndicator(color = Color.White, modifier = Modifier.size(28.dp))
+            else -> Text("This image couldn't be displayed.", color = Color.White)
+        }
+    }
+}
+
+@Composable
+private fun ZoomableImage(image: ImageBitmap, name: String) {
+    var scale by remember(image) { mutableFloatStateOf(1f) }
+    var offset by remember(image) { mutableStateOf(Offset.Zero) }
+    var viewport by remember(image) { mutableStateOf(IntSize.Zero) }
+    LaunchedEffect(viewport) {
+        offset = ImagePanRules.clamp(offset, scale, viewport, IntSize(image.width, image.height))
+    }
+    val transform = rememberTransformableState { zoomChange, panChange, _ ->
+        val next = (scale * zoomChange).coerceIn(1f, 5f)
+        scale = next
+        offset = if (next == 1f) {
+            Offset.Zero
+        } else {
+            ImagePanRules.clamp(offset + panChange, next, viewport, IntSize(image.width, image.height))
+        }
+    }
+    Box(modifier = Modifier.fillMaxSize().onSizeChanged { viewport = it }) {
+        Image(
+            bitmap = image,
+            contentDescription = name,
+            contentScale = ContentScale.Fit,
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer {
+                    scaleX = scale
+                    scaleY = scale
+                    translationX = offset.x
+                    translationY = offset.y
+                }
+                .transformable(transform),
+        )
+        if (scale > 1.01f) {
+            TextButton(
+                onClick = {
+                    scale = 1f
+                    offset = Offset.Zero
+                },
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(8.dp)
+                    .background(Color.Black.copy(alpha = 0.55f), androidx.compose.foundation.shape.RoundedCornerShape(18.dp)),
+            ) {
+                Text("Reset", color = Color.White)
+            }
+        }
+    }
+}
+
+/** Translation bounds for a ContentScale.Fit image after zoom. */
+object ImagePanRules {
+    fun clamp(offset: Offset, scale: Float, viewport: IntSize, image: IntSize): Offset {
+        if (viewport.width <= 0 || viewport.height <= 0 || image.width <= 0 || image.height <= 0) {
+            return Offset.Zero
+        }
+        val fit = minOf(
+            viewport.width.toFloat() / image.width,
+            viewport.height.toFloat() / image.height,
+        )
+        val renderedWidth = image.width * fit * scale
+        val renderedHeight = image.height * fit * scale
+        val maximumX = ((renderedWidth - viewport.width) / 2f).coerceAtLeast(0f)
+        val maximumY = ((renderedHeight - viewport.height) / 2f).coerceAtLeast(0f)
+        return Offset(
+            offset.x.coerceIn(-maximumX, maximumX),
+            offset.y.coerceIn(-maximumY, maximumY),
+        )
+    }
+}
+
+@Composable
+private fun GenericFilePreview(item: FilePreviewItem) {
+    val suffix = item.filename.substringAfterLast('.', "file").uppercase().take(8)
+    Column(
+        modifier = Modifier.fillMaxSize().padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(Modifier.weight(1f))
+        Box(
+            modifier = Modifier
+                .size(88.dp)
+                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f), androidx.compose.foundation.shape.RoundedCornerShape(22.dp)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(suffix, color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)
+        }
+        Text(
+            text = item.filename,
+            fontSize = 20.sp,
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = 18.dp),
+        )
+        Text(
+            text = "${AttachmentImportRules.formatBytes(item.data.size.toLong())} · ${item.contentType}",
+            color = secondaryTint,
+            fontSize = 13.sp,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = 6.dp),
+        )
+        Text(
+            text = "Use Open to view this file in a compatible app.",
+            color = secondaryTint,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = 16.dp),
+        )
+        Spacer(Modifier.weight(1f))
     }
 }

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/MessageRow.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/MessageRow.kt
@@ -1,7 +1,6 @@
 package com.openmausbot.companion.ui
 
 import android.content.ClipData
-import android.graphics.BitmapFactory
 import android.util.Base64
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
@@ -12,16 +11,20 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.rememberScrollState
@@ -56,13 +59,14 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.MotionDurationScale
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
@@ -70,18 +74,23 @@ import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.openmausbot.companion.core.Chat
 import com.openmausbot.companion.core.AttachedMessageContent
 import com.openmausbot.companion.core.DisplayedMessageAttachment
+import com.openmausbot.companion.core.DownloadedFile
 import com.openmausbot.companion.core.Message
 import com.openmausbot.companion.core.OptionCard
 import com.openmausbot.companion.core.ToolActivity
 import com.openmausbot.companion.core.TranscriptCard
 import com.openmausbot.companion.core.TranscriptCards
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /** What the clipboard shows this came from. */
 private const val MESSAGE_CLIP_LABEL = "OpenMausMobile message"
@@ -100,6 +109,8 @@ fun MessageRow(
     endsRun: Boolean = true,
     /** Where a tapped link in a bot reply goes; null leaves it to the system. */
     openLink: ((String, Message) -> Unit)? = null,
+    /** Open one exact user attachment through the authenticated computer route. */
+    openAttachment: ((DisplayedMessageAttachment, Message, DownloadedFile?) -> Unit)? = null,
 ) {
     val session = LocalCompanion.current.session
     val scope = rememberCoroutineScope()
@@ -133,7 +144,14 @@ fun MessageRow(
             horizontalAlignment = if (mine) Alignment.End else Alignment.Start,
             verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
-            MessageContent(chat = chat, message = message, endsRun = endsRun, haptics = haptics, openLink = openLink)
+            MessageContent(
+                chat = chat,
+                message = message,
+                endsRun = endsRun,
+                haptics = haptics,
+                openLink = openLink,
+                openAttachment = openAttachment,
+            )
 
             message.comm?.let {
                 Text(
@@ -255,15 +273,17 @@ fun MessageRow(
                     },
                 )
             }
-            // Edit and retry is user text on a bot only, and never while it runs.
-            if (mine && message.kind == Message.Kind.TEXT && bot != null) {
+            // Attachment messages cannot be reconstructed by a text-only edit.
+            // The policy also keeps their private transport paths out of the UI.
+            val editableText = MessageActions.editableText(message)
+            if (editableText != null && bot != null) {
                 HorizontalDivider()
                 DropdownMenuItem(
                     text = { Text("Edit and retry") },
                     enabled = bot.busy != true,
                     onClick = {
                         menuOpen = false
-                        editText = message.text.orEmpty()
+                        editText = editableText
                         editing = true
                     },
                 )
@@ -369,9 +389,10 @@ private fun MessageContent(
     endsRun: Boolean,
     haptics: Haptics,
     openLink: ((String, Message) -> Unit)?,
+    openAttachment: ((DisplayedMessageAttachment, Message, DownloadedFile?) -> Unit)?,
 ) {
     when (message.kind) {
-        Message.Kind.TEXT -> TextBubble(message, endsRun, openLink)
+        Message.Kind.TEXT -> TextBubble(chat.threadId, message, endsRun, openLink, openAttachment)
         Message.Kind.OPTIONS -> CardView(chat, message, haptics)
         Message.Kind.ACTIVITY -> ActivityChip(message.tool)
         Message.Kind.SCREEN -> ScreenShot(chat.threadId, message)
@@ -380,12 +401,20 @@ private fun MessageContent(
         // always better than a gap in the transcript. When there is nothing to
         // show, show nothing — a placeholder saying "unsupported" is a worse gap
         // than the gap.
-        Message.Kind.UNKNOWN -> if (!message.text.isNullOrEmpty()) TextBubble(message, endsRun, openLink)
+        Message.Kind.UNKNOWN -> if (!message.text.isNullOrEmpty()) {
+            TextBubble(chat.threadId, message, endsRun, openLink, openAttachment)
+        }
     }
 }
 
 @Composable
-private fun TextBubble(message: Message, endsRun: Boolean, openLink: ((String, Message) -> Unit)?) {
+private fun TextBubble(
+    threadId: String,
+    message: Message,
+    endsRun: Boolean,
+    openLink: ((String, Message) -> Unit)?,
+    openAttachment: ((DisplayedMessageAttachment, Message, DownloadedFile?) -> Unit)?,
+) {
     val mine = message.role == Message.Role.USER
     val tail = TranscriptLayout.tail(message, endsRun)
     // A reply that is *entirely* a patch or a table is drawn as one. The gate is
@@ -411,6 +440,7 @@ private fun TextBubble(message: Message, endsRun: Boolean, openLink: ((String, M
         Column(
             modifier = Modifier
                 .weight(1f, fill = false)
+                .widthIn(max = 640.dp)
                 // Room for the tail below, so the next row does not sit on it.
                 .padding(bottom = if (bubble && endsRun) SpeechBubble.tailDrop() else 0.dp)
                 .then(
@@ -448,13 +478,18 @@ private fun TextBubble(message: Message, endsRun: Boolean, openLink: ((String, M
             when (card) {
                 is TranscriptCard.Diff -> DiffCard(card)
                 is TranscriptCard.Table -> DataTableCard(card)
-                null -> SelectionContainer {
-                    if (mine) {
-                        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                            attached.attachments.forEach { attachment ->
-                                SharedAttachmentChip(attachment)
-                            }
-                            if (attached.text.isNotEmpty()) {
+                null -> if (mine) {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        attached.attachments.forEach { attachment ->
+                            SharedAttachmentView(
+                                threadId = threadId,
+                                message = message,
+                                attachment = attachment,
+                                onOpen = openAttachment,
+                            )
+                        }
+                        if (attached.text.isNotEmpty()) {
+                            SelectionContainer {
                                 Text(
                                     text = attached.text,
                                     fontSize = 17.sp,
@@ -462,7 +497,9 @@ private fun TextBubble(message: Message, endsRun: Boolean, openLink: ((String, M
                                 )
                             }
                         }
-                    } else {
+                    }
+                } else {
+                    SelectionContainer {
                         MarkdownText(
                             source = message.text.orEmpty(),
                             openLink = openLink?.let { open -> { url -> open(url, message) } },
@@ -476,19 +513,140 @@ private fun TextBubble(message: Message, endsRun: Boolean, openLink: ((String, M
 }
 
 @Composable
-private fun SharedAttachmentChip(attachment: DisplayedMessageAttachment) {
-    val type = if (attachment.kind == DisplayedMessageAttachment.Kind.IMAGE) "Image" else "File"
-    Text(
-        text = "$type: ${attachment.name}",
-        fontSize = 13.sp,
-        fontWeight = FontWeight.Medium,
-        maxLines = 1,
-        color = BubbleColor.mineText.copy(alpha = 0.84f),
+private fun SharedAttachmentView(
+    threadId: String,
+    message: Message,
+    attachment: DisplayedMessageAttachment,
+    onOpen: ((DisplayedMessageAttachment, Message, DownloadedFile?) -> Unit)?,
+) {
+    if (attachment.kind == DisplayedMessageAttachment.Kind.IMAGE) {
+        SharedImageAttachment(threadId, message, attachment, onOpen)
+        return
+    }
+    Row(
         modifier = Modifier
-            .background(BubbleColor.mineText.copy(alpha = 0.10f), RoundedCornerShape(16.dp))
-            .padding(horizontal = 10.dp, vertical = 6.dp)
-            .semantics { contentDescription = "$type attachment: ${attachment.name}" },
-    )
+            .widthIn(max = 360.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(BubbleColor.mineText.copy(alpha = 0.10f))
+            .clickable(enabled = onOpen != null, role = Role.Button) {
+                onOpen?.invoke(attachment, message, null)
+            }
+            .padding(horizontal = 12.dp, vertical = 10.dp)
+            .semantics { contentDescription = "File attachment: ${attachment.name}. Tap to preview." },
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text("FILE", fontSize = 11.sp, fontWeight = FontWeight.Bold, color = BubbleColor.mineText.copy(alpha = 0.68f))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                attachment.name,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Medium,
+                color = BubbleColor.mineText,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text("Tap to preview", fontSize = 12.sp, color = BubbleColor.mineText.copy(alpha = 0.68f))
+        }
+    }
+}
+
+private sealed interface AttachmentThumbnailState {
+    data object Loading : AttachmentThumbnailState
+    data class Ready(val file: DownloadedFile, val image: ImageBitmap) : AttachmentThumbnailState
+    data object Failed : AttachmentThumbnailState
+}
+
+@Composable
+private fun SharedImageAttachment(
+    threadId: String,
+    message: Message,
+    attachment: DisplayedMessageAttachment,
+    onOpen: ((DisplayedMessageAttachment, Message, DownloadedFile?) -> Unit)?,
+) {
+    val session = LocalCompanion.current.session
+    var attempt by remember(message.id, attachment.path) { mutableStateOf(0) }
+    var state by remember(message.id, attachment.path) {
+        mutableStateOf<AttachmentThumbnailState>(AttachmentThumbnailState.Loading)
+    }
+    LaunchedEffect(threadId, message.id, attachment.path, attempt) {
+        state = AttachmentThumbnailState.Loading
+        // A failed inline preview owns its own retry UI; it must not replace an
+        // unrelated composer or account alert while this row scrolls on screen.
+        val downloaded = session.downloadFile(
+            threadId,
+            message.id,
+            attachment.path,
+            reportError = false,
+            cacheResult = true,
+        )
+        if (downloaded == null) {
+            state = AttachmentThumbnailState.Failed
+            return@LaunchedEffect
+        }
+        val bitmap = withContext(Dispatchers.Default) {
+            decodeAttachmentImage(downloaded.data, AttachmentImageRules.THUMBNAIL_EDGE)
+        }
+        state = bitmap?.let { AttachmentThumbnailState.Ready(downloaded, it) }
+            ?: AttachmentThumbnailState.Failed
+    }
+
+    val ready = state as? AttachmentThumbnailState.Ready
+    Column(
+        modifier = Modifier
+            .widthIn(max = 360.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(BubbleColor.mineText.copy(alpha = 0.10f))
+            .clickable(enabled = ready != null && onOpen != null, role = Role.Button) {
+                ready?.let { onOpen?.invoke(attachment, message, it.file) }
+            }
+            .semantics { contentDescription = "Image attachment: ${attachment.name}. Tap to preview." },
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(4f / 3f),
+            contentAlignment = Alignment.Center,
+        ) {
+            when (val current = state) {
+                AttachmentThumbnailState.Loading ->
+                    CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                AttachmentThumbnailState.Failed -> AttachmentLoadFailure(
+                    label = "Image unavailable",
+                    onRetry = { attempt += 1 },
+                )
+                is AttachmentThumbnailState.Ready -> Image(
+                    bitmap = current.image,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxWidth().aspectRatio(4f / 3f),
+                )
+            }
+        }
+        Text(
+            attachment.name,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.Medium,
+            color = BubbleColor.mineText,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp),
+        )
+    }
+}
+
+@Composable
+private fun AttachmentLoadFailure(label: String, onRetry: () -> Unit) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Icon(
+            imageVector = Icons.Filled.Warning,
+            contentDescription = null,
+            tint = BubbleColor.mineText.copy(alpha = 0.70f),
+            modifier = Modifier.size(20.dp),
+        )
+        Text(label, fontSize = 13.sp, color = BubbleColor.mineText.copy(alpha = 0.80f))
+        TextButton(onClick = onRetry) { Text("Retry") }
+    }
 }
 
 /**
@@ -803,39 +961,74 @@ private fun CardView(chat: Chat, message: Message, haptics: Haptics) {
 @Composable
 private fun ScreenShot(threadId: String, message: Message) {
     val session = LocalCompanion.current.session
-    var image by remember(message.id) { mutableStateOf<ImageBitmap?>(null) }
+    var attempt by remember(message.id) { mutableStateOf(0) }
+    var state by remember(message.id) { mutableStateOf<ScreenShotState>(ScreenShotState.Loading) }
 
-    LaunchedEffect(message.id) {
-        if (image != null) return@LaunchedEffect
-        val bytes = message.png
-            ?.let { runCatching { Base64.decode(it, Base64.DEFAULT) }.getOrNull() }
-            ?: if (message.hasImage == true) session.image(threadId, message.id) else null
-        image = bytes
-            ?.let { runCatching { BitmapFactory.decodeByteArray(it, 0, it.size) }.getOrNull() }
-            ?.asImageBitmap()
-    }
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val renderedWidthPixels = with(LocalDensity.current) { maxWidth.toPx().toInt().coerceAtLeast(1) }
+        LaunchedEffect(threadId, message.id, attempt, renderedWidthPixels) {
+            state = ScreenShotState.Loading
+            val bytes = try {
+                message.png?.let { encoded ->
+                    withContext(Dispatchers.Default) {
+                        runCatching { Base64.decode(encoded, Base64.DEFAULT) }.getOrNull()
+                    }
+                } ?: if (message.hasImage == true) session.image(threadId, message.id) else null
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Throwable) {
+                null
+            }
+            val bitmap = bytes?.let {
+                withContext(Dispatchers.Default) {
+                    decodeScreenShotImage(it, renderedWidthPixels)
+                }
+            }
+            state = bitmap?.let(ScreenShotState::Ready) ?: ScreenShotState.Failed
+        }
 
-    val bitmap = image
-    if (bitmap == null) {
+        val aspectRatio = (state as? ScreenShotState.Ready)?.image?.let { image ->
+            image.width.toFloat() / image.height.coerceAtLeast(1).toFloat()
+        } ?: (16f / 10f)
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(160.dp)
-                .background(secondaryTint.copy(alpha = 0.13f), RoundedCornerShape(16.dp)),
+                .aspectRatio(aspectRatio)
+                .clip(RoundedCornerShape(16.dp))
+                .background(secondaryTint.copy(alpha = 0.13f)),
             contentAlignment = Alignment.Center,
         ) {
-            CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+            when (val current = state) {
+                ScreenShotState.Loading ->
+                    CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                ScreenShotState.Failed -> Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Warning,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.size(20.dp),
+                    )
+                    Text("Screenshot unavailable", fontSize = 13.sp, color = secondaryTint)
+                    TextButton(onClick = { attempt += 1 }) { Text("Retry") }
+                }
+                is ScreenShotState.Ready -> Image(
+                    bitmap = current.image,
+                    contentDescription = "A frame of this bot's computer",
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
         }
-    } else {
-        Image(
-            bitmap = bitmap,
-            contentDescription = "A frame of this bot's computer",
-            contentScale = ContentScale.Fit,
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(secondaryTint.copy(alpha = 0.13f), RoundedCornerShape(16.dp)),
-        )
     }
+}
+
+private sealed interface ScreenShotState {
+    data object Loading : ScreenShotState
+    data class Ready(val image: ImageBitmap) : ScreenShotState
+    data object Failed : ScreenShotState
 }
 
 /**

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/ShareSheet.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/ShareSheet.kt
@@ -247,7 +247,11 @@ private fun ShareSheetContent(
                                     val path = session.withPairedShareClient(computerId) { client ->
                                         client.uploadImage(data, attachment.mime, attachment.id)
                                     }
-                                    uploaded += SharedAttachmentReference(path, SharedAttachmentKind.IMAGE)
+                                    uploaded += SharedAttachmentReference(
+                                        path,
+                                        SharedAttachmentKind.IMAGE,
+                                        attachment.name,
+                                    )
                                 }
                                 LocalShareAttachment.Kind.FILE -> {
                                     val uploadedFile = session.withPairedShareClient(computerId) { client ->

--- a/android/app/src/test/kotlin/com/openmausbot/companion/ui/AttachmentRulesTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/ui/AttachmentRulesTest.kt
@@ -1,5 +1,7 @@
 package com.openmausbot.companion.ui
 
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntSize
 import com.openmausbot.companion.core.AttachmentPolicy
 import com.openmausbot.companion.core.PendingMessageAttachment
 import kotlin.test.Test
@@ -60,6 +62,8 @@ class AttachmentRulesTest {
 
     @Test
     fun `a downloaded file is shown by its type, then its suffix`() {
+        assertEquals(FilePreviewKind.IMAGE, FilePreviewRules.kind("image/png", "x.bin"))
+        assertEquals(FilePreviewKind.IMAGE, FilePreviewRules.kind("application/octet-stream", "photo.webp"))
         assertEquals(FilePreviewKind.MARKDOWN, FilePreviewRules.kind("text/markdown", "x.bin"))
         assertEquals(FilePreviewKind.MARKDOWN, FilePreviewRules.kind("application/octet-stream", "README.md"))
         assertEquals(FilePreviewKind.TEXT, FilePreviewRules.kind("text/plain", "notes"))
@@ -67,6 +71,55 @@ class AttachmentRulesTest {
         assertEquals(FilePreviewKind.OTHER, FilePreviewRules.kind("application/pdf", "report.pdf"))
         assertEquals("report.pdf", FilePreviewRules.nameForOpening("/Users/x/report.pdf"))
         assertEquals("report.pdf", FilePreviewRules.nameForOpening("""C:\Users\x\report.pdf"""))
+    }
+
+    @Test
+    fun `large attachment images decode near the requested display edge`() {
+        assertEquals(4, AttachmentImageRules.sampleSize(4_000, 2_000, 768))
+        assertEquals(2, AttachmentImageRules.sampleSize(1_600, 1_200, 768))
+        assertEquals(1, AttachmentImageRules.sampleSize(700, 500, 768))
+        assertEquals(1, AttachmentImageRules.sampleSize(0, 500, 768))
+        assertEquals(IntSize(768, 384), AttachmentImageRules.targetSize(4_000, 2_000, 768))
+        assertEquals(IntSize(500, 700), AttachmentImageRules.targetSize(500, 700, 768))
+    }
+
+    @Test
+    fun `android eight sampling bounds its intermediate without needless blur`() {
+        assertEquals(4, AttachmentImageRules.legacySampleSize(4_000, 3_000, 768))
+        // The no-undershoot plan is sample 2 (36 MP). One extra step yields a
+        // 3000 px edge, just below 3072, and a bounded 9 MP allocation.
+        assertEquals(4, AttachmentImageRules.legacySampleSize(12_000, 12_000, 3_072))
+        // Just over the soft 12 MP budget but close to the requested edge: keep
+        // the sharp source under the 14 MP hard cap, then scale to 3072 exactly.
+        assertEquals(1, AttachmentImageRules.legacySampleSize(3_500, 3_500, 3_072))
+        // The tolerance is hard bounded; a materially larger allocation still samples.
+        assertEquals(2, AttachmentImageRules.legacySampleSize(4_000, 4_000, 3_072))
+        assertEquals(1, AttachmentImageRules.legacySampleSize(700, 500, 768))
+    }
+
+    @Test
+    fun `computer screenshot budget follows rendered width and source aspect`() {
+        assertEquals(1_200, ScreenShotImageRules.maximumEdge(1_200, 2_400, 1_200))
+        assertEquals(2_400, ScreenShotImageRules.maximumEdge(1_200, 1_200, 2_400))
+        assertEquals(600, ScreenShotImageRules.maximumEdge(1_200, 600, 300))
+        assertEquals(4_096, ScreenShotImageRules.maximumEdge(2_000, 1_000, 5_000))
+    }
+
+    @Test
+    fun `zoomed image pan stays inside the visible content`() {
+        assertEquals(
+            Offset(500f, 0f),
+            ImagePanRules.clamp(
+                offset = Offset(9_000f, 9_000f),
+                scale = 2f,
+                viewport = IntSize(1_000, 1_000),
+                image = IntSize(2_000, 1_000),
+            ),
+        )
+        assertEquals(
+            Offset.Zero,
+            ImagePanRules.clamp(Offset(20f, 20f), 1f, IntSize(1_000, 1_000), IntSize(2_000, 1_000)),
+        )
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/openmausbot/companion/ui/ChatPolicyTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/ui/ChatPolicyTest.kt
@@ -558,6 +558,28 @@ class MessageActionsTest {
     }
 
     @Test
+    fun `copy and selection text omit attachment transport paths`() {
+        val attached = message(
+            Message.Kind.TEXT,
+            """Please review this.
+<attached-file path="/Users/alice/private/report.md" name="report.md" />""",
+        )
+
+        assertEquals("Please review this.", MessageActions.copyableText(attached))
+        assertFalse(MessageActions.copyableText(attached).orEmpty().contains("/Users/alice"))
+    }
+
+    @Test
+    fun `an attachment-only message offers no raw transport text to copy`() {
+        val attached = message(
+            Message.Kind.TEXT,
+            """<attached-image path="C:\\Users\\alice\\secret.png" name="secret.png" />""",
+        )
+
+        assertNull(MessageActions.copyableText(attached))
+    }
+
+    @Test
     fun `an unknown kind carrying text is copyable, like it is renderable`() {
         assertEquals("hello", MessageActions.copyableText(message(Message.Kind.UNKNOWN, "hello")))
     }
@@ -597,5 +619,24 @@ class MessageActionsTest {
         assertNull(MessageActions.copyableText(message(Message.Kind.ACTIVITY, "shell")))
         assertNull(MessageActions.copyableText(message(Message.Kind.SCREEN)))
     }
-}
 
+    @Test
+    fun `plain user text can be edited but attachment messages cannot`() {
+        val plain = Message(
+            id = "plain",
+            role = Message.Role.USER,
+            kind = Message.Kind.TEXT,
+            at = 0.0,
+            text = "Try this again",
+        )
+        val attached = plain.copy(
+            id = "attached",
+            text = """Try this again
+<attached-file path="/Users/alice/private/report.md" name="report.md" />""",
+        )
+
+        assertEquals("Try this again", MessageActions.editableText(plain))
+        assertNull(MessageActions.editableText(attached))
+        assertNull(MessageActions.editableText(plain.copy(role = Message.Role.BOT)))
+    }
+}

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/AttachedMessageContent.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/AttachedMessageContent.kt
@@ -4,6 +4,8 @@ package com.openmausbot.companion.core
 data class DisplayedMessageAttachment(
     val kind: Kind,
     val name: String,
+    /** The computer-local path carried by the exact standalone transport tag. */
+    val path: String,
 ) {
     enum class Kind { IMAGE, FILE }
 }
@@ -15,24 +17,153 @@ data class AttachedMessageContent(
     companion object {
         /** Split only exact standalone tags; inline examples remain ordinary prose. */
         fun parse(source: String): AttachedMessageContent {
-            val attachments = TAG.findAll(source).map { match ->
-                val kind = if (match.groupValues[1] == "image") {
-                    DisplayedMessageAttachment.Kind.IMAGE
+            val attachments = mutableListOf<DisplayedMessageAttachment>()
+            val visible = StringBuilder()
+            var fence: Fence? = null
+            var htmlBlock: HtmlBlock? = null
+            var cursor = 0
+            while (cursor < source.length) {
+                val newline = source.indexOf('\n', cursor)
+                val lineEnd = if (newline >= 0) newline else source.length
+                val wholeLineEnd = if (newline >= 0) newline + 1 else source.length
+                val rawLine = source.substring(cursor, lineEnd)
+                val line = rawLine.removeSuffix("\r")
+                var consumedTransportTag = false
+
+                val marker = fenceMarker(line)
+                val activeFence = fence
+                if (activeFence != null) {
+                    if (
+                        marker != null && marker.character == activeFence.character &&
+                        marker.length >= activeFence.length && marker.remainder.all { it == ' ' || it == '\t' }
+                    ) {
+                        fence = null
+                    }
+                } else if (htmlBlock != null) {
+                    val activeHTMLBlock = htmlBlock!!
+                    val shouldEnd = activeHTMLBlock.closingToken
+                        ?.let { it in line.lowercase() }
+                        ?: line.all { it == ' ' || it == '\t' }
+                    if (shouldEnd) {
+                        htmlBlock = null
+                    }
+                } else if (marker != null) {
+                    fence = Fence(marker.character, marker.length)
                 } else {
-                    DisplayedMessageAttachment.Kind.FILE
+                    val match = TAG.matchEntire(line)
+                    if (match != null) {
+                        val kind = if (match.groupValues[1] == "image") {
+                            DisplayedMessageAttachment.Kind.IMAGE
+                        } else {
+                            DisplayedMessageAttachment.Kind.FILE
+                        }
+                        val path = decodeAttribute(match.groupValues[2])
+                        val provided = match.groups[3]?.value?.let(::decodeAttribute)
+                        attachments += DisplayedMessageAttachment(
+                            kind = kind,
+                            name = displayName(provided, path, kind),
+                            path = path,
+                        )
+                        consumedTransportTag = true
+                    } else {
+                        htmlBlock = htmlBlockStarting(line)
+                    }
                 }
-                val path = decodeAttribute(match.groupValues[2])
-                val provided = match.groups[3]?.value?.let(::decodeAttribute)
-                DisplayedMessageAttachment(kind, displayName(provided, path, kind))
-            }.toList()
+
+                if (!consumedTransportTag) visible.append(source, cursor, wholeLineEnd)
+                cursor = wholeLineEnd
+            }
             return AttachedMessageContent(
-                text = TAG.replace(source, "").trim(),
+                text = visible.toString().trim(),
                 attachments = attachments,
             )
         }
 
+        private data class Fence(val character: Char, val length: Int)
+        private data class FenceMarker(val character: Char, val length: Int, val remainder: String)
+        /** A null token is a CommonMark type 6/7 block, which ends at a blank line. */
+        private data class HtmlBlock(val closingToken: String?)
+
+        private fun htmlBlockStarting(line: String): HtmlBlock? {
+            val lower = line.lowercase()
+            val comment = lower.indexOf("<!--")
+            if (comment >= 0 && lower.indexOf("-->", comment + 4) < 0) return HtmlBlock("-->")
+
+            val content = commonMarkContent(line) ?: return null
+            val lowerContent = content.lowercase()
+
+            if (PASTED_TEXT_START.containsMatchIn(line)) {
+                return if ("</pasted-text>" in lowerContent) null else HtmlBlock("</pasted-text>")
+            }
+
+            val typeOne = TYPE_ONE.find(line)
+            if (typeOne != null) {
+                val closingToken = "</${typeOne.groupValues[1].lowercase()}>"
+                return if (closingToken in lower) null else HtmlBlock(closingToken)
+            }
+
+            if (lowerContent.startsWith("<?")) {
+                return if ("?>" in lowerContent.drop(2)) null else HtmlBlock("?>")
+            }
+            if (lowerContent.startsWith("<![cdata[")) {
+                return if ("]]>" in lowerContent.drop(9)) null else HtmlBlock("]]>")
+            }
+            if (
+                content.startsWith("<!") &&
+                (content.getOrNull(2) in 'A'..'Z' || content.getOrNull(2) in 'a'..'z')
+            ) {
+                return if ('>' in content.drop(2)) null else HtmlBlock(">")
+            }
+
+            if (TYPE_SIX.containsMatchIn(line) || TYPE_SEVEN.matches(line)) return HtmlBlock(null)
+            return null
+        }
+
+        private fun commonMarkContent(line: String): String? {
+            var index = 0
+            while (index < line.length && line[index] == ' ') {
+                index += 1
+                if (index > 3) return null
+            }
+            return line.substring(index)
+        }
+
+        private fun fenceMarker(line: String): FenceMarker? {
+            var index = 0
+            while (index < line.length && index < 4 && line[index] == ' ') index += 1
+            if (index > 3 || index >= line.length) return null
+            val character = line[index]
+            if (character != '`' && character != '~') return null
+            val start = index
+            while (index < line.length && line[index] == character) index += 1
+            val length = index - start
+            if (length < 3) return null
+            return FenceMarker(character, length, line.substring(index))
+        }
+
         private val TAG = Regex(
-            """(?m)^[\t ]*<attached-(image|file)[\t ]+path="([^"\r\n]*)"(?:[\t ]+name="([^"\r\n]*)")?[\t ]*/>[\t ]*(?:\r?\n)?""",
+            """^<attached-(image|file)[\t ]+path="([^"\r\n]*)"(?:[\t ]+name="([^"\r\n]*)")?[\t ]*/>[\t ]*$""",
+        )
+
+        private val COMMONMARK_BLOCK_TAGS = listOf(
+            "address", "article", "aside", "base", "basefont", "blockquote", "body", "caption", "center", "col",
+            "colgroup", "dd", "details", "dialog", "dir", "div", "dl", "dt", "fieldset", "figcaption", "figure",
+            "footer", "form", "frame", "frameset", "h[1-6]", "head", "header", "hr", "html", "iframe", "legend",
+            "li", "link", "main", "menu", "menuitem", "nav", "noframes", "ol", "optgroup", "option", "p",
+            "param", "search", "section", "summary", "table", "tbody", "td", "tfoot", "th", "thead", "title",
+            "tr", "track", "ul",
+        ).joinToString("|")
+        private val PASTED_TEXT_START = Regex("""^ {0,3}<pasted-text(?:[\t >]|$)""", RegexOption.IGNORE_CASE)
+        private val TYPE_ONE = Regex(
+            """^ {0,3}<(script|pre|style|textarea)(?:[\t ]|>|$)""",
+            RegexOption.IGNORE_CASE,
+        )
+        private val TYPE_SIX = Regex(
+            """^ {0,3}</?(?:$COMMONMARK_BLOCK_TAGS)(?:[\t ]|/?>|$)""",
+            RegexOption.IGNORE_CASE,
+        )
+        private val TYPE_SEVEN = Regex(
+            """^ {0,3}(?:<[A-Za-z][A-Za-z0-9-]*(?:[\t ]+[A-Za-z_:][A-Za-z0-9_.:-]*(?:[\t ]*=[\t ]*(?:[^\s"'=<>`]+|'[^']*'|"[^"]*"))?)*[\t ]*/?>|</[A-Za-z][A-Za-z0-9-]*[\t ]*>)[\t ]*$""",
         )
 
         private fun decodeAttribute(value: String): String = value
@@ -49,23 +180,17 @@ data class AttachedMessageContent(
             path: String,
             kind: DisplayedMessageAttachment.Kind,
         ): String {
-            val fallback = path.split('/', '\\').lastOrNull(String::isNotEmpty)
-            val candidate = providedName?.trim()?.takeIf(String::isNotEmpty)
-            val raw = candidate ?: fallback ?: when (kind) {
+            fun basename(source: String?): String? {
+                val value = source?.trim()?.split('/', '\\')?.lastOrNull(String::isNotEmpty)
+                return value?.takeUnless { it == "." || it == ".." }
+            }
+            val fallback = basename(path)
+            val providedBasename = basename(providedName)
+            val generic = when (kind) {
                 DisplayedMessageAttachment.Kind.IMAGE -> "Image"
                 DisplayedMessageAttachment.Kind.FILE -> "File"
             }
-            return raw.map { character ->
-                if (
-                    character.isISOControl() ||
-                    character in '\u202A'..'\u202E' ||
-                    character in '\u2066'..'\u2069'
-                ) {
-                    ' '
-                } else {
-                    character
-                }
-            }.joinToString("").take(180)
+            return sanitisePortableFilename(providedBasename ?: fallback ?: generic, generic)
         }
     }
 }

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Client.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Client.kt
@@ -706,14 +706,7 @@ class CompanionClient(
                 ?: ordinary?.trim('"')
                 ?: fallbackPath.split('/', '\\').lastOrNull { it.isNotEmpty() }
                 ?: "file"
-            val basename = candidate.split('/', '\\').lastOrNull { it.isNotEmpty() } ?: "file"
-            val cleaned = basename.map { character ->
-                val code = character.code
-                val bidiControl = code in 0x202A..0x202E || code in 0x2066..0x2069
-                if (character.isISOControl() || bidiControl) ' ' else character
-            }.joinToString("").trim()
-            val shortened = cleaned.take(180)
-            return if (shortened.isEmpty() || shortened == "." || shortened == "..") "file" else shortened
+            return sanitisePortableFilename(candidate, "file")
         }
         private val AVATAR_MIME_TYPES = setOf("image/png", "image/jpeg", "image/gif", "image/webp")
         private val JSON_MEDIA_TYPE = "application/json".toMediaType()

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/MessageAttachments.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/MessageAttachments.kt
@@ -3,6 +3,10 @@ package com.openmausbot.companion.core
 import java.net.URI
 import java.net.URLDecoder
 import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
 
 /**
  * One attachment waiting in the composer — the port of
@@ -114,7 +118,8 @@ object AttachmentPolicy {
 /**
  * What tapping a Markdown link in a message is allowed to do. Web links go to
  * the system. Absolute desktop paths go back through the authenticated
- * companion file route. Relative and custom-scheme links do nothing.
+ * companion file route. Relative paths are resolved by that route against the
+ * originating conversation's workspace. Custom schemes do nothing.
  */
 sealed class LocalMessageLink {
     data class Web(val url: String) : LocalMessageLink()
@@ -124,35 +129,96 @@ sealed class LocalMessageLink {
         fun resolve(rawValue: String): LocalMessageLink? {
             val value = rawValue.trim()
             if (value.isEmpty() || value.toByteArray().size > 8_192 || value.any(Char::isISOControl)) return null
-            if (isWindowsAbsolutePath(value) || isUncPath(value)) return DesktopFile(value)
-            if (value.startsWith("/")) return DesktopFile(value)
-            val uri = runCatching { URI(value) }.getOrNull() ?: return null
-            val scheme = uri.scheme?.lowercase() ?: return null
-            if (scheme == "http" || scheme == "https") {
+            if (isWindowsAbsolutePath(value) || isBackslashUncPath(value)) return DesktopFile(value)
+            // //host/path is a protocol-relative web link in Markdown. A UNC
+            // share must use backslashes or the explicit file://host spelling.
+            if (value.startsWith("//")) {
+                val uri = runCatching { URI("https:$value") }.getOrNull() ?: return null
                 if (uri.host.isNullOrEmpty()) return null
-                return Web(value)
+                return Web(uri.toString())
             }
-            if (scheme == "file") {
-                if (uri.rawQuery != null || uri.rawFragment != null) return null
-                var path = uri.rawPath?.let { decode(it) } ?: return null
-                if (path.startsWith("/") && isWindowsAbsolutePath(path.drop(1))) path = path.drop(1)
-                val host = uri.host
-                if (!host.isNullOrEmpty() && host.lowercase() != "localhost") path = "//$host$path"
-                if (!(path.startsWith("/") || isWindowsAbsolutePath(path) || isUncPath(path))) return null
-                return DesktopFile(path)
+            if (value.startsWith("/")) return DesktopFile(value)
+            if (SCHEME.containsMatchIn(value)) {
+                val uri = runCatching { URI(value) }.getOrNull() ?: return null
+                val scheme = uri.scheme?.lowercase() ?: return null
+                if (scheme == "http" || scheme == "https") {
+                    if (uri.host.isNullOrEmpty()) return null
+                    return Web(value)
+                }
+                if (scheme == "file") {
+                    if (uri.rawQuery != null || uri.rawFragment != null) return null
+                    var path = uri.rawPath?.let(::decodeOrNull) ?: return null
+                    if (path.startsWith("/") && isWindowsAbsolutePath(path.drop(1))) path = path.drop(1)
+                    val host = uri.host
+                    if (!host.isNullOrEmpty() && host.lowercase() != "localhost") {
+                        path = "\\\\$host${path.replace('/', '\\')}"
+                    }
+                    if (!(path.startsWith("/") || isWindowsAbsolutePath(path) || isBackslashUncPath(path))) {
+                        return null
+                    }
+                    return DesktopFile(path)
+                }
+                return null
             }
-            return null
+
+            val delimiter = listOf(value.indexOf('?'), value.indexOf('#'))
+                .filter { it >= 0 }
+                .minOrNull() ?: value.length
+            if (delimiter == 0) return null
+            val path = decodeOrNull(value.substring(0, delimiter)) ?: return null
+            return path.takeIf(String::isNotEmpty)?.let(::DesktopFile)
         }
 
-        private fun decode(value: String): String =
-            runCatching { URLDecoder.decode(value.replace("+", "%2B"), "UTF-8") }.getOrDefault(value)
+        private val SCHEME = Regex("^[A-Za-z][A-Za-z0-9+.-]*:")
+
+        private fun decodeOrNull(value: String): String? =
+            runCatching { URLDecoder.decode(value.replace("+", "%2B"), "UTF-8") }.getOrNull()
 
         private fun isWindowsAbsolutePath(value: String): Boolean =
             value.length >= 3 && value[0].isLetter() && value[0].code < 128 && value[1] == ':' &&
                 (value[2] == '/' || value[2] == '\\')
 
-        private fun isUncPath(value: String): Boolean = value.startsWith("\\\\") || value.startsWith("//")
+        private fun isBackslashUncPath(value: String): Boolean = value.startsWith("\\\\")
     }
+}
+
+/** A display/storage filename bounded by UTF-8 bytes without splitting a surrogate pair. */
+internal fun sanitisePortableFilename(
+    source: String,
+    fallback: String,
+    maximumUTF8Bytes: Int = 180,
+): String {
+    val basename = source.split('/', '\\').lastOrNull { it.isNotEmpty() } ?: fallback
+    val output = StringBuilder()
+    var bytes = 0
+    var index = 0
+    while (index < basename.length) {
+        val character = basename[index]
+        val (rawCodePoint, consumed) = when {
+            Character.isHighSurrogate(character) &&
+                index + 1 < basename.length && Character.isLowSurrogate(basename[index + 1]) ->
+                Character.toCodePoint(character, basename[index + 1]) to 2
+            Character.isHighSurrogate(character) || Character.isLowSurrogate(character) -> ' '.code to 1
+            else -> character.code to 1
+        }
+        val codePoint = if (
+            Character.isISOControl(rawCodePoint) ||
+            rawCodePoint in 0x202A..0x202E ||
+            rawCodePoint in 0x2066..0x2069
+        ) {
+            ' '.code
+        } else {
+            rawCodePoint
+        }
+        val piece = String(Character.toChars(codePoint))
+        val pieceBytes = piece.toByteArray(Charsets.UTF_8).size
+        if (bytes + pieceBytes > maximumUTF8Bytes) break
+        output.append(piece)
+        bytes += pieceBytes
+        index += consumed
+    }
+    val cleaned = output.toString().trim()
+    return cleaned.takeUnless { it.isEmpty() || it == "." || it == ".." } ?: fallback
 }
 
 /** Bytes returned by the authenticated file route, with the sanitised name and type to show them under. */
@@ -161,3 +227,133 @@ class DownloadedFile(
     val filename: String,
     val contentType: String,
 )
+
+/** One authenticated attachment identity; connection id prevents cross-computer reuse. */
+internal data class AttachmentDownloadKey(
+    val connectionId: String,
+    val threadId: String,
+    val messageId: String,
+    val path: String,
+)
+
+/**
+ * Small session-owned LRU for transcript attachments. It also owns each active
+ * request so two rows asking for the same image await one network transfer.
+ */
+internal class AttachmentDownloadCache(
+    private val scope: CoroutineScope,
+    private val maximumEntries: Int = 12,
+    private val maximumBytes: Long = 50L * 1_024L * 1_024L,
+) {
+    private class Pending(val token: Any, var retainResult: Boolean) {
+        lateinit var deferred: Deferred<DownloadedFile>
+        var waiters: Int = 0
+    }
+    private sealed interface Lookup {
+        data class Cached(val file: DownloadedFile) : Lookup
+        data class PendingRequest(val pending: Pending, val created: Boolean) : Lookup
+    }
+
+    private val lock = Any()
+    private val entries = LinkedHashMap<AttachmentDownloadKey, DownloadedFile>()
+    private val inFlight = mutableMapOf<AttachmentDownloadKey, Pending>()
+    private var storedBytes = 0L
+
+    suspend fun getOrLoad(
+        key: AttachmentDownloadKey,
+        loader: suspend () -> DownloadedFile,
+    ): DownloadedFile = getOrLoad(key, retainResult = true, loader = loader)
+
+    suspend fun getOrLoad(
+        key: AttachmentDownloadKey,
+        retainResult: Boolean,
+        loader: suspend () -> DownloadedFile,
+    ): DownloadedFile {
+        val lookup = synchronized(lock) {
+            if (retainResult) {
+                entries.remove(key)?.let { cached ->
+                    entries[key] = cached
+                    return@synchronized Lookup.Cached(cached)
+                }
+            }
+            inFlight[key]?.let {
+                it.waiters += 1
+                it.retainResult = it.retainResult || retainResult
+                return@synchronized Lookup.PendingRequest(it, created = false)
+            }
+
+            val token = Any()
+            val pending = Pending(token, retainResult).apply { waiters = 1 }
+            pending.deferred = scope.async(start = CoroutineStart.LAZY) {
+                try {
+                    val file = loader()
+                    synchronized(lock) {
+                        if (inFlight[key]?.token === token) {
+                            inFlight.remove(key)
+                            if (pending.retainResult) storeLocked(key, file)
+                        }
+                    }
+                    file
+                } finally {
+                    synchronized(lock) {
+                        if (inFlight[key]?.token === token) inFlight.remove(key)
+                    }
+                }
+            }
+            inFlight[key] = pending
+            Lookup.PendingRequest(pending, created = true)
+        }
+
+        return when (lookup) {
+            is Lookup.Cached -> lookup.file
+            is Lookup.PendingRequest -> {
+                if (lookup.created) lookup.pending.deferred.start()
+                try {
+                    lookup.pending.deferred.await()
+                } finally {
+                    releaseWaiter(key, lookup.pending)
+                }
+            }
+        }
+    }
+
+    /** A computer switch or sign-out invalidates bytes and active transfers together. */
+    fun clear() {
+        val jobs = synchronized(lock) {
+            entries.clear()
+            storedBytes = 0
+            inFlight.values.map { it.deferred }.also { inFlight.clear() }
+        }
+        jobs.forEach { it.cancel() }
+    }
+
+    private fun storeLocked(key: AttachmentDownloadKey, file: DownloadedFile) {
+        val bytes = file.data.size.toLong()
+        if (maximumEntries <= 0 || bytes > maximumBytes) return
+        entries.remove(key)?.let { storedBytes -= it.data.size.toLong() }
+        while (entries.isNotEmpty() && (entries.size >= maximumEntries || storedBytes + bytes > maximumBytes)) {
+            val eldest = entries.entries.first()
+            entries.remove(eldest.key)
+            storedBytes -= eldest.value.data.size.toLong()
+        }
+        if (storedBytes + bytes <= maximumBytes) {
+            entries[key] = file
+            storedBytes += bytes
+        }
+    }
+
+    private fun releaseWaiter(key: AttachmentDownloadKey, pending: Pending) {
+        val orphan = synchronized(lock) {
+            val current = inFlight[key]
+            if (current?.token !== pending.token) return@synchronized null
+            current.waiters = (current.waiters - 1).coerceAtLeast(0)
+            if (current.waiters == 0) {
+                inFlight.remove(key)
+                current.deferred
+            } else {
+                null
+            }
+        }
+        orphan?.cancel()
+    }
+}

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Session.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Session.kt
@@ -69,6 +69,8 @@ class Session(
     private val metadataFn: suspend (CompanionClient) -> CompanionConnectionMetadata = { client ->
         client.connectionMetadata()
     },
+    /** Test seam for the handoff between a completed transfer and its caller. */
+    private val afterAttachmentDownload: suspend () -> Unit = {},
 ) {
     sealed interface Status {
         data object Unpaired : Status
@@ -127,6 +129,7 @@ class Session(
     private var screenWatchers = 0
     private val gate = Mutex()
     private val notificationGate = Mutex()
+    private val attachmentDownloads = AttachmentDownloadCache(scope)
     private val restored = CompletableDeferred<Unit>()
     /** QR credentials authoritatively rejected or redeemed — never start a new request (§6). */
     private val spentQrCredentials = mutableSetOf<String>()
@@ -503,6 +506,7 @@ class Session(
     }
 
     private fun stopActiveRuntimeLocked() {
+        attachmentDownloads.clear()
         streamGeneration += 1
         streamJob?.cancel()
         streamJob = null
@@ -1098,6 +1102,7 @@ class Session(
                     PendingMessageAttachment.Kind.IMAGE -> SharedAttachmentReference(
                         path = activeClient.uploadImage(attachment.data, mime, attachment.id),
                         kind = SharedAttachmentKind.IMAGE,
+                        displayName = attachment.name,
                     )
                     PendingMessageAttachment.Kind.FILE -> {
                         val file = activeClient.uploadFile(attachment.data, attachment.name, mime, attachment.id)
@@ -1153,16 +1158,33 @@ class Session(
      * Where the bytes are kept for viewing is the app's business (it owns a
      * cache directory); this only fetches and reports.
      */
-    suspend fun downloadFile(threadId: String, messageId: String, path: String): DownloadedFile? {
+    suspend fun downloadFile(
+        threadId: String,
+        messageId: String,
+        path: String,
+        reportError: Boolean = true,
+        cacheResult: Boolean = false,
+    ): DownloadedFile? {
         val activeClient = client ?: run {
-            _actionError.value = "This computer is offline."
+            if (reportError) _actionError.value = "This computer is offline."
             return null
         }
         val connectionId = _connection.value?.id
-        _actionError.value = null
+        if (reportError) _actionError.value = null
         return try {
-            val download = activeClient.downloadFile(threadId, messageId, path)
+            val id = connectionId ?: throw APIError.Transport("This computer is offline.")
+            val download = attachmentDownloads.getOrLoad(
+                AttachmentDownloadKey(id, threadId, messageId, path),
+                retainResult = cacheResult,
+            ) {
+                activeClient.downloadFile(threadId, messageId, path)
+            }
+            afterAttachmentDownload()
             currentCoroutineContext().ensureActive()
+            // A computer switch invalidates the meaning of every local path.
+            // The cache is cleared during the switch, but a transfer that won
+            // the completion race must still never surface old-computer bytes.
+            if (_connection.value?.id != id) return null
             download
         } catch (error: CancellationException) {
             throw error
@@ -1174,10 +1196,10 @@ class Session(
                     }
                 }
             }
-            _actionError.value = error.message
+            if (reportError) _actionError.value = error.message
             null
         } catch (error: Throwable) {
-            _actionError.value = error.message
+            if (reportError) _actionError.value = error.message
             null
         }
     }

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/SharedMessage.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/SharedMessage.kt
@@ -42,12 +42,9 @@ object SharedMessageComposer {
         attachments.forEach { attachment ->
             val path = escapeAttribute(attachment.path)
             val name = attachment.displayName?.trim().orEmpty()
-            parts += when {
-                attachment.kind == SharedAttachmentKind.FILE && name.isNotEmpty() ->
-                    "<attached-file path=\"$path\" name=\"${escapeAttribute(name)}\" />"
-                attachment.kind == SharedAttachmentKind.FILE -> "<attached-file path=\"$path\" />"
-                else -> "<attached-image path=\"$path\" />"
-            }
+            val tag = if (attachment.kind == SharedAttachmentKind.IMAGE) "attached-image" else "attached-file"
+            val nameAttribute = if (name.isEmpty()) "" else " name=\"${escapeAttribute(name)}\""
+            parts += "<$tag path=\"$path\"$nameAttribute />"
         }
         return parts.joinToString("\n\n")
     }

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/AttachedMessageContentTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/AttachedMessageContentTest.kt
@@ -19,8 +19,8 @@ class AttachedMessageContentTest {
         assertEquals("Please review these.", parsed.text)
         assertEquals(
             listOf(
-                DisplayedMessageAttachment(DisplayedMessageAttachment.Kind.IMAGE, "photo.png"),
-                DisplayedMessageAttachment(DisplayedMessageAttachment.Kind.FILE, "Project & notes.pdf"),
+                DisplayedMessageAttachment(DisplayedMessageAttachment.Kind.IMAGE, "photo.png", "/tmp/photo.png"),
+                DisplayedMessageAttachment(DisplayedMessageAttachment.Kind.FILE, "Project & notes.pdf", "/tmp/4ad3.pdf"),
             ),
             parsed.attachments,
         )
@@ -33,6 +33,7 @@ class AttachedMessageContentTest {
         )
         assertEquals("", parsed.text)
         assertEquals("brief.docx", parsed.attachments.single().name)
+        assertEquals("C:\\Users\\Maus\\brief.docx", parsed.attachments.single().path)
     }
 
     @Test
@@ -44,14 +45,157 @@ class AttachedMessageContentTest {
     }
 
     @Test
+    fun leavesFencedAndIndentedAttachmentExamplesVisible() {
+        val source = """```xml
+<attached-file path="/tmp/fenced.pdf" />
+```
+    <attached-image path="/tmp/spaces.png" />
+${'\t'}<attached-file path="/tmp/tab.md" />
+<attached-file path="/tmp/real.md" />"""
+        val parsed = AttachedMessageContent.parse(source)
+
+        assertEquals(listOf("/tmp/real.md"), parsed.attachments.map { it.path })
+        assertTrue("""<attached-file path="/tmp/fenced.pdf" />""" in parsed.text)
+        assertTrue("""<attached-image path="/tmp/spaces.png" />""" in parsed.text)
+        assertTrue("""<attached-file path="/tmp/tab.md" />""" in parsed.text)
+    }
+
+    @Test
+    fun unclosedStreamingFenceKeepsTransportLookingLinesLiteral() {
+        val source = """Before
+~~~
+<attached-file path="/tmp/not-transport.md" />"""
+        val parsed = AttachedMessageContent.parse(source)
+
+        assertEquals(source, parsed.text)
+        assertTrue(parsed.attachments.isEmpty())
+    }
+
+    @Test
+    fun leavesAttachmentExamplesInsideHtmlContextsVisible() {
+        val source = """<!--
+<attached-file path="/tmp/comment.md" />
+-->
+<div class="example">
+<attached-image path="/tmp/div.png" />
+</div>
+
+<pasted-text>
+<attached-file path="/tmp/paste.pdf" />
+</pasted-text>
+<attached-file path="/tmp/real.md" />"""
+        val parsed = AttachedMessageContent.parse(source)
+
+        assertEquals(listOf("/tmp/real.md"), parsed.attachments.map { it.path })
+        assertTrue("""<attached-file path="/tmp/comment.md" />""" in parsed.text)
+        assertTrue("""<attached-image path="/tmp/div.png" />""" in parsed.text)
+        assertTrue("""<attached-file path="/tmp/paste.pdf" />""" in parsed.text)
+    }
+
+    @Test
+    fun keepsPreBlocksThroughClosingTagAcrossBlankLines() {
+        val source = """<pre class="example">
+<attached-file path="/tmp/in-pre.md" />
+
+</pre>
+<attached-file path="/tmp/real.md" />"""
+        val parsed = AttachedMessageContent.parse(source)
+
+        assertEquals(listOf("/tmp/real.md"), parsed.attachments.map { it.path })
+        assertTrue("""<attached-file path="/tmp/in-pre.md" />""" in parsed.text)
+    }
+
+    @Test
+    fun keepsTableAndNestedSectionBlocksThroughBlankLine() {
+        val source = """<table>
+<attached-file path="/tmp/in-table.csv" />
+</table>
+
+<section aria-label="example">
+<div>
+<attached-image path="/tmp/in-nested-div.png" />
+</div>
+</section>
+<attached-file path="/tmp/still-html.md" />
+
+<attached-file path="/tmp/real.md" />"""
+        val parsed = AttachedMessageContent.parse(source)
+
+        assertEquals(listOf("/tmp/real.md"), parsed.attachments.map { it.path })
+        assertTrue("""<attached-file path="/tmp/in-table.csv" />""" in parsed.text)
+        assertTrue("""<attached-image path="/tmp/in-nested-div.png" />""" in parsed.text)
+        assertTrue("""<attached-file path="/tmp/still-html.md" />""" in parsed.text)
+    }
+
+    @Test
+    fun keepsSpecialAndGenericHtmlBlocksLiteral() {
+        val source = """<?example
+<attached-file path="/tmp/in-pi.md" />
+?>
+<![CDATA[
+<attached-file path="/tmp/in-cdata.md" />
+]]>
+<!example
+<attached-file path="/tmp/in-declaration.md" />
+>
+<widget data-name="example">
+<attached-file path="/tmp/in-generic.md" />
+</widget>
+
+<attached-file path="/tmp/real.md" />"""
+        val parsed = AttachedMessageContent.parse(source)
+
+        assertEquals(listOf("/tmp/real.md"), parsed.attachments.map { it.path })
+        for (name in listOf("in-pi.md", "in-cdata.md", "in-declaration.md", "in-generic.md")) {
+            assertTrue(name in parsed.text)
+        }
+    }
+
+    @Test
     fun boundsAndFlattensUntrustedDisplayNames() {
         val longName = "\u202E" + "a".repeat(200) + "&#10;.pdf"
         val parsed = AttachedMessageContent.parse(
             """<attached-file path="/tmp/file.pdf" name="$longName" />""",
         )
         val name = parsed.attachments.single().name
-        assertEquals(180, name.length)
+        assertTrue(name.toByteArray(Charsets.UTF_8).size <= 180)
         assertFalse('\n' in name)
         assertFalse('\u202E' in name)
+    }
+
+    @Test
+    fun boundsUnicodeDisplayNamesWithoutSplittingSurrogatePairs() {
+        val parsed = AttachedMessageContent.parse(
+            """<attached-file path="/tmp/file.md" name="${"📄".repeat(100)}.md" />""",
+        )
+        val name = parsed.attachments.single().name
+
+        assertTrue(name.toByteArray(Charsets.UTF_8).size <= 180)
+        assertFalse(name.indices.any { index ->
+            val value = name[index]
+            (Character.isHighSurrogate(value) &&
+                (index + 1 >= name.length || !Character.isLowSurrogate(name[index + 1]))) ||
+                (Character.isLowSurrogate(value) &&
+                    (index == 0 || !Character.isHighSurrogate(name[index - 1])))
+        })
+    }
+
+    @Test
+    fun preservesDecodedImageNameAndPathForAuthenticatedPreview() {
+        val parsed = AttachedMessageContent.parse(
+            """<attached-image path="/tmp/a&amp;b.png" name="Holiday photo.png" />""",
+        )
+
+        assertEquals("Holiday photo.png", parsed.attachments.single().name)
+        assertEquals("/tmp/a&b.png", parsed.attachments.single().path)
+    }
+
+    @Test
+    fun reducesProvidedNamesToSafeBasenames() {
+        val parsed = AttachedMessageContent.parse(
+            """<attached-file path="/tmp/id.pdf" name="../private/Project.pdf" />""",
+        )
+
+        assertEquals("Project.pdf", parsed.attachments.single().name)
     }
 }

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/AttachmentDownloadCacheTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/AttachmentDownloadCacheTest.kt
@@ -1,0 +1,133 @@
+package com.openmausbot.companion.core
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.yield
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class AttachmentDownloadCacheTest {
+    private fun key(connection: String = "mac-1", path: String = "/tmp/photo.jpg") =
+        AttachmentDownloadKey(connection, "thread-1", "message-1", path)
+
+    private fun file(value: Int, bytes: Int = 1) =
+        DownloadedFile(ByteArray(bytes) { value.toByte() }, "photo.jpg", "image/jpeg")
+
+    @Test
+    fun `concurrent thumbnail requests share one transfer`() = runTest {
+        val cache = AttachmentDownloadCache(this)
+        val started = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        var loads = 0
+        suspend fun load(): DownloadedFile {
+            loads += 1
+            started.complete(Unit)
+            release.await()
+            return file(7)
+        }
+
+        val first = async { cache.getOrLoad(key(), ::load) }
+        val second = async { cache.getOrLoad(key(), ::load) }
+        started.await()
+        assertEquals(1, loads)
+        release.complete(Unit)
+        assertContentEquals(first.await().data, second.await().data)
+        assertEquals(1, loads)
+    }
+
+    @Test
+    fun `cache is byte bounded and least recently used`() = runTest {
+        val cache = AttachmentDownloadCache(this, maximumEntries = 3, maximumBytes = 5)
+        var loads = 0
+        suspend fun load(value: Int): DownloadedFile {
+            loads += 1
+            return file(value, bytes = 3)
+        }
+
+        cache.getOrLoad(key(path = "/one")) { load(1) }
+        cache.getOrLoad(key(path = "/two")) { load(2) }
+        cache.getOrLoad(key(path = "/two")) { load(9) }
+        cache.getOrLoad(key(path = "/one")) { load(1) }
+
+        assertEquals(3, loads)
+    }
+
+    @Test
+    fun `non retained bot file links reload updated bytes`() = runTest {
+        val cache = AttachmentDownloadCache(this)
+        var loads = 0
+
+        val first = cache.getOrLoad(key(), retainResult = false) { file(++loads) }
+        val second = cache.getOrLoad(key(), retainResult = false) { file(++loads) }
+
+        assertEquals(2, loads)
+        assertContentEquals(byteArrayOf(1), first.data)
+        assertContentEquals(byteArrayOf(2), second.data)
+    }
+
+    @Test
+    fun `an immutable waiter retains a shared in flight transfer`() = runTest {
+        val cache = AttachmentDownloadCache(this)
+        val started = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        var loads = 0
+        suspend fun load(): DownloadedFile {
+            loads += 1
+            started.complete(Unit)
+            release.await()
+            return file(7)
+        }
+
+        val botLink = async { cache.getOrLoad(key(), retainResult = false, loader = ::load) }
+        started.await()
+        val immutableCard = async { cache.getOrLoad(key(), retainResult = true, loader = ::load) }
+        yield()
+        release.complete(Unit)
+        botLink.await()
+        immutableCard.await()
+        cache.getOrLoad(key(), retainResult = true) { file(++loads) }
+
+        assertEquals(1, loads)
+    }
+
+    @Test
+    fun `connection identity separates and clear invalidates downloads`() = runTest {
+        val cache = AttachmentDownloadCache(this)
+        var loads = 0
+        suspend fun load(): DownloadedFile = file(++loads)
+
+        cache.getOrLoad(key(connection = "mac-1"), ::load)
+        cache.getOrLoad(key(connection = "mac-2"), ::load)
+        cache.getOrLoad(key(connection = "mac-2"), ::load)
+        assertEquals(2, loads)
+
+        cache.clear()
+        cache.getOrLoad(key(connection = "mac-2"), ::load)
+        assertEquals(3, loads)
+    }
+
+    @Test
+    fun `orphaned transfer cancels only after its final waiter leaves`() = runTest {
+        val cache = AttachmentDownloadCache(this)
+        val started = CompletableDeferred<Unit>()
+        val cancelled = CompletableDeferred<Unit>()
+        suspend fun load(): DownloadedFile = try {
+            started.complete(Unit)
+            awaitCancellation()
+        } finally {
+            cancelled.complete(Unit)
+        }
+
+        val first = async { cache.getOrLoad(key(), ::load) }
+        val second = async { cache.getOrLoad(key(), ::load) }
+        started.await()
+        first.cancelAndJoin()
+        assertEquals(false, cancelled.isCompleted)
+        second.cancelAndJoin()
+        cancelled.await()
+    }
+}

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/FileDownloadClientTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/FileDownloadClientTest.kt
@@ -12,6 +12,8 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /** The authenticated file route — the download half of `ShareClientTests.swift`. */
 class FileDownloadClientTest {
@@ -77,6 +79,21 @@ class FileDownloadClientTest {
     }
 
     @Test
+    fun canonicalFilenameTruncationPreservesUnicodeScalarsAndUtf8Limit() {
+        val original = "📄".repeat(100) + ".md"
+        val name = CompanionClient.downloadFilename("attachment; filename=\"$original\"", "/fallback.md")
+
+        assertTrue(name.toByteArray(Charsets.UTF_8).size <= 180)
+        assertFalse(name.indices.any { index ->
+            val value = name[index]
+            (Character.isHighSurrogate(value) &&
+                (index + 1 >= name.length || !Character.isLowSurrogate(name[index + 1]))) ||
+                (Character.isLowSurrogate(value) &&
+                    (index == 0 || !Character.isHighSurrogate(name[index - 1])))
+        })
+    }
+
+    @Test
     fun fallsBackToTheRequestedPathsBasename() = runBlocking {
         server.enqueue(MockResponse().setHeader("Content-Type", "text/plain").setBody("x"))
         val file = client.downloadFile("thread-1", "message-1", "/Users/test/notes/todo.txt")
@@ -86,8 +103,22 @@ class FileDownloadClientTest {
     @Test
     fun rejectsAnUnsafeRequestBeforeNetworking() = runBlocking {
         assertFailsWith<APIError.BadUrl> { client.downloadFile("../thread", "message-1", "relative/report.md") }
-        assertFailsWith<APIError.BadUrl> { client.downloadFile("thread-1", "message-1", "relative/report.md") }
         assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun postsDecodedRelativeMarkdownPathThroughTheScopedRoute() = runBlocking {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "text/markdown")
+                .setHeader("Content-Disposition", "attachment; filename=report.md")
+                .setBody("# Report"),
+        )
+
+        client.downloadFile("thread-1", "message-1", "docs/Quarter%20Report.md?download=1#latest")
+
+        val body = CompanionJson.parseToJsonElement(server.takeRequest().body.readUtf8()).jsonObject
+        assertEquals("docs/Quarter Report.md", body.getValue("path").jsonPrimitive.content)
     }
 
     @Test

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/MessageAttachmentsTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/MessageAttachmentsTest.kt
@@ -3,7 +3,9 @@ package com.openmausbot.companion.core
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /** The port of `ios/Tests/CompanionCoreTests/MessageAttachmentsTests.swift`. */
 class MessageAttachmentsTest {
@@ -34,17 +36,53 @@ class MessageAttachmentsTest {
             LocalMessageLink.DesktopFile("""\\server\share\report.md"""),
             LocalMessageLink.resolve("""\\server\share\report.md"""),
         )
+        assertEquals(
+            LocalMessageLink.DesktopFile("""\\server\share\report.md"""),
+            LocalMessageLink.resolve("file://server/share/report.md"),
+        )
+        assertEquals(
+            LocalMessageLink.Web("https://files.example.com/report.md"),
+            LocalMessageLink.resolve("//files.example.com/report.md"),
+        )
+        assertEquals(
+            LocalMessageLink.DesktopFile("docs/My Report.md"),
+            LocalMessageLink.resolve("docs/My Report.md"),
+        )
+        assertEquals(
+            LocalMessageLink.DesktopFile("./reports/Quarter One.md"),
+            LocalMessageLink.resolve("./reports/Quarter%20One.md?download=1#latest"),
+        )
+        assertEquals(
+            LocalMessageLink.DesktopFile("/C:/posix/report.md"),
+            LocalMessageLink.resolve("/C:/posix/report.md"),
+        )
     }
 
     @Test
-    fun rejectsRelativeMalformedAndCustomSchemeLinks() {
-        assertNull(LocalMessageLink.resolve("notes/report.md"))
+    fun rejectsMalformedEmptyAndCustomSchemeLinks() {
+        assertNull(LocalMessageLink.resolve("#section"))
+        assertNull(LocalMessageLink.resolve("?download=1"))
         assertNull(LocalMessageLink.resolve("openmausbot://pair?token=secret"))
         assertNull(LocalMessageLink.resolve("javascript:alert(1)"))
         assertNull(LocalMessageLink.resolve("https:///missing-host.md"))
         assertNull(LocalMessageLink.resolve("file:///tmp/report.md?replace=1"))
+        assertNull(LocalMessageLink.resolve("docs/bad%ZZ.md"))
         assertNull(LocalMessageLink.resolve("/tmp/bad\u0000name.md"))
         assertNull(LocalMessageLink.resolve(""))
+    }
+
+    @Test
+    fun portableFilenamesNeverSplitUnicodeOrExceedTheirByteBudget() {
+        val name = sanitisePortableFilename("📄".repeat(100) + ".md", "file")
+        assertFalse(name.indices.any { index ->
+            val value = name[index]
+            (Character.isHighSurrogate(value) &&
+                (index + 1 >= name.length || !Character.isLowSurrogate(name[index + 1]))) ||
+                (Character.isLowSurrogate(value) &&
+                    (index == 0 || !Character.isHighSurrogate(name[index - 1])))
+        })
+        assertTrue(name.toByteArray(Charsets.UTF_8).size <= 180)
+        assertEquals("bad name.txt", sanitisePortableFilename("bad\uD800name.txt", "file"))
     }
 
     @Test

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/MultiComputerSessionTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/MultiComputerSessionTest.kt
@@ -10,6 +10,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -279,6 +280,51 @@ class MultiComputerSessionTest {
 
         assertEquals(Session.Status.Unauthorized, session.status.value)
         assertEquals(air, session.connection.value)
+    }
+
+    @Test
+    fun aDownloadThatCompletesDuringAComputerSwitchDiscardsTheOldBytes() = runTest {
+        val transferred = CompletableDeferred<Unit>()
+        val releaseResult = CompletableDeferred<Unit>()
+        val http = OkHttpClient.Builder().addInterceptor { chain ->
+            Response.Builder()
+                .request(chain.request())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .header("Content-Type", "text/plain")
+                .header("Content-Disposition", "attachment; filename=\"old.txt\"")
+                .body("old computer".toResponseBody("text/plain".toMediaType()))
+                .build()
+        }.build()
+        val connections = RegistryStore(ConnectionRegistry(listOf(air, pro), air.id))
+        val tokens = Tokens(mapOf(air.id to "air-token", pro.id to "pro-token"))
+        val session = Session(
+            scope = backgroundScope,
+            connectionStore = connections,
+            tokenStore = tokens,
+            onboardingStore = InMemoryOnboardingStore(),
+            deviceNameProvider = { "Pixel" },
+            clientFactory = { connection, token -> CompanionClient(connection, token, http) },
+            eventsFn = { _, _, _ -> emptyFlow() },
+            afterAttachmentDownload = {
+                transferred.complete(Unit)
+                releaseResult.await()
+            },
+        )
+        session.awaitRestored()
+
+        val result = async {
+            session.downloadFile("thread-1", "message-1", "/private/old.txt")
+        }
+        transferred.await()
+        session.switchComputer(pro.id)
+        runCurrent()
+        assertEquals(pro, session.connection.value)
+        releaseResult.complete(Unit)
+
+        assertNull(result.await())
+        assertNull(session.actionError)
     }
 
     private val sampleBot = Bot(

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/SharedMessageTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/SharedMessageTest.kt
@@ -14,7 +14,7 @@ class SharedMessageTest {
 
             https://example.com/story
 
-            <attached-image path="/tmp/a&amp;&quot;b.png" />
+            <attached-image path="/tmp/a&amp;&quot;b.png" name="Summer &amp; sun.png" />
 
             <attached-file path="/tmp/notes&lt;final&gt;.pdf" name="Project notes.pdf" />
             """.trimIndent(),
@@ -23,12 +23,31 @@ class SharedMessageTest {
                 text = listOf("  A useful excerpt.\n", "A useful excerpt.", " "),
                 urls = listOf("https://example.com/story", "https://example.com/story"),
                 attachments = listOf(
-                    SharedAttachmentReference("/tmp/a&\"b.png", SharedAttachmentKind.IMAGE),
+                    SharedAttachmentReference(
+                        "/tmp/a&\"b.png",
+                        SharedAttachmentKind.IMAGE,
+                        "Summer & sun.png",
+                    ),
                     SharedAttachmentReference(
                         "/tmp/notes<final>.pdf",
                         SharedAttachmentKind.FILE,
                         "Project notes.pdf",
                     ),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun oldAttachmentsWithoutANameKeepTheOriginalTagShape() {
+        assertEquals(
+            "<attached-image path=\"/tmp/photo.png\" />",
+            SharedMessageComposer.compose(
+                instruction = "",
+                text = emptyList(),
+                urls = emptyList(),
+                attachments = listOf(
+                    SharedAttachmentReference("/tmp/photo.png", SharedAttachmentKind.IMAGE),
                 ),
             ),
         )

--- a/ios/App/AttachmentViews.swift
+++ b/ios/App/AttachmentViews.swift
@@ -1,7 +1,27 @@
 import CompanionCore
+import ImageIO
 import QuickLook
 import SwiftUI
 import UIKit
+
+private struct SendableAttachmentImage: @unchecked Sendable {
+    let value: CGImage?
+}
+
+private func decodeAttachmentThumbnail(_ data: Data, maximumPixelSize: Int) -> SendableAttachmentImage {
+    guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
+        return SendableAttachmentImage(value: nil)
+    }
+    let options: [CFString: Any] = [
+        kCGImageSourceCreateThumbnailFromImageAlways: true,
+        kCGImageSourceCreateThumbnailWithTransform: true,
+        kCGImageSourceThumbnailMaxPixelSize: maximumPixelSize,
+        kCGImageSourceShouldCacheImmediately: true,
+    ]
+    return SendableAttachmentImage(
+        value: CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
+    )
+}
 
 enum AttachmentImportError: LocalizedError {
     case unreadable(String)
@@ -78,6 +98,306 @@ struct PendingAttachmentChip: View {
                 .accessibilityHidden(true)
         }
     }
+}
+
+/// One attachment already present in a user message. Its desktop path is
+/// transport metadata only: every byte still comes through the authenticated
+/// route for the message that introduced it.
+struct TranscriptAttachmentView: View {
+    let attachment: DisplayedMessageAttachment
+    let threadId: String
+    let messageId: String
+
+    @EnvironmentObject private var session: Session
+    @State private var thumbnail: UIImage?
+    @State private var thumbnailLoading = false
+    @State private var previewLoading = false
+    @State private var errorMessage: String?
+    @State private var thumbnailAttempt = 0
+    @State private var thumbnailVisible = false
+    @State private var preview: FilePreviewItem?
+    @State private var previewTask: Task<Void, Never>?
+
+    private var taskID: String {
+        "\(threadId)\u{1F}\(messageId)\u{1F}\(attachment.path)\u{1F}\(thumbnailAttempt)\u{1F}\(thumbnailVisible)"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if attachment.kind == .image {
+                imageCard
+            } else {
+                fileCard
+            }
+
+            if let errorMessage {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .accessibilityHidden(true)
+                    Text(errorMessage)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Spacer(minLength: 2)
+                    Button("Retry", action: retry)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(BubbleColor.mineText)
+                }
+                .font(.system(size: 11))
+                .foregroundStyle(BubbleColor.mineText.opacity(0.92))
+                .accessibilityElement(children: .contain)
+            }
+        }
+        .frame(maxWidth: attachment.kind == .image ? 360 : 320, alignment: .leading)
+        .background {
+            if attachment.kind == .image {
+                GeometryReader { proxy in
+                    let frame = proxy.frame(in: .global)
+                    Color.clear
+                        .onAppear { updateThumbnailVisibility(frame) }
+                        .onChange(of: frame) { _, nextFrame in
+                            updateThumbnailVisibility(nextFrame)
+                        }
+                }
+            }
+        }
+        .task(id: taskID) {
+            guard attachment.kind == .image, thumbnailVisible, thumbnail == nil else { return }
+            await loadThumbnail()
+        }
+        .onDisappear { previewTask?.cancel() }
+        .fullScreenCover(item: $preview) { item in
+            FilePreviewView(item: item) {
+                preview = nil
+            }
+        }
+    }
+
+    private var imageCard: some View {
+        Button(action: openPreview) {
+            ZStack(alignment: .bottomLeading) {
+                RoundedRectangle(cornerRadius: 13)
+                    .fill(BubbleColor.mineText.opacity(0.12))
+
+                if let thumbnail {
+                    Image(uiImage: thumbnail)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .clipped()
+                } else if thumbnailLoading {
+                    ProgressView()
+                        .tint(BubbleColor.mineText)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    Image(systemName: "photo")
+                        .font(.system(size: 30, weight: .medium))
+                        .foregroundStyle(BubbleColor.mineText.opacity(0.72))
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+
+                LinearGradient(
+                    colors: [.clear, .black.opacity(0.68)],
+                    startPoint: .center,
+                    endPoint: .bottom
+                )
+
+                HStack(spacing: 6) {
+                    Image(systemName: "photo")
+                        .accessibilityHidden(true)
+                    Text(attachment.name)
+                        .lineLimit(1)
+                    Spacer(minLength: 4)
+                    if previewLoading {
+                        ProgressView()
+                            .controlSize(.small)
+                            .tint(.white)
+                            .accessibilityHidden(true)
+                    }
+                }
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.white)
+                .padding(10)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 168)
+            .clipShape(RoundedRectangle(cornerRadius: 13))
+            .overlay {
+                RoundedRectangle(cornerRadius: 13)
+                    .strokeBorder(BubbleColor.mineText.opacity(0.18))
+            }
+            .contentShape(RoundedRectangle(cornerRadius: 13))
+        }
+        .buttonStyle(.plain)
+        .disabled(previewLoading || thumbnailLoading)
+        .accessibilityLabel("Image: \(attachment.name)")
+        .accessibilityHint(thumbnail == nil ? "Loads the image preview" : "Opens the image full screen")
+    }
+
+    private var fileCard: some View {
+        Button(action: openPreview) {
+            HStack(spacing: 10) {
+                Image(systemName: "doc.fill")
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundStyle(BubbleColor.mineText)
+                    .frame(width: 38, height: 38)
+                    .background(BubbleColor.mineText.opacity(0.12), in: RoundedRectangle(cornerRadius: 9))
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(attachment.name)
+                        .font(.system(size: 13, weight: .semibold))
+                        .lineLimit(1)
+                    Text(previewLoading ? "Opening…" : "Tap to preview")
+                        .font(.system(size: 11))
+                        .foregroundStyle(BubbleColor.mineText.opacity(0.68))
+                }
+
+                Spacer(minLength: 8)
+                if previewLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                        .tint(BubbleColor.mineText)
+                        .accessibilityHidden(true)
+                } else {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(BubbleColor.mineText.opacity(0.65))
+                        .accessibilityHidden(true)
+                }
+            }
+            .foregroundStyle(BubbleColor.mineText)
+            .padding(8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(BubbleColor.mineText.opacity(0.10), in: RoundedRectangle(cornerRadius: 13))
+            .overlay {
+                RoundedRectangle(cornerRadius: 13)
+                    .strokeBorder(BubbleColor.mineText.opacity(0.12))
+            }
+            .contentShape(RoundedRectangle(cornerRadius: 13))
+        }
+        .buttonStyle(.plain)
+        .disabled(previewLoading)
+        .accessibilityLabel("File: \(attachment.name)")
+        .accessibilityHint("Opens a preview")
+    }
+
+    @MainActor
+    private func loadThumbnail() async {
+        thumbnailLoading = true
+        errorMessage = nil
+        defer { thumbnailLoading = false }
+        do {
+            let downloaded = try await session.fetchAttachment(
+                threadId: threadId,
+                messageId: messageId,
+                path: attachment.path,
+                cacheResult: true
+            )
+            try Task.checkCancellation()
+            guard downloaded.data.count <= AttachmentPolicy.maximumImageBytes,
+                  AttachmentPolicy.normalizedMIME(downloaded.contentType).hasPrefix("image/")
+            else {
+                errorMessage = "This image couldn't be previewed."
+                return
+            }
+            let decoded = await Task.detached(priority: .userInitiated) {
+                decodeAttachmentThumbnail(downloaded.data, maximumPixelSize: 720)
+            }.value
+            try Task.checkCancellation()
+            guard let image = decoded.value else {
+                errorMessage = "This image couldn't be previewed."
+                return
+            }
+            thumbnail = UIImage(cgImage: image)
+        } catch is CancellationError {
+            return
+        } catch {
+            guard !Task.isCancelled else { return }
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func openPreview() {
+        guard !previewLoading else { return }
+        previewTask?.cancel()
+        errorMessage = nil
+        previewLoading = true
+        previewTask = Task { @MainActor in
+            var unfinishedItem: FilePreviewItem?
+            defer {
+                previewLoading = false
+                unfinishedItem?.cleanUp()
+            }
+            do {
+                let downloaded = try await session.prepareAttachmentPreview(
+                    threadId: threadId,
+                    messageId: messageId,
+                    path: attachment.path,
+                    cacheResult: attachment.kind == .image
+                )
+                guard let item = FilePreviewItem(downloaded: downloaded) else {
+                    errorMessage = "The downloaded file couldn't be previewed."
+                    return
+                }
+                // Adopt cleanup ownership before observing cancellation. The
+                // materialized directory otherwise has a one-suspension leak
+                // window between Session returning and this view owning it.
+                unfinishedItem = item
+                try Task.checkCancellation()
+                if attachment.kind == .image {
+                    guard downloaded.data.count <= AttachmentPolicy.maximumImageBytes,
+                          AttachmentPolicy.normalizedMIME(downloaded.contentType).hasPrefix("image/")
+                    else {
+                        errorMessage = "This image couldn't be previewed."
+                        return
+                    }
+                    if thumbnail == nil {
+                        let decoded = await Task.detached(priority: .userInitiated) {
+                            decodeAttachmentThumbnail(downloaded.data, maximumPixelSize: 64)
+                        }.value
+                        try Task.checkCancellation()
+                        guard decoded.value != nil else {
+                            errorMessage = "This image couldn't be previewed."
+                            return
+                        }
+                    }
+                }
+                preview = item
+                unfinishedItem = nil
+            } catch is CancellationError {
+                return
+            } catch {
+                guard !Task.isCancelled else { return }
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func retry() {
+        if attachment.kind == .image, thumbnail == nil {
+            thumbnailAttempt += 1
+        } else {
+            openPreview()
+        }
+    }
+
+    @MainActor
+    private func updateThumbnailVisibility(_ frame: CGRect) {
+        let windowBounds = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .first(where: \.isKeyWindow)?
+            .bounds ?? UIScreen.main.bounds
+        // Begin just before the card reaches the viewport so the placeholder
+        // usually resolves during the final part of the scroll gesture.
+        let visible = frame.intersects(windowBounds.insetBy(dx: 0, dy: -120))
+        if thumbnailVisible != visible { thumbnailVisible = visible }
+        // The transcript intentionally uses an eager VStack for correct
+        // bottom anchoring. Do not let that turn every image ever visited into
+        // permanent row state: keep nearby cards warm, then release the decode.
+        let retentionFrame = windowBounds.insetBy(dx: 0, dy: -windowBounds.height)
+        if !retentionFrame.intersects(frame), thumbnail != nil { thumbnail = nil }
+    }
+
 }
 
 struct FilePreviewItem: Identifiable {

--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -43,6 +43,7 @@ struct ChatView: View {
     @State private var fileOpenError: String?
     @State private var filePreview: FilePreviewItem?
     @State private var fileDownloadTask: Task<Void, Never>?
+    @State private var fileDownloadRequestID: UUID?
     @State private var acceptsNextHardwareLineBreak = false
     @FocusState private var composerFocused: Bool
     @StateObject private var dictation = SpeechDictation()
@@ -320,9 +321,15 @@ struct ChatView: View {
             // bit here rather than leaving a badge on an open conversation.
             if unread { Task { await session.markRead(current) } }
         }
+        .onChange(of: threadId) { _, _ in
+            // ChatView follows a bot when its active task changes. A download
+            // started in the previous task must not open a sheet (or surface
+            // its error) in the new one when the network reply arrives late.
+            resetFilePreview()
+        }
         .onDisappear {
             dictation.stop()
-            fileDownloadTask?.cancel()
+            resetFilePreview()
         }
         .onChange(of: scenePhase) { _, phase in
             if phase != .active { dictation.stop() }
@@ -891,30 +898,55 @@ struct ChatView: View {
 
     private func openFile(path: String, from message: Message) {
         fileDownloadTask?.cancel()
+        let requestID = UUID()
+        fileDownloadRequestID = requestID
+        let requestedThreadID = threadId
         fileOpenError = nil
         let name = URL(fileURLWithPath: path).lastPathComponent
         openingFileName = name.isEmpty ? "file" : name
         let task = Task {
             let downloaded = await session.downloadFile(
-                threadId: threadId,
+                threadId: requestedThreadID,
                 messageId: message.id,
                 path: path
             )
-            guard !Task.isCancelled else { return }
+            if let downloaded, let preview = FilePreviewItem(downloaded: downloaded) {
+                // Own the temporary file before checking cancellation so an
+                // old link tap cannot strand it between Session and the sheet.
+                guard !Task.isCancelled, fileDownloadRequestID == requestID else {
+                    preview.cleanUp()
+                    return
+                }
+                openingFileName = nil
+                filePreview?.cleanUp()
+                filePreview = preview
+                fileDownloadRequestID = nil
+                fileDownloadTask = nil
+                return
+            }
+            guard !Task.isCancelled, fileDownloadRequestID == requestID else { return }
             openingFileName = nil
-            guard let downloaded, downloaded.localURL != nil else {
+            fileDownloadRequestID = nil
+            fileDownloadTask = nil
+            guard downloaded != nil else {
                 fileOpenError = session.actionError ?? "Couldn't open that file. Try again."
                 session.actionError = nil
                 return
             }
-            filePreview?.cleanUp()
-            guard let preview = FilePreviewItem(downloaded: downloaded) else {
-                fileOpenError = "The downloaded file couldn't be previewed."
-                return
-            }
-            filePreview = preview
+            fileOpenError = "The downloaded file couldn't be previewed."
         }
         fileDownloadTask = task
+    }
+
+    /// End the preview lifecycle owned by the task that just left the screen.
+    private func resetFilePreview() {
+        fileDownloadTask?.cancel()
+        fileDownloadTask = nil
+        fileDownloadRequestID = nil
+        openingFileName = nil
+        fileOpenError = nil
+        filePreview?.cleanUp()
+        filePreview = nil
     }
 
     // MARK: - Composer
@@ -1164,6 +1196,12 @@ struct MessageRow: View {
         session.state.versions(of: message, inThread: chat.threadId)
     }
 
+    /// Transport tags contain paths on the paired computer. They belong in
+    /// attachment cards, never on the clipboard or in the text-selection UI.
+    private var attachedContent: AttachedMessageContent {
+        AttachedMessageContent.parse(message.text ?? "")
+    }
+
     var body: some View {
         VStack(alignment: message.role == .user ? .trailing : .leading, spacing: 6) {
             content
@@ -1213,20 +1251,27 @@ struct MessageRow: View {
                     Task { await session.react(to: message, in: chat.threadId, emoji: emoji) }
                 }
             }
-            if let text = message.text, !text.isEmpty {
+            let visibleText = attachedContent.text
+            if !visibleText.isEmpty {
                 Divider()
                 Button("Copy", systemImage: "doc.on.doc") {
-                    PlatformBridge.copyToPasteboard(text)
+                    PlatformBridge.copyToPasteboard(visibleText)
                 }
             }
             // Copy above takes the whole reply. Selection happens in a sheet
             // because long-press on the bubble already opens this menu.
-            if let body = message.text, !body.isEmpty {
+            if !visibleText.isEmpty {
                 Button("Select Text", systemImage: "selection.pin.in.out") {
-                    selecting = SelectableText(text: body)
+                    selecting = SelectableText(text: visibleText)
                 }
             }
-            if message.role == .user, message.kind == .text, case let .bot(bot) = chat {
+            // An attachment edit cannot faithfully reconstruct the upload.
+            // Hiding this action is safer than silently dropping the file or
+            // sending its computer-local transport path back as prose.
+            if message.role == .user,
+               message.kind == .text,
+               attachedContent.attachments.isEmpty,
+               case let .bot(bot) = chat {
                 Divider()
                 Button("Edit and retry", systemImage: "pencil") {
                     editingText = message.text ?? ""
@@ -1416,18 +1461,10 @@ struct TextBubble: View {
                 } else if mine {
                     let shared = attachedContent
                     ForEach(Array(shared.attachments.enumerated()), id: \.offset) { _, attachment in
-                        Label(
-                            attachment.name,
-                            systemImage: attachment.kind == .image ? "photo" : "doc"
-                        )
-                        .font(.system(size: 13, weight: .medium))
-                        .lineLimit(1)
-                        .foregroundStyle(BubbleColor.mineText.opacity(0.82))
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 6)
-                        .background(BubbleColor.mineText.opacity(0.10), in: Capsule())
-                        .accessibilityLabel(
-                            "\(attachment.kind == .image ? "Image" : "File"): \(attachment.name)"
+                        TranscriptAttachmentView(
+                            attachment: attachment,
+                            threadId: chat.threadId,
+                            messageId: message.id
                         )
                     }
                     if !shared.text.isEmpty {

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -19,6 +19,14 @@ import UIKit
 /// the transitions are worth being able to read.
 private let log = Logger(subsystem: "com.openmausbot.companion", category: "stream")
 
+private final class CachedAttachmentDownload: NSObject {
+    let value: DownloadedFile
+
+    init(_ value: DownloadedFile) {
+        self.value = value
+    }
+}
+
 @MainActor
 final class Session: ObservableObject {
     enum Status: Equatable {
@@ -88,10 +96,16 @@ final class Session: ObservableObject {
     /// for the same attachment path.
     private var avatarFetches: [String: (id: UUID, task: Task<Data?, Never>)] = [:]
     private var avatarCacheGeneration = 0
-    /// Only one downloaded document preview is retained. A replacement is
-    /// written completely before the previous directory is removed, so a
-    /// failed download cannot invalidate the file currently on screen.
-    private var filePreviewDirectory: URL?
+    /// Full image bytes are already fetched to draw a thumbnail. Keep a small,
+    /// cost-bounded window so tapping that thumbnail opens immediately instead
+    /// of downloading the same image twice.
+    private let attachmentCache: NSCache<NSString, CachedAttachmentDownload> = {
+        let cache = NSCache<NSString, CachedAttachmentDownload>()
+        cache.countLimit = 12
+        cache.totalCostLimit = 32 * 1_024 * 1_024
+        return cache
+    }()
+    private var attachmentCacheGeneration = 0
     /// An ambiguous network failure may happen after the server accepted a
     /// message. Reusing this id for the exact same retained draft makes Retry
     /// idempotent instead of sending the attachment twice.
@@ -417,7 +431,7 @@ final class Session: ObservableObject {
         rotation = CandidateRotation(hosts: [])
         state = CompanionState()
         resetAvatarCache()
-        clearFilePreview()
+        resetAttachmentCache()
         attachmentSendIDs.removeAll()
         NotificationCoordinator.shared.setBadge(0)
         status = .unpaired
@@ -449,7 +463,7 @@ final class Session: ObservableObject {
         token = nil
         state = CompanionState()
         resetAvatarCache()
-        clearFilePreview()
+        resetAttachmentCache()
         attachmentSendIDs.removeAll()
         NotificationCoordinator.shared.setBadge(0)
     }
@@ -851,7 +865,11 @@ final class Session: ObservableObject {
                         mime: mime,
                         uploadId: attachment.id.uuidString
                     )
-                    uploaded.append(SharedAttachmentReference(path: path, kind: .image))
+                    uploaded.append(SharedAttachmentReference(
+                        path: path,
+                        kind: .image,
+                        displayName: attachment.name
+                    ))
                 case .file:
                     let file = try await client.uploadFile(
                         data: attachment.data,
@@ -910,55 +928,112 @@ final class Session: ObservableObject {
         }
     }
 
-    /// Download one desktop path through its originating transcript message,
-    /// then place it in a private temporary directory for Quick Look.
-    func downloadFile(
+    /// Fetch one app-owned attachment through the message that introduced it.
+    /// The caller owns presentation errors so a failed thumbnail or preview can
+    /// explain itself beside the attachment that was tapped.
+    func fetchAttachment(
         threadId: String,
         messageId: String,
-        path: String
-    ) async -> DownloadedFile? {
+        path: String,
+        cacheResult: Bool = false
+    ) async throws -> DownloadedFile {
         guard let client else {
-            actionError = "This computer is offline."
-            return nil
+            throw APIError.transport("This computer is offline.")
         }
-        actionError = nil
+        let cacheKey = "\(threadId)\u{1F}\(messageId)\u{1F}\(path)"
+        if cacheResult,
+           let cached = attachmentCache.object(forKey: cacheKey as NSString) {
+            return cached.value
+        }
+        let generation = attachmentCacheGeneration
         do {
+            // Keep this structured. When the row scrolls away SwiftUI cancels
+            // its task, which now propagates directly into URLSession instead
+            // of leaving a shared unstructured download running.
             let download = try await client.downloadFile(
                 threadId: threadId,
                 messageId: messageId,
                 path: path
             )
             try Task.checkCancellation()
-            let manager = FileManager.default
-            let root = manager.temporaryDirectory
-                .appendingPathComponent("OpenMausBotFilePreviews", isDirectory: true)
-            let nextDirectory = root.appendingPathComponent(UUID().uuidString, isDirectory: true)
-            try manager.createDirectory(
-                at: nextDirectory,
-                withIntermediateDirectories: true,
-                attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
-            )
-            let fileURL = nextDirectory.appendingPathComponent(download.filename, isDirectory: false)
-            do {
-                try download.data.write(to: fileURL, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
-                // A synchronous write cannot be interrupted halfway through.
-                // Check immediately afterwards so a cancelled preview never
-                // leaves its completed temporary copy behind.
-                try Task.checkCancellation()
-            } catch {
-                try? manager.removeItem(at: nextDirectory)
-                throw error
+            guard generation == attachmentCacheGeneration else { throw CancellationError() }
+            if cacheResult {
+                attachmentCache.setObject(
+                    CachedAttachmentDownload(download),
+                    forKey: cacheKey as NSString,
+                    cost: download.data.count
+                )
             }
-            let previous = filePreviewDirectory
-            filePreviewDirectory = nextDirectory
-            if let previous { try? manager.removeItem(at: previous) }
-            actionError = nil
-            return download.stored(at: fileURL)
-        } catch is CancellationError {
-            return nil
+            return download
         } catch let error as APIError where error.isUnauthorized {
+            // A cancelled request from the previous computer may finish after
+            // a switch. Its 401 belongs to that old token and must not evict
+            // the current live session.
+            guard generation == attachmentCacheGeneration, !Task.isCancelled else {
+                throw CancellationError()
+            }
             status = .unauthorized
-            actionError = error.localizedDescription
+            throw error
+        } catch {
+            if Task.isCancelled || generation != attachmentCacheGeneration {
+                throw CancellationError()
+            }
+            throw error
+        }
+    }
+
+    /// Fetch and materialize an attachment in a protected temporary directory
+    /// for Quick Look, markdown/text preview, and the system share sheet.
+    func prepareAttachmentPreview(
+        threadId: String,
+        messageId: String,
+        path: String,
+        cacheResult: Bool = false
+    ) async throws -> DownloadedFile {
+        let download = try await fetchAttachment(
+            threadId: threadId,
+            messageId: messageId,
+            path: path,
+            cacheResult: cacheResult
+        )
+        try Task.checkCancellation()
+        let preparation = Task.detached(priority: .userInitiated) {
+            // Content-Disposition is the server's canonical, sanitised name.
+            // The transport tag's `name` is presentation-only and must never
+            // choose the on-disk preview/share filename.
+            try Self.materializePreview(download: download, filename: download.filename)
+        }
+        let prepared = try await withTaskCancellationHandler {
+            try await preparation.value
+        } onCancel: {
+            preparation.cancel()
+        }
+        do {
+            try Task.checkCancellation()
+            return prepared
+        } catch {
+            Self.removePreview(at: prepared.localURL)
+            throw error
+        }
+    }
+
+    /// Compatibility for file links in assistant markdown. User attachment
+    /// cards use the throwing API above so their feedback remains local.
+    func downloadFile(
+        threadId: String,
+        messageId: String,
+        path: String
+    ) async -> DownloadedFile? {
+        actionError = nil
+        do {
+            let download = try await prepareAttachmentPreview(
+                threadId: threadId,
+                messageId: messageId,
+                path: path
+            )
+            actionError = nil
+            return download
+        } catch is CancellationError {
             return nil
         } catch {
             actionError = error.localizedDescription
@@ -966,9 +1041,47 @@ final class Session: ObservableObject {
         }
     }
 
-    private func clearFilePreview() {
-        if let filePreviewDirectory { try? FileManager.default.removeItem(at: filePreviewDirectory) }
-        filePreviewDirectory = nil
+    private func resetAttachmentCache() {
+        attachmentCacheGeneration += 1
+        attachmentCache.removeAllObjects()
+    }
+
+    nonisolated private static func materializePreview(
+        download: DownloadedFile,
+        filename: String
+    ) throws -> DownloadedFile {
+        let manager = FileManager.default
+        let root = manager.temporaryDirectory
+            .appendingPathComponent("OpenMausBotFilePreviews", isDirectory: true)
+        let directory = root.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try Task.checkCancellation()
+        try manager.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
+        )
+        let fileURL = directory.appendingPathComponent(filename, isDirectory: false)
+        do {
+            try download.data.write(
+                to: fileURL,
+                options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication]
+            )
+            try Task.checkCancellation()
+            return DownloadedFile(
+                data: download.data,
+                filename: filename,
+                contentType: download.contentType,
+                localURL: fileURL
+            )
+        } catch {
+            try? manager.removeItem(at: directory)
+            throw error
+        }
+    }
+
+    nonisolated private static func removePreview(at fileURL: URL?) {
+        guard let fileURL else { return }
+        try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent())
     }
 
     private static func removeStaleFilePreviews() {

--- a/ios/ShareExtension/ShareViewModel.swift
+++ b/ios/ShareExtension/ShareViewModel.swift
@@ -268,7 +268,11 @@ final class ShareViewModel: ObservableObject {
                             uploadId: attachment.id.uuidString
                         )
                     }
-                    uploaded.append(SharedAttachmentReference(path: path, kind: .image))
+                    uploaded.append(SharedAttachmentReference(
+                        path: path,
+                        kind: .image,
+                        displayName: attachment.name
+                    ))
                 case .file:
                     let uploadedFile = try await withFailover(
                         requestTimeout: 20,

--- a/ios/Sources/CompanionCore/AttachedMessageContent.swift
+++ b/ios/Sources/CompanionCore/AttachedMessageContent.swift
@@ -10,10 +10,15 @@ public struct DisplayedMessageAttachment: Hashable, Sendable {
     }
 
     public let kind: Kind
+    /// The app-owned path written into the stored prompt. The phone sends it
+    /// back only through the originating message's authenticated file route;
+    /// it is never opened as a local URL on the phone.
+    public let path: String
     public let name: String
 
-    public init(kind: Kind, name: String) {
+    public init(kind: Kind, path: String, name: String) {
         self.kind = kind
+        self.path = path
         self.name = name
     }
 }
@@ -30,37 +35,198 @@ public struct AttachedMessageContent: Hashable, Sendable {
     /// Splits only the exact, standalone tags OpenMausBot writes. An inline
     /// example in somebody's prose stays prose instead of disappearing.
     public static func parse(_ source: String) -> AttachedMessageContent {
-        let range = NSRange(source.startIndex..<source.endIndex, in: source)
-        let matches = tagExpression.matches(in: source, range: range)
-        let attachments = matches.compactMap { match -> DisplayedMessageAttachment? in
-            guard
-                let kindRange = Range(match.range(at: 1), in: source),
-                let pathRange = Range(match.range(at: 2), in: source)
-            else { return nil }
+        var attachments: [DisplayedMessageAttachment] = []
+        var visible = ""
+        var fence: Fence?
+        var htmlBlock: HTMLBlock?
+        var cursor = source.startIndex
 
-            let kind: DisplayedMessageAttachment.Kind = source[kindRange] == "image" ? .image : .file
-            let path = decodeAttribute(String(source[pathRange]))
-            let providedName: String?
-            if match.range(at: 3).location != NSNotFound,
-               let nameRange = Range(match.range(at: 3), in: source) {
-                providedName = decodeAttribute(String(source[nameRange]))
-            } else {
-                providedName = nil
+        while cursor < source.endIndex {
+            let newline = source[cursor...].firstIndex(of: "\n")
+            let lineEnd = newline ?? source.endIndex
+            let wholeLineEnd = newline.map { source.index(after: $0) } ?? source.endIndex
+            var line = String(source[cursor..<lineEnd])
+            if line.hasSuffix("\r") { line.removeLast() }
+
+            var consumedTransportTag = false
+            if let activeFence = fence {
+                if let marker = fenceMarker(in: line),
+                   marker.character == activeFence.character,
+                   marker.length >= activeFence.length,
+                   marker.remainder.allSatisfy({ $0 == " " || $0 == "\t" }) {
+                    fence = nil
+                }
+            } else if let activeHTMLBlock = htmlBlock {
+                switch activeHTMLBlock {
+                case .untilBlank:
+                    if line.allSatisfy({ $0 == " " || $0 == "\t" }) { htmlBlock = nil }
+                case let .untilToken(closingToken):
+                    if line.lowercased().contains(closingToken) { htmlBlock = nil }
+                }
+            } else if let marker = fenceMarker(in: line) {
+                fence = Fence(character: marker.character, length: marker.length)
+            } else if let attachment = attachmentTag(in: line) {
+                attachments.append(attachment)
+                consumedTransportTag = true
+            } else if let openingHTMLBlock = htmlBlockStarting(in: line) {
+                htmlBlock = openingHTMLBlock
             }
-            return DisplayedMessageAttachment(
-                kind: kind,
-                name: displayName(providedName: providedName, path: path, kind: kind)
-            )
+
+            if !consumedTransportTag {
+                visible.append(contentsOf: source[cursor..<wholeLineEnd])
+            }
+            cursor = wholeLineEnd
         }
 
-        let stripped = tagExpression
-            .stringByReplacingMatches(in: source, range: range, withTemplate: "")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return AttachedMessageContent(text: stripped, attachments: attachments)
+        return AttachedMessageContent(
+            text: visible.trimmingCharacters(in: .whitespacesAndNewlines),
+            attachments: attachments
+        )
+    }
+
+    private struct Fence {
+        let character: Character
+        let length: Int
+    }
+
+    private enum HTMLBlock {
+        case untilBlank
+        case untilToken(String)
+    }
+
+    private static func htmlBlockStarting(in line: String) -> HTMLBlock? {
+        let lowercased = line.lowercased()
+        if let comment = lowercased.range(of: "<!--"),
+           lowercased[comment.upperBound...].range(of: "-->") == nil {
+            return .untilToken("-->")
+        }
+
+        guard let content = commonMarkContent(in: line) else { return nil }
+        let lowerContent = content.lowercased()
+
+        if matches(pastedTextStartExpression, in: line) {
+            return lowerContent.contains("</pasted-text>") ? nil : .untilToken("</pasted-text>")
+        }
+
+        if let name = firstCapture(of: typeOneExpression, in: line)?.lowercased() {
+            let closingToken = "</\(name)>"
+            return lowercased.contains(closingToken) ? nil : .untilToken(closingToken)
+        }
+
+        if lowerContent.hasPrefix("<?") {
+            return lowerContent.dropFirst(2).contains("?>") ? nil : .untilToken("?>")
+        }
+        if lowerContent.hasPrefix("<![cdata[") {
+            return lowerContent.dropFirst(9).contains("]]>") ? nil : .untilToken("]]>")
+        }
+        if content.hasPrefix("<!"),
+           let marker = content.dropFirst(2).unicodeScalars.first,
+           (65...90).contains(marker.value) || (97...122).contains(marker.value) {
+            return content.dropFirst(2).contains(">") ? nil : .untilToken(">")
+        }
+
+        if matches(typeSixExpression, in: line) || matches(typeSevenExpression, in: line) {
+            return .untilBlank
+        }
+        return nil
+    }
+
+    private static func commonMarkContent(in line: String) -> Substring? {
+        var index = line.startIndex
+        var spaces = 0
+        while index < line.endIndex, line[index] == " " {
+            spaces += 1
+            guard spaces <= 3 else { return nil }
+            index = line.index(after: index)
+        }
+        return line[index...]
+    }
+
+    private static func matches(_ expression: NSRegularExpression, in line: String) -> Bool {
+        expression.firstMatch(
+            in: line,
+            range: NSRange(line.startIndex..<line.endIndex, in: line)
+        ) != nil
+    }
+
+    private static func firstCapture(of expression: NSRegularExpression, in line: String) -> String? {
+        let range = NSRange(line.startIndex..<line.endIndex, in: line)
+        guard let match = expression.firstMatch(in: line, range: range),
+              let capture = Range(match.range(at: 1), in: line)
+        else { return nil }
+        return String(line[capture])
+    }
+
+    private static let commonMarkBlockTags = [
+        "address", "article", "aside", "base", "basefont", "blockquote", "body", "caption", "center", "col",
+        "colgroup", "dd", "details", "dialog", "dir", "div", "dl", "dt", "fieldset", "figcaption", "figure",
+        "footer", "form", "frame", "frameset", "h[1-6]", "head", "header", "hr", "html", "iframe", "legend",
+        "li", "link", "main", "menu", "menuitem", "nav", "noframes", "ol", "optgroup", "option", "p",
+        "param", "search", "section", "summary", "table", "tbody", "td", "tfoot", "th", "thead", "title",
+        "tr", "track", "ul",
+    ].joined(separator: "|")
+
+    private static let pastedTextStartExpression = try! NSRegularExpression(
+        pattern: #"^ {0,3}<pasted-text(?:[\t >]|$)"#,
+        options: .caseInsensitive
+    )
+    private static let typeOneExpression = try! NSRegularExpression(
+        pattern: #"^ {0,3}<(script|pre|style|textarea)(?:[\t ]|>|$)"#,
+        options: .caseInsensitive
+    )
+    private static let typeSixExpression = try! NSRegularExpression(
+        pattern: #"^ {0,3}</?(?:"# + commonMarkBlockTags + #")(?:[\t ]|/?>|$)"#,
+        options: .caseInsensitive
+    )
+    private static let typeSevenExpression = try! NSRegularExpression(
+        pattern: #"^ {0,3}(?:<[A-Za-z][A-Za-z0-9-]*(?:[\t ]+[A-Za-z_:][A-Za-z0-9_.:-]*(?:[\t ]*=[\t ]*(?:[^\s\"'=<>`]+|'[^']*'|\"[^\"]*\"))?)*[\t ]*/?>|</[A-Za-z][A-Za-z0-9-]*[\t ]*>)[\t ]*$"#
+    )
+
+    private static func fenceMarker(in line: String) -> (character: Character, length: Int, remainder: Substring)? {
+        var index = line.startIndex
+        var leadingSpaces = 0
+        while index < line.endIndex, line[index] == " ", leadingSpaces < 4 {
+            leadingSpaces += 1
+            index = line.index(after: index)
+        }
+        guard leadingSpaces <= 3, index < line.endIndex else { return nil }
+        let marker = line[index]
+        guard marker == "`" || marker == "~" else { return nil }
+        var end = index
+        var length = 0
+        while end < line.endIndex, line[end] == marker {
+            length += 1
+            end = line.index(after: end)
+        }
+        guard length >= 3 else { return nil }
+        return (marker, length, line[end...])
+    }
+
+    private static func attachmentTag(in line: String) -> DisplayedMessageAttachment? {
+        let range = NSRange(line.startIndex..<line.endIndex, in: line)
+        guard let match = tagExpression.firstMatch(in: line, range: range),
+              let kindRange = Range(match.range(at: 1), in: line),
+              let pathRange = Range(match.range(at: 2), in: line)
+        else { return nil }
+
+        let kind: DisplayedMessageAttachment.Kind = line[kindRange] == "image" ? .image : .file
+        let path = decodeAttribute(String(line[pathRange]))
+        let providedName: String?
+        if match.range(at: 3).location != NSNotFound,
+           let nameRange = Range(match.range(at: 3), in: line) {
+            providedName = decodeAttribute(String(line[nameRange]))
+        } else {
+            providedName = nil
+        }
+        return DisplayedMessageAttachment(
+            kind: kind,
+            path: path,
+            name: displayName(providedName: providedName, path: path, kind: kind)
+        )
     }
 
     private static let tagExpression = try! NSRegularExpression(
-        pattern: #"(?m)^[\t ]*<attached-(image|file)[\t ]+path="([^"\r\n]*)"(?:[\t ]+name="([^"\r\n]*)")?[\t ]*/>[\t ]*(?:\r?\n)?"#
+        pattern: #"^<attached-(image|file)[\t ]+path="([^"\r\n]*)"(?:[\t ]+name="([^"\r\n]*)")?[\t ]*/>[\t ]*$"#
     )
 
     private static func decodeAttribute(_ value: String) -> String {
@@ -79,10 +245,20 @@ public struct AttachedMessageContent: Hashable, Sendable {
         path: String,
         kind: DisplayedMessageAttachment.Kind
     ) -> String {
-        let fallback = path.components(separatedBy: CharacterSet(charactersIn: "/\\"))
-            .last(where: { !$0.isEmpty })
-        let candidate = providedName?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let value = (candidate?.isEmpty == false ? candidate : fallback) ?? (kind == .image ? "Image" : "File")
+        func basename(_ source: String?) -> String? {
+            guard let source else { return nil }
+            let value = source.trimmingCharacters(in: .whitespacesAndNewlines)
+                .components(separatedBy: CharacterSet(charactersIn: "/\\"))
+                .last(where: { !$0.isEmpty })?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let value, !value.isEmpty, value != ".", value != ".." else { return nil }
+            return value
+        }
+
+        // `name` is presentation metadata from stored chat text, not a path.
+        // Basename it just like the fallback so a crafted value can never look
+        // like (or later become) a directory traversal.
+        let value = basename(providedName) ?? basename(path) ?? (kind == .image ? "Image" : "File")
         let oneLine = value.unicodeScalars.map { scalar in
             let code = scalar.value
             let isBidiControl = (0x202A...0x202E).contains(code) || (0x2066...0x2069).contains(code)

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -404,11 +404,10 @@ public enum SharedMessageComposer {
 
         for attachment in attachments {
             let tag = attachment.kind == .image ? "attached-image" : "attached-file"
-            if attachment.kind == .file,
-               let displayName = attachment.displayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+            if let displayName = attachment.displayName?.trimmingCharacters(in: .whitespacesAndNewlines),
                !displayName.isEmpty {
                 parts.append(
-                    "<attached-file path=\"\(escapeAttribute(attachment.path))\" " +
+                    "<\(tag) path=\"\(escapeAttribute(attachment.path))\" " +
                     "name=\"\(escapeAttribute(displayName))\" />"
                 )
             } else {
@@ -869,8 +868,38 @@ public struct CompanionClient: Sendable {
             let isBidiControl = (0x202A...0x202E).contains(code) || (0x2066...0x2069).contains(code)
             return CharacterSet.controlCharacters.contains(scalar) || isBidiControl ? " " : String(scalar)
         }.joined().trimmingCharacters(in: .whitespacesAndNewlines)
-        let shortened = String(cleaned.prefix(180))
+        let shortened = boundedFilename(cleaned)
         return shortened.isEmpty || shortened == "." || shortened == ".." ? "file" : shortened
+    }
+
+    /// APFS limits one path component by bytes, not Swift characters. Keep
+    /// enough room for the preview cache's own suffix and retain a useful
+    /// extension whenever it fits.
+    private static func boundedFilename(_ value: String, maximumUTF8Bytes: Int = 180) -> String {
+        guard value.utf8.count > maximumUTF8Bytes else { return value }
+        let pathExtension = (value as NSString).pathExtension
+        let suffix = pathExtension.isEmpty ? "" : ".\(pathExtension)"
+        if !suffix.isEmpty,
+           suffix.utf8.count <= 32,
+           suffix.utf8.count < maximumUTF8Bytes {
+            let stem = String(value.dropLast(suffix.count))
+            let prefix = utf8Prefix(stem, maximumBytes: maximumUTF8Bytes - suffix.utf8.count)
+            if !prefix.isEmpty { return prefix + suffix }
+        }
+        return utf8Prefix(value, maximumBytes: maximumUTF8Bytes)
+    }
+
+    private static func utf8Prefix(_ value: String, maximumBytes: Int) -> String {
+        var result = ""
+        var bytes = 0
+        for character in value {
+            let piece = String(character)
+            let pieceBytes = piece.utf8.count
+            guard bytes + pieceBytes <= maximumBytes else { break }
+            result.append(character)
+            bytes += pieceBytes
+        }
+        return result
     }
 
     /// Fetch an app-owned avatar with the paired-device bearer token. Custom

--- a/ios/Sources/CompanionCore/MessageAttachments.swift
+++ b/ios/Sources/CompanionCore/MessageAttachments.swift
@@ -143,7 +143,8 @@ public enum AttachmentPolicy {
 
 /// What tapping a Markdown link in a message is allowed to do. Web links go
 /// to the system. Absolute desktop paths go back through the authenticated
-/// companion file route. Relative and custom-scheme links do nothing.
+/// companion file route. Relative paths are resolved by that route against
+/// the originating conversation's workspace. Custom schemes do nothing.
 public enum LocalMessageLink: Equatable, Sendable {
     case web(URL)
     case desktopFile(path: String)
@@ -154,39 +155,64 @@ public enum LocalMessageLink: Equatable, Sendable {
               !value.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains)
         else { return nil }
 
-        if isWindowsAbsolutePath(value) || isUNCPath(value) {
+        if isWindowsAbsolutePath(value) || isBackslashUNCPath(value) {
             return .desktopFile(path: value)
+        }
+        // In Markdown, //host/path is a protocol-relative web link. Keep it
+        // out of the UNC path branch; file://host/path remains the explicit
+        // spelling for a network share.
+        if value.hasPrefix("//") {
+            guard let components = URLComponents(string: "https:\(value)"),
+                  let url = components.url,
+                  components.host?.isEmpty == false
+            else { return nil }
+            return .web(url)
         }
         if value.hasPrefix("/") { return .desktopFile(path: value) }
 
-        guard let components = URLComponents(string: value),
-              let scheme = components.scheme?.lowercased()
-        else { return nil }
-        if scheme == "http" || scheme == "https" {
-            guard let url = components.url, components.host?.isEmpty == false else { return nil }
-            return .web(url)
+        if let schemeRange = value.range(
+            of: #"^[A-Za-z][A-Za-z0-9+.-]*:"#,
+            options: .regularExpression
+        ) {
+            guard schemeRange.lowerBound == value.startIndex,
+                  let components = URLComponents(string: value),
+                  let scheme = components.scheme?.lowercased()
+            else { return nil }
+            if scheme == "http" || scheme == "https" {
+                guard let url = components.url, components.host?.isEmpty == false else { return nil }
+                return .web(url)
+            }
+            if scheme == "file" {
+                guard components.query == nil, components.fragment == nil else { return nil }
+                guard var path = components.percentEncodedPath.removingPercentEncoding else { return nil }
+                if path.hasPrefix("/"), isWindowsAbsolutePath(String(path.dropFirst())) {
+                    path.removeFirst()
+                }
+                if let host = components.host, !host.isEmpty, host.lowercased() != "localhost" {
+                    let sharePath = path.replacingOccurrences(of: "/", with: "\\")
+                    path = "\\\\\(host)\(sharePath)"
+                }
+                guard path.hasPrefix("/") || isWindowsAbsolutePath(path) || isBackslashUNCPath(path) else {
+                    return nil
+                }
+                return .desktopFile(path: path)
+            }
+            return nil
         }
-        if scheme == "file" {
-            guard components.query == nil, components.fragment == nil else { return nil }
-            var path = components.percentEncodedPath.removingPercentEncoding ?? components.path
-            if path.hasPrefix("/"), isWindowsAbsolutePath(String(path.dropFirst())) {
-                path.removeFirst()
-            }
-            if let host = components.host, !host.isEmpty, host.lowercased() != "localhost" {
-                path = "//\(host)\(path)"
-            }
-            guard path.hasPrefix("/") || isWindowsAbsolutePath(path) || isUNCPath(path) else {
-                return nil
-            }
-            return .desktopFile(path: path)
-        }
-        return nil
+
+        // Query strings and fragments belong to the Markdown target, not the
+        // local filename. Decode the path the same way as the scoped server
+        // matcher, while refusing query-only/fragment-only links.
+        let delimiter = value.firstIndex(where: { $0 == "?" || $0 == "#" }) ?? value.endIndex
+        let pathPart = String(value[..<delimiter])
+        guard !pathPart.isEmpty, let path = pathPart.removingPercentEncoding, !path.isEmpty else { return nil }
+        return .desktopFile(path: path)
     }
 
     public static func resolve(_ url: URL) -> LocalMessageLink? {
         let value = url.absoluteString
         if let decoded = value.removingPercentEncoding,
-           isWindowsAbsolutePath(decoded) || isUNCPath(decoded) {
+           isWindowsAbsolutePath(decoded) || isBackslashUNCPath(decoded) {
             return .desktopFile(path: decoded)
         }
         return resolve(value)
@@ -199,8 +225,8 @@ public enum LocalMessageLink: Equatable, Sendable {
         return letter && bytes[1] == 58 && (bytes[2] == 47 || bytes[2] == 92)
     }
 
-    private static func isUNCPath(_ value: String) -> Bool {
-        value.hasPrefix("\\\\") || value.hasPrefix("//")
+    private static func isBackslashUNCPath(_ value: String) -> Bool {
+        value.hasPrefix("\\\\")
     }
 }
 

--- a/ios/Tests/CompanionCoreTests/AttachedMessageContentTests.swift
+++ b/ios/Tests/CompanionCoreTests/AttachedMessageContentTests.swift
@@ -13,8 +13,12 @@ final class AttachedMessageContentTests: XCTestCase {
 
         XCTAssertEqual(parsed.text, "Please review these.")
         XCTAssertEqual(parsed.attachments, [
-            DisplayedMessageAttachment(kind: .image, name: "photo.png"),
-            DisplayedMessageAttachment(kind: .file, name: "Project & notes.pdf"),
+            DisplayedMessageAttachment(kind: .image, path: "/tmp/photo.png", name: "photo.png"),
+            DisplayedMessageAttachment(
+                kind: .file,
+                path: "/tmp/4ad3.pdf",
+                name: "Project & notes.pdf"
+            ),
         ])
     }
 
@@ -25,7 +29,11 @@ final class AttachedMessageContentTests: XCTestCase {
 
         XCTAssertEqual(parsed.text, "")
         XCTAssertEqual(parsed.attachments, [
-            DisplayedMessageAttachment(kind: .file, name: "brief.docx"),
+            DisplayedMessageAttachment(
+                kind: .file,
+                path: #"C:\Users\Maus\brief.docx"#,
+                name: "brief.docx"
+            ),
         ])
     }
 
@@ -35,6 +43,119 @@ final class AttachedMessageContentTests: XCTestCase {
 
         XCTAssertEqual(parsed.text, source)
         XCTAssertTrue(parsed.attachments.isEmpty)
+    }
+
+    func testLeavesFencedAndIndentedAttachmentExamplesVisible() {
+        let source = """
+        ```xml
+        <attached-file path="/tmp/fenced.pdf" />
+        ```
+            <attached-image path="/tmp/spaces.png" />
+        \t<attached-file path="/tmp/tab.md" />
+        <attached-file path="/tmp/real.md" />
+        """
+        let parsed = AttachedMessageContent.parse(source)
+
+        XCTAssertEqual(parsed.attachments.map(\.path), ["/tmp/real.md"])
+        XCTAssertTrue(parsed.text.contains(#"<attached-file path="/tmp/fenced.pdf" />"#))
+        XCTAssertTrue(parsed.text.contains(#"<attached-image path="/tmp/spaces.png" />"#))
+        XCTAssertTrue(parsed.text.contains(#"<attached-file path="/tmp/tab.md" />"#))
+    }
+
+    func testUnclosedStreamingFenceKeepsTransportLookingLinesLiteral() {
+        let source = """
+        Before
+        ~~~
+        <attached-file path="/tmp/not-transport.md" />
+        """
+        let parsed = AttachedMessageContent.parse(source)
+
+        XCTAssertEqual(parsed.text, source)
+        XCTAssertTrue(parsed.attachments.isEmpty)
+    }
+
+    func testLeavesAttachmentExamplesInsideHTMLContextsVisible() {
+        let source = """
+        <!--
+        <attached-file path="/tmp/comment.md" />
+        -->
+        <div class="example">
+        <attached-image path="/tmp/div.png" />
+        </div>
+
+        <pasted-text>
+        <attached-file path="/tmp/paste.pdf" />
+        </pasted-text>
+        <attached-file path="/tmp/real.md" />
+        """
+        let parsed = AttachedMessageContent.parse(source)
+
+        XCTAssertEqual(parsed.attachments.map(\.path), ["/tmp/real.md"])
+        XCTAssertTrue(parsed.text.contains(#"<attached-file path="/tmp/comment.md" />"#))
+        XCTAssertTrue(parsed.text.contains(#"<attached-image path="/tmp/div.png" />"#))
+        XCTAssertTrue(parsed.text.contains(#"<attached-file path="/tmp/paste.pdf" />"#))
+    }
+
+    func testKeepsPreBlocksThroughClosingTagAcrossBlankLines() {
+        let source = """
+        <pre class="example">
+        <attached-file path="/tmp/in-pre.md" />
+
+        </pre>
+        <attached-file path="/tmp/real.md" />
+        """
+        let parsed = AttachedMessageContent.parse(source)
+
+        XCTAssertEqual(parsed.attachments.map(\.path), ["/tmp/real.md"])
+        XCTAssertTrue(parsed.text.contains(#"<attached-file path="/tmp/in-pre.md" />"#))
+    }
+
+    func testKeepsTableAndNestedSectionBlocksThroughBlankLine() {
+        let source = """
+        <table>
+        <attached-file path="/tmp/in-table.csv" />
+        </table>
+
+        <section aria-label="example">
+        <div>
+        <attached-image path="/tmp/in-nested-div.png" />
+        </div>
+        </section>
+        <attached-file path="/tmp/still-html.md" />
+
+        <attached-file path="/tmp/real.md" />
+        """
+        let parsed = AttachedMessageContent.parse(source)
+
+        XCTAssertEqual(parsed.attachments.map(\.path), ["/tmp/real.md"])
+        XCTAssertTrue(parsed.text.contains(#"<attached-file path="/tmp/in-table.csv" />"#))
+        XCTAssertTrue(parsed.text.contains(#"<attached-image path="/tmp/in-nested-div.png" />"#))
+        XCTAssertTrue(parsed.text.contains(#"<attached-file path="/tmp/still-html.md" />"#))
+    }
+
+    func testKeepsSpecialAndGenericHTMLBlocksLiteral() {
+        let source = """
+        <?example
+        <attached-file path="/tmp/in-pi.md" />
+        ?>
+        <![CDATA[
+        <attached-file path="/tmp/in-cdata.md" />
+        ]]>
+        <!example
+        <attached-file path="/tmp/in-declaration.md" />
+        >
+        <widget data-name="example">
+        <attached-file path="/tmp/in-generic.md" />
+        </widget>
+
+        <attached-file path="/tmp/real.md" />
+        """
+        let parsed = AttachedMessageContent.parse(source)
+
+        XCTAssertEqual(parsed.attachments.map(\.path), ["/tmp/real.md"])
+        for name in ["in-pi.md", "in-cdata.md", "in-declaration.md", "in-generic.md"] {
+            XCTAssertTrue(parsed.text.contains(name))
+        }
     }
 
     func testBoundsAndFlattensUntrustedDisplayNames() {
@@ -47,5 +168,36 @@ final class AttachedMessageContentTests: XCTestCase {
         XCTAssertEqual(parsed.attachments[0].name.count, 180)
         XCTAssertFalse(parsed.attachments[0].name.contains("\n"))
         XCTAssertFalse(parsed.attachments[0].name.contains("\u{202E}"))
+    }
+
+    func testRetainsDecodedPathForAuthenticatedPreviewRequest() throws {
+        let parsed = AttachedMessageContent.parse(
+            #"<attached-image path="/tmp/Photos &amp; Files/a&amp;b.png" />"#
+        )
+
+        let attachment = try XCTUnwrap(parsed.attachments.first)
+        XCTAssertEqual(attachment.kind, .image)
+        XCTAssertEqual(attachment.path, "/tmp/Photos & Files/a&b.png")
+        XCTAssertEqual(attachment.name, "a&b.png")
+    }
+
+    func testUsesOriginalNameFromNewImageTags() throws {
+        let parsed = AttachedMessageContent.parse(
+            #"<attached-image path="/tmp/9fd2.png" name="Launch &amp; hero.png" />"#
+        )
+
+        let attachment = try XCTUnwrap(parsed.attachments.first)
+        XCTAssertEqual(attachment.path, "/tmp/9fd2.png")
+        XCTAssertEqual(attachment.name, "Launch & hero.png")
+    }
+
+    func testBasenamesProvidedDisplayName() throws {
+        let parsed = AttachedMessageContent.parse(
+            #"<attached-file path="/tmp/9fd2.pdf" name="../private/Project.pdf" />"#
+        )
+
+        let attachment = try XCTUnwrap(parsed.attachments.first)
+        XCTAssertEqual(attachment.path, "/tmp/9fd2.pdf")
+        XCTAssertEqual(attachment.name, "Project.pdf")
     }
 }

--- a/ios/Tests/CompanionCoreTests/MessageAttachmentsTests.swift
+++ b/ios/Tests/CompanionCoreTests/MessageAttachmentsTests.swift
@@ -30,14 +30,36 @@ final class MessageAttachmentsTests: XCTestCase {
             LocalMessageLink.resolve(#"\\server\share\report.md"#),
             .desktopFile(path: #"\\server\share\report.md"#)
         )
+        XCTAssertEqual(
+            LocalMessageLink.resolve("file://server/share/report.md"),
+            .desktopFile(path: #"\\server\share\report.md"#)
+        )
+        XCTAssertEqual(
+            LocalMessageLink.resolve("//files.example.com/report.md"),
+            .web(try XCTUnwrap(URL(string: "https://files.example.com/report.md")))
+        )
+        XCTAssertEqual(
+            LocalMessageLink.resolve("docs/My Report.md"),
+            .desktopFile(path: "docs/My Report.md")
+        )
+        XCTAssertEqual(
+            LocalMessageLink.resolve("./reports/Quarter%20One.md?download=1#latest"),
+            .desktopFile(path: "./reports/Quarter One.md")
+        )
+        XCTAssertEqual(
+            LocalMessageLink.resolve("/C:/posix/report.md"),
+            .desktopFile(path: "/C:/posix/report.md")
+        )
     }
 
-    func testRejectsRelativeMalformedAndCustomSchemeLinks() {
-        XCTAssertNil(LocalMessageLink.resolve("notes/report.md"))
+    func testRejectsMalformedEmptyAndCustomSchemeLinks() {
+        XCTAssertNil(LocalMessageLink.resolve("#section"))
+        XCTAssertNil(LocalMessageLink.resolve("?download=1"))
         XCTAssertNil(LocalMessageLink.resolve("openmausbot://pair?token=secret"))
         XCTAssertNil(LocalMessageLink.resolve("javascript:alert(1)"))
         XCTAssertNil(LocalMessageLink.resolve("https:///missing-host.md"))
         XCTAssertNil(LocalMessageLink.resolve("file:///tmp/report.md?replace=1"))
+        XCTAssertNil(LocalMessageLink.resolve("docs/bad%ZZ.md"))
         XCTAssertNil(LocalMessageLink.resolve("/tmp/bad\0name.md"))
     }
 

--- a/ios/Tests/CompanionCoreTests/ShareClientTests.swift
+++ b/ios/Tests/CompanionCoreTests/ShareClientTests.swift
@@ -81,7 +81,11 @@ final class ShareClientTests: XCTestCase {
             text: ["  A useful excerpt.\n", "A useful excerpt.", "  "],
             urls: [url, url],
             attachments: [
-                SharedAttachmentReference(path: "/tmp/a&\"b.png", kind: .image),
+                SharedAttachmentReference(
+                    path: "/tmp/a&\"b.png",
+                    kind: .image,
+                    displayName: "Launch & hero.png"
+                ),
                 SharedAttachmentReference(
                     path: "/tmp/notes<final>.pdf",
                     kind: .file,
@@ -97,10 +101,21 @@ final class ShareClientTests: XCTestCase {
 
         https://example.com/story
 
-        <attached-image path="/tmp/a&amp;&quot;b.png" />
+        <attached-image path="/tmp/a&amp;&quot;b.png" name="Launch &amp; hero.png" />
 
         <attached-file path="/tmp/notes&lt;final&gt;.pdf" name="Project notes.pdf" />
         """)
+    }
+
+    func testComposesLegacyUnnamedImageTagWhenNoDisplayNameIsAvailable() {
+        let message = SharedMessageComposer.compose(
+            instruction: "",
+            text: [],
+            urls: [],
+            attachments: [SharedAttachmentReference(path: "/tmp/image.png", kind: .image)]
+        )
+
+        XCTAssertEqual(message, #"<attached-image path="/tmp/image.png" />"#)
     }
 
     func testRawImageUploadKeepsBytesOutOfJSONAndReturnsMacPath() async throws {
@@ -310,6 +325,24 @@ final class ShareClientTests: XCTestCase {
         XCTAssertEqual(file.contentType, "application/octet-stream")
     }
 
+    func testFileDownloadBoundsUnicodeFilenameByUTF8BytesAndKeepsExtension() async throws {
+        ShareRequestStub.responseBody = Data([1])
+        let encodedEmoji = String(repeating: "%F0%9F%93%84", count: 100)
+        ShareRequestStub.responseHeaders = [
+            "Content-Type": "application/pdf",
+            "Content-Disposition": "attachment; filename*=UTF-8''\(encodedEmoji).pdf",
+        ]
+
+        let file = try await client.downloadFile(
+            threadId: "thread-1",
+            messageId: "message-1",
+            path: "/Users/test/fallback.pdf"
+        )
+
+        XCTAssertLessThanOrEqual(file.filename.utf8.count, 180)
+        XCTAssertTrue(file.filename.hasSuffix(".pdf"))
+    }
+
     func testFileDownloadRejectsUnsafeRequestBeforeNetworking() async {
         do {
             _ = try await client.downloadFile(
@@ -323,6 +356,26 @@ final class ShareClientTests: XCTestCase {
         } catch {
             XCTFail("unexpected error: \(error)")
         }
+    }
+
+    func testFileDownloadAllowsScopedRelativeMarkdownTargets() async throws {
+        ShareRequestStub.responseBody = Data("# Report".utf8)
+        ShareRequestStub.responseHeaders = [
+            "Content-Type": "text/markdown",
+            "Content-Disposition": "attachment; filename=report.md",
+        ]
+
+        _ = try await client.downloadFile(
+            threadId: "thread-1",
+            messageId: "message-1",
+            path: "docs/Quarter%20Report.md?download=1#latest"
+        )
+
+        let body = try XCTUnwrap(ShareRequestStub.capturedBody)
+        XCTAssertEqual(
+            try JSONSerialization.jsonObject(with: body) as? [String: String],
+            ["path": "docs/Quarter Report.md"]
+        )
     }
 
     func testFileDownloadRejectsOversizedDeclaredResponse() async {

--- a/server/composer-attachments.test.ts
+++ b/server/composer-attachments.test.ts
@@ -43,7 +43,7 @@ describe("composer paste attachments", () => {
   it("keeps unusual file paths inside the attachment attribute", () => {
     const file = fileAttachment("report.txt", '/tmp/a"&<>\t\n\r.txt', 42);
     expect(composeMessage("", [file])).toBe(
-      '<attached-file path="/tmp/a&quot;&amp;&lt;&gt;&#9;&#10;&#13;.txt" />',
+      '<attached-file path="/tmp/a&quot;&amp;&lt;&gt;&#9;&#10;&#13;.txt" name="report.txt" />',
     );
   });
 

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -209,8 +209,9 @@ beforeAll(async () => {
         id: "test-linked-file-room",
         threadId: "test-linked-file-room-thread",
         name: "Linked file room",
-        memberIds: ["test-bot-a"],
-        defaultResponder: { kind: "member", botId: "test-bot-a" },
+        // Bot A authored the stored links before being removed from this room.
+        memberIds: ["test-bot-b"],
+        defaultResponder: { kind: "member", botId: "test-bot-b" },
         bulletin: "",
         unread: false,
         createdAt: 5,
@@ -232,12 +233,18 @@ beforeAll(async () => {
 
   const linkedWorkspace = join(home, ".openmausbot", "workspaces", "test-bot-a");
   const linkedFile = join(linkedWorkspace, "phone report.md");
+  const linkedImage = join(linkedWorkspace, "preview.png");
+  const privateAttachments = join(home, ".openmausbot", "attachments");
+  const userAttachment = join(privateAttachments, "shared-notes.pdf");
   mkdirSync(linkedWorkspace, { recursive: true });
+  mkdirSync(privateAttachments, { recursive: true, mode: 0o700 });
   writeFileSync(linkedFile, "# Phone-ready report\n");
+  writeFileSync(linkedImage, "png preview bytes");
+  writeFileSync(userAttachment, "%PDF shared from the phone\n", { mode: 0o600 });
   writeFileSync(
     join(home, ".openmausbot", "messages-test-linked-file-room-thread.json"),
     JSON.stringify({
-      activeLeafId: "prose-file-message",
+      activeLeafId: "user-outside-file-message",
       messages: [
         {
           id: "linked-file-message",
@@ -256,6 +263,31 @@ beforeAll(async () => {
           kind: "text",
           text: `I saved another copy at ${linkedFile}.`,
           from: { botId: "test-bot-a", name: "Test bot A", color: "purple" },
+        },
+        {
+          id: "linked-image-message",
+          at: 6.5,
+          parentId: "prose-file-message",
+          role: "bot",
+          kind: "text",
+          text: `![Preview](<${pathToFileURL(linkedImage).href}>)`,
+          from: { botId: "test-bot-a", name: "Test bot A", color: "purple" },
+        },
+        {
+          id: "user-attached-file-message",
+          at: 7,
+          parentId: "linked-image-message",
+          role: "user",
+          kind: "text",
+          text: `<attached-file path="${userAttachment}" name="Trip notes.exe" />`,
+        },
+        {
+          id: "user-outside-file-message",
+          at: 8,
+          parentId: "user-attached-file-message",
+          role: "user",
+          kind: "text",
+          text: `<attached-file path="${linkedFile}" />`,
         },
       ],
     }),
@@ -3474,7 +3506,7 @@ describe("harness HTTP API", () => {
           message.sendId?.startsWith(`calendar_${callId}_`)
         )?.text;
       }, { timeout: 5_000 }).toBe(
-        '@everyone Review the launch plan.\n\n<attached-file path="/tmp/a&quot;&amp;&lt;&gt;.txt" />',
+        '@everyone Review the launch plan.\n\n<attached-file path="/tmp/a&quot;&amp;&lt;&gt;.txt" name="Launch brief.txt" />',
       );
 
       const snapshot = await api("GET", "/api/bots?messages=50");
@@ -5750,6 +5782,56 @@ describe("message pages", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ path: linkedFile }),
     })).status).toBe(404);
+  });
+
+  it("downloads an image rendered by the exact stored bot message", async () => {
+    const threadId = "test-linked-file-room-thread";
+    const linkedImage = join(home, ".openmausbot", "workspaces", "test-bot-a", "preview.png");
+    const response = await fetch(`${BASE}/api/threads/${threadId}/messages/linked-image-message/file`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: linkedImage }),
+    });
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("png preview bytes");
+    expect(response.headers.get("content-type")).toBe("image/png");
+  });
+
+  it("downloads an exact user attachment only from the private attachment store", async () => {
+    const threadId = "test-linked-file-room-thread";
+    const shared = join(home, ".openmausbot", "attachments", "shared-notes.pdf");
+    const response = await fetch(
+      `${BASE}/api/threads/${threadId}/messages/user-attached-file-message/file`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ path: shared }),
+      },
+    );
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("%PDF shared from the phone\n");
+    expect(response.headers.get("content-type")).toBe("application/pdf");
+    expect(response.headers.get("content-disposition")).toContain("Trip%20notes.pdf");
+    expect(response.headers.get("content-disposition")).not.toContain(".exe");
+    expect(response.headers.get("content-disposition")).not.toContain("shared-notes.pdf");
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+
+    expect((await api(
+      "POST",
+      `/api/threads/${threadId}/messages/prose-file-message/file`,
+      { path: shared },
+    )).status).toBe(403);
+    expect((await api(
+      "POST",
+      `/api/threads/${threadId}/messages/user-attached-file-message/file`,
+      { path: join(home, ".openmausbot", "attachments", "different.pdf") },
+    )).status).toBe(403);
+    expect((await api(
+      "POST",
+      `/api/threads/${threadId}/messages/user-outside-file-message/file`,
+      { path: join(home, ".openmausbot", "workspaces", "test-bot-a", "phone report.md") },
+    )).status).toBe(403);
   });
 
   it("404s an image on a conversation that does not exist, without inventing one", async () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -46,6 +46,8 @@ import {
 } from "./attachments.ts";
 import {
   messageFileDisposition,
+  messageFileDownloadName,
+  messageAttachmentName,
   messageFileRoots,
   messageReferencesFile,
   openMessageFile,
@@ -5027,7 +5029,7 @@ function deliverCalendarCall(call: CalendarCall, scheduledFor: number): void {
   const text = [
     `@everyone ${call.description.trim() || call.name}`,
     ...call.attachments.map((attachment) =>
-      `<${attachment.kind === "image" ? "attached-image" : "attached-file"} path="${escapeAttribute(attachment.path)}" />`
+      `<${attachment.kind === "image" ? "attached-image" : "attached-file"} path="${escapeAttribute(attachment.path)}" name="${escapeAttribute(attachment.name)}" />`
     ),
   ].join("\n\n");
   const sendId = `calendar_${call.id}_${scheduledFor}`;
@@ -6854,11 +6856,12 @@ const server = createServer(async (req, res) => {
       return res.end(bytes);
     }
 
-    // Download one local file only when this exact stored bot message links
-    // to it. The message supplies both the capability (the requested path
-    // must be an actual rendered Markdown link target, allowing only
-    // URL-decoding differences) and the bot identity used to derive the
-    // narrow set of roots; this is deliberately not a general path reader.
+    // Download one local file only when this exact stored message grants it:
+    // a bot must render a Markdown link to it, while a user message must carry
+    // the exact standalone attachment tag written by the composer. The bot
+    // branch derives conversation/workspace roots; the user branch is limited
+    // to OpenMausBot's private attachment directory. This is deliberately not
+    // a general path reader.
     m = path.match(/^\/api\/threads\/([\w-]+)\/messages\/([\w-]+)\/file$/);
     if (m && method === "POST") {
       if (!String(req.headers["content-type"] ?? "").toLowerCase().startsWith("application/json")) {
@@ -6874,37 +6877,53 @@ const server = createServer(async (req, res) => {
       const body = await readBody(req);
       const href = typeof body.path === "string" ? body.path : "";
       if (!href) return json(res, 400, { error: "path is required" });
-      if (message.role !== "bot" || message.kind !== "text" || !message.text || !messageReferencesFile(message.text, href)) {
-        return json(res, 403, { error: "that bot message does not link to this file" });
+      if (message.kind !== "text" || !message.text) {
+        return json(res, 403, { error: "that message does not share this file" });
       }
 
-      const senderId = directBot?.id ?? message.from?.botId;
-      if (!senderId || (group && !group.memberIds.includes(senderId))) {
-        return json(res, 403, { error: "the file's bot author could not be verified" });
-      }
-      let pinnedCwd: string | null | undefined;
-      let configuredCwd: string | undefined;
-      if (directBot) {
-        pinnedCwd = store.taskByThread(directBot.id, threadId)?.cwd;
-        configuredCwd = directBot.cwd;
-      } else if (group) {
-        const task = store.groupTaskByThread(group.id, threadId);
-        pinnedCwd = task ? task.pinnedCwd : group.threadId === threadId ? group.pinnedCwd : undefined;
-        configuredCwd = group.cwd;
-      }
+      let roots: string[];
+      let downloadName: string | undefined;
+      if (message.role === "user") {
+        downloadName = messageAttachmentName(message.text, href) ?? undefined;
+        if (!downloadName) {
+          return json(res, 403, { error: "that message does not share this file" });
+        }
+        roots = [ATTACHMENTS_DIR];
+      } else {
+        if (!messageReferencesFile(message.text, href)) {
+          return json(res, 403, { error: "that bot message does not link to this file" });
+        }
+        const senderId = directBot?.id ?? message.from?.botId;
+        // The persisted bot-role message is the author record. Membership is
+        // intentionally not consulted: removing a bot must not break files it
+        // already shared in channel history.
+        if (!senderId) {
+          return json(res, 403, { error: "the file's bot author could not be verified" });
+        }
+        let pinnedCwd: string | null | undefined;
+        let configuredCwd: string | undefined;
+        if (directBot) {
+          pinnedCwd = store.taskByThread(directBot.id, threadId)?.cwd;
+          configuredCwd = directBot.cwd;
+        } else if (group) {
+          const task = store.groupTaskByThread(group.id, threadId);
+          pinnedCwd = task ? task.pinnedCwd : group.threadId === threadId ? group.pinnedCwd : undefined;
+          configuredCwd = group.cwd;
+        }
 
-      const roots = messageFileRoots({
-        senderWorkspace: workspaceDir(senderId),
-        attachments: ATTACHMENTS_DIR,
-        pinnedCwd,
-        configuredCwd,
-      });
+        roots = messageFileRoots({
+          senderWorkspace: workspaceDir(senderId),
+          attachments: ATTACHMENTS_DIR,
+          pinnedCwd,
+          configuredCwd,
+        });
+      }
 
       const file = await openMessageFile(href, roots);
       res.writeHead(200, {
         "content-type": file.mime,
         "content-length": String(file.bytes),
-        "content-disposition": messageFileDisposition(file.name),
+        "content-disposition": messageFileDisposition(messageFileDownloadName(downloadName, file.name)),
         "cache-control": "private, no-store",
         "cdn-cache-control": "no-store",
         "cloudflare-cdn-cache-control": "no-store",
@@ -6985,8 +7004,8 @@ const server = createServer(async (req, res) => {
     }
 
     // ── shared files ────────────────────────────────────────────────────
-    // The iOS share extension sends documents as raw bytes over the same
-    // authenticated companion connection as messages. saveFile writes each
+    // Companion apps and the desktop composer send documents as raw bytes
+    // over the same authenticated connection as messages. saveFile writes each
     // incoming chunk directly to disk, atomically commits it, and removes
     // partial uploads on error. Its optional UUID uploadId is stable across
     // route retries, while the aggregate store quota rejects rather than

--- a/server/message-file.test.ts
+++ b/server/message-file.test.ts
@@ -7,7 +7,10 @@ import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import {
   MESSAGE_FILE_MAX_BYTES,
   messageFileDisposition,
+  messageFileDownloadName,
+  messageAttachmentName,
   messageFileRoots,
+  messageReferencesAttachment,
   messageReferencesFile,
   openMessageFile,
 } from "./message-file.ts";
@@ -64,6 +67,10 @@ describe("message-linked files", () => {
       "\\\\server\\share\\phone report.md",
     )).toBe(true);
     expect(messageReferencesFile(
+      "[This is a website](//server/share/phone%20report.md)",
+      "\\\\server\\share\\phone report.md",
+    )).toBe(false);
+    expect(messageReferencesFile(
       "[Open A&amp;B](docs/A&amp;B.md \"download\")",
       "docs/A&B.md",
     )).toBe(true);
@@ -80,6 +87,28 @@ describe("message-linked files", () => {
       .toBe(false);
     expect(messageReferencesFile("[Open it](C:/Users/Maus/report.md)", "c:/users/maus/report.md"))
       .toBe(false);
+  });
+
+  it("normalizes encoded Windows and UNC targets before authorization", () => {
+    expect(messageReferencesFile(
+      "[Open it](C:/Users/Maus/release%20notes.md?download=1#latest)",
+      "C:\\Users\\Maus\\release notes.md",
+    )).toBe(true);
+    expect(messageReferencesFile(
+      "[Web link](//server/share/team%20notes.md?download=1#latest)",
+      "\\\\server\\share\\team notes.md",
+    )).toBe(false);
+    expect(messageReferencesFile(
+      "[Open it](%5C%5Cserver%5Cshare%5Cteam%20notes.md?download=1)",
+      "//server/share/team notes.md",
+    )).toBe(true);
+
+    // Decoding is deliberately single-pass: a double-encoded space must not
+    // authorize the ordinary decoded path.
+    expect(messageReferencesFile(
+      "[Open it](C:/Users/Maus/release%2520notes.md?download=1)",
+      "C:\\Users\\Maus\\release notes.md",
+    )).toBe(false);
   });
 
   it("resolves only definitions used by rendered reference links", () => {
@@ -105,9 +134,6 @@ describe("message-linked files", () => {
       "`[x](/project/.env)`",
       "``look at `[x](/project/.env)` here``",
       "\\[x](/project/.env)",
-      "![x](/project/.env)",
-      "![x](</project/.env>)",
-      "![x][secret]\n\n[secret]: /project/.env",
       "<!-- [x](/project/.env) -->",
       "<attached-file path=\"/project/.env\" />",
       "I saved it at /project/.env.",
@@ -120,10 +146,74 @@ describe("message-linked files", () => {
       path,
     )).toBe(true);
     expect(messageReferencesFile("\\![open](/project/.env)", path)).toBe(true);
+    expect(messageReferencesFile("![preview](/project/.env)", path)).toBe(true);
+    expect(messageReferencesFile("![preview][secret]\n\n[secret]: /project/.env", path)).toBe(true);
     expect(messageReferencesFile(
       "[not a valid destination](/project/foo\\ bar.md)",
       "/project/foo\\ bar.md",
     )).toBe(false);
+  });
+
+  it("matches only exact standalone attachment tags", () => {
+    const path = "/app/attachments/report & notes.pdf";
+    expect(messageReferencesAttachment(
+      '<attached-file path="/app/attachments/report &amp; notes.pdf" />',
+      path,
+    )).toBe(true);
+    expect(messageReferencesAttachment(
+      'A note\n<attached-image path="/app/attachments/report &amp; notes.pdf" name="report.pdf" />\n',
+      path,
+    )).toBe(true);
+    expect(messageReferencesAttachment(`<attached-file path="${path}" />`, "/app/attachments/other.pdf"))
+      .toBe(false);
+
+    for (const text of [
+      `Use <attached-file path="${path}" /> as an example`,
+      `<attached-file path="${path}" /> as an example`,
+      `\`<attached-file path="${path}" />\``,
+      `\`\`\`\n<attached-file path="${path}" />\n\`\`\``,
+      `    <attached-file path="${path}" />`,
+      `> <attached-file path="${path}" />`,
+      `<!-- example\n<attached-file path="${path}" />\n-->`,
+      `<pre>\n<attached-file path="${path}" />\n</pre>`,
+      `<div>\n<attached-file path="${path}" />\n</div>`,
+      `<pasted-text>\n<attached-file path="${path}" />\n</pasted-text>`,
+      `<attached-file name="report.pdf" path="${path}" />`,
+      `<attached-file path="${path}" extra="yes" />`,
+      `<attached-file path="${path}">`,
+    ]) {
+      expect(messageReferencesAttachment(text, path), text).toBe(false);
+    }
+  });
+
+  it("preserves the sanitized attachment display name", () => {
+    const path = "/app/attachments/4e8d.pdf";
+    expect(messageAttachmentName(
+      `<attached-file path="${path}" name="Quarterly &amp; review.pdf" />`,
+      path,
+    )).toBe("Quarterly & review.pdf");
+    expect(messageAttachmentName(`<attached-file path="${path}" name="../renamed.pdf" />`, path))
+      .toBe("renamed.pdf");
+    expect(messageAttachmentName("not an attachment", path)).toBeNull();
+    expect(messageAttachmentName(`<attached-file path="${path}" />`, "\0")).toBeNull();
+    const hostile = `folder\\sub/${"a".repeat(220)}\u202E\ud800.pdf`;
+    const safe = messageAttachmentName(`<attached-file path="${path}" name="${hostile}" />`, path);
+    expect(Buffer.byteLength(safe ?? "")).toBeLessThanOrEqual(180);
+    expect(safe).not.toContain("/");
+    expect(safe).not.toContain("\\");
+    expect(() => messageFileDisposition(hostile)).not.toThrow();
+  });
+
+  it("bounds Unicode display names by UTF-8 bytes while preserving the extension", () => {
+    const path = "/app/attachments/4e8d.pdf";
+    const safe = messageAttachmentName(
+      `<attached-file path="${path}" name="${"📄".repeat(100)}.pdf" />`,
+      path,
+    );
+
+    expect(safe).toMatch(/\.pdf$/);
+    expect(Buffer.byteLength(safe ?? "")).toBeLessThanOrEqual(180);
+    expect(() => messageFileDisposition(safe ?? "")).not.toThrow();
   });
 
   it("opens encoded relative and file URL links through a stable handle", async () => {
@@ -142,6 +232,33 @@ describe("message-linked files", () => {
     const absolute = await openMessageFile(pathToFileURL(path).href, [workspace]);
     expect(await absolute.handle.readFile("utf8")).toBe("# unchanged bytes\n");
     await absolute.handle.close();
+  });
+
+  it("normalizes an encoded Windows path before opening it", async () => {
+    const path = process.platform === "win32"
+      ? join(workspace, "release notes.md")
+      : join(workspace, "C:\\Users\\Maus\\release notes.md");
+    const href = process.platform === "win32"
+      ? `${path.replace("release notes.md", "release%20notes.md")}?download=1#latest`
+      : "C:\\Users\\Maus\\release%20notes.md?download=1#latest";
+    writeFileSync(path, "windows path bytes");
+
+    const opened = await openMessageFile(href, [workspace]);
+    expect(await opened.handle.readFile("utf8")).toBe("windows path bytes");
+    await opened.handle.close();
+  });
+
+  it("serves OpenDocument formats with their standard MIME types", async () => {
+    for (const [extension, mime] of [
+      ["odt", "application/vnd.oasis.opendocument.text"],
+      ["ods", "application/vnd.oasis.opendocument.spreadsheet"],
+      ["odp", "application/vnd.oasis.opendocument.presentation"],
+    ] as const) {
+      writeFileSync(join(workspace, `document.${extension}`), "open document");
+      const file = await openMessageFile(`document.${extension}`, [workspace]);
+      expect(file.mime).toBe(mime);
+      await file.handle.close();
+    }
   });
 
   it("refuses traversal and a symlink that resolves outside the allowed root", async () => {
@@ -172,5 +289,11 @@ describe("message-linked files", () => {
     expect(header).toContain("filename*=UTF-8''r%C3%A9sum%C3%A9%20%22final%22.md");
     expect(header).not.toContain("\r");
     expect(header).not.toContain("\n");
+  });
+
+  it("never lets a display name disguise the canonical file extension", () => {
+    expect(messageFileDownloadName("Quarterly report.pdf", "4e8d.pdf")).toBe("Quarterly report.pdf");
+    expect(messageFileDownloadName("setup.exe", "4e8d.pdf")).toBe("setup.pdf");
+    expect(messageFileDownloadName("preview.jpg", "4e8d.png")).toBe("preview.png");
   });
 });

--- a/server/message-file.ts
+++ b/server/message-file.ts
@@ -37,15 +37,42 @@ function statusError(status: number, message: string): Error & { status: number 
   return Object.assign(new Error(message), { status });
 }
 
-function referencedPath(href: string, portableFileURL = false): string {
+function decodePathWithSuffixRemoved(href: string): string {
+  // Split before decoding so an encoded `?` or `#` remains part of the
+  // filename, while a real Markdown query/fragment never reaches the file
+  // lookup. Decode exactly once so authorization and opening see the same
+  // path without making double-encoded input more privileged.
+  const path = href.split(/[?#]/, 1)[0]!;
+  if (!path) throw statusError(400, "path must be a non-empty file link");
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    throw statusError(400, "path must be a valid file link");
+  }
+}
+
+function referencedPath(
+  href: string,
+  portableFileURL = false,
+  allowForwardSlashUNC = true,
+): string {
   if (!href || Buffer.byteLength(href) > 8_192 || href.includes("\0")) {
     throw statusError(400, "path must be a non-empty file link");
   }
   // A Windows drive prefix is a path, not a one-letter URL scheme. UNC is
   // also already an absolute local path on Windows and must not be mistaken
   // for a protocol-relative web URL.
-  if (/^[a-z]:[\\/]/i.test(href) || href.startsWith("\\\\") || href.startsWith("//")) {
-    return href;
+  if (/^[a-z]:[\\/]/i.test(href) || href.startsWith("\\\\")) {
+    return decodePathWithSuffixRemoved(href);
+  }
+  // In Markdown, //host/path is a protocol-relative web URL. It is accepted
+  // only as the normalized request spelling of an explicit file:// UNC link,
+  // never as the authored capability itself.
+  if (href.startsWith("//")) {
+    if (!allowForwardSlashUNC) {
+      throw statusError(400, "protocol-relative web links are not local files");
+    }
+    return decodePathWithSuffixRemoved(href);
   }
   if (/^[a-z][a-z\d+.-]*:/i.test(href)) {
     let url: URL;
@@ -84,12 +111,7 @@ function referencedPath(href: string, portableFileURL = false): string {
 
   // Query strings and fragments belong to the Markdown link, not the local
   // filename. Percent-encoding is common for spaces in relative hrefs.
-  const path = href.split(/[?#]/, 1)[0]!;
-  try {
-    return decodeURIComponent(path);
-  } catch {
-    throw statusError(400, "path must be a valid file link");
-  }
+  return decodePathWithSuffixRemoved(href);
 }
 
 /**
@@ -100,8 +122,8 @@ function referencedPath(href: string, portableFileURL = false): string {
  * identity also prevents a POSIX path such as `/C:/notes.md` from being
  * mistaken for the Windows path `C:\\notes.md`.
  */
-function referencedPathIdentity(href: string): string {
-  const path = referencedPath(href, true);
+function referencedPathIdentity(href: string, allowForwardSlashUNC = true): string {
+  const path = referencedPath(href, true, allowForwardSlashUNC);
   if (/^[a-z]:[\\/]/i.test(path) || path.startsWith("\\\\") || path.startsWith("//")) {
     return `windows:${win32.resolve(path)}`;
   }
@@ -114,6 +136,11 @@ type MarkdownNode = {
   children?: MarkdownNode[];
   identifier?: string;
   url?: string;
+  value?: string;
+  position?: {
+    start: { offset?: number };
+    end: { offset?: number };
+  };
 };
 
 function walkMarkdown(node: MarkdownNode, visit: (node: MarkdownNode) => void): void {
@@ -136,9 +163,9 @@ function renderedMarkdownTargets(markdown: string): string[] {
   walkMarkdown(fromMarkdown(markdown), (node) => {
     if (node.type === "definition" && node.identifier && node.url) {
       if (!definitions.has(node.identifier)) definitions.set(node.identifier, node.url);
-    } else if (node.type === "link" && node.url) {
+    } else if ((node.type === "link" || node.type === "image") && node.url) {
       links.push(node.url);
-    } else if (node.type === "linkReference" && node.identifier) {
+    } else if ((node.type === "linkReference" || node.type === "imageReference") && node.identifier) {
       references.push(node.identifier);
     }
   });
@@ -167,12 +194,116 @@ export function messageReferencesFile(text: string, requested: string): boolean 
 
   for (const target of renderedMarkdownTargets(text)) {
     try {
-      if (referencedPathIdentity(target) === wanted) return true;
+      if (referencedPathIdentity(target, false) === wanted) return true;
     } catch {
       // A malformed candidate is not the link the client asked to open.
     }
   }
   return false;
+}
+
+/** Decode exactly the entity spellings emitted by the composer. A single
+ * pass is intentional: double-encoded input must not turn into a path only
+ * while it is being authorised. */
+function decodeAttachmentAttribute(value: string): string {
+  return value.replace(
+    /&(quot|lt|gt|amp);|&#(9|10|13);/g,
+    (entity, named: string | undefined, numeric: string | undefined) => {
+      if (numeric === "9") return "\t";
+      if (numeric === "10") return "\n";
+      if (numeric === "13") return "\r";
+      if (named === "quot") return '"';
+      if (named === "lt") return "<";
+      if (named === "gt") return ">";
+      if (named === "amp") return "&";
+      return entity;
+    },
+  );
+}
+
+function utf8Prefix(value: string, maximumBytes: number): string {
+  let bytes = 0;
+  let result = "";
+  for (const character of value) {
+    const size = Buffer.byteLength(character);
+    if (bytes + size > maximumBytes) break;
+    result += character;
+    bytes += size;
+  }
+  return result;
+}
+
+/** Keep the eventual native filename below common 255-byte component limits.
+ * 180 bytes leaves room for the app's temporary-file suffix. */
+function boundedDisplayName(value: string, maximumBytes = 180): string {
+  if (Buffer.byteLength(value) <= maximumBytes) return value;
+  const extension = extname(value);
+  const extensionBytes = Buffer.byteLength(extension);
+  if (extension && extensionBytes <= 32 && extensionBytes < maximumBytes) {
+    const stem = utf8Prefix(value.slice(0, -extension.length), maximumBytes - extensionBytes);
+    if (stem) return `${stem}${extension}`;
+  }
+  return utf8Prefix(value, maximumBytes) || "download";
+}
+
+function safeDisplayName(value: string): string {
+  const portable = value.split(/[\\/]/).at(-1) ?? "";
+  const clean = Array.from(portable, (character) => {
+    const code = character.codePointAt(0) ?? 0;
+    const invalid = code <= 31 || (code >= 127 && code <= 159)
+      || (code >= 0xd800 && code <= 0xdfff)
+      || (code >= 0x202a && code <= 0x202e)
+      || (code >= 0x2066 && code <= 0x2069);
+    return invalid ? "_" : character;
+  }).join("").trim();
+  return boundedDisplayName(clean || "download");
+}
+
+/**
+ * Confirm that a stored user message carries the requested attachment as an
+ * exact standalone transport tag. Plain prose, inline examples, fenced code,
+ * and near-matching paths do not grant access. The HTTP route pairs this
+ * message capability with ATTACHMENTS_DIR containment, so this can never
+ * become an arbitrary host-file reader.
+ */
+export function messageReferencesAttachment(text: string, requested: string): boolean {
+  return messageAttachmentName(text, requested) !== null;
+}
+
+/** Return the user-facing name carried by an authorised attachment tag. */
+export function messageAttachmentName(text: string, requested: string): string | null {
+  let wanted: string;
+  try {
+    wanted = referencedPathIdentity(requested);
+  } catch {
+    return null;
+  }
+
+  const tag = /^<attached-(?:image|file)[\t ]+path="([^"\r\n]*)"(?:[\t ]+name="([^"\r\n]*)")?[\t ]*\/>$/;
+  let found: string | null = null;
+  walkMarkdown(fromMarkdown(text), (node) => {
+    if (found !== null) return;
+    if (node.type !== "html" || !node.value || !node.position) return;
+    const start = node.position.start.offset;
+    const end = node.position.end.offset;
+    if (start === undefined || end === undefined) return;
+    const lineStart = text.lastIndexOf("\n", start - 1) + 1;
+    const nextLine = text.indexOf("\n", end);
+    const lineEnd = nextLine < 0 ? text.length : nextLine;
+    if (text.slice(lineStart, start).trim() || text.slice(end, lineEnd).trim()) return;
+    const match = tag.exec(node.value);
+    if (!match) return;
+    try {
+      if (referencedPathIdentity(decodeAttachmentAttribute(match[1]!)) === wanted) {
+        found = safeDisplayName(match[2]
+          ? decodeAttachmentAttribute(match[2])
+          : decodeAttachmentAttribute(match[1]!));
+      }
+    } catch {
+      // A malformed transport tag grants no capability.
+    }
+  });
+  return found;
 }
 
 function containedBy(root: string, candidate: string): boolean {
@@ -200,6 +331,9 @@ function mimeFor(path: string): string {
     case ".xlsx": return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
     case ".ppt": return "application/vnd.ms-powerpoint";
     case ".pptx": return "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+    case ".odt": return "application/vnd.oasis.opendocument.text";
+    case ".ods": return "application/vnd.oasis.opendocument.spreadsheet";
+    case ".odp": return "application/vnd.oasis.opendocument.presentation";
     default: return "application/octet-stream";
   }
 }
@@ -277,13 +411,28 @@ export async function openMessageFile(href: string, roots: readonly string[]): P
 
 /** A safe attachment header with a readable ASCII fallback and UTF-8 name. */
 export function messageFileDisposition(name: string): string {
-  const fallback = name
+  const safeName = safeDisplayName(name);
+  const fallback = safeName
     .normalize("NFKD")
     .replace(/[^\x20-\x7e]/g, "_")
     .replace(/["\\]/g, "_")
     .slice(0, 180) || "download";
-  const encoded = encodeURIComponent(name).replace(/[!'()*]/g, (char) =>
+  const encoded = encodeURIComponent(safeName).replace(/[!'()*]/g, (char) =>
     `%${char.charCodeAt(0).toString(16).toUpperCase()}`
   );
   return `attachment; filename="${fallback}"; filename*=UTF-8''${encoded}`;
+}
+
+/** Keep a friendly transport name without allowing it to disguise the bytes'
+ * canonical extension (for example PDF bytes named setup.exe). */
+export function messageFileDownloadName(displayName: string | undefined, canonicalName: string): string {
+  const canonical = safeDisplayName(canonicalName);
+  if (!displayName) return canonical;
+  const display = safeDisplayName(displayName);
+  const actualExtension = extname(canonical);
+  if (!actualExtension) return canonical;
+  if (extname(display).toLowerCase() === actualExtension.toLowerCase()) return display;
+  const displayExtension = extname(display);
+  const stem = displayExtension ? display.slice(0, -displayExtension.length) : display;
+  return safeDisplayName(`${stem || "download"}${actualExtension}`);
 }

--- a/server/replies.test.ts
+++ b/server/replies.test.ts
@@ -14,6 +14,8 @@ const message = (patch: Partial<Message> = {}): Message => ({
 describe("flat replies", () => {
   it("bounds and cleans quoted attachment text", () => {
     expect(replyExcerpt('<attached-image path="/tmp/shot.png" />  hello\nworld')).toBe("[image] hello world");
+    expect(replyExcerpt('<attached-image path="/tmp/shot.png" name="Shot.png" />')).toBe("[image]");
+    expect(replyExcerpt('<attached-file path="/tmp/plan.pdf" name="Plan.pdf" />')).toBe("[file]");
     expect(replyExcerpt("x".repeat(1_000), 20)).toHaveLength(20);
   });
 

--- a/server/replies.ts
+++ b/server/replies.ts
@@ -4,7 +4,10 @@ const MAX_REPLY_EXCERPT = 900;
 
 export function replyExcerpt(text: string, limit = MAX_REPLY_EXCERPT): string {
   const clean = text
-    .replace(/<attached-image\s+path="[^"]*"\s*\/>/g, "[image]")
+    .replace(
+      /<attached-(image|file)\s+path="[^"]*"(?:\s+name="[^"]*")?\s*\/>/g,
+      (_tag, kind: "image" | "file") => kind === "image" ? "[image]" : "[file]",
+    )
     .replace(/\s+/g, " ")
     .trim();
   if (clean.length <= limit) return clean;

--- a/server/routines.test.ts
+++ b/server/routines.test.ts
@@ -1122,7 +1122,7 @@ describe("RoutineManager", () => {
     h.setBot("ready");
     await h.manager.tick();
     expect(h.started[0]?.prompt).toBe(
-      'Use the original attachment\n\n<attached-file path="/tmp/original.txt" />',
+      'Use the original attachment\n\n<attached-file path="/tmp/original.txt" name="original.txt" />',
     );
     expect(h.manager.listRuns()[0]?.attachments?.[0]?.path).toBe("/tmp/original.txt");
     expect(h.manager.listRoutines()[0]?.attachments?.[0]?.path).toBe("/tmp/replacement.txt");
@@ -1148,7 +1148,7 @@ describe("RoutineManager", () => {
     await h.manager.tick();
 
     expect(h.started[0]?.prompt).toBe(
-      'Inspect it\n\n<attached-image path="/tmp/a&quot;&amp;&lt;&gt;&#9;&#10;&#13;.png" />',
+      'Inspect it\n\n<attached-image path="/tmp/a&quot;&amp;&lt;&gt;&#9;&#10;&#13;.png" name="image.png" />',
     );
     expect(h.manager.listRoutines()[0]?.prompt).toBe("Inspect it");
     expect(h.manager.listRoutines()[0]?.attachments?.[0]?.path).toBe(unusualPath);

--- a/server/routines.ts
+++ b/server/routines.ts
@@ -347,7 +347,9 @@ function composeExecutionPrompt(prompt: string, attachments: readonly RoutineCon
   const parts = [prompt];
   for (const attachment of attachments ?? []) {
     const tag = attachment.kind === "image" ? "attached-image" : "attached-file";
-    parts.push(`<${tag} path="${escapeAttachmentPath(attachment.path)}" />`);
+    parts.push(
+      `<${tag} path="${escapeAttachmentPath(attachment.path)}" name="${escapeAttachmentPath(attachment.name)}" />`,
+    );
   }
   return parts.filter(Boolean).join("\n\n");
 }

--- a/src/components/AttachmentPreview.test.ts
+++ b/src/components/AttachmentPreview.test.ts
@@ -1,0 +1,151 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  AttachedFileChips,
+  AttachedImageGallery,
+  MarkdownImagePreview,
+  canonicalDownloadFilename,
+  contentDispositionFilename,
+  imageGalleryLayout,
+  isExternalImageSource,
+  previewImage,
+  previewKeyAction,
+  safeDownloadFilename,
+  wrappedImageIndex,
+} from "./AttachmentPreview";
+
+describe("attachment image navigation", () => {
+  it("wraps previous and next navigation", () => {
+    expect(wrappedImageIndex(0, -1, 3)).toBe(2);
+    expect(wrappedImageIndex(2, 1, 3)).toBe(0);
+    expect(wrappedImageIndex(0, 1, 0)).toBe(0);
+  });
+
+  it("maps preview keys only when the action is available", () => {
+    expect(previewKeyAction("Escape", 1)).toBe("close");
+    expect(previewKeyAction("ArrowLeft", 3)).toBe("previous");
+    expect(previewKeyAction("ArrowRight", 3)).toBe("next");
+    expect(previewKeyAction("ArrowRight", 1)).toBeNull();
+    expect(previewKeyAction("Enter", 3)).toBeNull();
+  });
+
+  it("uses compact responsive grids for one, two, and many images", () => {
+    expect(imageGalleryLayout(1)).toContain("grid-cols-1");
+    expect(imageGalleryLayout(2)).toContain("grid-cols-2");
+    expect(imageGalleryLayout(3)).toContain("sm:grid-cols-3");
+  });
+});
+
+describe("attachment download filenames", () => {
+  it("prefers the UTF-8 server filename and makes it portable", () => {
+    expect(contentDispositionFilename(
+      `attachment; filename="fallback.md"; filename*=UTF-8''..%2Fnotes%2Fr%C3%A9sum%C3%A9%20%22final%22.md`,
+    )).toBe("résumé _final_.md");
+    expect(safeDownloadFilename("../../AUX.txt")).toBe("_AUX.txt");
+    expect(safeDownloadFilename(`bad\u202ename\ud800.txt`)).toBe("badname.txt");
+  });
+
+  it("uses a safe fallback when the response has no filename", () => {
+    expect(canonicalDownloadFilename({
+      fallback: "../reports/quarterly?.pdf",
+      source: "/private/attachment.pdf",
+      mime: "application/pdf",
+    })).toBe("quarterly_.pdf");
+  });
+
+  it("lets image bytes or their canonical source override a spoofed extension", () => {
+    expect(canonicalDownloadFilename({
+      contentDisposition: `attachment; filename="setup.exe"`,
+      source: "/private/opaque",
+      mime: "image/png",
+    })).toBe("setup.png");
+    expect(canonicalDownloadFilename({
+      contentDisposition: `attachment; filename="holiday.pdf"`,
+      source: "/api/attachments/123.jpeg?download=1",
+    })).toBe("holiday.jpeg");
+  });
+});
+
+describe("external image privacy", () => {
+  it("classifies the image source independently from an outer link", () => {
+    expect(isExternalImageSource("https://assets.example/image.png")).toBe(true);
+    expect(isExternalImageSource("//assets.example/image.png")).toBe(true);
+    expect(isExternalImageSource("https:assets.example/image.png")).toBe(true);
+    expect(isExternalImageSource("https:/assets.example/image.png")).toBe(true);
+    expect(isExternalImageSource("https:\\assets.example\\image.png")).toBe(true);
+    expect(isExternalImageSource("HTTP:assets.example/pixel.gif")).toBe(true);
+    expect(isExternalImageSource("/\t/assets.example/pixel.gif")).toBe(true);
+    expect(isExternalImageSource("/\n/assets.example/pixel.gif")).toBe(true);
+    expect(isExternalImageSource("/\r/assets.example/pixel.gif")).toBe(true);
+    expect(isExternalImageSource("\\\\assets.example\\pixel.gif")).toBe(true);
+    expect(isExternalImageSource("/api/attachments/image.png")).toBe(false);
+  });
+});
+
+describe("attachment preview surfaces", () => {
+  it("keeps a stable loading tile and the original image name", () => {
+    const html = renderToStaticMarkup(createElement(AttachedImageGallery, {
+      paths: [{
+        path: "/store/123e4567-e89b-12d3-a456-426614174000.png",
+        name: "Launch artwork.png",
+        private: true,
+      }],
+    }));
+
+    expect(html).toContain("aspect-[4/3]");
+    expect(html).toContain("Loading Launch artwork.png");
+    expect(html).toContain("Preview attached image Launch artwork.png");
+    expect(html).toContain("/api/attachments/123e4567-e89b-12d3-a456-426614174000.png");
+  });
+
+  it("keeps remote Markdown images private until explicitly loaded", () => {
+    const html = renderToStaticMarkup(createElement(MarkdownImagePreview, {
+      src: "https://assets.example/preview.png?signature=abc",
+      name: "Result image",
+      openUrl: "https://assets.example/preview.png?signature=abc",
+    }));
+
+    expect(html).toContain("External image hidden for privacy");
+    expect(html).toContain("Load image");
+    expect(html).not.toContain("src=\"https://assets.example/preview.png?signature=abc\"");
+    expect(html).toContain("https://assets.example/preview.png?signature=abc");
+  });
+
+  it("does not need an outer link to hide a remote Markdown image", () => {
+    const html = renderToStaticMarkup(createElement(MarkdownImagePreview, {
+      src: "//assets.example/preview.png",
+      name: "Result image",
+    }));
+
+    expect(html).toContain("External image hidden for privacy");
+    expect(html).not.toContain("src=\"//assets.example/preview.png\"");
+  });
+
+  it("uses the stored image extension for downloads, not the display label", () => {
+    expect(previewImage(
+      "/store/123e4567-e89b-12d3-a456-426614174000.png",
+      "quarterly-report.pdf",
+    )?.downloadName).toBe("quarterly-report.png");
+  });
+
+  it("keeps legacy transcript file chips visible but inert", () => {
+    const html = renderToStaticMarkup(createElement(AttachedFileChips, {
+      files: [{ path: "/store/123e4567-e89b-42d3-a456-426614174000.pdf", name: "Final report.pdf", private: true }],
+    }));
+
+    expect(html).toContain("Final report.pdf");
+    expect(html).toContain("Unavailable");
+    expect(html).not.toContain("type=\"button\"");
+  });
+
+  it("makes message-authorized transcript files explicit save actions", () => {
+    const html = renderToStaticMarkup(createElement(AttachedFileChips, {
+      files: [{ path: "/store/123e4567-e89b-42d3-a456-426614174000.pdf", name: "Final report.pdf", private: true }],
+      message: { threadId: "thread-1", messageId: "message-1" },
+    }));
+    expect(html).toContain("Save a copy of Final report.pdf");
+    expect(html).toContain("type=\"button\"");
+  });
+});

--- a/src/components/AttachmentPreview.tsx
+++ b/src/components/AttachmentPreview.tsx
@@ -1,40 +1,341 @@
-// Same-origin image thumbnails and an in-app lightbox. Transcript text can
-// contain arbitrary strings, so callers pass saved paths and this component
-// resolves them through attachmentImageUrl rather than loading them as URLs.
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+// Same-origin attachment previews plus the reusable image viewer used by
+// Markdown. Transcript paths are resolved through attachmentImageUrl; model
+// text never gets to turn an arbitrary local path into a browser request.
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
-import { Download, FileText, ImageOff, Maximize2, X } from "lucide-react";
+import {
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  Download,
+  ExternalLink,
+  FileText,
+  ImageOff,
+  LoaderCircle,
+  Maximize2,
+  RotateCcw,
+  X,
+} from "lucide-react";
 
-import { attachmentBasename, attachmentImageUrl, type TranscriptFileAttachment } from "@/lib/composer-attachments";
+import {
+  attachmentBasename,
+  attachmentImageUrl,
+  type TranscriptFileAttachment,
+  type TranscriptImageAttachment,
+} from "@/lib/composer-attachments";
 import { cn } from "@/lib/cn";
 
 export interface PreviewImage {
   src: string;
   name: string;
+  /** Same-origin images can be downloaded directly. */
+  downloadUrl?: string;
+  /** A portable filename chosen independently from the visible label. */
+  downloadName?: string;
+  /** Authored remote images keep an explicit way to open their source. */
+  openUrl?: string;
 }
 
-export function previewImage(path: string): PreviewImage | null {
+export interface MessageAttachmentContext { threadId: string; messageId: string }
+
+export function previewImage(path: string, name = attachmentBasename(path)): PreviewImage | null {
   const src = attachmentImageUrl(path);
   if (!src) return null;
-  return { src, name: attachmentBasename(path) };
+  return {
+    src,
+    name,
+    downloadUrl: src,
+    downloadName: canonicalDownloadFilename({ fallback: name, source: path }),
+  };
 }
 
-export function AttachmentPreviewDialog({ image, onClose }: { image: PreviewImage; onClose: () => void }) {
+export function wrappedImageIndex(index: number, step: -1 | 1, count: number): number {
+  if (count <= 0) return 0;
+  return (index + step + count) % count;
+}
+
+export type PreviewKeyAction = "close" | "previous" | "next" | null;
+
+export function previewKeyAction(key: string, count: number): PreviewKeyAction {
+  if (key === "Escape") return "close";
+  if (count > 1 && key === "ArrowLeft") return "previous";
+  if (count > 1 && key === "ArrowRight") return "next";
+  return null;
+}
+
+export function imageGalleryLayout(count: number): string {
+  if (count <= 1) return "w-[min(32rem,70vw)] grid-cols-1";
+  if (count === 2) return "w-[min(36rem,70vw)] grid-cols-2";
+  return "w-[min(38rem,70vw)] grid-cols-2 sm:grid-cols-3";
+}
+
+const IMAGE_EXTENSION_BY_MIME: Readonly<Record<string, string>> = {
+  "image/avif": "avif",
+  "image/bmp": "bmp",
+  "image/gif": "gif",
+  "image/heic": "heic",
+  "image/heif": "heif",
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/tiff": "tiff",
+  "image/webp": "webp",
+};
+
+const IMAGE_EXTENSIONS = new Set([
+  "avif",
+  "bmp",
+  "gif",
+  "heic",
+  "heif",
+  "jpeg",
+  "jpg",
+  "png",
+  "tif",
+  "tiff",
+  "webp",
+]);
+
+/** Keep a suggested download name portable and prevent it from naming a path. */
+export function safeDownloadFilename(value: string | null | undefined): string {
+  const basename = (value ?? "").split(/[\\/]/).at(-1) ?? "";
+  const cleaned = basename
+    .normalize("NFC")
+    .replace(/[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/g, "")
+    .replace(/[<>:"|?*]/g, "_")
+    .trim()
+    .replace(/[. ]+$/g, "");
+  const bounded = Array.from(cleaned)
+    .filter((character) => {
+      const code = character.charCodeAt(0);
+      return character.length > 1 || code < 0xd800 || code > 0xdfff;
+    })
+    .slice(0, 180)
+    .join("");
+  if (!bounded) return "download";
+  const stem = bounded.split(".", 1)[0]!.toUpperCase();
+  return /^(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/.test(stem) ? `_${bounded}` : bounded;
+}
+
+/** Read the server-selected filename, preferring RFC 5987's UTF-8 form. */
+export function contentDispositionFilename(header: string | null): string | null {
+  if (!header) return null;
+  const encoded = /(?:^|;)\s*filename\*\s*=\s*(?:UTF-8'[^']*')?([^;]*)/i.exec(header)?.[1]?.trim();
+  if (encoded) {
+    const unquoted = encoded.replace(/^"|"$/g, "");
+    try {
+      return safeDownloadFilename(decodeURIComponent(unquoted));
+    } catch {
+      // A malformed extended value may still have a valid ASCII fallback.
+    }
+  }
+  const quoted = /(?:^|;)\s*filename\s*=\s*"((?:\\.|[^"\\])*)"/i.exec(header)?.[1];
+  if (quoted !== undefined) return safeDownloadFilename(quoted.replace(/\\(.)/g, "$1"));
+  const plain = /(?:^|;)\s*filename\s*=\s*([^;]*)/i.exec(header)?.[1]?.trim();
+  return plain ? safeDownloadFilename(plain) : null;
+}
+
+function sourceImageExtension(source: string | undefined): string | null {
+  if (!source) return null;
+  let pathname = source;
+  try {
+    pathname = decodeURIComponent(new URL(source, "https://openmausbot.invalid").pathname);
+  } catch {
+    pathname = source.split(/[?#]/, 1)[0] ?? source;
+  }
+  const extension = /\.([a-z0-9]+)$/i.exec(pathname)?.[1]?.toLowerCase();
+  return extension && IMAGE_EXTENSIONS.has(extension) ? extension : null;
+}
+
+function replaceExtension(name: string, extension: string): string {
+  const suffix = `.${extension}`;
+  const stem = name.replace(/\.[^.]*$/, "") || "image";
+  const available = Math.max(1, 180 - Array.from(suffix).length);
+  return `${Array.from(stem).slice(0, available).join("")}${suffix}`;
+}
+
+/** The response chooses the label; image bytes/source choose the extension. */
+export function canonicalDownloadFilename({
+  contentDisposition,
+  fallback,
+  source,
+  mime,
+}: {
+  contentDisposition?: string | null;
+  fallback?: string;
+  source?: string;
+  mime?: string | null;
+}): string {
+  const selected = contentDispositionFilename(contentDisposition ?? null)
+    ?? safeDownloadFilename(fallback);
+  const mediaType = mime?.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+  const imageExtension = IMAGE_EXTENSION_BY_MIME[mediaType] ?? sourceImageExtension(source);
+  return imageExtension ? replaceExtension(selected, imageExtension) : selected;
+}
+
+export function isExternalImageSource(src: string): boolean {
+  const value = src.trim();
+  // The URL parser removes embedded ASCII tab/LF/CR and treats backslashes as
+  // slashes for special schemes. Normalize those parser quirks before deciding
+  // whether mounting the image would make a network request.
+  const networkSpelling = value.replace(/[\t\n\r]/g, "").replace(/\\/g, "/");
+  // Chromium canonicalizes special-scheme variants such as `https:host/x`,
+  // `https:/host/x`, and backslash spellings into network requests. Treat the
+  // whole scheme family as remote before an <img> can mount.
+  return networkSpelling.startsWith("//") || /^https?:/i.test(networkSpelling);
+}
+
+function revokeObjectUrlLater(url: string): void {
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+/** Shared save state for transcript file chips and bot-authored file links. */
+export function useLocalFileSave(filePath: string, name?: string, message?: MessageAttachmentContext) {
+  const [state, setState] = useState<"idle" | "saving" | "saved" | "failed">("idle");
+  const [reason, setReason] = useState("");
+  const [savedTo, setSavedTo] = useState("");
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const request = useRef<AbortController | null>(null);
+  const saving = useRef(false);
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+      request.current?.abort();
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    request.current?.abort();
+    request.current = null;
+    saving.current = false;
+    setReason("");
+    setSavedTo("");
+    setState("idle");
+  }, [filePath, message?.messageId, message?.threadId]);
+
+  const save = useCallback(async () => {
+    if (saving.current) return;
+    if (!message) {
+      setReason("This older file reference is no longer available to download");
+      setState("failed");
+      return;
+    }
+    saving.current = true;
+    if (resetTimer.current) {
+      clearTimeout(resetTimer.current);
+      resetTimer.current = null;
+    }
+    setReason("");
+    setState("saving");
+    request.current?.abort();
+    const controller = new AbortController();
+    request.current = controller;
+    try {
+      const response = await fetch(`/api/threads/${encodeURIComponent(message.threadId)}/messages/${encodeURIComponent(message.messageId)}/file`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ path: filePath }),
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => null) as { error?: string } | null;
+        throw new Error(body?.error ?? "That file could not be downloaded");
+      }
+      const blob = await response.blob();
+      if (!mounted.current || controller.signal.aborted) return;
+      const url = URL.createObjectURL(blob);
+      const saved = canonicalDownloadFilename({
+        contentDisposition: response.headers.get("content-disposition"),
+        fallback: name || attachmentBasename(filePath),
+        source: filePath,
+        mime: blob.type || response.headers.get("content-type"),
+      });
+      try {
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = saved;
+        link.style.display = "none";
+        document.body.append(link);
+        try {
+          link.click();
+        } finally {
+          link.remove();
+        }
+      } finally {
+        // Chromium may not consume a blob URL until after the click task ends.
+        revokeObjectUrlLater(url);
+      }
+      if (!mounted.current || controller.signal.aborted) return;
+      setSavedTo(saved);
+      setState("saved");
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+      resetTimer.current = setTimeout(() => {
+        if (mounted.current) setState("idle");
+      }, 4000);
+    } catch (error) {
+      if (!mounted.current || controller.signal.aborted) return;
+      setReason(error instanceof Error ? error.message : "That file could not be saved");
+      setState("failed");
+    } finally {
+      if (request.current === controller) {
+        request.current = null;
+        saving.current = false;
+      }
+    }
+  }, [filePath, message?.messageId, message?.threadId, name]);
+
+  return { state, reason, savedTo, save };
+}
+
+export function AttachmentPreviewDialog({
+  image,
+  images,
+  initialIndex = 0,
+  onClose,
+}: {
+  image: PreviewImage;
+  images?: PreviewImage[];
+  initialIndex?: number;
+  onClose: () => void;
+}) {
+  const items = images?.length ? images : [image];
+  const [index, setIndex] = useState(() => Math.min(Math.max(initialIndex, 0), items.length - 1));
+  const current = items[index] ?? image;
   const dialogRef = useRef<HTMLDivElement>(null);
   const closeRef = useRef(onClose);
-  const [failed, setFailed] = useState(false);
+  const [loadedSources, setLoadedSources] = useState<Set<string>>(() => new Set());
+  const [failedSource, setFailedSource] = useState<string | null>(null);
+  const [attempt, setAttempt] = useState(0);
 
   useLayoutEffect(() => {
     closeRef.current = onClose;
   }, [onClose]);
 
+  const navigate = useCallback((step: -1 | 1) => {
+    setIndex((value) => wrappedImageIndex(value, step, items.length));
+    setFailedSource(null);
+  }, [items.length]);
+
   useEffect(() => {
     const previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
     dialogRef.current?.focus();
     const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
+      const action = previewKeyAction(event.key, items.length);
+      if (action) {
         event.preventDefault();
-        closeRef.current();
+        event.stopPropagation();
+        if (action === "close") closeRef.current();
+        else navigate(action === "previous" ? -1 : 1);
         return;
       }
       if (event.key !== "Tab") return;
@@ -63,7 +364,19 @@ export function AttachmentPreviewDialog({ image, onClose }: { image: PreviewImag
       window.removeEventListener("keydown", onKey);
       previousFocus?.focus();
     };
-  }, []);
+  }, [items.length, navigate]);
+
+  const loaded = loadedSources.has(current.src);
+  const failed = failedSource === current.src;
+  const retry = () => {
+    setFailedSource(null);
+    setLoadedSources((sources) => {
+      const next = new Set(sources);
+      next.delete(current.src);
+      return next;
+    });
+    setAttempt((value) => value + 1);
+  };
 
   return createPortal(
     <div
@@ -74,25 +387,44 @@ export function AttachmentPreviewDialog({ image, onClose }: { image: PreviewImag
         ref={dialogRef}
         role="dialog"
         aria-modal="true"
-        aria-label={`Preview ${image.name}`}
+        aria-label={`Preview ${current.name}`}
         tabIndex={-1}
         className="animate-pop-in flex h-full max-h-[900px] w-full max-w-[1200px] flex-col overflow-hidden rounded-2xl border border-white/15 bg-black/70 shadow-2xl outline-none"
       >
         <header className="flex shrink-0 items-center justify-between gap-4 border-b border-white/10 bg-black/45 px-4 py-3">
           <div className="min-w-0">
-            <div className="truncate text-[13px] font-medium text-white">{image.name}</div>
-            <div className="text-[10.5px] text-white/50">Saved locally by OpenMausBot</div>
+            <div className="truncate text-[13px] font-medium text-white">{current.name}</div>
+            <div className="text-[10.5px] text-white/50">
+              {items.length > 1 ? `${index + 1} of ${items.length}` : "Image preview"}
+            </div>
           </div>
           <div className="flex shrink-0 items-center gap-1">
-            <a
-              href={image.src}
-              download={image.name}
-              className="flex size-9 items-center justify-center rounded-lg text-white/65 hover:bg-white/10 hover:text-white"
-              aria-label={`Download ${image.name}`}
-              title="Download"
-            >
-              <Download size={17} />
-            </a>
+            {current.downloadUrl && (
+              <a
+                href={current.downloadUrl}
+                download={current.downloadName ?? canonicalDownloadFilename({
+                  fallback: current.name,
+                  source: current.downloadUrl,
+                })}
+                className="flex size-9 items-center justify-center rounded-lg text-white/65 hover:bg-white/10 hover:text-white"
+                aria-label={`Download ${current.name}`}
+                title="Download"
+              >
+                <Download size={17} />
+              </a>
+            )}
+            {current.openUrl && (
+              <a
+                href={current.openUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="flex size-9 items-center justify-center rounded-lg text-white/65 hover:bg-white/10 hover:text-white"
+                aria-label={`Open original ${current.name}`}
+                title="Open original"
+              >
+                <ExternalLink size={17} />
+              </a>
+            )}
             <button
               onClick={onClose}
               className="flex size-9 items-center justify-center rounded-lg text-white/65 hover:bg-white/10 hover:text-white"
@@ -102,19 +434,58 @@ export function AttachmentPreviewDialog({ image, onClose }: { image: PreviewImag
             </button>
           </div>
         </header>
-        <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-4 sm:p-8">
+        <div className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden p-4 sm:p-8">
+          {!loaded && !failed && (
+            <div className="absolute inset-4 flex animate-pulse items-center justify-center rounded-xl bg-white/[0.055] sm:inset-8" role="status">
+              <span className="flex items-center gap-2 text-[13px] text-white/55">
+                <LoaderCircle size={17} className="animate-spin" /> Loading image…
+              </span>
+            </div>
+          )}
           {failed ? (
-            <div className="flex flex-col items-center gap-3 text-white/60" role="status">
+            <div className="flex flex-col items-center gap-3 text-white/60" role="alert">
               <ImageOff size={34} />
-              <span className="text-[13px]">This attachment is no longer available.</span>
+              <span className="text-[13px]">This image could not be loaded.</span>
+              <button
+                type="button"
+                onClick={retry}
+                className="flex items-center gap-1.5 rounded-lg border border-white/15 bg-white/10 px-3 py-1.5 text-[12px] text-white hover:bg-white/15"
+              >
+                <RotateCcw size={13} /> Retry
+              </button>
             </div>
           ) : (
             <img
-              src={image.src}
-              alt={image.name}
-              onError={() => setFailed(true)}
-              className="block max-h-full max-w-full rounded-lg object-contain shadow-2xl"
+              key={`${current.src}:${attempt}`}
+              src={current.src}
+              alt={current.name}
+              onLoad={() => setLoadedSources((sources) => new Set(sources).add(current.src))}
+              onError={() => setFailedSource(current.src)}
+              className={cn(
+                "block max-h-full max-w-full rounded-lg object-contain shadow-2xl transition-opacity duration-150",
+                loaded ? "opacity-100" : "opacity-0",
+              )}
             />
+          )}
+          {items.length > 1 && (
+            <>
+              <button
+                type="button"
+                onClick={() => navigate(-1)}
+                aria-label="Previous image"
+                className="absolute left-2 top-1/2 flex size-10 -translate-y-1/2 items-center justify-center rounded-full bg-black/55 text-white/80 backdrop-blur-sm hover:bg-black/75 hover:text-white sm:left-4"
+              >
+                <ChevronLeft size={21} />
+              </button>
+              <button
+                type="button"
+                onClick={() => navigate(1)}
+                aria-label="Next image"
+                className="absolute right-2 top-1/2 flex size-10 -translate-y-1/2 items-center justify-center rounded-full bg-black/55 text-white/80 backdrop-blur-sm hover:bg-black/75 hover:text-white sm:right-4"
+              >
+                <ChevronRight size={21} />
+              </button>
+            </>
           )}
         </div>
       </div>
@@ -123,64 +494,334 @@ export function AttachmentPreviewDialog({ image, onClose }: { image: PreviewImag
   );
 }
 
-function Thumbnail({ image, onPreview }: { image: PreviewImage; onPreview: () => void }) {
-  const [failed, setFailed] = useState(false);
-  if (failed) return null;
+function Thumbnail({
+  image,
+  onPreview,
+  className,
+}: {
+  image: PreviewImage;
+  onPreview: () => void;
+  className?: string;
+}) {
+  const [state, setState] = useState<"loading" | "ready" | "failed">("loading");
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => setState("loading"), [image.src]);
+
   return (
-    <button
-      onClick={onPreview}
-      className="group/image relative block max-w-[260px] overflow-hidden rounded-lg border border-hairline/40 bg-inset text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
-      aria-label={`Preview attached image ${image.name}`}
-      title={`Preview ${image.name}`}
-    >
-      <img
-        src={image.src}
-        alt={image.name}
-        loading="lazy"
-        onError={() => setFailed(true)}
-        className="block max-h-[220px] w-full object-cover transition-transform duration-200 group-hover/image:scale-[1.015]"
-      />
-      <span className="absolute right-1.5 top-1.5 flex size-7 items-center justify-center rounded-full bg-black/55 text-white opacity-0 backdrop-blur-sm transition-opacity group-hover/image:opacity-100 group-focus-visible/image:opacity-100">
-        <Maximize2 size={13} />
-      </span>
-    </button>
+    <span className={cn("group/image relative block aspect-[4/3] min-w-0 overflow-hidden rounded-xl border border-hairline/40 bg-inset", className)}>
+      {state === "loading" && (
+        <span className="absolute inset-0 flex animate-pulse items-center justify-center bg-raised/65" role="status">
+          <LoaderCircle size={17} className="animate-spin text-ink-secondary/65" />
+          <span className="sr-only">Loading {image.name}</span>
+        </span>
+      )}
+      {state === "failed" ? (
+        <span className="absolute inset-0 flex flex-col items-center justify-center gap-2 px-3 text-center text-ink-secondary" role="alert">
+          <ImageOff size={22} />
+          <span className="max-w-full truncate text-[11.5px]">Image unavailable</span>
+          <span
+            role="button"
+            tabIndex={0}
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              setState("loading");
+              setAttempt((value) => value + 1);
+            }}
+            onKeyDown={(event) => {
+              if (event.key !== "Enter" && event.key !== " ") return;
+              event.preventDefault();
+              event.stopPropagation();
+              setState("loading");
+              setAttempt((value) => value + 1);
+            }}
+            className="flex items-center gap-1 rounded-md border border-hairline/50 bg-panel px-2 py-1 text-[11px] text-ink hover:bg-raised"
+            aria-label={`Retry loading ${image.name}`}
+          >
+            <RotateCcw size={11} /> Retry
+          </span>
+        </span>
+      ) : (
+        <span
+          role="button"
+          tabIndex={state === "ready" ? 0 : -1}
+          aria-disabled={state !== "ready"}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            if (state === "ready") onPreview();
+          }}
+          onKeyDown={(event) => {
+            if (state === "ready" && (event.key === "Enter" || event.key === " ")) {
+              event.preventDefault();
+              onPreview();
+            }
+          }}
+          className="absolute inset-0 block size-full cursor-pointer text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/60 aria-disabled:cursor-default"
+          aria-label={`Preview attached image ${image.name}`}
+          title={`Preview ${image.name}`}
+        >
+          <img
+            key={`${image.src}:${attempt}`}
+            src={image.src}
+            alt={image.name}
+            loading="lazy"
+            onLoad={() => setState("ready")}
+            onError={() => setState("failed")}
+            className={cn(
+              "block size-full object-cover transition duration-200 group-hover/image:scale-[1.015]",
+              state === "ready" ? "opacity-100" : "opacity-0",
+            )}
+          />
+          <span className="absolute right-2 top-2 flex size-7 items-center justify-center rounded-full bg-black/55 text-white opacity-0 backdrop-blur-sm transition-opacity group-hover/image:opacity-100 group-focus-within/image:opacity-100">
+            <Maximize2 size={13} />
+          </span>
+        </span>
+      )}
+    </span>
   );
 }
 
-export function AttachedImageGallery({ paths, className }: { paths: string[]; className?: string }) {
-  const images = useMemo(() => paths.flatMap((path) => {
-    const image = previewImage(path);
+export function AttachedImageGallery({
+  paths,
+  className,
+}: {
+  paths: Array<string | TranscriptImageAttachment>;
+  className?: string;
+}) {
+  const images = useMemo(() => paths.flatMap((reference) => {
+    if (typeof reference !== "string" && !reference.private) return [];
+    const path = typeof reference === "string" ? reference : reference.path;
+    const name = typeof reference === "string" ? undefined : reference.name;
+    const image = previewImage(path, name);
     return image ? [image] : [];
   }), [paths]);
-  const [selected, setSelected] = useState<PreviewImage | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   if (images.length === 0) return null;
   return (
     <>
-      <div className={cn("mb-2 flex flex-wrap justify-end gap-2", className)}>
+      <div className={cn("mb-2 grid max-w-full gap-2", imageGalleryLayout(images.length), className)}>
         {images.map((image, index) => (
-          <Thumbnail key={`${image.src}:${index}`} image={image} onPreview={() => setSelected(image)} />
+          <Thumbnail key={`${image.src}:${index}`} image={image} onPreview={() => setSelectedIndex(index)} />
         ))}
       </div>
-      {selected && <AttachmentPreviewDialog image={selected} onClose={() => setSelected(null)} />}
+      {selectedIndex !== null && images[selectedIndex] && (
+        <AttachmentPreviewDialog
+          image={images[selectedIndex]}
+          images={images}
+          initialIndex={selectedIndex}
+          onClose={() => setSelectedIndex(null)}
+        />
+      )}
     </>
   );
 }
 
-/** A transcript file is a local prompt reference, not a public download.
- * Show what was sent without turning an untrusted stored path into a link. */
-export function AttachedFileChips({ files, className }: { files: TranscriptFileAttachment[]; className?: string }) {
+/** A Markdown image keeps its remote source, but receives the same stable
+ * loading/error surface and full-screen viewer as an attached image. */
+export function MarkdownImagePreview({
+  src,
+  name,
+  openUrl,
+  message,
+  filePath,
+}: {
+  src: string;
+  name: string;
+  openUrl?: string;
+  message?: MessageAttachmentContext;
+  filePath?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLSpanElement>(null);
+  const threadId = message?.threadId;
+  const messageId = message?.messageId;
+  const localMessageImage = Boolean(filePath && threadId && messageId);
+  const localImageKey = localMessageImage ? `${threadId}\u0000${messageId}\u0000${filePath}` : null;
+  const [visibleLocalImageKey, setVisibleLocalImageKey] = useState<string | null>(null);
+  const [localSource, setLocalSource] = useState<string | null>(localMessageImage ? null : src);
+  const [localDownloadName, setLocalDownloadName] = useState<string | null>(null);
+  const [localError, setLocalError] = useState("");
+  const [localAttempt, setLocalAttempt] = useState(0);
+  const external = !filePath && isExternalImageSource(src);
+  const [approvedExternalSource, setApprovedExternalSource] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!localImageKey) return;
+    const element = containerRef.current;
+    if (!element || typeof IntersectionObserver === "undefined") {
+      setVisibleLocalImageKey(localImageKey);
+      return;
+    }
+    setVisibleLocalImageKey(null);
+    const observer = new IntersectionObserver(([entry]) => {
+      setVisibleLocalImageKey(entry?.isIntersecting ? localImageKey : null);
+    }, { rootMargin: "320px 0px" });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [localImageKey]);
+
+  const shouldLoadLocalImage = localMessageImage && (visibleLocalImageKey === localImageKey || open);
+  useEffect(() => {
+    if (!filePath) {
+      setLocalSource(src);
+      setLocalDownloadName(null);
+      setLocalError("");
+      return;
+    }
+    if (!threadId || !messageId) {
+      setLocalSource(null);
+      setLocalDownloadName(null);
+      setLocalError("This older image reference is no longer available");
+      return;
+    }
+    if (!shouldLoadLocalImage) {
+      setLocalSource(null);
+      setLocalDownloadName(null);
+      setLocalError("");
+      return;
+    }
+    const controller = new AbortController();
+    let objectUrl: string | null = null;
+    let disposed = false;
+    setLocalSource(null);
+    setLocalDownloadName(null);
+    setLocalError("");
+    void fetch(`/api/threads/${encodeURIComponent(threadId)}/messages/${encodeURIComponent(messageId)}/file`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: filePath }),
+      signal: controller.signal,
+    }).then(async (response) => {
+      if (!response.ok) throw new Error("This image is unavailable");
+      const blob = await response.blob();
+      if (disposed || controller.signal.aborted) return;
+      objectUrl = URL.createObjectURL(blob);
+      if (disposed || controller.signal.aborted) {
+        URL.revokeObjectURL(objectUrl);
+        objectUrl = null;
+        return;
+      }
+      setLocalDownloadName(canonicalDownloadFilename({
+        contentDisposition: response.headers.get("content-disposition"),
+        fallback: name,
+        source: filePath,
+        mime: blob.type || response.headers.get("content-type"),
+      }));
+      setLocalSource(objectUrl);
+    }).catch((error) => {
+      if (!disposed && !controller.signal.aborted) {
+        setLocalError(error instanceof Error ? error.message : "This image is unavailable");
+      }
+    });
+    return () => {
+      disposed = true;
+      controller.abort();
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [filePath, localAttempt, messageId, name, shouldLoadLocalImage, src, threadId]);
+  const externalAllowed = !external || approvedExternalSource === src;
+  const visibleSource = externalAllowed ? localSource : null;
+  const image: PreviewImage = {
+    src: visibleSource ?? "",
+    name,
+    openUrl,
+    downloadUrl: localMessageImage ? visibleSource ?? undefined : undefined,
+    downloadName: localDownloadName ?? undefined,
+  };
+  return (
+    <>
+      <span ref={containerRef} className="my-2 block w-[min(36rem,70vw)] max-w-full">
+        {external && !externalAllowed ? (
+          <span className="flex aspect-[4/3] max-h-96 flex-col items-center justify-center gap-2 rounded-xl border border-hairline/40 bg-inset px-4 text-center text-[12px] text-ink-secondary">
+            <ImageOff size={20} />
+            <span>External image hidden for privacy</span>
+            <button type="button" className="rounded-md border border-hairline/50 bg-panel px-2.5 py-1 text-ink hover:bg-raised" onClick={(event) => { event.preventDefault(); event.stopPropagation(); setApprovedExternalSource(src); }}>Load image</button>
+          </span>
+        ) : localError ? (
+          <span className="flex aspect-[4/3] max-h-96 items-center justify-center gap-2 rounded-xl border border-hairline/40 bg-inset text-[12px] text-ink-secondary" role="alert">
+            <ImageOff size={17} /> {localError}
+            <span role="button" tabIndex={0} className="cursor-pointer text-accent hover:underline" onClick={(event) => { event.preventDefault(); event.stopPropagation(); setLocalAttempt((value) => value + 1); }} onKeyDown={(event) => { if (event.key === "Enter" || event.key === " ") { event.preventDefault(); setLocalAttempt((value) => value + 1); } }}>Retry</span>
+          </span>
+        ) : visibleSource ? (
+          <Thumbnail image={image} onPreview={() => setOpen(true)} className="max-h-96" />
+        ) : (
+          <span className="flex aspect-[4/3] max-h-96 animate-pulse items-center justify-center rounded-xl border border-hairline/40 bg-inset" role="status">
+            <LoaderCircle size={17} className="animate-spin text-ink-secondary/65" />
+            <span className="sr-only">Loading {name}</span>
+          </span>
+        )}
+        {openUrl && (
+          <a href={openUrl} target="_blank" rel="noreferrer" className="mt-1 inline-flex text-[11px] text-accent hover:underline">
+            Open original
+          </a>
+        )}
+      </span>
+      {open && visibleSource && <AttachmentPreviewDialog image={image} onClose={() => setOpen(false)} />}
+    </>
+  );
+}
+
+function AttachedFileChip({ file, message }: { file: TranscriptFileAttachment; message?: MessageAttachmentContext }) {
+  const save = useLocalFileSave(file.path, file.name, message);
+  const failed = save.state === "failed";
+  if (!message || !file.private) {
+    return (
+      <div title={`${file.name} — unavailable legacy attachment`} className="flex max-w-[280px] items-center gap-2 overflow-hidden rounded-lg border border-hairline/40 bg-inset/70 px-2.5 py-2 text-[12px] text-ink-secondary">
+        <FileText size={14} className="shrink-0" aria-hidden="true" />
+        <span className="min-w-0 flex-1 truncate text-ink">{file.name}</span>
+        <span className="text-[10.5px]">Unavailable</span>
+      </div>
+    );
+  }
+  return (
+    <div
+      title={save.state === "saved" && save.savedTo ? `Saved to ${save.savedTo}` : file.name}
+      className="max-w-[280px] overflow-hidden rounded-lg border border-hairline/40 bg-inset/70 text-[12px] text-ink-secondary"
+    >
+      <button
+        type="button"
+        onClick={() => void save.save()}
+        disabled={save.state === "saving"}
+        aria-label={`${failed ? "Retry saving" : "Save a copy of"} ${file.name}`}
+        className="flex w-full items-center gap-2 px-2.5 py-2 text-left hover:bg-raised/70 disabled:cursor-wait"
+      >
+        <FileText size={14} className="shrink-0" aria-hidden="true" />
+        <span className="min-w-0 flex-1 truncate text-ink">{file.name}</span>
+        {save.state === "saving" ? (
+          <LoaderCircle size={13} className="shrink-0 animate-spin" />
+        ) : save.state === "saved" ? (
+          <Check size={13} className="shrink-0 text-success" />
+        ) : save.state === "failed" ? (
+          <RotateCcw size={13} className="shrink-0 text-danger" />
+        ) : (
+          <Download size={13} className="shrink-0" />
+        )}
+      </button>
+      {save.state !== "idle" && (
+        <div
+          role={failed ? "alert" : "status"}
+          className={cn(
+            "border-t border-hairline/30 px-2.5 py-1.5 text-[10.5px]",
+            failed ? "text-danger" : save.state === "saved" ? "text-success" : "text-ink-secondary",
+          )}
+        >
+          {save.state === "saving" ? "Downloading…" : save.state === "saved" ? "Downloaded" : save.reason}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Transcript file paths stay inert until the person explicitly asks the
+ * desktop shell to validate and save a copy. */
+export function AttachedFileChips({ files, className, message }: { files: TranscriptFileAttachment[]; className?: string; message?: MessageAttachmentContext }) {
   if (files.length === 0) return null;
   return (
     <div className={cn("mb-2 flex max-w-full flex-wrap justify-end gap-1.5", className)}>
       {files.map((file, index) => (
-        <span
-          key={`${file.path}:${index}`}
-          title={file.name}
-          className="flex max-w-[260px] items-center gap-1.5 rounded-lg border border-hairline/40 bg-inset/70 px-2.5 py-1.5 text-[12px] text-ink-secondary"
-        >
-          <FileText size={13} className="shrink-0" aria-hidden="true" />
-          <span className="truncate text-ink">{file.name}</span>
-        </span>
+        <AttachedFileChip key={`${file.path}:${index}`} file={file} message={message} />
       ))}
     </div>
   );

--- a/src/components/ChatMarkdown.test.ts
+++ b/src/components/ChatMarkdown.test.ts
@@ -1,0 +1,128 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  ChatMarkdown,
+  chatUrlTransform,
+  markdownImageName,
+  markdownImageOpenUrl,
+  localFilePath,
+} from "./ChatMarkdown";
+
+describe("Markdown image metadata", () => {
+  it("prefers alt text and otherwise derives a readable filename", () => {
+    expect(markdownImageName("https://example.test/random.png", "Final render")).toBe("Final render");
+    expect(markdownImageName("https://example.test/output/Launch%20art.webp")).toBe("Launch art.webp");
+    expect(markdownImageName("")).toBe("Image");
+  });
+
+  it("only offers an external action for HTTP sources", () => {
+    expect(markdownImageOpenUrl("https://example.test/image.png?token=abc"))
+      .toBe("https://example.test/image.png?token=abc");
+    expect(markdownImageOpenUrl("http://127.0.0.1/image.png"))
+      .toBe("http://127.0.0.1/image.png");
+    expect(markdownImageOpenUrl("file:///tmp/image.png")).toBeUndefined();
+    expect(markdownImageOpenUrl("data:image/png;base64,abc")).toBeUndefined();
+    expect(markdownImageOpenUrl("/api/attachments/image.png")).toBeUndefined();
+    expect(markdownImageOpenUrl("//cdn.example.test/image.png"))
+      .toBe("https://cdn.example.test/image.png");
+  });
+});
+
+describe("message-scoped file targets", () => {
+  it("recognizes relative and Windows UNC paths without treating web URLs as files", () => {
+    expect(localFilePath("report.md#latest")).toBe("report.md#latest");
+    expect(localFilePath("output.png")).toBe("output.png");
+    expect(localFilePath("\\\\server\\share\\report.pdf")).toBe("\\\\server\\share\\report.pdf");
+    expect(localFilePath("file://server/share/report.pdf")).toBe("//server/share/report.pdf");
+    expect(localFilePath("//cdn.example.test/report.pdf")).toBeNull();
+    expect(localFilePath("/C:/posix/report.pdf")).toBe("/C:/posix/report.pdf");
+    expect(localFilePath("file:///C:/Users/Maus/report.pdf")).toBe("C:/Users/Maus/report.pdf");
+    expect(localFilePath("https://example.test/report.pdf")).toBeNull();
+    expect(localFilePath("#section")).toBeNull();
+    expect(localFilePath("javascript:alert(1)")).toBeNull();
+  });
+
+  it("preserves supported local file spellings without widening unsafe protocols", () => {
+    expect(chatUrlTransform("file:///Users/milind/report.md")).toBe("file:///Users/milind/report.md");
+    expect(chatUrlTransform("C:/Users/Maus/report.md")).toBe("C:/Users/Maus/report.md");
+    expect(chatUrlTransform("\\\\server\\share\\report.md")).toBe("\\\\server\\share\\report.md");
+    expect(chatUrlTransform("javascript:alert(1)")).toBe("");
+    expect(chatUrlTransform("https://example.test/report.md")).toBe("https://example.test/report.md");
+  });
+});
+
+describe("ChatMarkdown attachments", () => {
+  it("requires consent before loading a remote image", () => {
+    const html = renderToStaticMarkup(createElement(ChatMarkdown, {
+      text: "![Launch art](https://assets.example/hero.png)",
+    }));
+
+    expect(html).toContain("External image hidden for privacy");
+    expect(html).toContain("Load image");
+    expect(html).not.toContain("src=\"https://assets.example/hero.png\"");
+  });
+
+  it("requires consent for a protocol-relative image even inside a local link", () => {
+    const html = renderToStaticMarkup(createElement(ChatMarkdown, {
+      text: "[![Launch art](//assets.example/hero.png)](/workspace/original.png)",
+      message: { threadId: "thread-1", messageId: "message-1" },
+    }));
+
+    expect(html).toContain("External image hidden for privacy");
+    expect(html).not.toContain("src=\"//assets.example/hero.png\"");
+  });
+
+  it("keeps host paths private while routing them through the scoped file handler", () => {
+    const html = renderToStaticMarkup(createElement(ChatMarkdown, {
+      text: "[macOS](file:///Users/milind/report.md) [Windows](C:/Users/Maus/report.md)",
+      message: { threadId: "thread-1", messageId: "message-1" },
+    }));
+    expect(html).toContain('title="Save a copy"');
+    expect(html).not.toContain("/Users/milind/report.md");
+    expect(html).not.toContain("C:/Users/Maus/report.md");
+  });
+
+  it("keeps an unscoped legacy file link inert", () => {
+    const html = renderToStaticMarkup(createElement(ChatMarkdown, {
+      text: "[Download the report](/workspace/final-report.pdf)",
+    }));
+
+    expect(html).toContain("Download the report");
+    expect(html).toContain("Unavailable legacy file reference");
+    expect(html).not.toContain("href=\"/workspace/final-report.pdf\"");
+    expect(html).not.toContain("type=\"button\"");
+  });
+
+  it("makes a message-authorized file link downloadable", () => {
+    const html = renderToStaticMarkup(createElement(ChatMarkdown, {
+      text: "[Download the report](/workspace/final-report.pdf)",
+      message: { threadId: "thread-1", messageId: "message-1" },
+    }));
+    expect(html).toContain('title="Save a copy"');
+    expect(html).not.toContain("/workspace/final-report.pdf");
+    expect(html).toContain("type=\"button\"");
+  });
+
+  it("does not nest a preview button in an anchor or block in a paragraph", () => {
+    const standalone = renderToStaticMarkup(createElement(ChatMarkdown, {
+      text: "![Launch art](https://assets.example/hero.png)",
+    }));
+    const linked = renderToStaticMarkup(createElement(ChatMarkdown, {
+      text: "[![Launch art](https://assets.example/hero.png)](https://assets.example/original.png)",
+    }));
+    expect(standalone).not.toMatch(/<p[^>]*>\s*<div/);
+    expect(linked).not.toMatch(/<a[^>]*>[\s\S]*role="button"/);
+    expect(linked).toContain("href=\"https://assets.example/original.png\"");
+  });
+
+  it("does not expose a message-scoped host image path to the img element", () => {
+    const html = renderToStaticMarkup(createElement(ChatMarkdown, {
+      text: "![Generated preview](/workspace/output.png)",
+      message: { threadId: "thread-1", messageId: "message-1" },
+    }));
+    expect(html).toContain("Loading Generated preview");
+    expect(html).not.toContain("src=\"/workspace/output.png\"");
+  });
+});

--- a/src/components/ChatMarkdown.tsx
+++ b/src/components/ChatMarkdown.tsx
@@ -8,9 +8,11 @@
 // bubble, a fresh component instance, mounts straight from cache instead of
 // popping from plain to highlighted.
 import { memo, useEffect, useState, type ReactNode } from "react";
-import Markdown from "react-markdown";
+import Markdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { Check, Copy } from "lucide-react";
+import { Check, Copy, Download, LoaderCircle, RotateCcw } from "lucide-react";
+
+import { MarkdownImagePreview, useLocalFileSave, type MessageAttachmentContext } from "./AttachmentPreview";
 
 // tiny highlight cache so revisiting a thread doesn't re-tokenize settled
 // blocks; keys are content-hashed and capped. Streamed partials may land here
@@ -39,23 +41,62 @@ const hash = (s: string) => {
 // where a file:// URL's pathname also arrives as "/C:/…".
 const WINDOWS_PATH = /^[a-zA-Z]:[\\/]/;
 const absolutePath = (value: string): string | null => {
-  if (value.startsWith("/") && WINDOWS_PATH.test(value.slice(1))) return value.slice(1);
   if (value.startsWith("/") || WINDOWS_PATH.test(value)) return value;
   return null;
 };
 
-const localFilePath = (href?: string): string | null => {
+export const localFilePath = (href?: string): string | null => {
   if (!href) return null;
   // URL schemes are case-insensitive, so FILE:// is as valid as file://
   if (/^file:\/\//i.test(href)) {
     try {
-      return absolutePath(decodeURIComponent(new URL(href).pathname));
+      const url = new URL(href);
+      if (url.username || url.password || url.port || url.search || url.hash) return null;
+      const path = decodeURIComponent(url.pathname);
+      if (url.hostname && url.hostname !== "localhost") return `//${url.hostname}${path}`;
+      // WHATWG file URLs spell a Windows drive as /C:/ on every host. Only
+      // strip that sentinel for an actual file URL: a raw /C:/... Markdown
+      // target is a distinct POSIX path and must retain its identity.
+      return /^\/[a-z]:[\\/]/i.test(path) ? path.slice(1) : absolutePath(path);
     } catch {
       return null;
     }
   }
-  return absolutePath(href);
+  if (href.startsWith("\\\\")) return href;
+  // Forward-slash //host/path is a protocol-relative web URL in Markdown.
+  // UNC remains available through backslashes or file://server/share.
+  if (href.startsWith("//")) return null;
+  const absolute = absolutePath(href);
+  if (absolute) return absolute;
+  if (href.startsWith("#") || /^[a-z][a-z\d+.-]*:/i.test(href)) return null;
+  return href;
 };
+
+/** Keep only the local URL spellings our message-scoped file renderer knows
+ * about; all ordinary links still use react-markdown's protocol allow-list. */
+export function chatUrlTransform(value: string): string {
+  if (/^file:\/\//i.test(value) || WINDOWS_PATH.test(value) || value.startsWith("\\\\")) {
+    return localFilePath(value) ? value : "";
+  }
+  return defaultUrlTransform(value);
+}
+
+function unwrapLinkedImages() {
+  return (tree: { children?: any[] }) => {
+    const visit = (node: { children?: any[] }) => {
+      if (!node.children) return;
+      node.children = node.children.map((child) => {
+        if (child?.type === "link" && child.children?.length === 1 && child.children[0]?.type === "image") {
+          const image = child.children[0];
+          return { ...image, data: { ...image.data, hProperties: { ...image.data?.hProperties, "data-open-url": child.url } } };
+        }
+        visit(child);
+        return child;
+      });
+    };
+    visit(tree);
+  };
+}
 
 function CodeBlock({ code, lang, streaming }: { code: string; lang: string; streaming: boolean }) {
   const [html, setHtml] = useState<string | null>(null);
@@ -141,53 +182,72 @@ function CodeBlock({ code, lang, streaming }: { code: string; lang: string; stre
 // and an <a href="file://…"> would still reach setWindowOpenHandler on a
 // middle or modifier click, which calls shell.openExternal without the main
 // process' containment check.
-function LocalFileLink({ filePath, children }: { filePath: string; children?: ReactNode }) {
-  const [state, setState] = useState<"idle" | "saved" | "failed">("idle");
-  const [reason, setReason] = useState("");
-  const [savedTo, setSavedTo] = useState("");
-
-  const save = async () => {
-    const saveFile = window.ogb?.saveFile;
-    if (!saveFile) {
-      // an older shell has no save bridge; saying so beats the silent click
-      // this change exists to remove
-      setReason("Saving files needs a newer version of the desktop app");
-      setState("failed");
-      return;
-    }
-    try {
-      const saved = await saveFile(filePath);
-      // null means the user closed the save dialog, which is a decision
-      // rather than a failure — say nothing
-      if (!saved) return;
-      setSavedTo(saved);
-      setState("saved");
-      setTimeout(() => setState("idle"), 4000);
-    } catch (error) {
-      // the bug being fixed here was a click that failed silently, so a
-      // failed save says why rather than doing nothing
-      setReason(error instanceof Error ? error.message : "That file could not be saved");
-      setState("failed");
-    }
-  };
+function LocalFileLink({ filePath, children, message }: { filePath: string; children?: ReactNode; message?: MessageAttachmentContext }) {
+  const save = useLocalFileSave(filePath, undefined, message);
+  if (!message) {
+    return <span title="Unavailable legacy file reference" className="break-words text-ink-secondary">{children}</span>;
+  }
+  const label = save.state === "saving"
+    ? "Saving…"
+    : save.state === "saved"
+      ? "Saved"
+      : save.state === "failed"
+        ? "Retry"
+        : null;
 
   return (
-    <>
+    <span className="inline-flex flex-wrap items-center gap-x-1.5">
       <button
         type="button"
-        onClick={() => void save()}
-        title={`Save a copy — ${filePath}`}
-        className="break-words text-left text-accent underline decoration-accent/40 hover:decoration-accent"
+        onClick={() => void save.save()}
+        disabled={save.state === "saving"}
+        title="Save a copy"
+        className="inline-flex items-center gap-1 break-words text-left text-accent underline decoration-accent/40 hover:decoration-accent disabled:cursor-wait"
       >
         {children}
+        {save.state === "saving" ? (
+          <LoaderCircle size={12} className="shrink-0 animate-spin" aria-hidden="true" />
+        ) : save.state === "saved" ? (
+          <Check size={12} className="shrink-0 text-success" aria-hidden="true" />
+        ) : save.state === "failed" ? (
+          <RotateCcw size={12} className="shrink-0" aria-hidden="true" />
+        ) : (
+          <Download size={12} className="shrink-0" aria-hidden="true" />
+        )}
       </button>
-      {state !== "idle" && (
-        <span className={`ml-1.5 text-[12px] ${state === "saved" ? "text-success" : "text-danger"}`}>
-          {state === "saved" ? `Saved to ${savedTo}` : reason}
+      {label && (
+        <span
+          role={save.state === "failed" ? "alert" : "status"}
+          title={save.state === "saved" ? save.savedTo : undefined}
+          className={`text-[12px] ${save.state === "saved" ? "text-success" : save.state === "failed" ? "text-danger" : "text-ink-secondary"}`}
+        >
+          {save.state === "failed" ? save.reason : label}
         </span>
       )}
-    </>
+    </span>
   );
+}
+
+export function markdownImageName(src: string, alt?: string): string {
+  const supplied = alt?.trim();
+  if (supplied) return supplied;
+  try {
+    const path = decodeURIComponent(new URL(src, "https://openmausbot.invalid").pathname);
+    const name = path.split("/").filter(Boolean).at(-1)?.trim();
+    if (name) return name;
+  } catch {
+    // A malformed source still gets a useful accessible fallback.
+  }
+  return "Image";
+}
+
+export function markdownImageOpenUrl(src: string): string | undefined {
+  try {
+    const url = new URL(src.startsWith("//") ? `https:${src}` : src);
+    return url.protocol === "https:" || url.protocol === "http:" ? url.toString() : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 // Spoiler spans: GFM parses ~~text~~ to <del>; in bot messages that content
@@ -232,11 +292,12 @@ function Spoiler({ children }: { children?: ReactNode }) {
   );
 }
 
-function ChatMarkdownComponent({ text, streaming = false }: { text: string; streaming?: boolean }) {
+function ChatMarkdownComponent({ text, streaming = false, message }: { text: string; streaming?: boolean; message?: MessageAttachmentContext }) {
   return (
     <div className="chat-md min-w-0 [&>*+*]:mt-2">
       <Markdown
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={[remarkGfm, unwrapLinkedImages]}
+        urlTransform={chatUrlTransform}
         components={{
           pre({ children }: { children?: ReactNode }) {
             // fenced code arrives as <pre><code class="language-x">…</code></pre>
@@ -250,13 +311,19 @@ function ChatMarkdownComponent({ text, streaming = false }: { text: string; stre
             const code = flat(child?.props?.children).replace(/\n$/, "");
             return <CodeBlock code={code} lang={lang} streaming={streaming} />;
           },
-          img({ src, alt }: { src?: string; alt?: string }) {
+          img(props) {
+            const { src, alt } = props;
+            if (!src) {
+              return <span className="text-[12px] text-danger" role="alert">Image unavailable</span>;
+            }
+            const filePath = localFilePath(src) ?? undefined;
             return (
-              <img
+              <MarkdownImagePreview
                 src={src}
-                alt={alt ?? ""}
-                loading="lazy"
-                className="max-h-96 max-w-full rounded-lg border border-hairline/30"
+                name={markdownImageName(src, alt)}
+                openUrl={markdownImageOpenUrl(typeof (props as Record<string, unknown>)["data-open-url"] === "string" ? String((props as Record<string, unknown>)["data-open-url"]) : src)}
+                filePath={filePath}
+                message={filePath ? message : undefined}
               />
             );
           },
@@ -267,7 +334,7 @@ function ChatMarkdownComponent({ text, streaming = false }: { text: string; stre
           },
           a({ href, children }: { href?: string; children?: ReactNode }) {
             const localPath = localFilePath(href);
-            if (localPath) return <LocalFileLink filePath={localPath}>{children}</LocalFileLink>;
+            if (localPath) return <LocalFileLink filePath={localPath} message={message}>{children}</LocalFileLink>;
             return (
               <a
                 href={href}
@@ -337,4 +404,9 @@ function ChatMarkdownComponent({ text, streaming = false }: { text: string; stre
   );
 }
 
-export const ChatMarkdown = memo(ChatMarkdownComponent);
+export const ChatMarkdown = memo(ChatMarkdownComponent, (previous, next) => (
+  previous.text === next.text
+  && Boolean(previous.streaming) === Boolean(next.streaming)
+  && previous.message?.threadId === next.message?.threadId
+  && previous.message?.messageId === next.message?.messageId
+));

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -317,10 +317,11 @@ function Bubble({
   const webhookView = user ? webhookMessageView(text) : null;
   const attachments = user && !webhookView ? splitTranscriptAttachments(text) : null;
   const visibleText = webhookView?.task ?? attachments?.display ?? text;
+  const hasAttachments = Boolean(attachments && (attachments.images.length || attachments.files.length));
   const collapsible =
     user && !webhookView && !expanded && (visibleText.length > USER_COLLAPSE_CHARS || visibleText.split("\n").length > USER_COLLAPSE_LINES);
 
-  if (user && editing && !webhookView) {
+  if (user && editing && !webhookView && !hasAttachments) {
     return (
       <div className="flex w-full justify-end">
         <BubbleEditor initial={text} onCancel={onCancelEdit} onSubmit={onSubmitEdit} />
@@ -340,7 +341,7 @@ function Bubble({
       <div className={cn("flex w-full items-center gap-1.5", user ? "justify-end" : "justify-start")}>
         {/* editing rewinds the thread, so it waits for the turn to end —
             same rule as the version switcher below */}
-        {user && message.kind === "text" && !webhookView && !bot.busy && (
+        {user && message.kind === "text" && !webhookView && !hasAttachments && !bot.busy && (
           <button
             onClick={onStartEdit}
             aria-label="Edit message"
@@ -350,7 +351,7 @@ function Bubble({
             <Pencil size={14} />
           </button>
         )}
-        {user && <CopyButton text={visibleText} />}
+        {user && Boolean(visibleText.trim()) && <CopyButton text={visibleText} />}
         {user && (
           <>
             <button
@@ -425,7 +426,7 @@ function Bubble({
                 <AttachedImageGallery paths={attachments.images} />
               )}
               {attachments && attachments.files.length > 0 && (
-                <AttachedFileChips files={attachments.files} className={!visibleText ? "mb-0" : undefined} />
+                <AttachedFileChips files={attachments.files} message={{ threadId: bot.threadId, messageId: message.id }} className={!visibleText ? "mb-0" : undefined} />
               )}
               {visibleText && (
                 <div
@@ -458,7 +459,7 @@ function Bubble({
                   className={text ? "justify-start" : "mb-0 justify-start"}
                 />
               ) : null}
-              {text ? <ChatMarkdown text={text} /> : null}
+              {text ? <ChatMarkdown text={text} message={{ threadId: bot.threadId, messageId: message.id }} /> : null}
             </MessageBoundary>
           )}
         </div>
@@ -922,6 +923,11 @@ export function ChatView({ bot }: { bot: Bot }) {
     () => [...messages].reverse().find((m) => m.role === "user" && m.kind === "text"),
     [messages],
   );
+  const lastUserMessageHasAttachments = useMemo(() => {
+    if (!lastUserMessage?.text) return false;
+    const attached = splitTranscriptAttachments(lastUserMessage.text);
+    return attached.images.length > 0 || attached.files.length > 0;
+  }, [lastUserMessage]);
 
   // Mascot while the turn works. Streaming stays invisible — when the reply
   // is finished, the whole bubble pops in above the mascot.
@@ -1302,7 +1308,7 @@ export function ChatView({ bot }: { bot: Bot }) {
                       className={popping.text ? "justify-start" : "mb-0 justify-start"}
                     />
                   ) : null}
-                  {popping.text ? <ChatMarkdown text={popping.text} /> : null}
+                  {popping.text ? <ChatMarkdown text={popping.text} message={{ threadId: bot.threadId, messageId: popping.id }} /> : null}
                 </MessageBoundary>
               </div>
             ) : null}
@@ -1334,7 +1340,9 @@ export function ChatView({ bot }: { bot: Bot }) {
         onClearReply={clearReply}
         onConsumeReply={consumeReply}
         onRestoreReply={restoreReply}
-        onEditLast={lastUserMessage && !bot.busy ? () => setEditingId(lastUserMessage.id) : undefined}
+        onEditLast={lastUserMessage && !lastUserMessageHasAttachments && !bot.busy
+          ? () => setEditingId(lastUserMessage.id)
+          : undefined}
       />
       </div>
       </div>

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -5,12 +5,15 @@ import { useStore, visibleMessages, type Bot, type Group, type Message } from "@
 import { cn } from "@/lib/cn";
 import {
   draftRevision,
+  appendDraftAttachments,
+  changeDraftAttachmentPending,
   forgetFailedComposerSend,
   markDraftEdited,
   recoverFailedComposerSend,
   rememberFailedComposerSend,
   restoredSendId,
   useComposerDraft,
+  useDraftAttachmentPending,
   useFailedComposerSends,
   type ComposerSendSnapshot,
   type FailedComposerSend,
@@ -225,6 +228,7 @@ export function Composer({
     draftId,
     !group && bot ? `bot:${bot.id}` : undefined,
   );
+  const attachmentPending = useDraftAttachmentPending(draftId);
   const failedSends = useFailedComposerSends(draftId);
   // Goal mode is opt-in and one-shot so the next ordinary channel message
   // cannot accidentally start another multi-turn team run.
@@ -255,8 +259,8 @@ export function Composer({
     [onRestoreReply],
   );
   const addAttachments = useCallback(
-    (next: Attachment[]) => editAttachments((prev) => [...prev, ...next]),
-    [editAttachments],
+    (next: Attachment[]) => appendDraftAttachments(draftId, next),
+    [draftId],
   );
   const removeAttachment = useCallback(
     (id: string) => editAttachments((prev) => prev.filter((a) => a.id !== id)),
@@ -420,15 +424,18 @@ export function Composer({
   const autoBot = group ? undefined : bot;
   const pickFiles = async (picked: FileList | null) => {
     if (!picked?.length) return;
-    const { attachments: added, notice } = await intakeFiles(Array.from(picked), {
-      allowImages: engineSupportsImages,
-      getPath: pathForFile,
-      uploadImage: imageAttachmentFromFile,
-    });
-    if (added.length) addAttachments(added);
-    // Keep file-specific failures beside the attachments. A successful
-    // overlapping intake must not erase an earlier failure before it is read.
-    if (notice) setAttachmentNotice(notice);
+    changeDraftAttachmentPending(draftId, true);
+    try {
+      const { attachments: added, notice } = await intakeFiles(Array.from(picked), {
+        allowImages: engineSupportsImages,
+        getPath: pathForFile,
+        uploadImage: imageAttachmentFromFile,
+      });
+      if (added.length) addAttachments(added);
+      if (notice) setAttachmentNotice(notice);
+    } finally {
+      changeDraftAttachmentPending(draftId, false);
+    }
   };
   const setAuto = (auto: boolean) => {
     if (!autoBot) return;
@@ -474,7 +481,7 @@ export function Composer({
     }
   };
   const send = () => {
-    if (locked) return;
+    if (locked || attachmentPending) return;
     if (
       attachments.some((attachment) => attachment.kind === "image") &&
       !imageTargetsSupport(effectiveText, effectiveChannelMode)
@@ -718,6 +725,7 @@ export function Composer({
           allowImages={engineSupportsImages}
           notice={attachmentNotice}
           onNotice={setAttachmentNotice}
+          onPendingChange={(pending) => changeDraftAttachmentPending(draftId, pending)}
         />
         <div className="relative">
           {/* App-ground from the pill midline down, full-bleed. Bubbles may
@@ -802,17 +810,22 @@ export function Composer({
             const imageFiles = Array.from(e.clipboardData.files).filter(isImageFile);
             if (imageFiles.length && engineSupportsImages) {
               e.preventDefault();
+              changeDraftAttachmentPending(draftId, true);
               void (async () => {
-                for (const file of imageFiles) {
-                  try {
-                    const attachment = await imageAttachmentFromFile(file);
-                    if (attachment) editAttachments((prev) => [...prev, attachment]);
-                  } catch (err) {
-                    dispatch({
-                      type: "error",
-                      message: err instanceof Error ? err.message : "image upload failed",
-                    });
+                try {
+                  for (const file of imageFiles) {
+                    try {
+                      const attachment = await imageAttachmentFromFile(file);
+                      if (attachment) appendDraftAttachments(draftId, [attachment]);
+                    } catch (err) {
+                      dispatch({
+                        type: "error",
+                        message: err instanceof Error ? err.message : "image upload failed",
+                      });
+                    }
                   }
+                } finally {
+                  changeDraftAttachmentPending(draftId, false);
                 }
               })();
               return;
@@ -885,12 +898,14 @@ export function Composer({
             }
             if (e.key === "Escape" && recording) setRecording(false);
           }}
-          disabled={Boolean(approval) || locked}
+          disabled={Boolean(approval) || locked || attachmentPending}
           placeholder={
             locked
               ? "Finish room setup to start chatting"
               : approval
               ? "Answer the approval above to continue"
+              : attachmentPending
+              ? "Attaching files…"
               : recording
               ? "Listening…"
               : canInject
@@ -943,6 +958,7 @@ export function Composer({
         {hasContent && !locked && (
           <button
             onClick={send}
+            disabled={attachmentPending}
             aria-label={
               busy && canSteer
                   ? "Send into the running turn"

--- a/src/components/ComposerAttachments.tsx
+++ b/src/components/ComposerAttachments.tsx
@@ -30,6 +30,7 @@ export function ComposerAttachments({
   allowImages = true,
   notice,
   onNotice,
+  onPendingChange,
 }: {
   items: Attachment[];
   onAdd: (attachments: Attachment[]) => void;
@@ -38,15 +39,18 @@ export function ComposerAttachments({
   allowImages?: boolean;
   notice: string | null;
   onNotice: (notice: string | null) => void;
+  onPendingChange?: (pending: boolean) => void;
 }) {
   const [dragging, setDragging] = useState(false);
   const [preview, setPreview] = useState<PreviewImage | null>(null);
   // dragenter/dragleave fire once per element crossed, so the overlay
   // tracks depth rather than the last event it happened to see
   const depth = useRef(0);
+  const callbacks = useRef({ onAdd, onNotice, onPendingChange, allowImages });
+  callbacks.current = { onAdd, onNotice, onPendingChange, allowImages };
+  const pendingDrops = useRef(new Set<symbol>());
 
   useEffect(() => {
-    let active = true;
     const carriesFiles = (e: DragEvent) => Array.from(e.dataTransfer?.types ?? []).includes("Files");
 
     const onEnter = (e: DragEvent) => {
@@ -72,16 +76,20 @@ export function ComposerAttachments({
       const files = Array.from(e.dataTransfer?.files ?? []);
       // Same intake the attach button uses: a dropped file and a picked one
       // must not appear in a different order.
-      const { attachments, notice: message } = await intakeFiles(files, {
-        allowImages,
-        getPath: pathForFile,
-        uploadImage: imageAttachmentFromFile,
-      });
-      if (!active) return;
-      if (attachments.length) onAdd(attachments);
-      // Only a failure changes the notice. This keeps a concurrent successful
-      // intake from clearing an error before the user can read it.
-      if (message) onNotice(message);
+      const operation = Symbol("attachment-drop");
+      pendingDrops.current.add(operation);
+      callbacks.current.onPendingChange?.(true);
+      try {
+        const { attachments, notice: message } = await intakeFiles(files, {
+          allowImages: callbacks.current.allowImages,
+          getPath: pathForFile,
+          uploadImage: imageAttachmentFromFile,
+        });
+        if (attachments.length) callbacks.current.onAdd(attachments);
+        if (message) callbacks.current.onNotice(message);
+      } finally {
+        if (pendingDrops.current.delete(operation)) callbacks.current.onPendingChange?.(false);
+      }
     };
 
     window.addEventListener("dragenter", onEnter);
@@ -89,20 +97,19 @@ export function ComposerAttachments({
     window.addEventListener("dragover", onOver);
     window.addEventListener("drop", onDrop);
     return () => {
-      active = false;
       window.removeEventListener("dragenter", onEnter);
       window.removeEventListener("dragleave", onLeave);
       window.removeEventListener("dragover", onOver);
       window.removeEventListener("drop", onDrop);
     };
-  }, [onAdd, allowImages, onNotice]);
+  }, []);
 
   return (
     <>
       {dragging && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 p-10">
           <div className="rounded-2xl border-2 border-dashed border-accent/70 bg-panel/90 px-8 py-6 text-[14px] font-medium text-ink shadow-2xl">
-            Drop to attach — the bot gets the file path
+            Drop to attach
           </div>
         </div>
       )}
@@ -152,7 +159,7 @@ export function ComposerAttachments({
               <Chip key={a.id} label="IMAGE" title={a.name} onRemove={() => onRemove(a.id)}>
                 <button
                   type="button"
-                  onClick={() => setPreview(previewImage(a.path))}
+                  onClick={() => setPreview(previewImage(a.path, a.name))}
                   className="flex h-[76px] w-full items-center justify-center overflow-hidden rounded-lg bg-inset focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
                   aria-label={`Preview ${a.name}`}
                 >

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -266,6 +266,7 @@ const Transcript = memo(function Transcript({
                       {attachments && attachments.files.length > 0 && (
                         <AttachedFileChips
                           files={attachments.files}
+                          message={{ threadId: group.threadId, messageId: m.id }}
                           className={!attachments.display ? "mb-0" : undefined}
                         />
                       )}
@@ -279,7 +280,7 @@ const Transcript = memo(function Transcript({
                           className={m.text ? "justify-start" : "mb-0 justify-start"}
                         />
                       ) : null}
-                      {m.text ? <ChatMarkdown text={m.text} /> : null}
+                      {m.text ? <ChatMarkdown text={m.text} message={{ threadId: group.threadId, messageId: m.id }} /> : null}
                     </>
                   )}
                 </div>
@@ -1287,7 +1288,7 @@ export function GroupView({ group }: { group: Group }) {
                       className={popping.text ? "justify-start" : "mb-0 justify-start"}
                     />
                   ) : null}
-                  {popping.text ? <ChatMarkdown text={popping.text} /> : null}
+                  {popping.text ? <ChatMarkdown text={popping.text} message={{ threadId: group.threadId, messageId: popping.id }} /> : null}
                 </div>
               ) : null}
             </TurnPresence>

--- a/src/components/RoutineCalendarPage.tsx
+++ b/src/components/RoutineCalendarPage.tsx
@@ -376,6 +376,8 @@ function EventEditor({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
   const [attachmentNotice, setAttachmentNotice] = useState("");
+  const [attachmentPendingCount, setAttachmentPendingCount] = useState(0);
+  const attachmentPending = attachmentPendingCount > 0;
   const fileInput = useRef<HTMLInputElement>(null);
   const cloudInstance = state.instances.find((instance) => instance.driverKind === "boxAgent");
   const cloudReady = Boolean(state.config?.box.configured && cloudInstance?.snapshot.state === "available");
@@ -429,20 +431,26 @@ function EventEditor({
 
   const pickFiles = async (files: FileList | null) => {
     if (!files?.length || isRoomGoal) return;
-    const result = await intakeFiles(Array.from(files), {
-      allowImages: true,
-      getPath: pathForFile,
-      uploadImage: imageAttachmentFromFile,
-    });
-    const added = toContextAttachments(result.attachments);
-    if (added.length) {
-      setAttachments((current) => [...current, ...added].slice(0, 20));
-      if (runOn === "cloud") setRunOn("maus");
+    setAttachmentPendingCount((count) => count + 1);
+    try {
+      const result = await intakeFiles(Array.from(files), {
+        allowImages: true,
+        getPath: pathForFile,
+        uploadImage: imageAttachmentFromFile,
+      });
+      const added = toContextAttachments(result.attachments);
+      if (added.length) {
+        setAttachments((current) => [...current, ...added].slice(0, 20));
+        if (runOn === "cloud") setRunOn("maus");
+      }
+      if (result.notice) setAttachmentNotice(result.notice);
+    } finally {
+      setAttachmentPendingCount((count) => Math.max(0, count - 1));
     }
-    if (result.notice) setAttachmentNotice(result.notice);
   };
 
   const save = async () => {
+    if (attachmentPending) return;
     setSaving(true);
     setError("");
     try {
@@ -776,7 +784,7 @@ function EventEditor({
 
         <div className="sticky bottom-0 flex items-center justify-end gap-2 border-t border-hairline/40 bg-panel/95 px-5 py-3.5 backdrop-blur">
           <button onClick={onClose} className="rounded-lg px-4 py-2 text-[12.5px] text-ink-secondary hover:bg-raised hover:text-ink">Cancel</button>
-          <button onClick={save} disabled={saving || !valid} className="flex items-center gap-2 rounded-lg bg-accent px-5 py-2 text-[12.5px] font-semibold text-white hover:brightness-110 disabled:opacity-40">{saving && <Loader2 size={14} className="animate-spin" />}{existingRoutine || existingCall ? "Save" : kind === "call" ? "Schedule call" : isRoomGoal ? "Schedule team goal" : "Schedule routine"}</button>
+          <button onClick={save} disabled={saving || attachmentPending || !valid} className="flex items-center gap-2 rounded-lg bg-accent px-5 py-2 text-[12.5px] font-semibold text-white hover:brightness-110 disabled:opacity-40">{(saving || attachmentPending) && <Loader2 size={14} className="animate-spin" />}{attachmentPending ? "Attaching…" : existingRoutine || existingCall ? "Save" : kind === "call" ? "Schedule call" : isRoomGoal ? "Schedule team goal" : "Schedule routine"}</button>
         </div>
       </div>
     </div>

--- a/src/lib/composer-attachments.test.ts
+++ b/src/lib/composer-attachments.test.ts
@@ -1,12 +1,16 @@
 // composeMessage with images, the image tag round-trip through
 // transcript attachment splitting, and the mime gate the composer pastes through.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   appendPastedText,
   attachmentBasename,
   attachmentImageUrl,
   composeMessage,
+  documentMime,
+  fileAttachment,
+  fileAttachmentFromFile,
+  imageAttachmentFromFile,
   isImageFile,
   splitTranscriptAttachments,
   type ImageAttachment,
@@ -49,10 +53,10 @@ function image(path: string): ImageAttachment {
 }
 
 describe("composeMessage with images", () => {
-  it("emits an attached-image tag carrying the server path", () => {
+  it("emits an attached-image tag carrying the server path and display name", () => {
     const prompt = composeMessage("what is this?", [image("/home/u/.openmausbot/attachments/abc.png")]);
     expect(prompt).toBe(
-      'what is this?\n\n<attached-image path="/home/u/.openmausbot/attachments/abc.png" />',
+      'what is this?\n\n<attached-image path="/home/u/.openmausbot/attachments/abc.png" name="shot.png" />',
     );
   });
 
@@ -60,8 +64,17 @@ describe("composeMessage with images", () => {
     const prompt = composeMessage("", [image('/x/")} onload="evil()')]);
     // every quote is entity-encoded, so the payload can never break out of
     // the attribute — the tag stays one well-formed element
-    expect(prompt).toMatch(/<attached-image path="[^"]*" \/>/);
+    expect(prompt).toMatch(/<attached-image path="[^"]*" name="shot.png" \/>/);
     expect(prompt).toContain("&quot;");
+  });
+
+  it("keeps an escaped display name on file tags", () => {
+    const prompt = composeMessage("", [
+      fileAttachment('Project & "notes".pdf', "/store/123.pdf", 42),
+    ]);
+    expect(prompt).toBe(
+      '<attached-file path="/store/123.pdf" name="Project &amp; &quot;notes&quot;.pdf" />',
+    );
   });
 });
 
@@ -71,20 +84,33 @@ describe("splitTranscriptAttachments", () => {
       'look at this\n\n<attached-image path="/a/b/one.png" />\n\n<attached-image path="/a/b/two.jpg" />';
     const { display, images, files } = splitTranscriptAttachments(stored);
     expect(display).toBe("look at this");
-    expect(images).toEqual(["/a/b/one.png", "/a/b/two.jpg"]);
+    expect(images).toEqual([
+      { path: "/a/b/one.png", name: "one.png" },
+      { path: "/a/b/two.jpg", name: "two.jpg" },
+    ]);
     expect(files).toEqual([]);
   });
 
   it("unescapes attribute entities so the path round-trips", () => {
     const stored = '<attached-image path="/a/b/&amp;x.png" />';
     const { images } = splitTranscriptAttachments(stored);
-    expect(images).toEqual(["/a/b/&x.png"]);
+    expect(images).toEqual([{ path: "/a/b/&x.png", name: "&x.png" }]);
+  });
+
+  it("keeps a safe original image name while accepting legacy unnamed tags", () => {
+    const stored =
+      '<attached-image path="/store/123.png" name="Holiday &amp; notes.png" />\n' +
+      '<attached-image path="/store/456.webp" />';
+    expect(splitTranscriptAttachments(stored).images).toEqual([
+      { path: "/store/123.png", name: "Holiday & notes.png" },
+      { path: "/store/456.webp", name: "456.webp" },
+    ]);
   });
 
   it("hides file tags and uses their safe display names", () => {
     const stored =
       'review these\n\n<attached-file path="/tmp/one.pdf" name="Project &amp; plan.pdf" />\n\n' +
-      '<attached-file name="folder\\notes&#10;final.txt" path="C:\\saved\\generated.txt" />';
+      '<attached-file path="C:\\saved\\generated.txt" name="folder\\notes&#10;final.txt" />';
     const { display, files } = splitTranscriptAttachments(stored);
     expect(display).toBe("review these");
     expect(files).toEqual([
@@ -103,6 +129,21 @@ describe("splitTranscriptAttachments", () => {
     ]);
   });
 
+  it("marks only private-store UUID attachment names as actionable", () => {
+    const privatePath = "/home/me/.openmausbot/attachments/123e4567-e89b-42d3-a456-426614174000.pdf";
+    expect(splitTranscriptAttachments(`<attached-file path="${privatePath}" name="Report.pdf" />`).files[0])
+      .toMatchObject({ path: privatePath, name: "Report.pdf", private: true });
+    expect(splitTranscriptAttachments('<attached-file path="/Users/me/Desktop/report.pdf" />').files[0]?.private)
+      .toBeUndefined();
+  });
+
+  it("accepts every UUID version supported by the private attachment store", () => {
+    const versionEight = "/private/123e4567-e89b-82d3-a456-426614174000.pdf";
+    const versionNine = "/private/123e4567-e89b-92d3-a456-426614174000.pdf";
+    expect(splitTranscriptAttachments(`<attached-file path="${versionEight}" />`).files[0]?.private).toBe(true);
+    expect(splitTranscriptAttachments(`<attached-file path="${versionNine}" />`).files[0]?.private).toBeUndefined();
+  });
+
   it("does not decode unsupported or repeatedly encoded entities", () => {
     const { files } = splitTranscriptAttachments(
       '<attached-file path="/tmp/a.pdf" name="&amp;quot;draft&apos;.pdf" />',
@@ -119,6 +160,161 @@ describe("splitTranscriptAttachments", () => {
     const stored =
       'Example: <attached-file path="/tmp/inline.pdf" />\n' +
       '<attached-image path="/tmp/not-self-closing.png">';
+    expect(splitTranscriptAttachments(stored)).toEqual({ display: stored, images: [], files: [] });
+  });
+
+  it("recognises only exact unindented standalone transport tags", () => {
+    const stored =
+      'before\r\n<attached-image path="/tmp/shot.png" name="Screen shot.png" />  \r\n' +
+      '<attached-file path="/tmp/brief.pdf" />\r\nafter';
+    expect(splitTranscriptAttachments(stored)).toEqual({
+      display: "before\r\nafter",
+      images: [{ path: "/tmp/shot.png", name: "Screen shot.png" }],
+      files: [{ path: "/tmp/brief.pdf", name: "brief.pdf" }],
+    });
+  });
+
+  it("keeps attachment-looking lines inside backtick and tilde fences", () => {
+    const stored = [
+      "```xml",
+      '<attached-file path="/tmp/backtick.pdf" />',
+      "```",
+      "~~~",
+      '<attached-image path="/tmp/tilde.png" />',
+      "~~~~",
+      "```unclosed",
+      '<attached-file path="/tmp/unclosed.pdf" />',
+    ].join("\n");
+    expect(splitTranscriptAttachments(stored)).toEqual({ display: stored, images: [], files: [] });
+  });
+
+  it("keeps indented attachment-looking lines as code", () => {
+    const stored =
+      'Code examples:\n    <attached-file path="/tmp/spaces.pdf" />\n' +
+      '\t<attached-image path="/tmp/tab.png" />';
+    expect(splitTranscriptAttachments(stored)).toEqual({ display: stored, images: [], files: [] });
+  });
+
+  it("keeps attachment-looking lines inside multiline HTML comments", () => {
+    const stored = [
+      "<!-- this is an example",
+      '<attached-file path="/tmp/comment.pdf" />',
+      "-->",
+      '<attached-file path="/tmp/real.pdf" />',
+    ].join("\n");
+    const parsed = splitTranscriptAttachments(stored);
+    expect(parsed.display).toBe([
+      "<!-- this is an example",
+      '<attached-file path="/tmp/comment.pdf" />',
+      "-->",
+    ].join("\n"));
+    expect(parsed.files).toEqual([{ path: "/tmp/real.pdf", name: "real.pdf" }]);
+    expect(parsed.images).toEqual([]);
+  });
+
+  it("keeps CommonMark block tags through the next blank line", () => {
+    const stored = [
+      '<div class="example">',
+      '<attached-image path="/tmp/example.png" />',
+      "</div>",
+      '<attached-image path="/tmp/after-close.png" />',
+      "",
+      '<attached-image path="/tmp/real.png" />',
+    ].join("\n");
+    const parsed = splitTranscriptAttachments(stored);
+    expect(parsed.display).toBe([
+      '<div class="example">',
+      '<attached-image path="/tmp/example.png" />',
+      "</div>",
+      '<attached-image path="/tmp/after-close.png" />',
+    ].join("\n"));
+    expect(parsed.images).toEqual([{ path: "/tmp/real.png", name: "real.png" }]);
+    expect(parsed.files).toEqual([]);
+  });
+
+  it("keeps pre blocks through their closing tag even across blank lines", () => {
+    const stored = [
+      '<pre class="example">',
+      '<attached-file path="/tmp/in-pre.md" />',
+      "",
+      "</pre>",
+      '<attached-file path="/tmp/real.md" />',
+    ].join("\n");
+    const parsed = splitTranscriptAttachments(stored);
+    expect(parsed.files).toEqual([{ path: "/tmp/real.md", name: "real.md" }]);
+    expect(parsed.display).toContain('<attached-file path="/tmp/in-pre.md" />');
+  });
+
+  it("does not end table or nested section blocks at closing tags", () => {
+    const stored = [
+      "<table>",
+      '<attached-file path="/tmp/in-table.csv" />',
+      "</table>",
+      "",
+      '<section aria-label="example">',
+      "<div>",
+      '<attached-image path="/tmp/in-nested-div.png" />',
+      "</div>",
+      "</section>",
+      '<attached-file path="/tmp/still-html.md" />',
+      "",
+      '<attached-file path="/tmp/real.md" />',
+    ].join("\n");
+    const parsed = splitTranscriptAttachments(stored);
+    expect(parsed.images).toEqual([]);
+    expect(parsed.files).toEqual([{ path: "/tmp/real.md", name: "real.md" }]);
+    expect(parsed.display).toContain('<attached-file path="/tmp/in-table.csv" />');
+    expect(parsed.display).toContain('<attached-image path="/tmp/in-nested-div.png" />');
+    expect(parsed.display).toContain('<attached-file path="/tmp/still-html.md" />');
+  });
+
+  it("keeps processing instructions, CDATA, declarations, and generic HTML literal", () => {
+    const stored = [
+      "<?example",
+      '<attached-file path="/tmp/in-pi.md" />',
+      "?>",
+      "<![CDATA[",
+      '<attached-file path="/tmp/in-cdata.md" />',
+      "]]>",
+      "<!example",
+      '<attached-file path="/tmp/in-declaration.md" />',
+      ">",
+      '<widget data-name="example">',
+      '<attached-file path="/tmp/in-generic.md" />',
+      "</widget>",
+      "",
+      '<attached-file path="/tmp/real.md" />',
+    ].join("\n");
+    const parsed = splitTranscriptAttachments(stored);
+    expect(parsed.files).toEqual([{ path: "/tmp/real.md", name: "real.md" }]);
+    for (const path of ["in-pi.md", "in-cdata.md", "in-declaration.md", "in-generic.md"]) {
+      expect(parsed.display).toContain(path);
+    }
+  });
+
+  it("keeps attachment-looking lines inside pasted-text blocks", () => {
+    const stored = [
+      '<pasted-text index="1">',
+      '<attached-file path="/tmp/pasted.pdf" />',
+      "</pasted-text>",
+      '<attached-file path="/tmp/real.pdf" name="Actual.pdf" />',
+    ].join("\n");
+    const parsed = splitTranscriptAttachments(stored);
+    expect(parsed.display).toBe([
+      '<pasted-text index="1">',
+      '<attached-file path="/tmp/pasted.pdf" />',
+      "</pasted-text>",
+    ].join("\n"));
+    expect(parsed.files).toEqual([{ path: "/tmp/real.pdf", name: "Actual.pdf" }]);
+    expect(parsed.images).toEqual([]);
+  });
+
+  it("leaves unsupported attributes and attribute order visible", () => {
+    const stored = [
+      '<attached-file path="/tmp/extra.pdf" extra="yes" />',
+      '<attached-file name="First.pdf" path="/tmp/reordered.pdf" />',
+      '<attached-file path="/tmp/duplicate.pdf" name="One.pdf" name="Two.pdf" />',
+    ].join("\n");
     expect(splitTranscriptAttachments(stored)).toEqual({ display: stored, images: [], files: [] });
   });
 
@@ -155,5 +351,110 @@ describe("isImageFile", () => {
     expect(isImageFile({ type: "image/webp", size: 10 })).toBe(true);
     expect(isImageFile({ type: "image/svg+xml", size: 10 })).toBe(false);
     expect(isImageFile({ type: "text/plain", size: 10 })).toBe(false);
+  });
+});
+
+describe("private document intake", () => {
+  it("recognises supported documents by declared mime or filename", () => {
+    expect(documentMime({ name: "notes.bin", type: "text/markdown; charset=utf-8" })).toBe("text/markdown");
+    expect(documentMime({ name: "REPORT.PDF", type: "" })).toBe("application/pdf");
+    expect(documentMime({ name: "archive.zip", type: "application/zip" })).toBeNull();
+  });
+
+  it("uses the server path and safe name returned by the private store", async () => {
+    const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      path: "/private/attachments/123.pdf",
+      name: "Quarterly plan.pdf",
+      bytes: 3,
+    }), { status: 201, headers: { "content-type": "application/json" } }));
+    try {
+      const file = new File([new Uint8Array([1, 2, 3])], "Quarterly plan.pdf", { type: "application/pdf" });
+      await expect(fileAttachmentFromFile(file)).resolves.toMatchObject({
+        kind: "file",
+        path: "/private/attachments/123.pdf",
+        name: "Quarterly plan.pdf",
+        size: 3,
+      });
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /^\/api\/files\?name=Quarterly%20plan\.pdf&uploadId=[0-9a-f-]{36}$/,
+        ),
+        expect.objectContaining({ method: "POST", body: file }),
+      );
+    } finally {
+      fetch.mockRestore();
+    }
+  });
+
+  it("retries a transient document response once with the same upload id", async () => {
+    const fetch = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("temporarily unavailable", { status: 503 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        path: "/private/attachments/22222222-2222-4222-8222-222222222222.pdf",
+        name: "Report.pdf",
+        bytes: 3,
+      }), { status: 201, headers: { "content-type": "application/json" } }));
+    try {
+      const file = new File([new Uint8Array([1, 2, 3])], "Report.pdf", { type: "application/pdf" });
+      await expect(fileAttachmentFromFile(file)).resolves.toMatchObject({ name: "Report.pdf", size: 3 });
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(fetch.mock.calls[0]?.[0]).toBe(fetch.mock.calls[1]?.[0]);
+    } finally {
+      fetch.mockRestore();
+    }
+  });
+});
+
+describe("private image intake", () => {
+  it("retries a lost response with one upload id and canonicalises the display extension", async () => {
+    const fetch = vi.spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new TypeError("connection closed"))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        path: "/private/attachments/11111111-1111-4111-8111-111111111111.png",
+        mime: "image/png",
+        bytes: 3,
+      }), { status: 201, headers: { "content-type": "application/json" } }));
+    try {
+      const file = new File([new Uint8Array([1, 2, 3])], "setup.exe", { type: "image/png" });
+      await expect(imageAttachmentFromFile(file)).resolves.toMatchObject({
+        kind: "image",
+        path: "/private/attachments/11111111-1111-4111-8111-111111111111.png",
+        name: "setup.png",
+        size: 3,
+        mime: "image/png",
+      });
+      expect(fetch).toHaveBeenCalledTimes(2);
+      const firstUrl = String(fetch.mock.calls[0]?.[0]);
+      expect(firstUrl).toMatch(/^\/api\/attachments\?uploadId=[0-9a-f-]{36}$/);
+      expect(fetch.mock.calls[1]?.[0]).toBe(fetch.mock.calls[0]?.[0]);
+    } finally {
+      fetch.mockRestore();
+    }
+  });
+
+  it("bounds repeated network failures to one recovery attempt", async () => {
+    const fetch = vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("offline"));
+    try {
+      const file = new File([new Uint8Array([1])], "photo.png", { type: "image/png" });
+      await expect(imageAttachmentFromFile(file)).rejects.toThrow("offline");
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(fetch.mock.calls[1]?.[0]).toBe(fetch.mock.calls[0]?.[0]);
+    } finally {
+      fetch.mockRestore();
+    }
+  });
+
+  it("rejects inconsistent image metadata instead of surfacing a misleading filename", async () => {
+    const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      path: "/private/attachments/11111111-1111-4111-8111-111111111111.jpg",
+      mime: "image/png",
+      bytes: 3,
+    }), { status: 201, headers: { "content-type": "application/json" } }));
+    try {
+      const file = new File([new Uint8Array([1, 2, 3])], "photo.exe", { type: "image/png" });
+      await expect(imageAttachmentFromFile(file)).rejects.toThrow("invalid image metadata");
+    } finally {
+      fetch.mockRestore();
+    }
   });
 });

--- a/src/lib/composer-attachments.ts
+++ b/src/lib/composer-attachments.ts
@@ -80,6 +80,26 @@ function newId(): string {
   return globalThis.crypto?.randomUUID?.() ?? `a${Math.random().toString(36).slice(2)}`;
 }
 
+/** The upload id is a server-validated UUID and remains stable across the
+ * one recovery attempt. That makes a lost success response safe to retry:
+ * the server returns the already committed attachment instead of creating a
+ * second file. */
+function newUploadId(): string {
+  if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
+  const bytes = new Uint8Array(16);
+  if (globalThis.crypto?.getRandomValues) {
+    globalThis.crypto.getRandomValues(bytes);
+  } else {
+    for (let index = 0; index < bytes.length; index += 1) {
+      bytes[index] = Math.floor(Math.random() * 256);
+    }
+  }
+  bytes[6] = (bytes[6]! & 0x0f) | 0x40;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"));
+  return `${hex.slice(0, 4).join("")}-${hex.slice(4, 6).join("")}-${hex.slice(6, 8).join("")}-${hex.slice(8, 10).join("")}-${hex.slice(10).join("")}`;
+}
+
 export function fileAttachment(name: string, path: string, size: number): FileAttachment {
   return { kind: "file", id: newId(), path, name, size };
 }
@@ -87,12 +107,100 @@ export function fileAttachment(name: string, path: string, size: number): FileAt
 /** Matches the server's IMAGE_MAX_BYTES — checked client-side so an
  * oversized paste is refused before the upload starts, not mid-stream. */
 export const IMAGE_MAX_BYTES = 10 * 1024 * 1024;
+export const FILE_MAX_BYTES = 25 * 1024 * 1024;
+
+const DOCUMENT_MIMES: Readonly<Record<string, string>> = {
+  txt: "text/plain",
+  md: "text/markdown",
+  markdown: "text/markdown",
+  csv: "text/csv",
+  tsv: "text/tab-separated-values",
+  json: "application/json",
+  pdf: "application/pdf",
+  rtf: "application/rtf",
+  doc: "application/msword",
+  docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  xls: "application/vnd.ms-excel",
+  xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ppt: "application/vnd.ms-powerpoint",
+  pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  odt: "application/vnd.oasis.opendocument.text",
+  ods: "application/vnd.oasis.opendocument.spreadsheet",
+  odp: "application/vnd.oasis.opendocument.presentation",
+};
+
+const ACCEPTED_DOCUMENT_MIMES = new Set(Object.values(DOCUMENT_MIMES));
+
+export function documentMime(file: Pick<File, "name" | "type">): string | null {
+  const declared = file.type.split(";", 1)[0]!.trim().toLowerCase();
+  if (ACCEPTED_DOCUMENT_MIMES.has(declared)) return declared;
+  const extension = file.name.split(".").at(-1)?.toLowerCase() ?? "";
+  return DOCUMENT_MIMES[extension] ?? null;
+}
 
 export function isImageFile(file: { type: string; size: number }): boolean {
   return (
     file.type.startsWith("image/") &&
     ["image/png", "image/jpeg", "image/gif", "image/webp"].includes(file.type.split(";")[0]!.trim().toLowerCase())
   );
+}
+
+const IMAGE_EXTENSION_BY_MIME: Readonly<Record<string, string>> = {
+  "image/png": ".png",
+  "image/jpeg": ".jpg",
+  "image/gif": ".gif",
+  "image/webp": ".webp",
+};
+
+const UPLOAD_ATTEMPTS = 2;
+
+function retryableUploadStatus(status: number): boolean {
+  return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+/** Retry only failures where the server may already have committed the body.
+ * A validation/authentication response is final, while a network failure or
+ * transient response gets one replay with the same upload id. */
+async function uploadWithRetry<T>(url: string, init: RequestInit): Promise<T> {
+  for (let attempt = 0; attempt < UPLOAD_ATTEMPTS; attempt += 1) {
+    let response: Response;
+    try {
+      response = await fetch(url, init);
+    } catch (error) {
+      const aborted = typeof error === "object" && error !== null && "name" in error && error.name === "AbortError";
+      if (aborted || attempt === UPLOAD_ATTEMPTS - 1) throw error;
+      continue;
+    }
+    if (!response.ok) {
+      if (retryableUploadStatus(response.status) && attempt < UPLOAD_ATTEMPTS - 1) {
+        await response.body?.cancel().catch(() => undefined);
+        continue;
+      }
+      const detail = (await response.json().catch(() => ({ error: response.statusText }))) as { error?: string };
+      throw Object.assign(new Error(detail.error ?? "upload failed"), { status: response.status });
+    }
+    try {
+      return await response.json() as T;
+    } catch (error) {
+      if (attempt === UPLOAD_ATTEMPTS - 1) {
+        throw new Error("upload returned an invalid response", { cause: error });
+      }
+    }
+  }
+  throw new Error("upload failed");
+}
+
+function canonicalImageName(originalName: string, path: string, mime: string): string {
+  const normalizedMime = mime.split(";", 1)[0]!.trim().toLowerCase();
+  const extension = IMAGE_EXTENSION_BY_MIME[normalizedMime];
+  const pathName = attachmentBasename(path);
+  if (!extension || !pathName.toLowerCase().endsWith(extension)) {
+    throw new Error("upload returned invalid image metadata");
+  }
+  const original = attachmentBasename(originalName.trim());
+  const dot = original.lastIndexOf(".");
+  const stem = (dot > 0 ? original.slice(0, dot) : original).trim() || "pasted image";
+  return `${stem}${extension}`;
 }
 
 /** Persist a pasted image server-side and return the attachment chip data.
@@ -102,17 +210,44 @@ export async function imageAttachmentFromFile(file: File): Promise<ImageAttachme
   if (!isImageFile(file)) return null;
   if (file.size > IMAGE_MAX_BYTES) throw Object.assign(new Error(`${file.name} exceeds 10 MB`), { status: 413 });
   const bytes = new Uint8Array(await file.arrayBuffer());
-  const response = await fetch("/api/attachments", {
-    method: "POST",
-    headers: { "content-type": file.type },
-    body: bytes,
-  });
-  if (!response.ok) {
-    const detail = (await response.json().catch(() => ({ error: response.statusText }))) as { error?: string };
-    throw Object.assign(new Error(detail.error ?? "upload failed"), { status: response.status });
+  const uploadId = newUploadId();
+  const saved = await uploadWithRetry<{ path: string; mime: string; bytes: number }>(
+    `/api/attachments?uploadId=${encodeURIComponent(uploadId)}`,
+    {
+      method: "POST",
+      headers: { "content-type": file.type },
+      body: bytes,
+    },
+  );
+  return {
+    kind: "image",
+    id: newId(),
+    path: saved.path,
+    name: canonicalImageName(file.name, saved.path, saved.mime),
+    size: saved.bytes,
+    mime: saved.mime,
+  };
+}
+
+/** Copy a supported document into the private attachment store. The prompt
+ * then carries the same durable path for the local agent and paired phones,
+ * instead of exposing an arbitrary Finder path to the companion route. */
+export async function fileAttachmentFromFile(file: File): Promise<FileAttachment | null> {
+  const mime = documentMime(file);
+  if (!mime) return null;
+  if (file.size > FILE_MAX_BYTES) {
+    throw Object.assign(new Error(`${file.name} exceeds 25 MB`), { status: 413 });
   }
-  const saved = (await response.json()) as { path: string; mime: string; bytes: number };
-  return { kind: "image", id: newId(), path: saved.path, name: file.name || "pasted image", size: saved.bytes, mime: saved.mime };
+  const uploadId = newUploadId();
+  const saved = await uploadWithRetry<{ path: string; name: string; bytes: number }>(
+    `/api/files?name=${encodeURIComponent(file.name)}&uploadId=${encodeURIComponent(uploadId)}`,
+    {
+      method: "POST",
+      headers: { "content-type": mime },
+      body: file,
+    },
+  );
+  return fileAttachment(saved.name || file.name, saved.path, saved.bytes);
 }
 
 export function pasteAttachment(text: string): PasteAttachment {
@@ -131,7 +266,8 @@ export function appendPastedText(text: string, pasted: string): string {
 
 export const INLINE_DROP_LIMIT = 512 * 1024;
 
-export type DroppedFile = Pick<File, "name" | "size" | "type" | "text">;
+export type DroppedFile = Pick<File, "name" | "size" | "type" | "text"> &
+  Partial<Pick<File, "arrayBuffer">>;
 
 /** Turn a browser drop into composer attachments. Electron-backed files
  * keep their disk path; small pathless text drops keep their contents.
@@ -195,16 +331,16 @@ export function formatSize(bytes: number): string {
 /** The prompt the bot receives: what was typed, then one block per
  * attachment. Tagged blocks rather than fences — pasted code and markdown
  * carry fences of their own, and nesting them loses the boundary. A file
- * needs only its path: every driver here is an agent that can open it. */
+ * carries its path for the agent and its original name for the transcript. */
 export function composeMessage(text: string, attachments: Attachment[]): string {
   const parts = [text.trim()];
   attachments.forEach((a, i) => {
     if (a.kind === "paste") {
       parts.push(`<pasted-text index="${i + 1}">\n${a.text}\n</pasted-text>`);
     } else if (a.kind === "image") {
-      parts.push(`<attached-image path="${escapeAttribute(a.path)}" />`);
+      parts.push(`<attached-image path="${escapeAttribute(a.path)}" name="${escapeAttribute(a.name)}" />`);
     } else {
-      parts.push(`<attached-file path="${escapeAttribute(a.path)}" />`);
+      parts.push(`<attached-file path="${escapeAttribute(a.path)}" name="${escapeAttribute(a.name)}" />`);
     }
   });
   return parts.filter(Boolean).join("\n\n");
@@ -226,11 +362,18 @@ export function escapeAttribute(value: string): string {
 export type TranscriptFileAttachment = {
   path: string;
   name: string;
+  private?: boolean;
+};
+
+export type TranscriptImageAttachment = {
+  path: string;
+  name: string;
+  private?: boolean;
 };
 
 export type TranscriptAttachments = {
   display: string;
-  images: string[];
+  images: TranscriptImageAttachment[];
   files: TranscriptFileAttachment[];
 };
 
@@ -265,34 +408,180 @@ function transcriptFileName(path: string, suppliedName?: string): string {
   return Array.from(safe || fallback || "Attached file").slice(0, 180).join("");
 }
 
+export function isPrivateAttachmentPath(path: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.[a-z0-9]+$/i
+    .test(attachmentBasename(path));
+}
+
+type TranscriptFence = {
+  marker: "`" | "~";
+  length: number;
+};
+
+type TranscriptBlock =
+  | { kind: "untilBlank" }
+  | { kind: "untilToken"; closingToken: string };
+
+/** Recognise CommonMark-style fenced code without pulling a Markdown parser
+ * into the composer bundle. An unterminated fence deliberately protects the
+ * rest of the message: examples must never turn into actionable attachments. */
+function transcriptFenceMarker(line: string): (TranscriptFence & { remainder: string }) | null {
+  let index = 0;
+  while (index < line.length && index < 4 && line[index] === " ") index += 1;
+  if (index > 3) return null;
+  const marker = line[index];
+  if (marker !== "`" && marker !== "~") return null;
+  const start = index;
+  while (index < line.length && line[index] === marker) index += 1;
+  const length = index - start;
+  if (length < 3) return null;
+  return { marker, length, remainder: line.slice(index) };
+}
+
+const COMMONMARK_BLOCK_TAGS = [
+  "address", "article", "aside", "base", "basefont", "blockquote", "body", "caption", "center", "col",
+  "colgroup", "dd", "details", "dialog", "dir", "div", "dl", "dt", "fieldset", "figcaption", "figure",
+  "footer", "form", "frame", "frameset", "h[1-6]", "head", "header", "hr", "html", "iframe", "legend",
+  "li", "link", "main", "menu", "menuitem", "nav", "noframes", "ol", "optgroup", "option", "p",
+  "param", "search", "section", "summary", "table", "tbody", "td", "tfoot", "th", "thead", "title",
+  "tr", "track", "ul",
+].join("|");
+
+const COMMONMARK_TYPE_1 = /^ {0,3}<(script|pre|style|textarea)(?:[\t ]|>|$)/i;
+const COMMONMARK_TYPE_6 = new RegExp(
+  `^ {0,3}</?(?:${COMMONMARK_BLOCK_TAGS})(?:[\\t ]|/?>|$)`,
+  "i",
+);
+const HTML_ATTRIBUTE_NAME = "[A-Za-z_:][A-Za-z0-9_.:-]*";
+const HTML_ATTRIBUTE_VALUE = `(?:[^\\s"'=<>\\x60]+|'[^']*'|"[^"]*")`;
+const HTML_ATTRIBUTE = `(?:[\\t ]+${HTML_ATTRIBUTE_NAME}(?:[\\t ]*=[\\t ]*${HTML_ATTRIBUTE_VALUE})?)`;
+const COMMONMARK_TYPE_7 = new RegExp(
+  `^ {0,3}(?:<[A-Za-z][A-Za-z0-9-]*${HTML_ATTRIBUTE}*[\\t ]*/?>|</[A-Za-z][A-Za-z0-9-]*[\\t ]*>)[\\t ]*$`,
+);
+
+/** Attachment-looking examples inside CommonMark HTML blocks stay literal.
+ * Types 1-5 use their specified terminator; types 6-7 last through the next
+ * blank line. The app's pasted-text wrapper is deliberately stronger than a
+ * generic custom tag and lasts through its closing tag, including blanks. */
+function transcriptBlockStarting(line: string): TranscriptBlock | null {
+  const lower = line.toLowerCase();
+  const commentStart = lower.indexOf("<!--");
+  if (commentStart >= 0 && lower.indexOf("-->", commentStart + 4) < 0) {
+    return { kind: "untilToken", closingToken: "-->" };
+  }
+
+  const content = line.match(/^ {0,3}(.*)$/)?.[1];
+  if (content === undefined) return null;
+  const lowerContent = content.toLowerCase();
+
+  const pastedText = /^<pasted-text(?:[\t >]|$)/i.exec(content);
+  if (pastedText) {
+    return lowerContent.includes("</pasted-text>")
+      ? null
+      : { kind: "untilToken", closingToken: "</pasted-text>" };
+  }
+
+  const typeOne = COMMONMARK_TYPE_1.exec(line);
+  if (typeOne) {
+    const closingToken = `</${typeOne[1]!.toLowerCase()}>`;
+    return lower.includes(closingToken)
+      ? null
+      : { kind: "untilToken", closingToken };
+  }
+
+  const processing = lowerContent.indexOf("<?");
+  if (processing === 0) {
+    return lowerContent.indexOf("?>", 2) >= 0
+      ? null
+      : { kind: "untilToken", closingToken: "?>" };
+  }
+  const cdata = lowerContent.indexOf("<![cdata[");
+  if (cdata === 0) {
+    return lowerContent.indexOf("]]>", 9) >= 0
+      ? null
+      : { kind: "untilToken", closingToken: "]]>" };
+  }
+  if (/^<![A-Za-z]/.test(content)) {
+    return content.indexOf(">", 2) >= 0
+      ? null
+      : { kind: "untilToken", closingToken: ">" };
+  }
+
+  if (COMMONMARK_TYPE_6.test(line) || COMMONMARK_TYPE_7.test(line)) {
+    return { kind: "untilBlank" };
+  }
+  return null;
+}
+
+const TRANSCRIPT_ATTACHMENT_TAG =
+  /^<attached-(image|file)[\t ]+path="([^"\r\n]*)"(?:[\t ]+name="([^"\r\n]*)")?[\t ]*\/>[\t ]*$/;
+
 /** Split a stored user message into its display text and attachments for
  * transcript rendering. Prompt-only tags never show in the bubble. */
 export function splitTranscriptAttachments(text: string): TranscriptAttachments {
-  const images: string[] = [];
+  const images: TranscriptImageAttachment[] = [];
   const files: TranscriptFileAttachment[] = [];
-  const display = text.replace(
-    /^[\t ]*<attached-(image|file)\b((?:[\t ]+[A-Za-z_:][\w:.-]*="[^"\r\n]*")*)[\t ]*\/>[\t ]*(?:\r?\n)?/gm,
-    (match, kind: "image" | "file", rawAttributes: string) => {
-      const attributes = new Map<string, string>();
-      for (const attribute of rawAttributes.matchAll(/\s+([A-Za-z_:][\w:.-]*)="([^"]*)"/g)) {
-        if (!attributes.has(attribute[1]!)) attributes.set(attribute[1]!, attribute[2]!);
+  let display = "";
+  let fence: TranscriptFence | null = null;
+  let block: TranscriptBlock | null = null;
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const newline = text.indexOf("\n", cursor);
+    const lineEnd = newline >= 0 ? newline : text.length;
+    const wholeLineEnd = newline >= 0 ? newline + 1 : text.length;
+    const rawLine = text.slice(cursor, lineEnd);
+    const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+    const marker = transcriptFenceMarker(line);
+    let consumed = false;
+
+    if (fence) {
+      if (
+        marker &&
+        marker.marker === fence.marker &&
+        marker.length >= fence.length &&
+        /^[\t ]*$/.test(marker.remainder)
+      ) {
+        fence = null;
       }
-      const rawPath = attributes.get("path");
-      if (rawPath === undefined) return match;
-      const path = decodeAttachmentAttribute(rawPath);
-      if (!path) return match;
-      if (kind === "image") images.push(path);
-      else files.push({ path, name: transcriptFileName(path, attributes.get("name")) });
-      return "";
-    },
-  );
+    } else if (block) {
+      if (block.kind === "untilBlank") {
+        if (/^[\t ]*$/.test(line)) block = null;
+      } else if (line.toLowerCase().includes(block.closingToken)) {
+        block = null;
+      }
+    } else if (marker) {
+      fence = { marker: marker.marker, length: marker.length };
+    } else {
+      const match = TRANSCRIPT_ATTACHMENT_TAG.exec(line);
+      if (match) {
+        const kind = match[1] as "image" | "file";
+        const path = decodeAttachmentAttribute(match[2]!);
+        if (path) {
+          const attachment = {
+            path,
+            name: transcriptFileName(path, match[3]),
+            ...(isPrivateAttachmentPath(path) ? { private: true } : {}),
+          };
+          if (kind === "image") images.push(attachment);
+          else files.push(attachment);
+          consumed = true;
+        }
+      }
+      if (!consumed) block = transcriptBlockStarting(line);
+    }
+
+    if (!consumed) display += text.slice(cursor, wholeLineEnd);
+    cursor = wholeLineEnd;
+  }
+
   return { display: display.trim(), images, files };
 }
 
 /** Kept for callers outside the desktop bundle that used the old helper. */
 export function splitAttachedImages(text: string): { display: string; images: string[] } {
   const { display, images } = splitTranscriptAttachments(text);
-  return { display, images };
+  return { display, images: images.map((image) => image.path) };
 }
 
 /** The bare filename a saved attachment path ends in — what the serving
@@ -314,21 +603,26 @@ export function attachmentImageUrl(path: string): string | null {
 
 /** One intake path for files arriving by drop OR by the composer's attach
  * button, so a picked file and a dropped one can never behave differently.
- * The image uploader is injected: the caller owns the network, this owns
- * the ordering and the sentence the user reads when something is refused. */
+ * Uploaders are injected for deterministic tests: callers own the network,
+ * while this function owns ordering and the sentence shown on failure. */
 export async function intakeFiles<T extends DroppedFile & { type: string }>(
   _files: readonly T[],
   _opts: {
     allowImages: boolean;
     getPath: (file: T) => string;
     uploadImage: (file: T) => Promise<Attachment | null>;
+    uploadFile?: (file: T) => Promise<FileAttachment | null>;
   },
 ): Promise<{ attachments: Attachment[]; notice: string | null }> {
   const files = [..._files];
   const { allowImages, getPath, uploadImage } = _opts;
+  const uploadFile = _opts.uploadFile ?? (async (file: T) => {
+    if (!file.arrayBuffer) return null;
+    return fileAttachmentFromFile(file as unknown as File);
+  });
   const attachments: Attachment[] = [];
   const rejectedNames: string[] = [];
-  const imageErrors: string[] = [];
+  const uploadErrors: string[] = [];
   // Finish each selected file in sequence so the chips retain the order in
   // which the user chose or dropped them.
   for (const file of files) {
@@ -337,8 +631,18 @@ export async function intakeFiles<T extends DroppedFile & { type: string }>(
         const attachment = await uploadImage(file);
         if (attachment) attachments.push(attachment);
       } catch (err) {
-        imageErrors.push(`${file.name}: ${err instanceof Error ? err.message : "upload failed"}`);
+        uploadErrors.push(`${file.name}: ${err instanceof Error ? err.message : "upload failed"}`);
       }
+      continue;
+    }
+    try {
+      const attachment = await uploadFile(file);
+      if (attachment) {
+        attachments.push(attachment);
+        continue;
+      }
+    } catch (err) {
+      uploadErrors.push(`${file.name}: ${err instanceof Error ? err.message : "upload failed"}`);
       continue;
     }
     const result = await attachmentsFromDroppedFiles([file], getPath);
@@ -348,7 +652,7 @@ export async function intakeFiles<T extends DroppedFile & { type: string }>(
   const pathless = rejectedNames.length
     ? `${rejectedNames.join(", ")} — that file has no path on disk. Save it first, then attach it from Finder.`
     : null;
-  const failed = imageErrors.length ? imageErrors.join("; ") : null;
+  const failed = uploadErrors.length ? uploadErrors.join("; ") : null;
   return {
     attachments,
     notice: pathless && failed ? `${pathless} (${failed})` : (pathless ?? failed),

--- a/src/lib/drafts.test.ts
+++ b/src/lib/drafts.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  appendDraftAttachments,
+  changeDraftAttachmentPending,
+  getDraft,
+  getDraftAttachments,
+  isDraftAttachmentPending,
+  setDraft,
+  setDraftAttachments,
+} from "./drafts";
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() { return values.size; },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => [...values.keys()][index] ?? null,
+    removeItem: (key) => { values.delete(key); },
+    setItem: (key, value) => { values.set(key, value); },
+  };
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, "localStorage");
+});
+
+describe("durable attachment completion", () => {
+  it("appends to the keyed draft without a mounted React state updater", () => {
+    const store = memoryStorage();
+    Object.defineProperty(globalThis, "localStorage", { configurable: true, value: store });
+    appendDraftAttachments("bot:a:thread-a", [{
+      kind: "file",
+      id: "file-1",
+      path: "/private/attachments/file.pdf",
+      name: "file.pdf",
+      size: 42,
+    }]);
+    expect(getDraftAttachments(store, "bot:a:thread-a")).toHaveLength(1);
+    expect(getDraftAttachments(store, "bot:b:thread-b")).toEqual([]);
+  });
+
+  it("merges with the live in-memory draft when storage rejects writes", () => {
+    const readable = memoryStorage();
+    const store: Storage = {
+      ...readable,
+      setItem: () => { throw new DOMException("quota exceeded", "QuotaExceededError"); },
+    };
+    Object.defineProperty(globalThis, "localStorage", { configurable: true, value: store });
+    const draftId = "bot:quota:thread-quota";
+    setDraft(store, draftId, "keep this text");
+    setDraftAttachments(store, draftId, [{
+      kind: "file",
+      id: "existing",
+      path: "/private/attachments/existing.pdf",
+      name: "existing.pdf",
+      size: 10,
+    }]);
+
+    appendDraftAttachments(draftId, [{
+      kind: "file",
+      id: "late",
+      path: "/private/attachments/late.pdf",
+      name: "late.pdf",
+      size: 20,
+    }]);
+
+    expect(getDraft(store, draftId)).toBe("keep this text");
+    expect(getDraftAttachments(store, draftId).map((attachment) => attachment.id))
+      .toEqual(["existing", "late"]);
+  });
+
+  it("keeps concurrent pending uploads scoped to their originating draft", () => {
+    changeDraftAttachmentPending("bot:pending:a", true);
+    changeDraftAttachmentPending("bot:pending:a", true);
+    changeDraftAttachmentPending("bot:pending:b", true);
+    expect(isDraftAttachmentPending("bot:pending:a")).toBe(true);
+    expect(isDraftAttachmentPending("bot:pending:b")).toBe(true);
+
+    // A completion decrements only one operation; extra completions clamp at
+    // zero rather than poisoning a later upload with a negative count.
+    changeDraftAttachmentPending("bot:pending:a", false);
+    changeDraftAttachmentPending("bot:pending:a", false);
+    changeDraftAttachmentPending("bot:pending:a", false);
+    changeDraftAttachmentPending("bot:pending:b", false);
+    expect(isDraftAttachmentPending("bot:pending:a")).toBe(false);
+    expect(isDraftAttachmentPending("bot:pending:b")).toBe(false);
+
+    // Starting again after the balanced cleanup remains a fresh pending item.
+    changeDraftAttachmentPending("bot:pending:a", true);
+    expect(isDraftAttachmentPending("bot:pending:a")).toBe(true);
+    changeDraftAttachmentPending("bot:pending:a", false);
+    expect(isDraftAttachmentPending("bot:pending:a")).toBe(false);
+  });
+});

--- a/src/lib/drafts.ts
+++ b/src/lib/drafts.ts
@@ -1,7 +1,7 @@
 // Unsent composer input, kept per task. Switching tasks unmounts the Composer
 // and its local state. Drafts live in localStorage, so coming back to a task — in this
 // session or after a restart — finds what you were typing still there.
-import { useCallback, useEffect, useState, type SetStateAction } from "react";
+import { useCallback, useEffect, useState, useSyncExternalStore, type SetStateAction } from "react";
 import { isAttachment, type Attachment } from "./composer-attachments.js";
 
 const KEY = "omb-drafts";
@@ -18,6 +18,8 @@ const replyDrafts = new Map<string, string>();
 type DraftRestore = { text: string; attachments: Attachment[] };
 type DraftRestoreListener = (draft: DraftRestore) => void;
 const restoreListeners = new Map<string, Set<DraftRestoreListener>>();
+const attachmentPendingCounts = new Map<string, number>();
+const attachmentPendingListeners = new Map<string, Set<() => void>>();
 export interface FailedComposerSend {
   id: string;
   sendId: string;
@@ -42,6 +44,29 @@ let failedSendSequence = 0;
 type Values = Record<string, unknown>;
 type Store = Pick<Storage, "getItem" | "setItem"> | undefined;
 
+// localStorage is normally authoritative, but it can be unavailable or reject
+// writes (private browsing, a full quota, hardened environments). Keep the
+// same per-store snapshot in memory so an upload completing outside React can
+// merge with the live draft instead of replacing it with an empty fallback.
+const fallbackTextDrafts = new Map<string, string>();
+const fallbackAttachmentDrafts = new Map<string, Attachment[]>();
+const textDraftsByStore = new WeakMap<object, Map<string, string>>();
+const attachmentDraftsByStore = new WeakMap<object, Map<string, Attachment[]>>();
+
+function memoryFor<T>(
+  store: Store,
+  stored: WeakMap<object, Map<string, T>>,
+  fallback: Map<string, T>,
+): Map<string, T> {
+  if (!store) return fallback;
+  const key = store as object;
+  const existing = stored.get(key);
+  if (existing) return existing;
+  const created = new Map<string, T>();
+  stored.set(key, created);
+  return created;
+}
+
 // Storage is best-effort: a full quota, a locked-down origin, or a garbled
 // value must never cost a keystroke — every failure reads as "no drafts".
 function read(store: Store, key: string): Values {
@@ -55,11 +80,16 @@ function read(store: Store, key: string): Values {
 }
 
 export function getDraft(store: Store, id: string): string {
+  const memory = memoryFor(store, textDraftsByStore, fallbackTextDrafts);
+  if (memory.has(id)) return memory.get(id)!;
   const text = read(store, KEY)[id];
-  return typeof text === "string" ? text : "";
+  const value = typeof text === "string" ? text : "";
+  memory.set(id, value);
+  return value;
 }
 
 export function setDraft(store: Store, id: string, text: string): void {
+  memoryFor(store, textDraftsByStore, fallbackTextDrafts).set(id, text);
   const drafts = read(store, KEY);
   // an emptied composer drops its entry rather than storing "" forever
   if (text) drafts[id] = text;
@@ -72,11 +102,16 @@ export function setDraft(store: Store, id: string, text: string): void {
 }
 
 export function getDraftAttachments(store: Store, id: string): Attachment[] {
+  const memory = memoryFor(store, attachmentDraftsByStore, fallbackAttachmentDrafts);
+  if (memory.has(id)) return [...memory.get(id)!];
   const attachments = read(store, ATTACHMENTS_KEY)[id];
-  return Array.isArray(attachments) ? attachments.filter(isAttachment) : [];
+  const value = Array.isArray(attachments) ? attachments.filter(isAttachment) : [];
+  memory.set(id, value);
+  return [...value];
 }
 
 export function setDraftAttachments(store: Store, id: string, attachments: Attachment[]): void {
+  memoryFor(store, attachmentDraftsByStore, fallbackAttachmentDrafts).set(id, [...attachments]);
   const drafts = read(store, ATTACHMENTS_KEY);
   if (attachments.length) drafts[id] = attachments;
   else delete drafts[id];
@@ -207,6 +242,54 @@ export function restoreComposerDraft(id: string, draft: DraftRestore): void {
   setDraft(store, id, draft.text);
   setDraftAttachments(store, id, draft.attachments);
   for (const listener of restoreListeners.get(id) ?? []) listener(draft);
+}
+
+/** Append completed uploads directly to the keyed durable draft. This is
+ * safe after the Composer that started the upload has unmounted. */
+export function appendDraftAttachments(id: string, additions: Attachment[]): void {
+  if (additions.length === 0) return;
+  markDraftEdited(id);
+  const store = getStore();
+  const draft = {
+    text: getDraft(store, id),
+    attachments: [...getDraftAttachments(store, id), ...additions],
+  };
+  setDraftAttachments(store, id, draft.attachments);
+  for (const listener of restoreListeners.get(id) ?? []) listener(draft);
+}
+
+/** Track upload work outside the mounted composer so task navigation cannot
+ * briefly unlock Send and detach a file that is still being persisted. */
+export function changeDraftAttachmentPending(id: string, pending: boolean): void {
+  const previous = attachmentPendingCounts.get(id) ?? 0;
+  const next = pending ? previous + 1 : Math.max(0, previous - 1);
+  if (next === previous) return;
+  if (next > 0) attachmentPendingCounts.set(id, next);
+  else attachmentPendingCounts.delete(id);
+  for (const listener of attachmentPendingListeners.get(id) ?? []) listener();
+}
+
+function subscribeToAttachmentPending(id: string, listener: () => void): () => void {
+  const listeners = attachmentPendingListeners.get(id) ?? new Set<() => void>();
+  listeners.add(listener);
+  attachmentPendingListeners.set(id, listeners);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) attachmentPendingListeners.delete(id);
+  };
+}
+
+export function isDraftAttachmentPending(id: string): boolean {
+  return (attachmentPendingCounts.get(id) ?? 0) > 0;
+}
+
+export function useDraftAttachmentPending(id: string): boolean {
+  const subscribe = useCallback(
+    (listener: () => void) => subscribeToAttachmentPending(id, listener),
+    [id],
+  );
+  const snapshot = useCallback(() => isDraftAttachmentPending(id), [id]);
+  return useSyncExternalStore(subscribe, snapshot, () => false);
 }
 
 function subscribeToDraftRestores(id: string, listener: DraftRestoreListener): () => void {

--- a/src/lib/intake-files.test.ts
+++ b/src/lib/intake-files.test.ts
@@ -33,6 +33,40 @@ describe("intakeFiles", () => {
     expect(out.notice).toBeNull();
   });
 
+  it("uses a private uploaded path for supported documents", async () => {
+    const out = await intakeFiles([file("notes.pdf", "application/pdf")], {
+      allowImages: true,
+      getPath: onDisk,
+      uploadImage: upload,
+      uploadFile: async (value) => ({
+        kind: "file",
+        id: "private-file",
+        name: value.name,
+        path: "/private/attachments/id.pdf",
+        size: value.size,
+      }),
+    });
+
+    expect(out.attachments).toEqual([expect.objectContaining({
+      kind: "file",
+      name: "notes.pdf",
+      path: "/private/attachments/id.pdf",
+    })]);
+    expect(out.notice).toBeNull();
+  });
+
+  it("does not fall back to an arbitrary disk path when a private upload fails", async () => {
+    const out = await intakeFiles([file("notes.pdf", "application/pdf")], {
+      allowImages: true,
+      getPath: onDisk,
+      uploadImage: upload,
+      uploadFile: async () => { throw new Error("private store is full"); },
+    });
+
+    expect(out.attachments).toEqual([]);
+    expect(out.notice).toContain("notes.pdf: private store is full");
+  });
+
   it("treats an image as an ordinary file when the engine cannot read one", async () => {
     const out = await intakeFiles([file("shot.png", "image/png")], {
       allowImages: false,

--- a/src/lib/replies.test.ts
+++ b/src/lib/replies.test.ts
@@ -14,6 +14,8 @@ describe("reply display", () => {
 
   it("turns saved images into a readable bounded snippet", () => {
     expect(replySnippet('<attached-image path="/tmp/a.png" /> hi\nthere')).toBe("[image] hi there");
+    expect(replySnippet('<attached-image path="/tmp/a.png" name="Beach.png" />')).toBe("[image]");
+    expect(replySnippet('<attached-file path="/tmp/a.pdf" name="Plan.pdf" />')).toBe("[file]");
     expect(replySnippet("123456", 5)).toBe("1234…");
   });
 });

--- a/src/lib/replies.ts
+++ b/src/lib/replies.ts
@@ -2,7 +2,10 @@ import type { Message } from "@/state/store";
 
 export function replySnippet(text: string, limit = 160): string {
   const clean = text
-    .replace(/<attached-image\s+path="[^"]*"\s*\/>/g, "[image]")
+    .replace(
+      /<attached-(image|file)\s+path="[^"]*"(?:\s+name="[^"]*")?\s*\/>/g,
+      (_tag, kind: "image" | "file") => kind === "image" ? "[image]" : "[file]",
+    )
     .replace(/\s+/g, " ")
     .trim();
   if (clean.length <= limit) return clean;


### PR DESCRIPTION
## Summary

- Add responsive inline image and file cards across desktop, iPhone, iPad, and Android
- Add full-screen image viewing plus native Markdown, text, share, and open-in previews
- Make composer and routine uploads durable across navigation with bounded retries and a 25 MB limit
- Serve computer-local files only through authenticated, message-scoped routes without exposing host paths
- Block silent remote-image fetching and stale downloads after switching computers or tasks
- Keep attachment transport metadata out of copy, edit, and reply text

## Validation

- TypeScript typecheck
- Full Vitest suite: 3,201 passed, 20 skipped, 1 todo
- Swift package suite: 315 passed
- iOS simulator app build
- Android core/app tests and debug APK build
- Fresh isolated server fixture health check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer attachment previews across web, Android, and iOS, including full-screen images, zooming, galleries, retry actions, sharing, and system open/save options.
  * Added support for uploading and downloading document attachments, with display names preserved.
  * Added attachment thumbnails directly within chat messages.
  * Added safer handling for local and remote attachment links.

* **Bug Fixes**
  * Prevented outdated downloads and previews from appearing after switching chats or tasks.
  * Prevented sending while attachments are still uploading and preserved attachments in drafts.
  * Improved attachment text copying and disabled editing for messages containing attachments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->