### PR TITLE
fix(desktop): use a calmer first-launch window size

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -82,7 +82,7 @@ const {
   decodeBrowserLifecycleMessage,
 } = require("./browser-control-sync.cjs");
 const { createCuaConnectionStore: createDescriptorStore } = require("./cua-connection.cjs");
-const { normalizeUnreadCount, parseWindowState, resolveWindowState } = require("./window-state.cjs");
+const { MIN_BOUNDS, normalizeUnreadCount, parseWindowState, resolveWindowState } = require("./window-state.cjs");
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // 127.0.0.1 explicitly — vite binds IPv4; a bare "localhost" here can
@@ -1528,8 +1528,8 @@ function createWindow() {
   const restored = resolveWindowState(readWindowState(), displays.map((display) => display.workArea));
   const win = new BrowserWindow({
     ...restored.bounds,
-    minWidth: 900,
-    minHeight: 600,
+    minWidth: MIN_BOUNDS.width,
+    minHeight: MIN_BOUNDS.height,
     // The renderer restores its persisted skin before mounting React and
     // mirrors it over desktop:skin. Keep Windows hidden until that handshake
     // recolors the native caption-button overlay, otherwise a saved light

--- a/electron/window-state.cjs
+++ b/electron/window-state.cjs
@@ -1,5 +1,5 @@
-const DEFAULT_BOUNDS = Object.freeze({ width: 1440, height: 920 });
-const MIN_BOUNDS = Object.freeze({ width: 900, height: 600 });
+const DEFAULT_BOUNDS = Object.freeze({ width: 1100, height: 780 });
+const MIN_BOUNDS = Object.freeze({ width: 840, height: 620 });
 
 const integer = (value) => Number.isFinite(value) && Number.isInteger(value);
 const clamp = (value, min, max) => Math.min(Math.max(value, min), max);

--- a/electron/window-state.test.mjs
+++ b/electron/window-state.test.mjs
@@ -29,12 +29,12 @@ describe("desktop window state", () => {
         { bounds: { x: 7000, y: 7000, width: 4000, height: 200 }, maximized: false },
         [primary, left],
       ),
-    ).toEqual({ bounds: { x: 0, y: 240, width: 1920, height: 600 }, maximized: false });
+    ).toEqual({ bounds: { x: 0, y: 230, width: 1920, height: 620 }, maximized: false });
   });
 
   it("uses safe default dimensions when there is no saved state", () => {
     expect(resolveWindowState(null, [primary])).toEqual({
-      bounds: { width: 1440, height: 920 },
+      bounds: { width: 1100, height: 780 },
       maximized: false,
     });
   });


### PR DESCRIPTION
OpenMausBot currently fills most laptop displays on its first launch with a 1440 × 920 window. Match T3 Code’s more approachable desktop default while preserving the existing saved-window restoration behavior.

- open first-time installs at 1100 × 780
- use the matching 840 × 620 minimum
- keep saved size, position, and maximized state on later launches
- share the minimum-size constants with Electron so they cannot drift

Verification:
- `pnpm exec vitest run electron/window-state.test.mjs`
- `pnpm test:electron` (90 passed)
- `pnpm check:electron` (96 modules syntax-checked)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Updated the application’s default window size to 1100×780.
  * Reduced the minimum window size to 840×620, allowing the app to fit more comfortably on smaller screens.
  * Improved handling of oversized or off-screen windows so they reopen within usable screen bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->