### PR TITLE
fix(delegations): make terminal delivery crash-safe and idempotent

### DIFF
--- a/server/delegations.test.ts
+++ b/server/delegations.test.ts
@@ -11,6 +11,7 @@ import type { CommsBus } from "./comms-visibility.ts";
 import { DATA_DIR } from "./config.ts";
 import type { ModelSelection } from "./contracts.ts";
 import {
+  abandonDelegationsForSourceThread,
   buildDelegationFailurePrompt,
   buildDelegationRevivalPrompt,
   DELEGATION_WAKE_MAX_PER_WINDOW,
@@ -27,9 +28,12 @@ import {
   releaseDelegationsWaitingOn,
   summarizeDelegatedActivity,
   threadsWaitingOn,
+  _loadPending,
   _pendingCount,
+  _resetPending,
 } from "./delegations.ts";
 import { peerAllowKey, resolvePeerComms } from "./peer-approval.ts";
+import * as mdb from "./message-db.ts";
 import { Store, type BotRecord } from "./store.ts";
 
 const selection = (): ModelSelection => ({ instanceId: "claude", model: "fake-model" });
@@ -116,6 +120,17 @@ describe("queueDelegation", () => {
     }, 1);
     expect(result.result).toBe("no_target");
     expect(_pendingCount(from.threadId)).toBe(0);
+  });
+
+  it("fails closed when the durable ledger cannot record a handoff", () => {
+    const create = vi.spyOn(mdb, "createDelegationTask").mockImplementationOnce(() => {
+      throw new Error("disk full");
+    });
+    const result = queueDelegation(commsBus, from, { toBotId: target.id, message: "do not dispatch", depth: 0 }, 1);
+    create.mockRestore();
+    expect(result).toEqual({ result: "persistence_error" });
+    expect(_pendingCount(from.threadId)).toBe(0);
+    expect(store.messagesFor(from.threadId).some((message) => message.tool?.name.includes("durable storage failed"))).toBe(true);
   });
 
   it("queues, broadcasts, and drops a 'Delegated to @Target' chip on the source thread", () => {
@@ -208,6 +223,103 @@ describe("drainDelegations", () => {
     // double-check by counting the module's pending map: tests that didn't
     // resolve should be re-examined if this ever fires.
     void runTargetCalls;
+  });
+
+  it("terminalizes a persisted launch on restart instead of dispatching it twice", async () => {
+    const queued = queueDelegation(commsBus, from, { toBotId: target.id, message: "one external side effect", depth: 0 }, 1);
+    let calls = 0;
+    drainDelegations(commsBus, approvalBus, from.threadId, () => {
+      calls += 1;
+      return new Promise<void>(() => {}); // crash after launch claim, before acknowledgement
+    });
+    await waitFor(() => calls === 1);
+
+    _resetPending();
+    _loadPending();
+    expect(_pendingCount(from.threadId)).toBe(0);
+    expect(findDelegationReceipt(queued.id!)).toMatchObject({ status: "failed" });
+    drainDelegations(commsBus, approvalBus, from.threadId, () => { calls += 1; });
+    await Promise.resolve();
+    expect(calls).toBe(1);
+  });
+
+  it("terminalizes and abandons a queued task when its source bot was removed before restart drain", async () => {
+    const queued = queueDelegation(commsBus, from, { toBotId: target.id, message: "never dispatch this", depth: 0 }, 1);
+    expect(queued.id).toBeTruthy();
+    store.deleteBot(from.id);
+
+    _resetPending();
+    _loadPending();
+    let calls = 0;
+    drainDelegations(commsBus, approvalBus, from.threadId, () => { calls += 1; });
+    await waitFor(() => _pendingCount(from.threadId) === 0);
+
+    expect(calls).toBe(0);
+    expect(findDelegationReceipt(queued.id!)).toMatchObject({
+      status: "dropped",
+      result: expect.stringContaining("source bot or task was removed"),
+    });
+    expect(mdb.delegationTask(queued.id!)).toMatchObject({
+      state: "terminal",
+      sourceDelivery: "abandoned",
+      sourceContext: "abandoned",
+      sourceWake: "abandoned",
+    });
+  });
+
+  it("abandons inactive-task handoffs before bot deletion so reload cannot dispatch them", async () => {
+    const inactiveTask = store.createTask(from.id, "Inactive source", false)!;
+    const queued = queueDelegation(
+      commsBus,
+      from,
+      { toBotId: target.id, message: "never dispatch inactive work", depth: 0 },
+      1,
+      inactiveTask.threadId,
+    );
+    abandonDelegationsForSourceThread(inactiveTask.threadId);
+    store.deleteBot(from.id);
+
+    _resetPending();
+    _loadPending();
+    let calls = 0;
+    drainDelegations(commsBus, approvalBus, inactiveTask.threadId, () => { calls += 1; });
+    await Promise.resolve();
+
+    expect(calls).toBe(0);
+    expect(_pendingCount(inactiveTask.threadId)).toBe(0);
+    expect(mdb.delegationTask(queued.id!)).toMatchObject({
+      state: "terminal",
+      sourceDelivery: "abandoned",
+      sourceWake: "abandoned",
+    });
+  });
+
+  it("abandons a task handoff before task deletion so reload cannot dispatch it", async () => {
+    const deletedTask = store.createTask(from.id, "Deleted source", false)!;
+    const queued = queueDelegation(
+      commsBus,
+      from,
+      { toBotId: target.id, message: "never dispatch deleted task work", depth: 0 },
+      1,
+      deletedTask.threadId,
+    );
+    abandonDelegationsForSourceThread(deletedTask.threadId);
+    expect(store.deleteTask(from.id, deletedTask.threadId)).toBeTruthy();
+
+    _resetPending();
+    _loadPending();
+    let calls = 0;
+    drainDelegations(commsBus, approvalBus, deletedTask.threadId, () => { calls += 1; });
+    await Promise.resolve();
+
+    expect(calls).toBe(0);
+    expect(_pendingCount(deletedTask.threadId)).toBe(0);
+    expect(mdb.delegationTask(queued.id!)).toMatchObject({
+      state: "terminal",
+      sourceDelivery: "abandoned",
+      sourceContext: "abandoned",
+      sourceWake: "abandoned",
+    });
   });
 
   it("runs the target's turn via runTarget and mirrors the exchange", async () => {
@@ -498,7 +610,7 @@ describe("drainDelegations", () => {
 
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { _loadPending, _resetPending, discardDelegations, pendingThreads } from "./delegations.ts";
+import { discardDelegations, pendingThreads } from "./delegations.ts";
 
 describe("delegations survive a restart", () => {
   let store: Store;

--- a/server/delegations.ts
+++ b/server/delegations.ts
@@ -19,6 +19,7 @@ import { getOrCreateChannel, mirrorExchange, type CommsBus } from "./comms-visib
 import { DATA_DIR } from "./config.ts";
 import { newId } from "./contracts.ts";
 import { requestPeerApproval, type ApprovalBus } from "./peer-approval.ts";
+import * as mdb from "./message-db.ts";
 import { sectionKey, type BotRecord, type GroupRecord } from "./store.ts";
 
 export interface DelegationItem {
@@ -66,7 +67,7 @@ export interface DelegationReceipt {
   finishedAt: number;
 }
 
-export type QueueResult = "ok" | "no_target" | "self" | "too_deep" | "too_many";
+export type QueueResult = "ok" | "no_target" | "self" | "too_deep" | "too_many" | "persistence_error";
 
 /** What queueDelegation hands back: the verdict, and on success the task id
  * the delegating bot can later read back with check/wait_delegation. */
@@ -105,8 +106,19 @@ function saveReceipts(): void {
 
 /** Record one terminal outcome. Newest first; pruned by count and age so the
  * drawer can never grow without bound. */
-export function recordDelegationReceipt(receipt: Omit<DelegationReceipt, "finishedAt"> & { finishedAt?: number }): void {
+export function recordDelegationReceipt(receipt: Omit<DelegationReceipt, "finishedAt"> & { finishedAt?: number }): boolean {
   const now = Date.now();
+  // New ledger-backed tasks transition before the legacy receipt cache is
+  // touched. The cache remains for older installations/read compatibility,
+  // never as the authority for a new task's crash recovery.
+  const task = mdb.delegationTask(receipt.id);
+  // The ledger's compare-and-set makes the first terminal observation the
+  // authority. Later completion events must not reopen source delivery or
+  // replace a result which may already have reached the source transcript.
+  const settled = task
+    ? mdb.settleDelegationTask(receipt.id, receipt.status, receipt.result?.slice(0, RESULT_MAX_CHARS), receipt.finishedAt ?? now)
+    : undefined;
+  if (task && !settled) return false;
   const bounded: DelegationReceipt = {
     id: receipt.id,
     sourceThreadId: receipt.sourceThreadId,
@@ -120,9 +132,22 @@ export function recordDelegationReceipt(receipt: Omit<DelegationReceipt, "finish
     .filter((existing) => now - existing.finishedAt <= RECEIPT_MAX_AGE_MS)
     .slice(0, MAX_RECEIPTS);
   saveReceipts();
+  return true;
 }
 
 export function findDelegationReceipt(id: string): DelegationReceipt | null {
+  const task = mdb.delegationTask(id);
+  if (task?.state === "terminal" && task.terminalStatus && task.finishedAt) {
+    return {
+      id: task.taskId,
+      sourceThreadId: task.sourceThreadId,
+      toBotId: task.toBotId,
+      toBotName: task.toBotName,
+      status: task.terminalStatus as DelegationOutcome,
+      ...(task.terminalResult !== undefined ? { result: task.terminalResult } : {}),
+      finishedAt: task.finishedAt,
+    };
+  }
   return receipts.find((receipt) => receipt.id === id) ?? null;
 }
 
@@ -152,7 +177,10 @@ export function releaseDelegationsWaitingOn(toBotId: string): string[] {
   if (!threads.length) return threads;
   for (const threadId of threads) {
     for (const item of pendingDelegations.get(threadId) ?? []) {
-      if (item.toBotId === toBotId) delete item.waitingOnBusy;
+      if (item.toBotId === toBotId) {
+        delete item.waitingOnBusy;
+        mdb.updateDelegationTask(item.id, { waitingOnBusy: false });
+      }
     }
   }
   savePending();
@@ -225,6 +253,78 @@ export function _loadPending(): void {
   } catch {
     /* no receipts yet */
   }
+
+  // One-way compatibility import: old queue rows become ledger rows before
+  // any boot drain. Existing ids are stable in supported versions; malformed
+  // legacy rows were already discarded above.
+  for (const [sourceThreadId, items] of pendingDelegations) {
+    for (const item of items) {
+      if (mdb.delegationTask(item.id)) continue;
+      try {
+        mdb.createDelegationTask({
+          taskId: item.id,
+          sourceThreadId,
+          toBotId: item.toBotId,
+          toBotName: item.toBotId,
+          message: item.message,
+          ...(item.reason ? { reason: item.reason } : {}),
+          depth: item.depth,
+          approvalGranted: item.approvalAlreadyGranted === true,
+          attempts: item.attempts,
+          waitingOnBusy: item.waitingOnBusy === true,
+          state: "queued",
+          sourceDelivery: "pending",
+          createdAt: Date.now(),
+        });
+      } catch {
+        // Leave the legacy item visible rather than silently starting work
+        // without a ledger. processOne will fail closed at its launch claim.
+      }
+    }
+  }
+  // Never redispatch an ambiguous provider launch after process death.
+  mdb.terminalizeInterruptedDelegations("the delegated turn was interrupted when OpenMausBot restarted");
+  pendingDelegations.clear();
+  mdb.pruneDelegationTasks(Date.now() - RECEIPT_MAX_AGE_MS, MAX_RECEIPTS);
+  for (const task of mdb.delegationTasks(["queued"])) {
+    const item: PendingDelegationItem = {
+      id: task.taskId,
+      toBotId: task.toBotId,
+      message: task.message,
+      ...(task.reason ? { reason: task.reason } : {}),
+      depth: task.depth,
+      attempts: task.attempts,
+    };
+    if (task.approvalGranted) item.approvalAlreadyGranted = true;
+    if (task.waitingOnBusy) item.waitingOnBusy = true;
+    const list = pendingDelegations.get(task.sourceThreadId) ?? [];
+    list.push(item);
+    pendingDelegations.set(task.sourceThreadId, list);
+  }
+}
+
+/** Terminal outcomes which survived a crash before their source transcript
+ * was updated. The server owns rendering/wake policy; this module owns the
+ * durable task state. */
+export function pendingDelegationDeliveries(): mdb.DelegationTaskRow[] {
+  return mdb.pendingDelegationDeliveries();
+}
+
+/** Claim one queued item before provider dispatch. */
+function claimDelegationLaunch(itemId: string, targetThreadId: string): boolean {
+  return mdb.claimDelegationLaunch(itemId, targetThreadId);
+}
+
+export function markDelegationRunning(taskId: string): void {
+  const task = mdb.delegationTask(taskId);
+  if (!task || task.state !== "launching") return;
+  mdb.updateDelegationTask(taskId, { state: "running" });
+}
+
+/** Register an already-running peer turn when ask_bot's bounded wait expires.
+ * This writes before the waiter resolves, closing the timeout/completion race. */
+export function registerRunningDelegation(task: Omit<mdb.DelegationTaskRow, "state" | "sourceDelivery" | "sourceContext" | "sourceWake" | "createdAt">): void {
+  mdb.createDelegationTask({ ...task, state: "running", sourceDelivery: "pending", sourceContext: "pending", sourceWake: "pending", createdAt: Date.now() });
 }
 
 /** Source threads with something queued — what a boot drain iterates. */
@@ -271,6 +371,33 @@ export function queueDelegation(
   // and fan out into as many real turns on the next settle.
   if (list.length >= MAX_QUEUED_PER_THREAD) return { result: "too_many" };
   const id = newId();
+  // This is the dispatch boundary: if the ledger cannot be written, do not
+  // leave an item that could later start an untracked external worker.
+  try {
+    mdb.createDelegationTask({
+      taskId: id,
+      sourceThreadId,
+      toBotId: item.toBotId,
+      toBotName: target.name,
+      message: item.message,
+      ...(item.reason ? { reason: item.reason } : {}),
+      depth: item.depth,
+      approvalGranted: item.approvalAlreadyGranted === true,
+      attempts: 0,
+      waitingOnBusy: false,
+      state: "queued",
+      sourceDelivery: "pending",
+      createdAt: Date.now(),
+    });
+  } catch (error) {
+    const why = error instanceof Error ? error.message : String(error);
+    bus.store.appendMessage(sourceThreadId, {
+      role: "bot",
+      kind: "activity",
+      tool: { name: `Delegation was not queued — durable storage failed: ${why.slice(0, 120)}`, ok: false },
+    });
+    return { result: "persistence_error" };
+  }
   list.push({ ...item, id, attempts: 0 });
   pendingDelegations.set(sourceThreadId, list);
   savePending();
@@ -310,6 +437,10 @@ export function drainDelegations(
   if (!list?.length) return;
   const from = bus.store.botByThread(threadId);
   if (!from) {
+    // This queue may have survived a restart after its bot/task was deleted.
+    // It must become a terminal abandoned record, never an immortal queued
+    // payload that rehydrates on every later boot.
+    for (const item of list) abandonMissingSourceDelegation(threadId, item);
     pendingDelegations.delete(threadId);
     savePending();
     return;
@@ -332,11 +463,7 @@ export function drainDelegations(
           result: why.slice(0, 200),
         });
         try {
-          bus.store.appendMessage(threadId, {
-            role: "bot",
-            kind: "activity",
-            tool: { name: `error: delegation failed — ${why.slice(0, 120)}`, ok: false },
-          });
+          deliverDelegationActivity(bus, threadId, item.id, `error: delegation failed — ${why.slice(0, 120)}`);
         } catch (reportError) {
           console.error("delegation failed and could not be reported", reportError);
         }
@@ -362,6 +489,50 @@ export function drainDelegations(
 }
 
 /** Remove one terminal handoff only after approval/dispatch has settled. */
+function deliverDelegationActivity(
+  bus: CommsBus,
+  sourceThreadId: string,
+  taskId: string,
+  name: string,
+  ok = false,
+): void {
+  bus.store.appendDelegationOutcome(sourceThreadId, taskId, {
+    role: "bot",
+    kind: "activity",
+    tool: { name, ok },
+  });
+  // The server supplies this continuation hook. Keeping the queue module
+  // harness-free preserves its focused tests while every settled terminal
+  // path still drives the same durable context/wake outbox.
+  (bus as CommsBus & { onDelegationTerminal?: (id: string, threadId: string) => void })
+    .onDelegationTerminal?.(taskId, sourceThreadId);
+}
+
+function abandonMissingSourceDelegation(threadId: string, item: PendingDelegationItem): void {
+  const settled = recordDelegationReceipt({
+    id: item.id,
+    sourceThreadId: threadId,
+    toBotId: item.toBotId,
+    toBotName: item.toBotId,
+    status: "dropped",
+    result: "the source bot or task was removed before this delegation could dispatch",
+  });
+  if (settled) mdb.abandonDelegationDelivery(item.id);
+}
+
+/** Called by task/bot deletion before the transcript disappears. The ledger
+ * operation covers queued, ambiguous, terminal, and outbox states; this map
+ * cleanup prevents a same-process drain from retaining stale work. */
+export function abandonDelegationsForSourceThread(threadId: string): void {
+  pendingDelegations.delete(threadId);
+  queuedRedrains.delete(threadId);
+  mdb.abandonDelegationsForSourceThread(
+    threadId,
+    "the source bot or task was removed before this delegation could dispatch",
+  );
+  savePending();
+}
+
 function acknowledgeDelegation(threadId: string, itemId: string): void {
   const current = pendingDelegations.get(threadId);
   if (!current) return;
@@ -378,17 +549,19 @@ export function discardDelegations(bus: CommsBus, threadId: string): void {
   if (!list?.length) return;
   pendingDelegations.delete(threadId);
   savePending();
+  const from = bus.store.botByThread(threadId);
   for (const item of list) {
+    const targetName = bus.store.bot(item.toBotId)?.name ?? item.toBotId;
     recordDelegationReceipt({
       id: item.id,
       sourceThreadId: threadId,
       toBotId: item.toBotId,
-      toBotName: bus.store.bot(item.toBotId)?.name ?? item.toBotId,
+      toBotName: targetName,
       status: "dropped",
       result: "the delegating turn did not finish",
     });
+    if (from) deliverDelegationActivity(bus, threadId, item.id, `Delegation to @${targetName} dropped — the delegating turn did not finish`);
   }
-  const from = bus.store.botByThread(threadId);
   if (!from) return;
   bus.store.appendMessage(threadId, {
     role: "bot",
@@ -414,6 +587,10 @@ async function processOne(
 ): Promise<"settled" | "requeued"> {
   let sender = from;
   let target = bus.store.bot(item.toBotId);
+  if (!bus.store.taskByThread(sender.id, sourceThreadId)) {
+    abandonMissingSourceDelegation(sourceThreadId, item);
+    return "settled";
+  }
   if (!target) {
     recordDelegationReceipt({
       id: item.id,
@@ -423,11 +600,7 @@ async function processOne(
       status: "error",
       result: "no such bot",
     });
-    bus.store.appendMessage(sourceThreadId, {
-      role: "bot",
-      kind: "activity",
-      tool: { name: `error: delegation to ${item.toBotId} failed — no such bot`, ok: false },
-    });
+    deliverDelegationActivity(bus, sourceThreadId, item.id, `error: delegation to ${item.toBotId} failed — no such bot`);
     return "settled";
   }
   if (dropIfSectionsChanged(bus, sender, target, sourceThreadId, item)) {
@@ -437,6 +610,7 @@ async function processOne(
     if (item.waitingOnBusy) return "requeued";
     item.attempts += 1;
     item.waitingOnBusy = true;
+    mdb.updateDelegationTask(item.id, { attempts: item.attempts, waitingOnBusy: true });
     if (item.attempts < MAX_BUSY_ATTEMPTS) {
       savePending();
       bus.store.appendMessage(sourceThreadId, {
@@ -454,15 +628,12 @@ async function processOne(
       status: "busy_gave_up",
       result: `@${target.name} stayed busy through ${MAX_BUSY_ATTEMPTS} retries`,
     });
-    bus.store.appendMessage(sourceThreadId, {
-      role: "bot",
-      kind: "activity",
-      tool: { name: `Delegation to @${target.name} canceled — still busy after ${MAX_BUSY_ATTEMPTS} retries`, ok: false },
-    });
+    deliverDelegationActivity(bus, sourceThreadId, item.id, `Delegation to @${target.name} canceled — still busy after ${MAX_BUSY_ATTEMPTS} retries`);
     return "settled";
   }
   if (item.waitingOnBusy) {
     delete item.waitingOnBusy;
+    mdb.updateDelegationTask(item.id, { waitingOnBusy: false });
     savePending();
   }
   if (sender.approvePeerComms && !item.approvalAlreadyGranted) {
@@ -483,11 +654,7 @@ async function processOne(
         status: "denied",
         result: "the user denied this handoff",
       });
-      bus.store.appendMessage(sourceThreadId, {
-        role: "bot",
-        kind: "activity",
-        tool: { name: `Delegation to @${target.name} denied by user`, ok: false },
-      });
+      deliverDelegationActivity(bus, sourceThreadId, item.id, `Delegation to @${target.name} denied by user`);
       return "settled";
     }
     // The approval could have been sitting for up to 15 minutes. Everything
@@ -496,7 +663,22 @@ async function processOne(
     // and mirror a "Messaged @X" chip for an exchange that never happens.
     const current = bus.store.bot(item.toBotId);
     const currentSender = bus.store.bot(from.id);
-    if (!current || !currentSender || !bus.store.taskByThread(currentSender.id, sourceThreadId)) return "settled";
+    if (!currentSender || !bus.store.taskByThread(currentSender.id, sourceThreadId)) {
+      abandonMissingSourceDelegation(sourceThreadId, item);
+      return "settled";
+    }
+    if (!current) {
+      recordDelegationReceipt({
+        id: item.id,
+        sourceThreadId,
+        toBotId: item.toBotId,
+        toBotName: item.toBotId,
+        status: "error",
+        result: "the target bot was removed before this delegation could dispatch",
+      });
+      deliverDelegationActivity(bus, sourceThreadId, item.id, `error: delegation to ${item.toBotId} failed — target bot was removed`);
+      return "settled";
+    }
     if (dropIfSectionsChanged(bus, currentSender, current, sourceThreadId, item)) {
       return "settled";
     }
@@ -504,6 +686,7 @@ async function processOne(
       if (item.waitingOnBusy) return "requeued";
       item.attempts += 1;
       item.waitingOnBusy = true;
+      mdb.updateDelegationTask(item.id, { attempts: item.attempts, waitingOnBusy: true });
       if (item.attempts < MAX_BUSY_ATTEMPTS) {
         savePending();
         bus.store.appendMessage(sourceThreadId, {
@@ -521,15 +704,17 @@ async function processOne(
         status: "busy_gave_up",
         result: `@${current.name} stayed busy through ${MAX_BUSY_ATTEMPTS} retries`,
       });
-      bus.store.appendMessage(sourceThreadId, {
-        role: "bot",
-        kind: "activity",
-        tool: { name: `Delegation to @${current.name} canceled — still busy after ${MAX_BUSY_ATTEMPTS} retries`, ok: false },
-      });
+      deliverDelegationActivity(bus, sourceThreadId, item.id, `Delegation to @${current.name} canceled — still busy after ${MAX_BUSY_ATTEMPTS} retries`);
       return "settled";
     }
     sender = currentSender;
     target = current;
+  }
+  // Persist launch intent before mirroring or provider dispatch. If this
+  // compare-and-set fails, a concurrent/recovered drain already owns the
+  // task and must be allowed to settle it alone.
+  if (!claimDelegationLaunch(item.id, target.threadId)) {
+    return "settled";
   }
   const channel = getOrCreateChannel(bus.store, sender, target);
   mirrorExchange(bus, sender, target, item.message, channel, sourceThreadId);
@@ -560,11 +745,7 @@ function dropIfSectionsChanged(
     status: "dropped",
     result,
   });
-  bus.store.appendMessage(sourceThreadId, {
-    role: "bot",
-    kind: "activity",
-    tool: { name: `Delegation to @${target.name} canceled — bots now belong to different sections`, ok: false },
-  });
+  deliverDelegationActivity(bus, sourceThreadId, item.id, `Delegation to @${target.name} canceled — bots now belong to different sections`);
   return true;
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -136,9 +136,9 @@ import type { GroupGoalRunCardData, GroupGoalRunStatus } from "../shared/group-g
 
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
 import { getOrCreateChannel, mirrorActivity, mirrorExchange, mirrorReply, type CommsBus } from "./comms-visibility.ts";
-import { searchMessages } from "./message-db.ts";
+import { abandonDelegationDelivery, acknowledgeDelegationContext, acknowledgeDelegationWake, claimDelegationWake, delegationTask, releaseDelegationWakeClaim, searchMessages } from "./message-db.ts";
 import { promptWithReply, transcriptText } from "./replies.ts";
-import { _loadPending, buildDelegationFailurePrompt, buildDelegationRevivalPrompt, DelegationWakeBudget, discardDelegations, drainDelegations, findDelegationReceipt, pendingDelegationInfo, pendingDelegationSnapshot, pendingThreads, queueDelegation, recordDelegationReceipt, releaseDelegationsWaitingOn, summarizeDelegatedActivity, type QueueResult } from "./delegations.ts";
+import { _loadPending, abandonDelegationsForSourceThread, buildDelegationFailurePrompt, buildDelegationRevivalPrompt, DELEGATION_WAKE_WINDOW_MS, DelegationWakeBudget, discardDelegations, drainDelegations, findDelegationReceipt, markDelegationRunning, pendingDelegationDeliveries, pendingDelegationInfo, pendingDelegationSnapshot, pendingThreads, queueDelegation, recordDelegationReceipt, registerRunningDelegation, releaseDelegationsWaitingOn, summarizeDelegatedActivity, type QueueResult } from "./delegations.ts";
 import {
   cancelSteeredMessage,
   drainSteeredMessages,
@@ -708,11 +708,18 @@ function controlIntegration(botId: string) {
 type AskBotOutcome = {
   status: "reply" | "failed" | "timeout" | "error";
   text: string;
+  taskId?: string;
   /** Provider's stop reason when the turn completed not-ok. */
   stopReason?: string | null;
 };
 
-function askBotAndWait(targetBotId: string, message: string, depth: number, fromBotId?: string): Promise<AskBotOutcome> {
+function askBotAndWait(
+  targetBotId: string,
+  message: string,
+  depth: number,
+  fromBotId?: string,
+  onTimeout?: () => string | undefined,
+): Promise<AskBotOutcome> {
   const target = store.bot(targetBotId);
   if (!target) return Promise.resolve({ status: "error", text: "(no such bot)" });
   const threadId = target.threadId;
@@ -741,7 +748,13 @@ function askBotAndWait(targetBotId: string, message: string, depth: number, from
     });
     // Timing out does NOT stop the peer's turn — the caller decides whether
     // the still-running work becomes a delegation claim ticket instead.
-    const timer = setTimeout(() => finish({ status: "timeout", text }), ASK_BOT_TIMEOUT_MS);
+    const timer = setTimeout(() => {
+      // Register the durable handoff before finish() removes this event
+      // listener. A provider completion racing this timeout then sees the
+      // watch instead of becoming an untracked orphan.
+      const taskId = onTimeout?.();
+      finish({ status: "timeout", text, ...(taskId ? { taskId } : {}) });
+    }, ASK_BOT_TIMEOUT_MS);
     startTurn(targetBotId, message, {
       commsDepth: depth + 1,
       unattended: isUnattended(fromBotId),
@@ -2421,56 +2434,106 @@ const delegationWatch = new Map<string, {
 // fold the result in and answer the user instead of sitting idle. Mirrors
 // the cardContinuation resume pattern used for connector/credential cards.
 const delegationWakeBudget = new DelegationWakeBudget();
-const pendingDelegationWakes = new Map<string, { botId: string; targetName: string; failureReason?: string }>();
+// Keyed by task id, not source thread: two completed delegations on one
+// thread each retain an independent durable wake claim.
+const pendingDelegationWakes = new Map<string, { botId: string; threadId: string; targetName: string; failureReason?: string }>();
+const delegationWakeRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
-function dispatchDelegationWake(botId: string, threadId: string, targetName: string, failureReason?: string): void {
-  const prompt = failureReason
-    ? buildDelegationFailurePrompt(targetName, failureReason)
-    : buildDelegationRevivalPrompt(targetName);
+function deferDelegationWakeDrain(threadId: string): void {
+  if (delegationWakeRetryTimers.has(threadId)) return;
+  const timer = setTimeout(() => {
+    delegationWakeRetryTimers.delete(threadId);
+    drainDelegationWakes();
+  }, DELEGATION_WAKE_WINDOW_MS);
+  timer.unref?.();
+  delegationWakeRetryTimers.set(threadId, timer);
+}
+
+function dispatchDelegationWake(taskId: string, botId: string, threadId: string, targetName: string, failureReason?: string): void {
+  const prompt = failureReason ? buildDelegationFailurePrompt(targetName, failureReason) : buildDelegationRevivalPrompt(targetName);
+  let accepted = false;
+  const handleDispatchError = (reason: unknown) => {
+    const message = reason instanceof Error ? reason.message : String(reason);
+    // A deletion can race this detached setup callback. Never recreate the
+    // vanished transcript or requeue a wake for an owner that no longer has
+    // the task; the ledger remains terminal but all source effects are done.
+    if (!store.bot(botId) || !store.taskByThread(botId, threadId)) {
+      pendingDelegationWakes.delete(taskId);
+      abandonDelegationDelivery(taskId);
+      return;
+    }
+    // No provider dispatch happened for an already-working race or a setup
+    // cancellation, so release this persisted claim and retry when the source
+    // becomes idle. Other setup failures are reported once under the existing
+    // non-retry policy.
+    if (!accepted && /(already working|stopped before dispatch|setup cancelled)/i.test(message)) {
+      releaseDelegationWakeClaim(taskId);
+      pendingDelegationWakes.set(taskId, { botId, threadId, targetName, failureReason });
+      return;
+    }
+    if (!accepted) acknowledgeDelegationWake(taskId);
+    store.appendMessage(threadId, {
+      role: "bot", kind: "activity",
+      tool: { name: `error: could not resume after delegation — ${message.slice(0, 120)}`, ok: false },
+    });
+  };
   void startTurn(botId, prompt, {
     threadId,
     cardContinuation: true,
     unattended: isUnattended(botId),
-  })
-    .then(() => undefined)
-    .catch((error) => {
-      const message = error instanceof Error ? error.message : String(error);
-      // Raced with a user turn claiming the bot — retry once it settles.
-      if (/already working/i.test(message)) {
-        pendingDelegationWakes.set(threadId, { botId, targetName, failureReason });
-        return;
-      }
-      store.appendMessage(threadId, {
-        role: "bot",
-        kind: "activity",
-        tool: {
-          name: `error: could not resume after delegation — ${message.slice(0, 120)}`,
-          ok: false,
-        },
-      });
-    });
+    onDispatchAccepted: () => {
+      accepted = true;
+      acknowledgeDelegationWake(taskId);
+    },
+    onDispatchError: handleDispatchError,
+  }).catch(handleDispatchError);
 }
 
-function wakeDelegationSource(source: BotRecord, threadId: string, targetName: string, failureReason?: string): void {
-  // Busy? Hold the wake until the source settles, then drain it — the
-  // delegated reply is already in the thread, so nothing is lost, and the
-  // source processes it the moment it is free rather than only on a later
-  // user nudge.
+function wakeDelegationSource(taskId: string, source: BotRecord, threadId: string, targetName: string, failureReason?: string): void {
   if (store.bot(source.id)?.busy) {
-    pendingDelegationWakes.set(threadId, { botId: source.id, targetName, failureReason });
+    pendingDelegationWakes.set(taskId, { botId: source.id, threadId, targetName, failureReason });
     return;
   }
-  if (!delegationWakeBudget.tryAcquire(threadId)) return;
-  dispatchDelegationWake(source.id, threadId, targetName, failureReason);
+  if (!delegationWakeBudget.tryAcquire(threadId)) {
+    pendingDelegationWakes.set(taskId, { botId: source.id, threadId, targetName, failureReason });
+    deferDelegationWakeDrain(threadId);
+    return;
+  }
+  // Persist before starting the provider. On restart, a claimed wake becomes
+  // a clear interrupted-continuation notice instead of a duplicate model run.
+  if (!claimDelegationWake(taskId)) return;
+  dispatchDelegationWake(taskId, source.id, threadId, targetName, failureReason);
 }
 
 function drainDelegationWakes(): void {
-  for (const [threadId, entry] of pendingDelegationWakes) {
-    if (store.bot(entry.botId)?.busy) continue;
-    pendingDelegationWakes.delete(threadId);
-    if (!delegationWakeBudget.tryAcquire(threadId)) continue;
-    dispatchDelegationWake(entry.botId, threadId, entry.targetName, entry.failureReason);
+  for (const [taskId, entry] of pendingDelegationWakes) {
+    const source = store.bot(entry.botId);
+    if (!source || !store.taskByThread(source.id, entry.threadId)) {
+      pendingDelegationWakes.delete(taskId);
+      abandonDelegationDelivery(taskId);
+      continue;
+    }
+    if (source.busy) continue;
+    if (!delegationWakeBudget.tryAcquire(entry.threadId)) {
+      deferDelegationWakeDrain(entry.threadId);
+      continue;
+    }
+    pendingDelegationWakes.delete(taskId);
+    if (!claimDelegationWake(taskId)) continue;
+    dispatchDelegationWake(taskId, entry.botId, entry.threadId, entry.targetName, entry.failureReason);
   }
+}
+
+/** Deletion removes a source transcript permanently, so it must cancel every
+ * queued/terminal source effect before Store removes task ownership. */
+function abandonSourceDelegationThread(threadId: string): void {
+  abandonDelegationsForSourceThread(threadId);
+  for (const [taskId, entry] of pendingDelegationWakes) {
+    if (entry.threadId === threadId) pendingDelegationWakes.delete(taskId);
+  }
+  const timer = delegationWakeRetryTimers.get(threadId);
+  if (timer) clearTimeout(timer);
+  delegationWakeRetryTimers.delete(threadId);
 }
 
 // Provider-native sessions only know about messages produced inside their
@@ -2498,9 +2561,69 @@ function markTaskContextExternallyUpdated(bot: BotRecord, threadId: string): voi
   store.patchBot(bot.id, patch);
 }
 
+/** Deliver a persisted terminal outcome once. The ledger transaction writes
+ * the stable source message id and delivery acknowledgement together; a boot
+ * retry can therefore safely call this again after any crash boundary. */
+function deliverDelegationOutcome(
+  taskId: string,
+  sourceThreadId: string,
+  targetId: string,
+  targetName: string,
+  ok: boolean,
+  reply: string,
+  failureName: string,
+): void {
+  const source = store.botByThread(sourceThreadId);
+  if (!source || !store.taskByThread(source.id, sourceThreadId)) {
+    // A deleted source cannot consume this result. Acknowledge abandonment so
+    // every startup does not retry an impossible delivery forever.
+    abandonDelegationDelivery(taskId);
+    return;
+  }
+  const target = store.bot(targetId);
+  if (ok && reply.trim()) {
+    const sourceReply: Omit<Message, "id" | "at"> = {
+      role: "bot", kind: "text",
+      text: `@${targetName} replied to the delegated task:\n\n${reply.trim()}`,
+    };
+    if (target) sourceReply.from = { botId: target.id, name: target.name, color: target.color };
+    store.appendDelegationOutcome(sourceThreadId, taskId, sourceReply);
+  } else {
+    store.appendDelegationOutcome(sourceThreadId, taskId, {
+      role: "bot", kind: "activity",
+      tool: { name: ok ? `Delegation to @${targetName} completed without a text reply` : `Delegation to @${targetName} failed — ${failureName}`, ok },
+    });
+  }
+  // The source message and context marker use independent durable acks. If
+  // either process boundary crashes, boot replays just the missing safe step.
+  // Mark first, then acknowledge. A crash in between safely repeats the
+  // idempotent invalidation at boot; reversing that order could acknowledge
+  // a context marker that never reached the bot store.
+  if (delegationTask(taskId)?.sourceContext === "pending") {
+    markTaskContextExternallyUpdated(source, sourceThreadId);
+    acknowledgeDelegationContext(taskId);
+  }
+  wakeDelegationSource(taskId, source, sourceThreadId, targetName, ok && reply.trim() ? undefined : (failureName || "the delegated turn did not finish"));
+}
+
 /** Consume one delegated-turn watch and mirror exactly one terminal state.
  * Some harness paths settle a busy bot without a provider turn.completed
  * event, so they call this same finalizer explicitly. */
+function resumeTerminalDelegation(taskId: string, sourceThreadId: string): void {
+  const task = delegationTask(taskId);
+  if (!task || task.state !== "terminal" || task.sourceThreadId !== sourceThreadId) return;
+  const ok = task.terminalStatus === "done";
+  deliverDelegationOutcome(
+    task.taskId,
+    task.sourceThreadId,
+    task.toBotId,
+    task.toBotName,
+    ok,
+    ok ? (task.terminalResult ?? "") : "",
+    ok ? "" : (task.terminalResult ?? "the delegated turn did not finish"),
+  );
+}
+
 function finalizeDelegationWatch(
   threadId: string,
   ok: boolean,
@@ -2509,12 +2632,12 @@ function finalizeDelegationWatch(
 ): boolean {
   const watched = delegationWatch.get(threadId);
   if (!watched) return false;
-  delegationWatch.delete(threadId);
-  // The receipt is written before any mirror short-circuits: the delegating
-  // bot's check/wait_delegation must see a terminal state even when the
-  // channel or target is gone.
+  // The first terminal transition wins before any externally visible mirror.
+  // Keep the watch if persistence fails so an explicit failure path can still
+  // retry it rather than silently forgetting an unrecorded terminal result.
+  let settled = true;
   if (watched.taskId && watched.sourceThreadId) {
-    recordDelegationReceipt({
+    settled = recordDelegationReceipt({
       id: watched.taskId,
       sourceThreadId: watched.sourceThreadId,
       toBotId: watched.toBotId,
@@ -2523,42 +2646,12 @@ function finalizeDelegationWatch(
       result: ok ? reply : failureName,
     });
   }
+  delegationWatch.delete(threadId);
+  if (!settled) return true;
   const target = store.bot(watched.toBotId);
   const targetName = target?.name ?? watched.toBotName ?? watched.toBotId;
-  const source = watched.sourceThreadId ? store.botByThread(watched.sourceThreadId) : undefined;
-  if (source && watched.sourceThreadId) {
-    if (ok && reply.trim()) {
-      const sourceReply: Omit<Message, "id" | "at"> = {
-        role: "bot",
-        kind: "text",
-        text: `@${targetName} replied to the delegated task:\n\n${reply.trim()}`,
-      };
-      if (target) sourceReply.from = { botId: target.id, name: target.name, color: target.color };
-      store.appendMessage(watched.sourceThreadId, sourceReply);
-    } else {
-      store.appendMessage(watched.sourceThreadId, {
-        role: "bot",
-        kind: "activity",
-        tool: {
-          name: ok
-            ? `Delegation to @${targetName} completed without a text reply`
-            : `Delegation to @${targetName} failed — ${failureName}`,
-          ok,
-        },
-      });
-    }
-    markTaskContextExternallyUpdated(source, watched.sourceThreadId);
-    // Peer wake: a settled delegated turn resumes the source bot so it
-    // folds the result in and answers the user, instead of sitting idle
-    // with the reply only visible in the thread (the "delegated and went
-    // silent" gap). Failures wake it too — the user must hear the task did
-    // not finish. Idle-checked and burst-capped so a busy source or a
-    // re-delegating loop cannot spin up runs.
-    if (ok && reply.trim()) {
-      wakeDelegationSource(source, watched.sourceThreadId, targetName);
-    } else if (!ok) {
-      wakeDelegationSource(source, watched.sourceThreadId, targetName, failureName || "the delegated turn did not finish");
-    }
+  if (watched.taskId && watched.sourceThreadId) {
+    deliverDelegationOutcome(watched.taskId, watched.sourceThreadId, watched.toBotId, targetName, ok, reply, failureName);
   }
   const channel = watched.channelId ? store.group(watched.channelId) : undefined;
   if (!target || !channel) return true;
@@ -2650,7 +2743,9 @@ const runDelegatedTurn: Parameters<typeof drainDelegations>[3] = (toBotId, text,
       // busy. Those asynchronous setup failures do not emit turn.completed,
       // so clear the watch and report them through this callback too.
       onDispatchError: reportStartFailure,
-    }).then(() => undefined).catch((err) => {
+    }).then(() => {
+      markDelegationRunning(taskId);
+    }).catch((err) => {
       reportStartFailure(err);
     });
 };
@@ -2895,6 +2990,8 @@ async function startTurn(
     /** Stable identity supplied by the composer so a network retry cannot
      * dispatch the same user action twice. */
     sendId?: string;
+    /** Called only after the provider accepted the turn dispatch. */
+    onDispatchAccepted?: () => void;
     onDispatchError?: (message: string) => void;
   },
 ) {
@@ -3416,6 +3513,14 @@ async function startTurn(
       if (dispatch.cancelled) {
         retireProviderTurn(dispatch.value.turnId);
         throw new DirectTurnSetupCancelled("turn stopped during provider setup");
+      }
+      // The provider has accepted this turn. Consumers that own a durable
+      // outbox may safely acknowledge their dispatch claim here; `startTurn`
+      // itself returned before this detached setup/send path began.
+      try {
+        opts?.onDispatchAccepted?.();
+      } catch (error) {
+        console.error("turn dispatch accepted callback failed", error);
       }
       clearDirectTurnDispatch(bot.id, dispatchClaimId);
       // dispatched: the rewind is spent, and the old cursors are dead
@@ -3951,6 +4056,7 @@ function serializeRoomContext(threadId: string, userName: string): string {
 // they can mirror messages + chips without re-deriving SSE plumbing. Same
 // shape every comms entry point uses (ask_bot, delegate_bot).
 const commsBus: CommsBus = { store, broadcast };
+(commsBus as CommsBus & { onDelegationTerminal?: (id: string, threadId: string) => void }).onDelegationTerminal = resumeTerminalDelegation;
 
 // approval bus: peer-approval.ts only needs to push cards and broadcast
 // them — its pending map lives in the module so the two respond endpoints
@@ -3970,6 +4076,29 @@ const approvalBus: ApprovalBus = { store, broadcast };
 // Run them now, through the same drain — target and approvePeerComms are
 // re-checked there as always; a source bot that no longer exists is skipped.
 _loadPending();
+for (const task of pendingDelegationDeliveries()) {
+  const source = store.botByThread(task.sourceThreadId);
+  if (!source || !store.taskByThread(source.id, task.sourceThreadId)) {
+    abandonDelegationDelivery(task.taskId);
+    continue;
+  }
+  if (task.sourceWake === "claimed") {
+    // A provider dispatch may already have happened. Do not duplicate it;
+    // record a visible durable notice alongside the preserved source result.
+    store.appendDelegationWakeInterrupted(task.sourceThreadId, task.taskId);
+    continue;
+  }
+  const ok = task.terminalStatus === "done";
+  deliverDelegationOutcome(
+    task.taskId,
+    task.sourceThreadId,
+    task.toBotId,
+    task.toBotName,
+    ok,
+    ok ? (task.terminalResult ?? "") : "",
+    ok ? "" : (task.terminalResult ?? "the delegated turn was interrupted when OpenMausBot restarted"),
+  );
+}
 {
   const leftover = pendingThreads();
   if (leftover.length) console.log(`delegations: ${leftover.length} thread(s) with queued handoffs from a previous run — draining`);
@@ -6205,7 +6334,11 @@ const server = createServer(async (req, res) => {
             MAX_COMMS_DEPTH,
             fromThreadId,
           );
-          if (queued.result !== "ok" || !queued.id) return json(res, 200, { busy: true });
+          if (queued.result !== "ok" || !queued.id) {
+            return json(res, 200, queued.result === "persistence_error"
+              ? { busy: true, error: "could not durably queue the busy peer handoff; do not assume it will run" }
+              : { busy: true });
+          }
           return json(res, 200, { busy: true, taskId: queued.id, toBotName: target.name });
         };
         if (target.busy) return queueBusyFallback();
@@ -6254,28 +6387,49 @@ const server = createServer(async (req, res) => {
         const channel = getOrCreateChannel(store, currentFrom, currentTarget);
         mirrorExchange(commsBus, currentFrom, currentTarget, message, channel, fromThreadId);
         const prefixed = `[Message from @${currentFrom.name}, another bot in this OpenMausBot workspace. Reply to them.]\n\n${message}`;
-        const outcome = await askBotAndWait(toBotId, prefixed, depth, fromBotId);
-        if (outcome.status === "timeout" && !delegationWatch.has(currentTarget.threadId)) {
-          // The peer's turn is still running — only the wait ended. Convert
-          // the ask into a delegation claim ticket: the watch mirrors the
-          // terminal state into the channel AND the asker's thread when the
-          // turn settles, and check/wait_delegation read the same receipt.
-          // Losing the reply was the old behavior, and it read as "the bots
-          // don't respond to each other".
-          const taskId = newId();
+        const timeoutTaskId = newId();
+        const outcome = await askBotAndWait(toBotId, prefixed, depth, fromBotId, () => {
+          if (delegationWatch.has(currentTarget.threadId)) return undefined;
+          try {
+            registerRunningDelegation({
+              taskId: timeoutTaskId,
+              sourceThreadId: fromThreadId,
+              toBotId,
+              toBotName: currentTarget.name,
+              targetThreadId: currentTarget.threadId,
+              message,
+              reason: "ask timed out",
+              depth,
+              approvalGranted: true,
+              attempts: 0,
+              waitingOnBusy: false,
+            });
+          } catch (error) {
+            const why = error instanceof Error ? error.message : String(error);
+            store.appendMessage(fromThreadId, {
+              role: "bot",
+              kind: "activity",
+              tool: { name: `Ask could not become a durable delegation — ${why.slice(0, 120)}`, ok: false },
+            });
+            return undefined;
+          }
           delegationWatch.set(currentTarget.threadId, {
             channelId: channel.id,
             toBotId,
             toBotName: currentTarget.name,
-            taskId,
+            taskId: timeoutTaskId,
             sourceThreadId: fromThreadId,
+            startedAtMs: Date.now(),
           });
+          return timeoutTaskId;
+        });
+        if (outcome.status === "timeout" && outcome.taskId) {
           store.appendMessage(fromThreadId, {
             role: "bot",
             kind: "activity",
             tool: { name: `@${currentTarget.name} is still working — ask converted to a delegation` },
           });
-          return json(res, 200, { timeout: true, taskId, toBotName: currentTarget.name, waitedMs: ASK_BOT_TIMEOUT_MS });
+          return json(res, 200, { timeout: true, taskId: outcome.taskId, toBotName: currentTarget.name, waitedMs: ASK_BOT_TIMEOUT_MS });
         }
         if (outcome.status === "failed" && !outcome.text.trim()) {
           // No partial answer to hand back — mirror the failure where the
@@ -6374,6 +6528,7 @@ const server = createServer(async (req, res) => {
             too_deep: "delegation chains are limited to one hop — do this one yourself",
             no_target: "no such bot",
             too_many: "too many delegations queued on this turn — finish some first",
+            persistence_error: "delegation was not queued because durable storage failed — do the work yourself or retry later",
           };
           return json(res, 200, { error: said[queued.result === "ok" ? "no_target" : queued.result] });
         }
@@ -8352,7 +8507,11 @@ const server = createServer(async (req, res) => {
         // a peer approval naming this bot can never be meaningfully answered
         // now, and its caller would otherwise wait out the 15-minute timeout
         cancelPeerApprovalsFor(bot.id);
-        discardDelegations(commsBus, bot.threadId);
+        // No source output should be appended while these task transcripts
+        // are being removed. Cover inactive tasks too, not only bot.threadId.
+        for (const threadId of new Set([bot.threadId, ...(bot.tasks ?? []).map((task) => task.threadId)])) {
+          abandonSourceDelegationThread(threadId);
+        }
         computerControl.forget(bot.id);
         computerControlRevision.delete(bot.id);
         const target = perBotLocalVmTarget(bot.id);
@@ -8950,12 +9109,21 @@ const server = createServer(async (req, res) => {
       return json(res, 200, { task: wireTask(task) });
     }
     if (m && method === "DELETE") {
-      const bot = store.bot(m[1]);
-      if (bot?.busy && (bot.threadId === m[2] || routines!.isActiveThread(m[2]))) {
+      const [botId, taskThreadId] = [m[1], m[2]];
+      const bot = store.bot(botId);
+      if (bot?.busy && (bot.threadId === taskThreadId || routines!.isActiveThread(taskThreadId))) {
         return json(res, 409, { error: "this task is running — stop it first" });
       }
-      const stagedSkillCleanups = stagedSkillCleanupsForThread(m[2]);
-      const updated = store.deleteTask(m[1], m[2]);
+      // Do not abandon a live task's handoffs if the delete itself will be
+      // refused (unknown task or the only remaining task).
+      if (!bot || !bot.tasks || bot.tasks.length < 2 || !bot.tasks.some((task) => task.threadId === taskThreadId)) {
+        return json(res, 400, { error: "a bot keeps at least one task" });
+      }
+      const stagedSkillCleanups = stagedSkillCleanupsForThread(taskThreadId);
+      // The task transcript is about to disappear, so atomically abandon any
+      // queued/running handoff and its terminal delivery/wake outboxes first.
+      abandonSourceDelegationThread(taskThreadId);
+      const updated = store.deleteTask(botId, taskThreadId);
       if (!updated) return json(res, 400, { error: "a bot keeps at least one task" });
       rejectDeletedThreadSkillStages(stagedSkillCleanups);
       const fresh = botWithThread(updated);

--- a/server/message-db.test.ts
+++ b/server/message-db.test.ts
@@ -6,12 +6,26 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { DATA_DIR } from "./config.ts";
 import {
+  appendDelegationDelivery,
+  appendDelegationWakeInterrupted,
+  acknowledgeDelegationContext,
+  acknowledgeDelegationWake,
+  abandonDelegationDelivery,
+  abandonDelegationsForSourceThread,
+  claimDelegationWake,
   closeMessageDb,
+  createDelegationTask,
+  delegationTask,
+  delegationTasks,
   deleteThread,
   insertMessage,
   readThread,
+  pendingDelegationDeliveries,
+  pruneDelegationTasks,
   searchMessages,
+  settleDelegationTask,
   setActiveLeaf,
+  terminalizeInterruptedDelegations,
   updateMessage,
 } from "./message-db.ts";
 import { Store, type Message } from "./store.ts";
@@ -80,6 +94,134 @@ describe("message-db", () => {
     new Store(selection);
     expect(searchMessages("unopened legacy")).toMatchObject([{ threadId: bot.threadId, messageId: "old" }]);
     expect(existsSync(`${legacy(bot.threadId)}.imported`)).toBe(true);
+  });
+
+  it("terminalizes ambiguous launches and appends each task outcome once", () => {
+    createDelegationTask({
+      taskId: "task-a",
+      sourceThreadId: "source",
+      toBotId: "target",
+      toBotName: "Target",
+      message: "do work",
+      depth: 0,
+      approvalGranted: false,
+      attempts: 0,
+      waitingOnBusy: false,
+      state: "launching",
+      sourceDelivery: "pending",
+      createdAt: 1,
+    });
+    expect(terminalizeInterruptedDelegations("interrupted on restart")).toHaveLength(1);
+    expect(delegationTask("task-a")).toMatchObject({ state: "terminal", terminalStatus: "failed" });
+    const outcome = msg("delegation-result:task-a", "worker interrupted", { role: "bot", parentId: null });
+    expect(appendDelegationDelivery("source", "task-a", outcome)).toEqual({ inserted: true });
+    expect(appendDelegationDelivery("source", "task-a", outcome)).toEqual({ inserted: false });
+    expect(readThread("source", legacy("source")).messages.filter((message) => message.id === outcome.id)).toHaveLength(1);
+    expect(pendingDelegationDeliveries()).toMatchObject([{ taskId: "task-a", sourceDelivery: "delivered", sourceContext: "pending", sourceWake: "pending" }]);
+  });
+
+  it("keeps the first terminal settlement and its delivery state", () => {
+    createDelegationTask({
+      taskId: "cas-task", sourceThreadId: "source", toBotId: "target", toBotName: "Target", message: "do work",
+      depth: 0, approvalGranted: false, attempts: 0, waitingOnBusy: false, state: "running", sourceDelivery: "pending", createdAt: 1,
+    });
+    expect(settleDelegationTask("cas-task", "done", "first", 1)).toMatchObject({ terminalResult: "first" });
+    appendDelegationDelivery("source", "cas-task", msg("delegation-result:cas-task", "first", { role: "bot", parentId: null }));
+    expect(settleDelegationTask("cas-task", "failed", "late", 2)).toBeNull();
+    expect(delegationTask("cas-task")).toMatchObject({ terminalStatus: "done", terminalResult: "first", sourceDelivery: "delivered" });
+  });
+
+  it("keeps simultaneous task deliveries independent", () => {
+    for (const taskId of ["task-a", "task-b"]) {
+      createDelegationTask({
+        taskId,
+        sourceThreadId: "source",
+        toBotId: "target",
+        toBotName: "Target",
+        message: "do work",
+        depth: 0,
+        approvalGranted: false,
+        attempts: 0,
+        waitingOnBusy: false,
+        state: "terminal",
+        terminalStatus: "done",
+        terminalResult: taskId,
+        finishedAt: 1,
+        sourceDelivery: "pending",
+        createdAt: 1,
+      });
+      appendDelegationDelivery("source", taskId, msg(`delegation-result:${taskId}`, taskId, { role: "bot", parentId: null }));
+    }
+    expect(readThread("source", legacy("source")).messages.map((message) => message.id)).toEqual([
+      "delegation-result:task-a",
+      "delegation-result:task-b",
+    ]);
+  });
+
+  it("recovers context and wake outboxes independently, then prunes settled payloads", () => {
+    createDelegationTask({
+      taskId: "outbox", sourceThreadId: "source", toBotId: "target", toBotName: "Target", message: "sensitive prompt",
+      depth: 0, approvalGranted: false, attempts: 0, waitingOnBusy: false, state: "terminal", terminalStatus: "done", terminalResult: "answer", finishedAt: 1, sourceDelivery: "pending", createdAt: 1,
+    });
+    appendDelegationDelivery("source", "outbox", msg("delegation-result:outbox", "answer", { role: "bot", parentId: null }));
+    expect(pendingDelegationDeliveries()).toHaveLength(1); // context/wake remain recoverable
+    expect(acknowledgeDelegationContext("outbox")).toBe(true);
+    expect(claimDelegationWake("outbox")).toBe(true);
+    expect(acknowledgeDelegationWake("outbox")).toBeUndefined();
+    expect(pendingDelegationDeliveries()).toEqual([]);
+    pruneDelegationTasks(2, 0);
+    expect(delegationTask("outbox")).toBeNull();
+
+    createDelegationTask({
+      taskId: "gone", sourceThreadId: "missing", toBotId: "target", toBotName: "Target", message: "secret",
+      depth: 0, approvalGranted: false, attempts: 0, waitingOnBusy: false, state: "terminal", terminalStatus: "failed", finishedAt: 1, sourceDelivery: "pending", createdAt: 1,
+    });
+    abandonDelegationDelivery("gone");
+    expect(delegationTask("gone")).toMatchObject({ sourceDelivery: "abandoned", sourceContext: "abandoned", sourceWake: "abandoned" });
+
+    createDelegationTask({
+      taskId: "claimed-wake", sourceThreadId: "source", toBotId: "target", toBotName: "Target", message: "work",
+      depth: 0, approvalGranted: false, attempts: 0, waitingOnBusy: false, state: "terminal", terminalStatus: "done", finishedAt: 1, sourceDelivery: "pending", createdAt: 1,
+    });
+    appendDelegationDelivery("source", "claimed-wake", msg("delegation-result:claimed-wake", "answer", { role: "bot", parentId: null }));
+    acknowledgeDelegationContext("claimed-wake");
+    // A wake claim remains recoverable until the real provider-dispatch
+    // callback acknowledges it; merely scheduling startTurn must not clear it.
+    expect(claimDelegationWake("claimed-wake")).toBe(true);
+    expect(delegationTask("claimed-wake")).toMatchObject({ sourceWake: "claimed" });
+    const interrupted = msg("delegation-wake-interrupted:claimed-wake", "wake interrupted", { role: "bot", parentId: null });
+    expect(appendDelegationWakeInterrupted("source", "claimed-wake", interrupted)).toEqual({ inserted: true });
+    expect(appendDelegationWakeInterrupted("source", "claimed-wake", interrupted)).toEqual({ inserted: false });
+    expect(delegationTask("claimed-wake")).toMatchObject({ sourceWake: "abandoned" });
+  });
+
+  it("abandons every lifecycle state for a removed source thread atomically", () => {
+    for (const [taskId, state] of [["queued", "queued"], ["launching", "launching"], ["running", "running"], ["terminal", "terminal"]] as const) {
+      createDelegationTask({
+        taskId,
+        sourceThreadId: "removed-source",
+        toBotId: "target",
+        toBotName: "Target",
+        message: "sensitive task",
+        depth: 0,
+        approvalGranted: false,
+        attempts: 0,
+        waitingOnBusy: false,
+        state,
+        ...(state === "terminal" ? { terminalStatus: "done", terminalResult: "preserve me", finishedAt: 1 } : {}),
+        sourceDelivery: "pending",
+        createdAt: 1,
+      });
+    }
+    expect(abandonDelegationsForSourceThread("removed-source", "source removed")).toBe(4);
+    expect(delegationTasks().map((task) => ({ id: task.taskId, state: task.state, delivery: task.sourceDelivery, context: task.sourceContext, wake: task.sourceWake }))).toEqual([
+      { id: "queued", state: "terminal", delivery: "abandoned", context: "abandoned", wake: "abandoned" },
+      { id: "launching", state: "terminal", delivery: "abandoned", context: "abandoned", wake: "abandoned" },
+      { id: "running", state: "terminal", delivery: "abandoned", context: "abandoned", wake: "abandoned" },
+      { id: "terminal", state: "terminal", delivery: "abandoned", context: "abandoned", wake: "abandoned" },
+    ]);
+    expect(delegationTask("running")).toMatchObject({ terminalStatus: "dropped", terminalResult: "source removed" });
+    expect(delegationTask("terminal")).toMatchObject({ terminalStatus: "done", terminalResult: "preserve me" });
   });
 
   it("stores transcripts with owner-only permissions", () => {

--- a/server/message-db.ts
+++ b/server/message-db.ts
@@ -50,7 +50,37 @@ function open(): DatabaseSync {
       thread_id TEXT PRIMARY KEY,
       active_leaf_id TEXT
     );
+    CREATE TABLE IF NOT EXISTS delegation_tasks (
+      task_id TEXT PRIMARY KEY,
+      source_thread_id TEXT NOT NULL,
+      to_bot_id TEXT NOT NULL,
+      to_bot_name TEXT NOT NULL,
+      target_thread_id TEXT,
+      message TEXT NOT NULL,
+      reason TEXT,
+      depth INTEGER NOT NULL,
+      approval_granted INTEGER NOT NULL DEFAULT 0,
+      attempts INTEGER NOT NULL DEFAULT 0,
+      waiting_on_busy INTEGER NOT NULL DEFAULT 0,
+      state TEXT NOT NULL CHECK (state IN ('queued', 'launching', 'running', 'terminal')),
+      terminal_status TEXT,
+      terminal_result TEXT,
+      finished_at INTEGER,
+      source_delivery TEXT NOT NULL DEFAULT 'pending' CHECK (source_delivery IN ('pending', 'delivered', 'abandoned')),
+      source_context TEXT NOT NULL DEFAULT 'pending' CHECK (source_context IN ('pending', 'acknowledged', 'abandoned')),
+      source_wake TEXT NOT NULL DEFAULT 'pending' CHECK (source_wake IN ('pending', 'claimed', 'acknowledged', 'abandoned')),
+      created_at INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS delegation_tasks_state ON delegation_tasks(state, source_thread_id);
+    CREATE INDEX IF NOT EXISTS delegation_tasks_delivery ON delegation_tasks(state, source_delivery);
   `);
+  // The first ledger revision shipped without context/wake outboxes. SQLite
+  // cannot add their CHECK constraints with ALTER TABLE, but the values are
+  // still constrained by every writer below and old rows safely default.
+  const columns = db.prepare("PRAGMA table_info(delegation_tasks)").all() as Array<{ name: string }> ;
+  const names = new Set(columns.map((column) => column.name));
+  if (!names.has("source_context")) db.exec("ALTER TABLE delegation_tasks ADD COLUMN source_context TEXT NOT NULL DEFAULT 'pending'");
+  if (!names.has("source_wake")) db.exec("ALTER TABLE delegation_tasks ADD COLUMN source_wake TEXT NOT NULL DEFAULT 'pending'");
   return db;
 }
 
@@ -249,6 +279,198 @@ export function searchMessages(query: string, limit = 40, threadId?: string): Se
       ...(row.from_name ? { from: row.from_name } : {}),
     };
   });
+}
+
+export type DelegationTaskState = "queued" | "launching" | "running" | "terminal";
+export type SourceDeliveryState = "pending" | "delivered" | "abandoned";
+export type SourceContextState = "pending" | "acknowledged" | "abandoned";
+export type SourceWakeState = "pending" | "claimed" | "acknowledged" | "abandoned";
+
+export interface DelegationTaskRow {
+  taskId: string;
+  sourceThreadId: string;
+  toBotId: string;
+  toBotName: string;
+  targetThreadId?: string;
+  message: string;
+  reason?: string;
+  depth: number;
+  approvalGranted: boolean;
+  attempts: number;
+  waitingOnBusy: boolean;
+  state: DelegationTaskState;
+  terminalStatus?: string;
+  terminalResult?: string;
+  finishedAt?: number;
+  sourceDelivery: SourceDeliveryState;
+  sourceContext: SourceContextState;
+  sourceWake: SourceWakeState;
+  createdAt: number;
+}
+
+function rowToDelegation(row: Record<string, unknown>): DelegationTaskRow {
+  return {
+    taskId: String(row.task_id), sourceThreadId: String(row.source_thread_id),
+    toBotId: String(row.to_bot_id), toBotName: String(row.to_bot_name),
+    ...(typeof row.target_thread_id === "string" && row.target_thread_id ? { targetThreadId: row.target_thread_id } : {}),
+    message: String(row.message), ...(typeof row.reason === "string" ? { reason: row.reason } : {}),
+    depth: Number(row.depth), approvalGranted: Number(row.approval_granted) === 1,
+    attempts: Number(row.attempts), waitingOnBusy: Number(row.waiting_on_busy) === 1,
+    state: row.state as DelegationTaskState,
+    ...(typeof row.terminal_status === "string" ? { terminalStatus: row.terminal_status } : {}),
+    ...(typeof row.terminal_result === "string" ? { terminalResult: row.terminal_result } : {}),
+    ...(typeof row.finished_at === "number" ? { finishedAt: row.finished_at } : {}),
+    sourceDelivery: (row.source_delivery === "delivered" || row.source_delivery === "abandoned") ? row.source_delivery : "pending",
+    sourceContext: (row.source_context === "acknowledged" || row.source_context === "abandoned") ? row.source_context : "pending",
+    sourceWake: (["claimed", "acknowledged", "abandoned"] as string[]).includes(String(row.source_wake)) ? row.source_wake as SourceWakeState : "pending",
+    createdAt: Number(row.created_at),
+  };
+}
+
+export function createDelegationTask(task: Omit<DelegationTaskRow, "sourceContext" | "sourceWake"> & Partial<Pick<DelegationTaskRow, "sourceContext" | "sourceWake">>): void {
+  db().prepare(
+    "INSERT INTO delegation_tasks (task_id, source_thread_id, to_bot_id, to_bot_name, target_thread_id, message, reason, depth, approval_granted, attempts, waiting_on_busy, state, terminal_status, terminal_result, finished_at, source_delivery, source_context, source_wake, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+  ).run(task.taskId, task.sourceThreadId, task.toBotId, task.toBotName, task.targetThreadId ?? null, task.message, task.reason ?? null, task.depth, task.approvalGranted ? 1 : 0, task.attempts, task.waitingOnBusy ? 1 : 0, task.state, task.terminalStatus ?? null, task.terminalResult ?? null, task.finishedAt ?? null, task.sourceDelivery, task.sourceContext ?? "pending", task.sourceWake ?? "pending", task.createdAt);
+}
+
+export function delegationTask(taskId: string): DelegationTaskRow | null {
+  const row = db().prepare("SELECT * FROM delegation_tasks WHERE task_id = ?").get(taskId) as Record<string, unknown> | undefined;
+  return row ? rowToDelegation(row) : null;
+}
+
+export function delegationTasks(states?: readonly DelegationTaskState[]): DelegationTaskRow[] {
+  const rows = states?.length
+    ? db().prepare(`SELECT * FROM delegation_tasks WHERE state IN (${states.map(() => "?").join(",")}) ORDER BY created_at`).all(...states) as Record<string, unknown>[]
+    : db().prepare("SELECT * FROM delegation_tasks ORDER BY created_at").all() as Record<string, unknown>[];
+  return rows.map(rowToDelegation);
+}
+
+/** Non-terminal bookkeeping only. Terminal settlement must use settleDelegationTask. */
+export function updateDelegationTask(taskId: string, patch: Partial<Pick<DelegationTaskRow, "targetThreadId" | "attempts" | "waitingOnBusy" | "state">>): boolean {
+  const current = delegationTask(taskId);
+  if (!current || current.state === "terminal") return false;
+  const next = { ...current, ...patch };
+  const result = db().prepare("UPDATE delegation_tasks SET target_thread_id = ?, attempts = ?, waiting_on_busy = ?, state = ? WHERE task_id = ? AND state != 'terminal'")
+    .run(next.targetThreadId ?? null, next.attempts, next.waitingOnBusy ? 1 : 0, next.state, taskId) as { changes?: number };
+  return result.changes === 1;
+}
+
+/** First terminal outcome wins. This CAS is the sole terminal transition;
+ * later provider events/restarts must never reopen delivery or replace output. */
+export function settleDelegationTask(taskId: string, status: string, result: string | undefined, finishedAt = Date.now()): DelegationTaskRow | null {
+  const database = db();
+  database.exec("BEGIN IMMEDIATE");
+  try {
+    const write = database.prepare("UPDATE delegation_tasks SET state = 'terminal', terminal_status = ?, terminal_result = ?, finished_at = ?, source_delivery = 'pending', source_context = 'pending', source_wake = 'pending' WHERE task_id = ? AND state != 'terminal'")
+      .run(status, result ?? null, finishedAt, taskId) as { changes?: number };
+    if (write.changes !== 1) { database.exec("COMMIT"); return null; }
+    const row = database.prepare("SELECT * FROM delegation_tasks WHERE task_id = ?").get(taskId) as Record<string, unknown>;
+    database.exec("COMMIT");
+    return rowToDelegation(row);
+  } catch (error) { database.exec("ROLLBACK"); throw error; }
+}
+
+/** Claim a queued task before provider dispatch. A crash after this write is
+ * terminalized at boot rather than risking a second external worker. */
+export function claimDelegationLaunch(taskId: string, targetThreadId: string): boolean {
+  const result = db().prepare("UPDATE delegation_tasks SET state = 'launching', target_thread_id = ? WHERE task_id = ? AND state = 'queued'").run(targetThreadId, taskId) as { changes?: number };
+  return result.changes === 1;
+}
+
+export function terminalizeInterruptedDelegations(reason: string): DelegationTaskRow[] {
+  const candidates = delegationTasks(["launching", "running"]);
+  const settled: DelegationTaskRow[] = [];
+  for (const task of candidates) {
+    const winner = settleDelegationTask(task.taskId, "failed", reason);
+    if (winner) settled.push(winner);
+  }
+  return settled;
+}
+
+/** Append a stable terminal message and acknowledge delivery atomically. */
+export function appendDelegationDelivery(threadId: string, taskId: string, message: Message): { inserted: boolean } {
+  const database = db(); database.exec("BEGIN IMMEDIATE");
+  try {
+    const task = database.prepare("SELECT state, source_thread_id, source_delivery FROM delegation_tasks WHERE task_id = ?").get(taskId) as { state: string; source_thread_id: string; source_delivery: string } | undefined;
+    if (!task || task.state !== "terminal" || task.source_thread_id !== threadId || task.source_delivery === "abandoned") throw new Error("delegation is not deliverable for this thread");
+    const result = database.prepare("INSERT OR IGNORE INTO messages (thread_id, id, at, role, kind, text, json) VALUES (?, ?, ?, ?, ?, ?, ?)")
+      .run(threadId, message.id, message.at, message.role, message.kind, message.text ?? null, JSON.stringify(message)) as { changes?: number };
+    const inserted = result.changes === 1;
+    if (inserted) setActiveLeaf(threadId, message.id);
+    database.prepare("UPDATE delegation_tasks SET source_delivery = 'delivered' WHERE task_id = ?").run(taskId);
+    database.exec("COMMIT"); return { inserted };
+  } catch (error) { database.exec("ROLLBACK"); throw error; }
+}
+
+export function acknowledgeDelegationContext(taskId: string): boolean {
+  const result = db().prepare("UPDATE delegation_tasks SET source_context = 'acknowledged' WHERE task_id = ? AND state = 'terminal' AND source_delivery = 'delivered' AND source_context = 'pending'").run(taskId) as { changes?: number };
+  return result.changes === 1;
+}
+
+/** Claim before calling startTurn. A claimed wake is never replayed after a
+ * process crash because provider turns lack an idempotency key. */
+export function claimDelegationWake(taskId: string): boolean {
+  const result = db().prepare("UPDATE delegation_tasks SET source_wake = 'claimed' WHERE task_id = ? AND state = 'terminal' AND source_delivery = 'delivered' AND source_context = 'acknowledged' AND source_wake = 'pending'").run(taskId) as { changes?: number };
+  return result.changes === 1;
+}
+export function acknowledgeDelegationWake(taskId: string): void {
+  db().prepare("UPDATE delegation_tasks SET source_wake = 'acknowledged' WHERE task_id = ? AND source_wake = 'claimed'").run(taskId);
+}
+/** startTurn rejected before provider dispatch (usually a race with a user
+ * turn), so this claim is safe to retry when the source becomes idle. */
+export function releaseDelegationWakeClaim(taskId: string): void {
+  db().prepare("UPDATE delegation_tasks SET source_wake = 'pending' WHERE task_id = ? AND source_wake = 'claimed'").run(taskId);
+}
+export function abandonDelegationDelivery(taskId: string): void {
+  db().prepare("UPDATE delegation_tasks SET source_delivery = CASE WHEN source_delivery = 'pending' THEN 'abandoned' ELSE source_delivery END, source_context = CASE WHEN source_context = 'pending' THEN 'abandoned' ELSE source_context END, source_wake = CASE WHEN source_wake IN ('pending', 'claimed') THEN 'abandoned' ELSE source_wake END WHERE task_id = ? AND state = 'terminal'").run(taskId);
+}
+
+/** Remove every remaining responsibility for a source thread before its bot
+ * or task is deleted. A single statement makes queued/ambiguous work terminal
+ * and abandons every outbox without ever appending into the doomed transcript.
+ * Existing terminal outcomes retain their first-wins result; only their
+ * undeliverable source effects are abandoned. */
+export function abandonDelegationsForSourceThread(sourceThreadId: string, reason: string): number {
+  const result = db().prepare(
+    "UPDATE delegation_tasks SET " +
+    "state = CASE WHEN state = 'terminal' THEN state ELSE 'terminal' END, " +
+    "terminal_status = CASE WHEN state = 'terminal' THEN terminal_status ELSE 'dropped' END, " +
+    "terminal_result = CASE WHEN state = 'terminal' THEN terminal_result ELSE ? END, " +
+    "finished_at = CASE WHEN state = 'terminal' THEN finished_at ELSE ? END, " +
+    "source_delivery = 'abandoned', source_context = 'abandoned', source_wake = 'abandoned' " +
+    "WHERE source_thread_id = ?",
+  ).run(reason, Date.now(), sourceThreadId) as { changes?: number };
+  return result.changes ?? 0;
+}
+export function pendingDelegationDeliveries(): DelegationTaskRow[] {
+  return (db().prepare("SELECT * FROM delegation_tasks WHERE state = 'terminal' AND (source_delivery = 'pending' OR (source_delivery = 'delivered' AND (source_context = 'pending' OR source_wake = 'pending' OR source_wake = 'claimed'))) ORDER BY finished_at, created_at").all() as Record<string, unknown>[]).map(rowToDelegation);
+}
+/** Discard old terminal payloads only after the same retention period used by
+ * receipts. Delivered/abandoned rows are no longer needed for recovery. */
+export function pruneDelegationTasks(cutoff: number, keep = 100): void {
+  const database = db();
+  database.prepare("DELETE FROM delegation_tasks WHERE task_id IN (SELECT task_id FROM delegation_tasks WHERE state = 'terminal' AND source_delivery IN ('delivered', 'abandoned') AND source_wake IN ('acknowledged', 'abandoned') AND finished_at < ? ORDER BY finished_at DESC LIMIT -1 OFFSET ?)").run(cutoff, keep);
+}
+/** Mark previously claimed wakes as interrupted without rerunning a possibly
+ * externally visible provider turn. The caller appends an explicit activity. */
+export function abandonClaimedDelegationWake(taskId: string): boolean {
+  const result = db().prepare("UPDATE delegation_tasks SET source_wake = 'abandoned' WHERE task_id = ? AND state = 'terminal' AND source_wake = 'claimed'").run(taskId) as { changes?: number };
+  return result.changes === 1;
+}
+
+/** Persist the conservative notice used after a crash interrupts a claimed
+ * source wake. It shares the state transition so restart retries cannot
+ * create duplicate activity chips. */
+export function appendDelegationWakeInterrupted(threadId: string, taskId: string, message: Message): { inserted: boolean } {
+  const database = db(); database.exec("BEGIN IMMEDIATE");
+  try {
+    const claimed = database.prepare("UPDATE delegation_tasks SET source_wake = 'abandoned' WHERE task_id = ? AND state = 'terminal' AND source_thread_id = ? AND source_wake = 'claimed'").run(taskId, threadId) as { changes?: number };
+    if (claimed.changes !== 1) { database.exec("COMMIT"); return { inserted: false }; }
+    const result = database.prepare("INSERT OR IGNORE INTO messages (thread_id, id, at, role, kind, text, json) VALUES (?, ?, ?, ?, ?, ?, ?)")
+      .run(threadId, message.id, message.at, message.role, message.kind, message.text ?? null, JSON.stringify(message)) as { changes?: number };
+    if (result.changes === 1) setActiveLeaf(threadId, message.id);
+    database.exec("COMMIT"); return { inserted: result.changes === 1 };
+  } catch (error) { database.exec("ROLLBACK"); throw error; }
 }
 
 /** Test/shutdown hook — closes the handle so a wiped DATA_DIR starts clean. */

--- a/server/store.ts
+++ b/server/store.ts
@@ -1111,6 +1111,54 @@ export class Store {
     return full;
   }
 
+  /** Append one terminal delegation outcome exactly once. The stable id is
+   * task-derived and the SQLite ledger delivery marker commits atomically with
+   * the message, so boot recovery cannot duplicate a worker result. */
+  appendDelegationOutcome(threadId: string, taskId: string, message: Omit<Message, "id" | "at">): { message: Message; inserted: boolean } {
+    const t = this.thread(threadId);
+    const id = `delegation-result:${taskId}`;
+    const existing = t.messages.find((candidate) => candidate.id === id);
+    if (existing) return { message: existing, inserted: false };
+    const full: Message = { id, at: Date.now(), parentId: t.activeLeafId, ...redactBotAuthored(message) };
+    const { inserted } = mdb.appendDelegationDelivery(threadId, taskId, full);
+    if (!inserted) {
+      const persisted = t.messages.find((candidate) => candidate.id === id);
+      if (persisted) return { message: persisted, inserted: false };
+      // The DB row can predate this Store cache only after a fresh process;
+      // reload the thread rather than manufacturing a duplicate event.
+      const loaded = mdb.readThread(threadId, messagesFile(threadId));
+      t.messages = loaded.messages;
+      t.activeLeafId = loaded.activeLeafId;
+      return { message: t.messages.find((candidate) => candidate.id === id) ?? full, inserted: false };
+    }
+    t.messages.push(full);
+    t.activeLeafId = full.id;
+    this.emit({ type: "message", threadId, message: full });
+    return { message: full, inserted: true };
+  }
+
+  /** A claimed source wake is deliberately not replayed after a crash; leave
+   * one durable, task-specific notice instead of silently losing continuity. */
+  appendDelegationWakeInterrupted(threadId: string, taskId: string): boolean {
+    const t = this.thread(threadId);
+    const id = `delegation-wake-interrupted:${taskId}`;
+    if (t.messages.some((candidate) => candidate.id === id)) return false;
+    const full: Message = {
+      id,
+      at: Date.now(),
+      parentId: t.activeLeafId,
+      role: "bot",
+      kind: "activity",
+      tool: { name: "Automatic continuation was interrupted by a restart; the delegated result is preserved above", ok: false },
+    };
+    const { inserted } = mdb.appendDelegationWakeInterrupted(threadId, taskId, full);
+    if (!inserted) return false;
+    t.messages.push(full);
+    t.activeLeafId = full.id;
+    this.emit({ type: "message", threadId, message: full });
+    return true;
+  }
+
   /** Insert a message into the active chain directly after `anchorId` — the
    * home for turn artifacts that finish AFTER the world moved on (the
    * settle-time screen capture races a fast follow-up send, which used to


### PR DESCRIPTION
## What changed

- Adds a SQLite-backed delegation ledger keyed by task ID, with queued, launching, running, and terminal lifecycle states.
- Makes terminal settlement compare-and-set, and makes source transcript delivery append-once with a stable task-derived message ID.
- Persists source context and continuation-wake outboxes; restart recovery delivers unfinished outcomes, avoids redispatching ambiguous work, and reports interrupted claimed wakes instead of duplicating provider turns.
- Registers `ask_bot` timeout conversion before its waiter unsubscribes, closing the timeout/completion race.
- Cleans up ledger rows and stale wakes when a source bot or task is deleted.

## Why

Delegations previously split queue, running watch, receipt, and source delivery state across JSON and memory. A crash could redispatch ambiguous work, lose terminal outcomes, duplicate source delivery, or leave the source session stale.

## How it was verified

- `pnpm typecheck`
- `pnpm build:server`
- `pnpm vitest run server/message-db.test.ts server/delegations.test.ts server/comms.test.ts` — 82 passed
- `pnpm lint` — existing repository warnings only
- `pnpm i18n:check`
- `git diff --check`
- Independent crash-order review: approved

`pnpm test` remains baseline-sensitive: one run had 3,148 passing tests and the known `server/control-omb.test.ts` provider-list failure; a later run also reproduced the known intermittent `server/steer-e2e.test.ts` timing failure. This PR does not modify either suite.

## Screenshots (UI changes)

None — server-side durability change.

## Checklist

- [x] `pnpm typecheck` passes locally; full `pnpm test` was run and has the documented pre-existing baseline-sensitive failures above
- [x] Server behavior changes come with tests
- [x] No `dist-server/` edits
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv
