### PR TITLE
fix(connected-apps): prompt for an alias on the first account too

### DIFF
--- a/apps/docs/content/docs/connected-apps/multiple-accounts.mdx
+++ b/apps/docs/content/docs/connected-apps/multiple-accounts.mdx
@@ -6,15 +6,15 @@ icon: UsersRound
 
 OpenMausBot supports several labeled accounts for the same toolkit. This is useful for two Gmail inboxes, several Slack workspaces, or separate personal and work services.
 
-## Add another account
+## Add an account
 
 1. Open **Connected apps**.
-2. Find an already connected toolkit.
-3. Choose **Add account**.
+2. Find the toolkit you want to connect.
+3. Choose **Connect** (or **Add account** if you already have one).
 4. Enter a unique label such as `work`, `personal`, or the workspace name.
 5. Complete authorization in your browser.
 
-When more than one account could execute a tool, the Composio session requires explicit account selection. A new authorization does not silently become the default for the old one.
+OpenMausBot asks for a label on every new account, including the first, so the Connected tab shows your chosen name instead of a generated id. When more than one account could execute a tool, the Composio session requires explicit account selection. A new authorization does not silently become the default for the old one.
 
 ## Disconnect safely
 

--- a/docs/composio.md
+++ b/docs/composio.md
@@ -8,10 +8,10 @@ OpenMausBot uses one Composio project API key and one reusable Composio Session.
 2. Select **Platform**, select or create a project, then open **Settings → API Keys**.
 3. Copy a project key beginning with `ak_`.
 4. In OpenMausBot, open **App Settings → Connections** and save it under **Composio project key**.
-5. Open **Connected apps** and choose Gmail, GitHub, Slack, or another service. Authentication happens in your normal browser.
-6. To connect another account for the same app, choose **Add account**, give it a unique label such as `work` or `personal`, and finish the second authorization in your browser.
+5. Open **Connected apps** and choose Gmail, GitHub, Slack, or another service. Enter a unique label such as `work` or `personal`, then finish the authorization in your normal browser.
+6. To connect another account for the same app, choose **Add account**, give it a unique label, and finish the second authorization in your browser.
 
-The Connected tab lists every account separately. **Disconnect** revokes only the account named on that row. OpenMausBot requires a label for a second account and configures Composio to require explicit selection when more than one account could run a tool; a new OAuth flow never silently becomes the default for an existing connection.
+The Connected tab lists every account separately. **Disconnect** revokes only the account named on that row. OpenMausBot asks for a label for every new account and configures Composio to require explicit selection when more than one account could run a tool; a new OAuth flow never silently becomes the default for an existing connection.
 
 The desktop app validates the key before saving it. The key is encrypted using Electron's operating-system-backed `safeStorage`; the local JSON configuration stores only the non-secret Composio user and Session identifiers.
 

--- a/server/composio.test.ts
+++ b/server/composio.test.ts
@@ -495,4 +495,17 @@ describe.sequential("Composio Sessions", () => {
       malformedConnectedAccounts = false;
     }
   });
+
+  it("uses the provided alias for the first account authorization", async () => {
+    const cfg: AppConfig = {
+      composio: { apiKey: "ak_test", userId: "openmausbot_existing", sessionId: "trs_test" },
+    };
+    const before = calls.length;
+    await expect(authorizeService(cfg, "slack", "team")).resolves.toEqual({
+      url: "https://connect.composio.dev/link/slack",
+    });
+    const linkCalls = calls.slice(before).filter((call) => call.method === "POST" && call.path.endsWith("/link"));
+    expect(linkCalls).toHaveLength(1);
+    expect(linkCalls[0].body).toEqual({ toolkit: "slack", alias: "team" });
+  });
 });

--- a/src/components/PluginsPanel.tsx
+++ b/src/components/PluginsPanel.tsx
@@ -656,10 +656,10 @@ export function PluginsPanel() {
                         if (pending && pendingUrls[card.slug]) {
                           setError(null);
                           void openConnectUrl(pendingUrls[card.slug]).catch((e) => setError(e.message));
-                        } else if (accounts.length) {
+                        } else {
                           setAliasSlug((current) => current === card.slug ? null : card.slug);
                           setAliasDraft("");
-                        } else void connect(card.slug);
+                        }
                       }}
                       className="flex min-w-[88px] items-center justify-center gap-1.5 rounded-full bg-raised px-3 py-2 text-[12.5px] text-ink transition-colors hover:bg-raised-hover disabled:opacity-40"
                     >
@@ -727,7 +727,7 @@ export function PluginsPanel() {
                         maxLength={64}
                         onChange={(event) => setAliasDraft(event.target.value)}
                         placeholder="Account label (work, personal…)"
-                        aria-label={`Label for another ${card.label} account`}
+                        aria-label={accounts.length > 0 ? `Label for another ${card.label} account` : `Label for the new ${card.label} account`}
                         className="min-w-0 flex-1 rounded-lg bg-raised px-3 py-2 text-[12px] text-ink placeholder:text-ink-secondary focus:outline-none focus:ring-1 focus:ring-accent"
                       />
                       <button


### PR DESCRIPTION
## Summary

The Connected apps panel now opens the alias form on the first Connect click, so every new account gets a user-chosen label instead of a generated Composio id.

## Changes

- `src/components/PluginsPanel.tsx` — always open the alias form on Connect; aria-label now says "new account" when none exist.
- `docs/composio.md` — updated steps and copy to say a label is asked for every account.
- `apps/docs/content/docs/connected-apps/multiple-accounts.mdx` — generalized the instructions.
- `server/composio.test.ts` — added a test that verifies the alias is sent for a first-account authorization.

## Test plan

- [x] `pnpm vitest run src/components/PluginsPanel.test.ts server/composio.test.ts` passes.
- [x] `pnpm typecheck` passes.
- [x] Commit is SSH-signed.

Closes #685

Co-Authored-By: Paperclip <noreply@paperclip.ing>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Account connection now prompts for a label when adding the first account or additional accounts.
  - Chosen labels are displayed in the Connected tab instead of generated IDs.
  - Marketplace connection prompts clearly distinguish between adding a new account and another account.

- **Documentation**
  - Updated account-connection instructions to cover both first-time and additional accounts.
  - Clarified labeling requirements in the packaged desktop app setup guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->