### PR TITLE
Show and steer messages sent mid-turn (Android)

### DIFF
--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/ChatScreen.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/ChatScreen.kt
@@ -101,6 +101,7 @@ import com.openmausbot.companion.core.Chat
 import com.openmausbot.companion.core.ChatTarget
 import com.openmausbot.companion.core.LocalMessageLink
 import com.openmausbot.companion.core.PendingMessageAttachment
+import com.openmausbot.companion.core.QueuedSend
 import com.openmausbot.companion.core.CompanionState
 import com.openmausbot.companion.core.Dictation
 import com.openmausbot.companion.core.DisplayedMessageAttachment
@@ -112,6 +113,7 @@ import com.openmausbot.companion.core.transcriptRows
 import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -207,6 +209,38 @@ private fun LoadedChat(
     val haptics = rememberHaptics()
     val scope = rememberCoroutineScope()
     val lifecycleOwner = LocalLifecycleOwner.current
+    // Words this computer is holding until the running turn settles.
+    val queuedSends = state.pendingQueued[threadId].orEmpty()
+    val steeringInstanceIds by session.steeringInstanceIds.collectAsState()
+    // Whether this bot's engine can take a message INTO the running turn.
+    // Unknown reads as false, which is the promise that is always safe to
+    // make: the message will be sent, just not necessarily right now.
+    val steerTarget = (chat as? Chat.BotChat)?.bot
+    val engineCanSteer = steerTarget?.modelSelection?.instanceId
+        ?.let { it in steeringInstanceIds }
+        ?: false
+    // A Steer is in flight. Cleared when the queue drains or the turn ends,
+    // whichever the engine gets to first — and after twenty seconds even if
+    // neither frame ever arrives, because a control that spins for ever is
+    // worse than one that admits it does not know.
+    var steering by remember(threadId) { mutableStateOf(false) }
+    LaunchedEffect(queuedSends.size, chat.busy) {
+        if (queuedSends.isEmpty() || !chat.busy) steering = false
+    }
+    LaunchedEffect(steering) {
+        if (steering) {
+            delay(20_000)
+            steering = false
+        }
+    }
+    val steerNow: (() -> Unit)? = steerTarget?.let { target ->
+        {
+            haptics.play(HapticCue.SELECT)
+            dictation.stop()
+            steering = true
+            scope.launch { session.interrupt(target) }
+        }
+    }
     var showingTasks by remember { mutableStateOf(false) }
     // Saveable: the profile form is a form, and a rotation must not throw away
     // what was typed into it — the sheet has to come back for that to matter.
@@ -846,6 +880,14 @@ private fun LoadedChat(
                 attachments = attachments,
                 sending = sendingMessage,
                 preparing = preparingAttachments,
+                busy = chat.busy,
+                engineCanSteer = engineCanSteer,
+                queuedSends = queuedSends,
+                steering = steering,
+                onSteer = steerNow,
+                onCancelQueued = { queued ->
+                    scope.launch { session.cancelQueued(queued, chat) }
+                },
                 openingFileName = openingFileName,
                 attachmentError = fileOpenError ?: attachmentError,
                 onRemoveAttachment = { attachment ->
@@ -1299,6 +1341,12 @@ private fun Composer(
     attachments: List<PendingMessageAttachment>,
     sending: Boolean,
     preparing: Boolean,
+    busy: Boolean,
+    engineCanSteer: Boolean,
+    queuedSends: List<QueuedSend>,
+    steering: Boolean,
+    onSteer: (() -> Unit)?,
+    onCancelQueued: (QueuedSend) -> Unit,
     openingFileName: String?,
     attachmentError: String?,
     onRemoveAttachment: (PendingMessageAttachment) -> Unit,
@@ -1363,6 +1411,17 @@ private fun Composer(
                         .padding(horizontal = 6.dp, vertical = 4.dp),
                 )
             }
+        }
+        // Everything the computer is holding, stacked straight above the chat
+        // bar in the order it was sent.
+        queuedSends.forEach { queued ->
+            QueuedSendRow(
+                send = queued,
+                onSteer = onSteer,
+                steering = steering,
+                onCancel = { onCancelQueued(queued) },
+                modifier = Modifier.fillMaxWidth(),
+            )
         }
         if (attachments.isNotEmpty()) {
             Row(
@@ -1476,11 +1535,13 @@ private fun Composer(
                 ) {
                     if (draft.isEmpty()) {
                         Text(
-                            text = when {
-                                sending -> "Sending…"
-                                dictationListening -> "Listening…"
-                                else -> "Ask $name"
-                            },
+                            text = ComposerPromise.placeholder(
+                                name = name,
+                                busy = busy,
+                                engineCanSteer = engineCanSteer,
+                                sending = sending,
+                                listening = dictationListening,
+                            ),
                             fontSize = 17.sp,
                             color = secondaryTint,
                         )

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/QueuedSendRow.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/QueuedSendRow.kt
@@ -1,0 +1,140 @@
+package com.openmausbot.companion.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.openmausbot.companion.core.QueuedSend
+
+/**
+ * A message the computer is holding, sitting just above the chat bar.
+ *
+ * A mid-turn send to a bot that cannot take words into a running turn does
+ * not reach the transcript: the harness holds it, because appending it now
+ * would make it the active leaf and the rest of the turn would hang off a
+ * line the model never saw. Correct — but with nothing on screen it reads as
+ * the phone having eaten the message, which is the bug this row fixes.
+ *
+ * It lives above the composer rather than in the transcript because that is
+ * where a thing you have not said yet belongs — still in your hands, next to
+ * the field you typed it in. Both actions are words, not glyphs: Steer stops
+ * the turn so these words run now (the harness deliberately keeps its queue
+ * across an interrupt, which is what makes stopping a send), and the bin
+ * drops them.
+ */
+@Composable
+fun QueuedSendRow(
+    send: QueuedSend,
+    /**
+     * Stop the turn so this runs now. Null where the phone cannot interrupt —
+     * a room — so the button is not offered rather than offered and broken.
+     */
+    onSteer: (() -> Unit)?,
+    /**
+     * The interrupt is in flight. Engines take their time noticing one — codex
+     * needs about six seconds — and a button that looks untouched for six
+     * seconds has, as far as the person is concerned, done nothing.
+     */
+    steering: Boolean,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(18.dp))
+            .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f))
+            .padding(start = 12.dp, end = 6.dp, top = 6.dp, bottom = 6.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = send.text,
+            fontSize = 15.sp,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        if (onSteer != null) {
+            Row(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(50))
+                    .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f))
+                    .clickable(enabled = !steering, role = Role.Button, onClick = onSteer)
+                    .padding(horizontal = 11.dp, vertical = 6.dp),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (steering) {
+                    CircularProgressIndicator(
+                        strokeWidth = 1.5.dp,
+                        modifier = Modifier.size(12.dp),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.Send,
+                        contentDescription = null,
+                        modifier = Modifier.size(13.dp),
+                    )
+                }
+                Text(
+                    text = if (steering) "Steering…" else "Steer",
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium,
+                )
+            }
+        }
+        Icon(
+            imageVector = Icons.Filled.Delete,
+            contentDescription = "Delete this queued message",
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier
+                .clip(RoundedCornerShape(50))
+                .clickable(role = Role.Button, onClick = onCancel)
+                .padding(6.dp)
+                .size(16.dp),
+        )
+    }
+}
+
+/** What the composer promises about the message being typed. */
+object ComposerPromise {
+    /**
+     * The name is in the header a thumb's width above; spending the field's
+     * whole width repeating it truncates the part that says what pressing
+     * send will actually do.
+     */
+    fun placeholder(
+        name: String,
+        busy: Boolean,
+        engineCanSteer: Boolean,
+        sending: Boolean,
+        listening: Boolean,
+    ): String = when {
+        sending -> "Sending…"
+        listening -> "Listening…"
+        !busy -> "Ask $name"
+        engineCanSteer -> "Sends into this turn"
+        else -> "Sends after this turn"
+    }
+}

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Client.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Client.kt
@@ -428,22 +428,56 @@ class CompanionClient(
         return send<CreatedRoom>(makeRequest("POST", "/api/groups", body = body)).group
     }
 
-    suspend fun sendToBot(botId: String, text: String) {
-        sendUnit(makeRequest("POST", "/api/bots/${segment(botId)}/messages", body = jsonBody("text" to text)))
-    }
+    suspend fun sendToBot(botId: String, text: String): SendReceipt =
+        sendForReceipt(
+            makeRequest("POST", "/api/bots/${segment(botId)}/messages", body = jsonBody("text" to text)),
+        )
 
-    suspend fun sendToRoom(groupId: String, text: String) {
-        sendUnit(makeRequest("POST", "/api/groups/${segment(groupId)}/messages", body = jsonBody("text" to text)))
+    suspend fun sendToRoom(groupId: String, text: String): SendReceipt =
+        sendForReceipt(
+            makeRequest("POST", "/api/groups/${segment(groupId)}/messages", body = jsonBody("text" to text)),
+        )
+
+    /**
+     * Drop a message the harness is still holding, before the turn it is
+     * waiting behind settles.
+     *
+     * An entry that drained a moment ago is not an error worth showing — that
+     * is the outcome the caller wanted. But that is matched positively on the
+     * harness's own wording and never on the status alone: the sidecar answers
+     * 404 "no route" for a route it does not allow, so a computer too old to
+     * have this route looks identical to a drained entry. Reading those as the
+     * same thing takes the message off the phone while it is still queued on
+     * the computer, and it then arrives anyway.
+     */
+    suspend fun cancelQueued(queueId: String, to: MessageDestination) {
+        if (!isSafeRouteId(queueId)) throw APIError.BadUrl
+        val route = when (to) {
+            is MessageDestination.Bot -> "/api/bots/${safeRouteId(to.id)}/queue/$queueId"
+            is MessageDestination.Room -> "/api/groups/${safeRouteId(to.id)}/queue/$queueId"
+        }
+        try {
+            sendUnit(makeRequest("DELETE", route))
+        } catch (error: APIError.Status) {
+            if (error.code != 404) throw error
+            // The harness's own words, not Throwable.message, which falls
+            // back to generic text for a 404 and would swallow everything.
+            if (error.serverMessage?.contains(ALREADY_DRAINED, ignoreCase = true) == true) return
+            throw APIError.Status(
+                404,
+                "This computer is too old to take back a queued message. Update OpenMausBot on it.",
+            )
+        }
     }
 
     /** Retry-safe send: [threadId] is fixed at destination selection, never inferred on retry. */
-    suspend fun send(text: String, to: MessageDestination, sendId: String) {
+    suspend fun send(text: String, to: MessageDestination, sendId: String): SendReceipt {
         val route = when (to) {
             is MessageDestination.Bot -> "/api/bots/${safeRouteId(to.id)}/messages"
             is MessageDestination.Room -> "/api/groups/${safeRouteId(to.id)}/messages"
         }
         if (!isSafeRouteId(to.threadId) || !isSafeSendId(sendId)) throw APIError.BadUrl
-        sendUnit(makeRequest(
+        return sendForReceipt(makeRequest(
             "POST",
             route,
             body = buildJsonObject {
@@ -630,6 +664,24 @@ class CompanionClient(
         check(raw)
     }
 
+    /**
+     * A send, and what the harness did with it. Unlike [send] an unreadable
+     * body is not an error here: the request succeeded, and an older harness
+     * answering with a shape this build has never seen still made a plain
+     * send. Only the extra mid-turn detail is lost.
+     */
+    private suspend fun sendForReceipt(request: Request): SendReceipt {
+        val raw = perform(request)
+        check(raw)
+        return try {
+            CompanionJson
+                .decodeFromString<SendReceiptBody>(raw.data.toString(Charsets.UTF_8))
+                .receipt()
+        } catch (_: SerializationException) {
+            SendReceipt.Sent(threadId = null, steered = false)
+        }
+    }
+
     private suspend fun perform(
         request: Request,
         requestClient: OkHttpClient = actionClient,
@@ -677,6 +729,12 @@ class CompanionClient(
     private data class RawResponse(val code: Int, val headers: Headers, val data: ByteArray)
 
     companion object {
+        /**
+         * The harness's own answer when the entry is not in its queue.
+         * Matched positively, never by status alone — see [cancelQueued].
+         */
+        const val ALREADY_DRAINED = "no such queued message"
+
         private const val ACTION_TIMEOUT_SECONDS = 20L
         private const val AVATAR_GENERATION_TIMEOUT_SECONDS = 150L
         private const val STREAM_IDLE_TIMEOUT_SECONDS = 90L

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Models.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Models.kt
@@ -157,6 +157,17 @@ data class Message(
     val hasImage: Boolean? = null,
     val png: String? = null,
     val mime: String? = null,
+    /**
+     * A user line the engine took INTO the turn that was already running,
+     * rather than one that started a turn of its own.
+     */
+    val steered: Boolean? = null,
+    /**
+     * The steer-queue entry this user line drained from. It is how a client
+     * showing the held message knows which row to retire when the real line
+     * finally lands.
+     */
+    val queueId: String? = null,
 ) {
     @Serializable(with = MessageKindSerializer::class)
     enum class Kind { TEXT, OPTIONS, ACTIVITY, SCREEN, UNKNOWN }
@@ -518,7 +529,15 @@ data class Instance(
 }
 
 @Serializable
-data class InstanceCapabilities(val images: Boolean? = null)
+data class InstanceCapabilities(
+    val images: Boolean? = null,
+    /**
+     * The engine can take a message into a turn that is already running.
+     * Engines without it hold mid-turn sends until the turn settles, which is
+     * a different promise and deserves different words in the composer.
+     */
+    val queueing: Boolean? = null,
+)
 
 @Serializable
 data class InstanceList(val instances: List<Instance>)

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/SendReceipt.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/SendReceipt.kt
@@ -1,0 +1,54 @@
+package com.openmausbot.companion.core
+
+import kotlinx.serialization.Serializable
+
+/**
+ * What the harness says it did with a message the moment it was posted.
+ *
+ * A send is not one outcome. When the bot is idle the line lands in the
+ * transcript and a turn starts. When the bot is mid-turn there are two more:
+ * an engine with a live session can take the words INTO the running turn
+ * ([Sent.steered]), and one that cannot has the harness hold them
+ * off-transcript until the turn settles ([Queued]) — deliberately
+ * off-transcript, because a held line appended now would become the active
+ * leaf and the rest of the running turn would hang off something the model
+ * never saw.
+ *
+ * The distinction only exists in the POST's 202 body. A client that throws
+ * that body away, as this one used to, shows nothing at all for a queued
+ * send: the composer clears and the words reappear minutes later, or not at
+ * all. So the receipt is the contract, and it is decoded, not ignored.
+ */
+sealed interface SendReceipt {
+    /**
+     * In the transcript now. [steered] means it went into a turn that was
+     * already running rather than starting one.
+     */
+    data class Sent(val threadId: String?, val steered: Boolean) : SendReceipt
+
+    /** Held in the harness's steer queue until the current turn settles. */
+    data class Queued(val queueId: String, val threadId: String) : SendReceipt
+}
+
+/**
+ * The 202 body, read leniently. Every field is optional on purpose: a harness
+ * older than this app answers `{ok:true}` and nothing else, and that is a
+ * plain send, not a failure.
+ */
+@Serializable
+data class SendReceiptBody(
+    val threadId: String? = null,
+    val queued: Boolean? = null,
+    val queueId: String? = null,
+    val steered: Boolean? = null,
+) {
+    fun receipt(): SendReceipt =
+        if (queued == true && queueId != null && threadId != null) {
+            SendReceipt.Queued(queueId, threadId)
+        } else {
+            SendReceipt.Sent(threadId, steered == true)
+        }
+}
+
+/** A message waiting in the harness's steer queue, as this client knows it. */
+data class QueuedSend(val queueId: String, val text: String)

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Session.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Session.kt
@@ -65,6 +65,10 @@ class Session(
     private val hydrateFn: suspend (CompanionClient, Int?) -> Fleet = { client, messages ->
         client.fleet(messages)
     },
+    /** Test seam: override the engine list read for composer wording. */
+    private val instancesFn: suspend (CompanionClient) -> List<Instance> = { client ->
+        client.instances()
+    },
     /** Test seam: override the authenticated endpoint snapshot. */
     private val metadataFn: suspend (CompanionClient) -> CompanionConnectionMetadata = { client ->
         client.connectionMetadata()
@@ -88,6 +92,15 @@ class Session(
 
     private val _state = MutableStateFlow(CompanionState())
     val state: StateFlow<CompanionState> = _state.asStateFlow()
+
+    /**
+     * Engines that can take a message INTO a turn that is already running.
+     * Loaded once per hydrate and only ever used to word the composer: an
+     * empty set means "we do not know", and the wording falls back to the
+     * weaker promise, which is the one that is always true.
+     */
+    private val _steeringInstanceIds = MutableStateFlow<Set<String>>(emptySet())
+    val steeringInstanceIds: StateFlow<Set<String>> = _steeringInstanceIds.asStateFlow()
 
     private val _connection = MutableStateFlow<Connection?>(null)
     val connection: StateFlow<Connection?> = _connection.asStateFlow()
@@ -828,6 +841,23 @@ class Session(
         val fleet = hydrateFn(activeClient, 50)
         _state.update { it.hydrate(fleet) }
         notificationSink.setBadge(_state.value.unreadCount)
+        // Deliberately off hydrate's critical path: this only words the
+        // composer, and the cursor commit — and with it the whole stream —
+        // must not wait on a request that says nothing about the transcript.
+        // An older harness omits the flag and every engine reads as
+        // non-steering, which is the conservative wording.
+        scope.launch {
+            _steeringInstanceIds.value = try {
+                instancesFn(activeClient)
+                    .filter { it.capabilities?.queueing == true }
+                    .map { it.instanceId }
+                    .toSet()
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Exception) {
+                emptySet()
+            }
+        }
     }
 
     /**
@@ -1034,10 +1064,44 @@ class Session(
 
     suspend fun send(text: String, to: Chat) {
         perform {
-            when (to) {
+            val receipt = when (to) {
                 is Chat.BotChat -> it.sendToBot(to.bot.id, text)
                 is Chat.RoomChat -> it.sendToRoom(to.room.id, text)
             }
+            record(receipt, text, to.threadId)
+        }
+    }
+
+    /**
+     * A send the harness held rather than ran has to stay on screen, or the
+     * words simply vanish from the phone until the turn settles. [text] is
+     * what the person typed; the harness echoes back only an id.
+     */
+    private fun record(receipt: SendReceipt, text: String, fallbackThreadId: String) {
+        val queued = receipt as? SendReceipt.Queued ?: return
+        val threadId = queued.threadId.ifEmpty { fallbackThreadId }
+        _state.update { it.rememberQueued(QueuedSend(queued.queueId, text), threadId) }
+    }
+
+    /**
+     * Take back a held message before its turn settles. The row goes only
+     * once the harness confirms, so a failed cancel leaves the words on
+     * screen still waiting — which is what is actually true.
+     */
+    suspend fun cancelQueued(send: QueuedSend, chat: Chat) {
+        val activeClient = client ?: return
+        val destination = when (chat) {
+            is Chat.BotChat -> MessageDestination.Bot(chat.bot.id, chat.threadId)
+            is Chat.RoomChat -> MessageDestination.Room(chat.room.id, chat.threadId)
+        }
+        try {
+            activeClient.cancelQueued(send.queueId, destination)
+            _state.update { it.forgetQueued(send.queueId, chat.threadId) }
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: APIError) {
+            if (error.isUnauthorized) _status.value = Status.Unauthorized
+            _actionError.value = error.message
         }
     }
 
@@ -1116,7 +1180,12 @@ class Session(
                 urls = emptyList(),
                 attachments = uploaded,
             )
-            activeClient.send(message, destination, sendId)
+            val receipt = activeClient.send(message, destination, sendId)
+            // The row shows what was typed, not what was sent: `message`
+            // carries the <attached-file …> tags the harness reads, and a
+            // held message is a person's own words waiting, not transport.
+            // An attachment-only send has no words, so it falls back.
+            record(receipt, text.trim().ifEmpty { message }, to.threadId)
             attachmentSendIds.remove(key)
             _actionError.value = null
             true

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Store.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Store.kt
@@ -25,6 +25,21 @@ data class CompanionState(
     val streaming: Map<String, String> = emptyMap(),
     val reasoning: Map<String, String> = emptyMap(),
     val screens: Map<String, ScreenFrame> = emptyMap(),
+    /**
+     * Mid-turn sends the harness is holding until the current turn settles,
+     * by thread. They are deliberately NOT in [messages]: appending one now
+     * would make it the active leaf, and the rest of the running turn would
+     * hang off a line the model never saw. So the harness keeps them and this
+     * is the phone's copy, shown as a row above the chat bar. Identified by
+     * the harness's queueId, never by text.
+     */
+    val pendingQueued: Map<String, List<QueuedSend>> = emptyMap(),
+    /**
+     * queueIds whose drain frame beat the POST's own continuation. A short,
+     * bounded tombstone list, so a slow response cannot re-add a row for a
+     * message that is already in the transcript.
+     */
+    val drainedQueueIds: List<String> = emptyList(),
 ) {
     fun transcript(threadId: String): List<Message> = messages[threadId].orEmpty()
 
@@ -123,12 +138,15 @@ data class CompanionState(
             fleet.bots.forEach { put(it.threadId, it.hasMore ?: false) }
             fleet.groups.forEach { put(it.threadId, it.hasMore ?: false) }
         }
+        // A hydrate can be the first thing this window sees after a turn
+        // settled behind its back, so rows it still holds may already have
+        // drained into these transcripts.
         return copy(
             bots = fleet.bots,
             rooms = fleet.groups,
             messages = hydratedMessages,
             hasMore = hydratedHasMore,
-        )
+        ).reconcileAllQueued()
     }
 
     fun prepend(page: ThreadPage, threadId: String): CompanionState {
@@ -147,7 +165,7 @@ data class CompanionState(
         return copy(
             messages = messages + (threadId to merged),
             hasMore = page.hasMore?.let { hasMore + (threadId to it) } ?: hasMore,
-        )
+        ).reconcileQueued(threadId)
     }
 
     fun versions(message: Message, threadId: String): List<Message> {
@@ -181,6 +199,7 @@ data class CompanionState(
             if (frame.message.role == Message.Role.BOT && frame.message.kind == Message.Kind.TEXT) {
                 result = result.clearStream(frame.threadId)
             }
+            frame.message.queueId?.let { result = result.retireQueued(it, frame.threadId) }
             result
         }
 
@@ -220,6 +239,63 @@ data class CompanionState(
         reasoning = reasoning - threadId,
     )
 
+    // MARK: - Held mid-turn sends
+
+    /**
+     * Remember a message the harness said it is holding.
+     *
+     * The drain frame can arrive before the POST that created the entry has
+     * even returned — the harness settles a turn on its own clock. When it
+     * already has, the words are in the transcript and adding a row for them
+     * would show the message twice, so the tombstone wins and is spent.
+     */
+    fun rememberQueued(send: QueuedSend, threadId: String): CompanionState {
+        if (send.queueId in drainedQueueIds) {
+            return copy(drainedQueueIds = drainedQueueIds - send.queueId)
+        }
+        val waiting = pendingQueued[threadId].orEmpty()
+        if (waiting.any { it.queueId == send.queueId }) return this
+        return copy(pendingQueued = pendingQueued + (threadId to (waiting + send)))
+    }
+
+    /**
+     * Drop a row with no tombstone — the entry is gone from the harness too,
+     * so nothing can arrive later to be matched against it.
+     */
+    fun forgetQueued(queueId: String, threadId: String): CompanionState {
+        val waiting = pendingQueued[threadId] ?: return this
+        val rest = waiting.filterNot { it.queueId == queueId }
+        return copy(
+            pendingQueued = if (rest.isEmpty()) {
+                pendingQueued - threadId
+            } else {
+                pendingQueued + (threadId to rest)
+            },
+        )
+    }
+
+    /** Drop a row because its line landed, and leave a tombstone behind. */
+    private fun retireQueued(queueId: String, threadId: String): CompanionState {
+        val tombstones = (drainedQueueIds + queueId).takeLast(MAX_DRAINED_QUEUE_IDS)
+        return forgetQueued(queueId, threadId).copy(drainedQueueIds = tombstones)
+    }
+
+    /**
+     * Reconcile rows against a transcript that arrived whole — a hydrate, a
+     * page fetch, or a bot frame carrying its own messages. A window that was
+     * backgrounded through the drain never saw the message frame, and its
+     * rows have to go.
+     */
+    private fun reconcileQueued(threadId: String): CompanionState {
+        if (!pendingQueued.containsKey(threadId)) return this
+        val landed = transcript(threadId).mapNotNull(Message::queueId).toSet()
+        if (landed.isEmpty()) return this
+        return landed.fold(this) { state, queueId -> state.retireQueued(queueId, threadId) }
+    }
+
+    private fun reconcileAllQueued(): CompanionState =
+        pendingQueued.keys.toList().fold(this) { state, threadId -> state.reconcileQueued(threadId) }
+
     fun resetCursor(cursor: String): CompanionState = copy(cursor = cursor)
 
     fun advance(seq: Int?): CompanionState {
@@ -245,7 +321,12 @@ data class CompanionState(
                 messages = previous.messages,
                 activeLeafId = bot.activeLeafId ?: previous.activeLeafId,
             )
-            return copy(bots = bots.replacing(index, merged))
+            val next = copy(bots = bots.replacing(index, merged))
+            // A turn can end without a settled reply — an engine that dies
+            // mid-sentence reports the failure as activity, not text — and
+            // the half-written answer would otherwise sit in the buffer
+            // streaming for ever.
+            return if (bot.busy != true) next.clearStream(bot.threadId) else next
         }
 
         var result = copy(
@@ -254,7 +335,10 @@ data class CompanionState(
             hasMore = hasMore + (bot.threadId to (bot.hasMore ?: false)),
         ).clearStream(previous.threadId)
         if (previous.threadId != bot.threadId) result = result.clearStream(bot.threadId)
-        return result
+        // A replacement bypasses `append`, which is what normally retires a
+        // row. Without this the held message stays above the chat bar for
+        // ever, long after its line has landed.
+        return result.reconcileQueued(bot.threadId)
     }
 
     private fun deleteBot(botId: String): CompanionState {
@@ -346,5 +430,13 @@ data class CompanionState(
 
         fun <T> List<T>.replacing(index: Int, value: T): List<T> =
             toMutableList().also { it[index] = value }
+
+        /**
+         * How many tombstones to keep. One per queued send that drained while
+         * its own POST was still in flight — a handful at the very most, but
+         * other clients queue into the same thread, so it is bounded.
+         */
+        const val MAX_DRAINED_QUEUE_IDS = 64
     }
+
 }

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/QueuedSendTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/QueuedSendTest.kt
@@ -1,0 +1,198 @@
+package com.openmausbot.companion.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+
+/**
+ * Mid-turn sends: what the phone shows between posting a message and the
+ * computer actually running it.
+ *
+ * The harness answers a mid-turn send in one of three ways, and only one of
+ * them puts anything in the transcript. These are claims about the other two
+ * — the ones that used to leave the screen blank.
+ */
+class QueuedSendTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun drained(id: String, queueId: String, text: String = "and add tests") = Message(
+        id = id,
+        role = Message.Role.USER,
+        kind = Message.Kind.TEXT,
+        at = 10.0,
+        text = text,
+        queueId = queueId,
+    )
+
+    private fun echo(busy: Boolean? = null) = com.openmausbot.companion.core.Bot(
+        id = "b1",
+        threadId = "t1",
+        name = "Echo",
+        title = "",
+        description = "",
+        notifications = true,
+        color = "blue",
+        unread = false,
+        modelSelection = ModelSelection("codex", "gpt-5.5"),
+        createdAt = 1.0,
+        busy = busy,
+    )
+
+    // MARK: - The receipt
+
+    @Test
+    fun `a held send decodes as queued`() {
+        val body = """{"ok":true,"queued":true,"queueId":"q1","threadId":"t1"}"""
+        assertEquals(
+            SendReceipt.Queued("q1", "t1"),
+            json.decodeFromString<SendReceiptBody>(body).receipt(),
+        )
+    }
+
+    @Test
+    fun `a send taken into the running turn decodes as steered`() {
+        val body = """{"ok":true,"steered":true,"threadId":"t1"}"""
+        assertEquals(
+            SendReceipt.Sent("t1", steered = true),
+            json.decodeFromString<SendReceiptBody>(body).receipt(),
+        )
+    }
+
+    /** An older harness answers `{ok:true}`. That is a plain send. */
+    @Test
+    fun `an answer without mid-turn detail is a plain send`() {
+        assertEquals(
+            SendReceipt.Sent(null, steered = false),
+            json.decodeFromString<SendReceiptBody>("""{"ok":true}""").receipt(),
+        )
+    }
+
+    /**
+     * `queued` without the id it is identified by is not something this client
+     * can track, cancel, or retire. Treating it as queued would strand a row.
+     */
+    @Test
+    fun `queued without an id falls back to a plain send`() {
+        val body = """{"ok":true,"queued":true,"threadId":"t1"}"""
+        assertEquals(
+            SendReceipt.Sent("t1", steered = false),
+            json.decodeFromString<SendReceiptBody>(body).receipt(),
+        )
+    }
+
+    // MARK: - The fold
+
+    @Test
+    fun `a held send stays on screen until its line lands`() {
+        var state = CompanionState().rememberQueued(QueuedSend("q1", "and add tests"), "t1")
+        assertEquals(listOf("and add tests"), state.pendingQueued["t1"]?.map { it.text })
+
+        state = state.apply(Frame.Message("t1", drained("m1", "q1")))
+        assertNull(state.pendingQueued["t1"])
+        assertEquals(1, state.transcript("t1").size)
+    }
+
+    @Test
+    fun `holds are kept in send order and never twice`() {
+        val state = CompanionState()
+            .rememberQueued(QueuedSend("q1", "first"), "t1")
+            .rememberQueued(QueuedSend("q2", "second"), "t1")
+            .rememberQueued(QueuedSend("q1", "first"), "t1")
+        assertEquals(listOf("first", "second"), state.pendingQueued["t1"]?.map { it.text })
+    }
+
+    /**
+     * The turn can settle before the POST that queued the message has even
+     * returned. Its line is already in the transcript by then, so the late
+     * receipt must not put a row for it back on screen.
+     */
+    @Test
+    fun `a drain that beats its own receipt does not resurrect the row`() {
+        val state = CompanionState()
+            .apply(Frame.Message("t1", drained("m1", "q1")))
+            .rememberQueued(QueuedSend("q1", "and add tests"), "t1")
+        assertNull(state.pendingQueued["t1"])
+    }
+
+    /** One tombstone, one use. */
+    @Test
+    fun `the tombstone is spent once`() {
+        val state = CompanionState()
+            .apply(Frame.Message("t1", drained("m1", "q1")))
+            .rememberQueued(QueuedSend("q1", "first"), "t1")
+            .rememberQueued(QueuedSend("q1", "first"), "t1")
+        assertEquals(listOf("first"), state.pendingQueued["t1"]?.map { it.text })
+    }
+
+    @Test
+    fun `cancelling a hold removes it and only it`() {
+        var state = CompanionState()
+            .rememberQueued(QueuedSend("q1", "first"), "t1")
+            .rememberQueued(QueuedSend("q2", "second"), "t1")
+        state = state.forgetQueued("q1", "t1")
+        assertEquals(listOf("second"), state.pendingQueued["t1"]?.map { it.text })
+        state = state.forgetQueued("q2", "t1")
+        assertNull(state.pendingQueued["t1"])
+    }
+
+    @Test
+    fun `holds are kept per thread`() {
+        val state = CompanionState()
+            .rememberQueued(QueuedSend("q1", "first"), "t1")
+            .rememberQueued(QueuedSend("q2", "second"), "t2")
+            .apply(Frame.Message("t1", drained("m1", "q1")))
+        assertNull(state.pendingQueued["t1"])
+        assertEquals(listOf("second"), state.pendingQueued["t2"]?.map { it.text })
+    }
+
+    /**
+     * A bot frame carrying a whole transcript replaces `messages` outright
+     * rather than appending, so it never runs the retirement that `append`
+     * does. Without reconciling here the held message sits above the chat bar
+     * for ever, long after its line has landed.
+     */
+    @Test
+    fun `a wholesale transcript replacement retires the row`() {
+        var state = CompanionState().apply(Frame.Bot(echo()))
+        state = state.rememberQueued(QueuedSend("q1", "Count to 5"), "t1")
+        assertEquals(1, state.pendingQueued["t1"]?.size)
+
+        state = state.apply(Frame.Bot(echo().copy(messages = listOf(drained("m1", "q1")))))
+        assertNull(state.pendingQueued["t1"])
+    }
+
+    /**
+     * An engine that dies mid-sentence reports the failure as activity, not as
+     * a settled reply, so nothing else clears the buffer. Left alone it renders
+     * as an answer that streams for ever.
+     */
+    @Test
+    fun `an idle bot has nothing streaming`() {
+        var state = CompanionState().apply(Frame.Bot(echo(busy = true)))
+        state = state.apply(
+            Frame.Runtime(RuntimeEvent("content.delta", "t1", "A History of Comp", "assistant_text")),
+        )
+        assertTrue(state.streaming["t1"].orEmpty().isNotEmpty())
+
+        state = state.apply(Frame.Bot(echo(busy = false)))
+        assertNull(state.streaming["t1"])
+    }
+
+    // MARK: - The message
+
+    @Test
+    fun `a transcript line carries its mid-turn markers`() {
+        val body = """{"id":"m1","role":"user","kind":"text","at":1,"text":"stop","steered":true}"""
+        val message = json.decodeFromString<Message>(body)
+        assertEquals(true, message.steered)
+        assertNull(message.queueId)
+    }
+
+    @Test
+    fun `an engine that can take words into a turn says so`() {
+        val body = """{"images":true,"queueing":true}"""
+        assertEquals(true, json.decodeFromString<InstanceCapabilities>(body).queueing)
+    }
+}


### PR DESCRIPTION
Android port of #750. Same bug, same shape, same words.

## The bug

Android had no `queueId` or `steered` anywhere, and `sendToBot`/`send` threw the POST's 202 body away — which is where the entire mid-turn contract lives.

When the bot is idle the line lands and a turn starts. When it is mid-turn, an engine with a live session can take the words **into** the running turn (`steered`), and one that cannot has the harness **hold** them off-transcript until the turn settles (`queued`, with a `queueId`). Off-transcript deliberately: a held line appended now would become the active leaf, and the rest of the running turn would hang off something the model never saw.

Reading none of it, the phone showed nothing at all for a held message — the composer cleared and the words reappeared minutes later, or not at all. Only the Claude driver declares `capabilities.queueing`, so on every other engine the queue is the only path and mid-turn sending looked completely broken.

## What this does

- **`SendReceipt`** decodes the 202 leniently — an older harness answering `{ok:true}` is a plain send, not a failure.
- **`CompanionState.pendingQueued`**, keyed by `queueId`, with a bounded tombstone list for a drain that beats its own POST. Hydrate, page merge, **and wholesale bot-frame replacement** all reconcile.
- **The held message is a row above the chat bar** — its text, a labelled `Steer` button, and a bin. Steer stops the turn so those words run now: the harness keeps its steer queue across an interrupt, which is what makes stopping a send.
- **The composer says what will happen** — *"Sends into this turn"* vs *"Sends after this turn"*.

## Carried over from testing #750 on a real phone

Every one of these was found by using the iOS build against a live harness, and is built in here from the start rather than discovered again:

- **The row could stick for ever.** A bot frame carrying a whole transcript replaces `messages[…]` outright rather than appending, so it never runs the retirement `append` does.
- **A dead turn streamed for ever.** A turn can end without a settled reply — an engine dying mid-sentence reports the failure as activity, not text — so nothing cleared the buffer. An idle bot now clears it.
- **Steer looked dead.** An interrupt takes ~6.3s to actually stop a codex turn. The button says *"Steering…"* and disables immediately, with a 20s floor so it cannot spin for ever.
- **Cancel could lie.** The sidecar answers `404 no route` for a route it does not allow; the harness answers `404 no such queued message` when the entry is gone. Matched positively on the harness's own wording, so an unfamiliar 404 fails safe and the row stays.

## One thing worth reviewing

The engine-capability read that words the composer is `launch`ed rather than awaited. It says nothing about the transcript, so the cursor commit — and with it the stream going live — must not wait on it. Blocking hydrate on it failed `helloNotResumedHydratesBeforeCommittingCursor` and `screenWatcherTurnsScreensOnAndLastCloseClears` outright; #750 has the same change applied to iOS.

## Testing

471 core + app unit tests pass, 15 new in `QueuedSendTest.kt` covering the receipt shapes, the fold, the drain/POST race, the tombstone, per-thread isolation, wholesale replacement, and the idle-bot stream clear.

Depends on the sidecar allowlist for `DELETE /api/{bots,groups}/:id/queue/:id` in #750 — without it Android's cancel gets a 404 and correctly says the computer needs updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Send messages while a bot is still responding; queued messages now appear above the chat composer.
  * Steer eligible conversations by sending a queued message immediately into the current turn.
  * Cancel queued messages before they are processed.
  * Added visual status indicators for queued, steering, listening, and sending states.
  * Messages sent into an active turn are retained and identified correctly in the conversation.
* **Bug Fixes**
  * Improved handling when queued messages are processed or removed before the app refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->