### PR TITLE
Make compaction verifiable through the control surface

### DIFF
--- a/docs/verification/context-runtime.md
+++ b/docs/verification/context-runtime.md
@@ -47,31 +47,49 @@ that impossible. On a 200k window nothing clips:
 family floor for `claude-*`, not a figure the driver declared. Only
 `"catalog"` means the engine actually said so.
 
-## What this harness cannot prove
+## Driving compaction
 
-**Compaction does not fire here, and that is not a failure.** Two independent
-reasons, both worth knowing before you spend an afternoon on it:
+Compaction needs two things the default fixture does not give you: a window
+small enough to overflow on a short thread, and a turn that REBUILDS rather
+than resumes. A cleanly resumed turn never compacts — the vendor CLI owns its
+own context, and that is by design.
 
-- `control-omb launch` builds its child env from scratch — an allowlist of
-  platform keys plus fixed fixture values (see `childEnv` in
-  `scripts/control-omb.ts`). Arbitrary parent env is dropped on purpose, so
-  `OMB_CONTEXT_WINDOW=…` never reaches the server and every model keeps its
-  real window.
-- Compaction only runs on a turn that will REPLAY — a rewind, an engine
-  switch, an external update, or an `omb-replay` engine. The fixture's fake
-  engine resumes cleanly, so `willReplay` is false and no rebuild is
-  attempted. A resumed turn paying nothing is the intended design, not a bug.
+```sh
+OMB_CONTEXT_WINDOW=12000 node --experimental-strip-types scripts/control-omb.ts launch
+```
 
-Driving 30 long turns against the fixture therefore produces zero compaction
-records, correctly. The real coverage is `server/context/rebuild.test.ts`,
-which exercises it against a live `Store`: the fold, the display path staying
-whole, the summarizer prompt, previous-summary carry-forward, and the three
-failure modes (no summarizer, a throwing one, a blank summary — all write
-nothing and none fail the turn).
+`launch` builds its child env from scratch so the fixture cannot inherit your
+shell; `OMB_CONTEXT_WINDOW` and `FAKE_CLAUDE_MODE` are the two overrides it
+forwards when explicitly set, because without them whole features cannot be
+exercised here.
 
-Closing this properly needs two changes to the control surface: forwarding
-`OMB_CONTEXT_WINDOW` to the child, and a mapped command that can force a
-replay path. Neither exists yet; do not add a map entry claiming otherwise.
+Then fill the thread past the budget and rewind:
+
+```sh
+omb() { node --experimental-strip-types scripts/control-omb.ts "$@"; }
+LONG=$(python3 -c "print('please remember this carefully: ' + 'context ' * 150)")
+for i in $(seq 1 30); do
+  omb send --bot "$BOT" --text "turn $i: $LONG" --url $URL
+  omb wait --bot "$BOT" --timeout 30 --url $URL
+done
+# edit the LATEST user turn — editing an early one forks away the history you
+# just built, and the shorter branch fits again
+omb edit --bot "$BOT" --message "$LAST_USER_MESSAGE_ID" --text "summarise everything" --url $URL
+omb wait --bot "$BOT" --timeout 30 --url $URL
+```
+
+`edit` is the rewind a person performs in the composer, and the only mapped
+way to make the harness rebuild instead of resume.
+
+Expected — the last `context.prepared` reports `"mode":"replay-required"` and
+`"compacted":true`, and one record lands in the database:
+
+```sh
+sqlite3 "$DATA_DIR/messages.db" "SELECT json FROM messages WHERE kind='compaction'"
+```
+
+Observed on 2026-09-04: `tokensBefore 5358` against a 4,800-token budget on a
+12k window, one record, the display path still holding every message.
 
 ## Gotchas
 
@@ -82,3 +100,7 @@ replay path. Neither exists yet; do not add a map entry claiming otherwise.
   bug reports.
 - Item counts are semantic units, not messages: one chat turn usually
   produces a user turn, an assistant turn, and a tool observation.
+- A resumed turn never compacts. If `mode` says `resume-preferred`, no rebuild
+  was attempted and `compacted:false` proves nothing about compaction.
+- Rewind at the newest user turn. An edit forks the branch at that message, so
+  editing an early one discards the history you were trying to overflow.

--- a/scripts/control-omb.ts
+++ b/scripts/control-omb.ts
@@ -14,7 +14,7 @@ import { freePortBlock } from "../server/testing/ports.ts";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const FAKE_CLI = join(ROOT, "server", "testing", "fake-claude-cli.ts");
-const MUTATING = new Set(["new-bot", "new-channel", "send", "send-channel", "interrupt"]);
+const MUTATING = new Set(["new-bot", "new-channel", "send", "send-channel", "interrupt", "edit"]);
 
 export class ControlOmbError extends Error {
   readonly hint?: string;
@@ -53,6 +53,7 @@ mutating (an explicit --url or OPENMAUSBOT_URL/OMB_PORT is required):
   send-channel --channel ID --text TEXT [--dry-run] [--url URL]
   interrupt --bot ID [--dry-run] [--url URL]
   interrupt --channel ID [--dry-run] [--url URL]
+  edit --bot ID --message ID --text TEXT [--url URL]
 
 isolated fixture:
   node --experimental-strip-types scripts/control-omb.ts launch
@@ -186,6 +187,22 @@ export async function runControlOmb(
     }, values.url);
   }
 
+  if (command === "edit") {
+    // The rewind a person performs in the composer. It is the only mapped
+    // way to make the harness REBUILD a thread rather than resume the
+    // provider's session — which is what compaction needs to be observable.
+    const opts = parse(command, args, {
+      bot: { type: "string" },
+      message: { type: "string" },
+      text: { type: "string" },
+    });
+    return call("edit_bot_message", {
+      bot_id: required(opts.bot, "--bot"),
+      message_id: required(opts.message, "--message"),
+      text: required(opts.text, "--text"),
+    }, opts.url);
+  }
+
   if (command === "new-channel") {
     const values = parse(command, args, {
       name: { type: "string" },
@@ -307,6 +324,15 @@ export async function launchVerificationServer(
     FAKE_CLAUDE_DUMP: fixtureDumpPath,
     PATH: "",
   });
+  // The child env is built from scratch so the fixture cannot inherit the
+  // user's shell. Two overrides are forwarded when explicitly set, because
+  // without them whole features are unverifiable here: OMB_CONTEXT_WINDOW
+  // shrinks every model's window so compaction can be watched on a short
+  // thread, and FAKE_CLAUDE_MODE drives the CLI failure paths.
+  for (const key of ["OMB_CONTEXT_WINDOW", "FAKE_CLAUDE_MODE"]) {
+    const value = parentEnv[key];
+    if (value) childEnv[key] = value;
+  }
   const child = spawn(process.execPath, ["--experimental-strip-types", join(ROOT, "server", "index.ts")], {
     cwd: ROOT,
     env: childEnv,

--- a/scripts/mcp-server.ts
+++ b/scripts/mcp-server.ts
@@ -403,6 +403,24 @@ export const TOOLS: McpToolDefinition[] = [
     annotations: MUTATING,
   },
   {
+    name: "edit_bot_message",
+    description:
+      "Edit an earlier user message, which forks the conversation from that point and answers again. "
+      + "This is the rewind a person performs in the composer, and the only mapped way to make the "
+      + "harness rebuild a thread's context instead of resuming the provider's own session.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        bot_id: { type: "string", description: "The ID of the bot." },
+        message_id: { type: "string", description: "The user message to replace." },
+        text: { type: "string", description: "What that message should say instead." },
+      },
+      required: ["bot_id", "message_id", "text"],
+      additionalProperties: false,
+    },
+    annotations: MUTATING,
+  },
+  {
     name: "list_available_models",
     description: "List configured model instances and capabilities without exposing local executable paths.",
     inputSchema: {
@@ -1107,6 +1125,24 @@ export async function handleToolCall(
         body: JSON.stringify({ modelSelection: selection, requireAvailableModel: true }),
       });
       return { success: true, bot: projectBot(res.bot) };
+    }
+
+    case "edit_bot_message": {
+      const botId = idArg(args, "bot_id");
+      const messageId = idArg(args, "message_id");
+      const text = String(args.text ?? "").trim();
+      if (!text) throw new Error("text is required");
+      const current = await fleet(fetcher);
+      const bot = records(current.bots).find((candidate) => candidate.id === botId);
+      if (!bot) throw new Error(`Bot not found: ${botId}`);
+      // the server refuses a rewind under a live turn — branching beneath a
+      // dying turn is how a thread ends up with two tails
+      if (bot.busy) throw new Error("Interrupt the bot or let it finish before editing a message");
+      const res = await fetcher(
+        `/api/bots/${encodeURIComponent(botId)}/messages/${encodeURIComponent(messageId)}/edit`,
+        { method: "POST", body: JSON.stringify({ text }) },
+      );
+      return { success: true, threadId: res.threadId, message: res.message };
     }
 
     case "list_available_models": {

--- a/server/control-omb.test.ts
+++ b/server/control-omb.test.ts
@@ -89,6 +89,44 @@ describe("control-omb command mapping", () => {
     expect(callTool).toHaveBeenCalledTimes(1);
   });
 
+  it("maps the rewind that makes the harness rebuild instead of resume", async () => {
+    // `edit` is the composer rewind. It is the only mapped way to reach a
+    // replay path, which is what compaction needs to be observable at all —
+    // a cleanly resumed turn never compacts.
+    const callTool = vi.fn(async (name: string, args: Record<string, unknown>) => ({ name, args }));
+    await expect(runControlOmb(
+      ["edit", "--bot", "bot-1", "--message", "msg-9", "--text", "say that again"],
+      { callTool: callTool as any, env: { OPENMAUSBOT_URL: "http://127.0.0.1:19999" } },
+    )).resolves.toEqual({
+      name: "edit_bot_message",
+      args: { bot_id: "bot-1", message_id: "msg-9", text: "say that again" },
+    });
+  });
+
+  it("treats edit as mutating, so it cannot reach a silently discovered app", async () => {
+    // it forks a live conversation and starts a turn; it must never land on
+    // whatever instance happened to be running
+    await expect(runControlOmb(["edit", "--bot", "b", "--message", "m", "--text", "x"], {
+      callTool: vi.fn() as any,
+      env: {},
+    })).rejects.toMatchObject({
+      message: "mutating commands require an explicit OpenMausBot instance",
+    });
+  });
+
+  it("requires every part of an edit before calling the shared tool", async () => {
+    const callTool = vi.fn();
+    const env = { OPENMAUSBOT_URL: "http://127.0.0.1:19999" };
+    for (const args of [
+      ["edit", "--message", "m", "--text", "x"],
+      ["edit", "--bot", "b", "--text", "x"],
+      ["edit", "--bot", "b", "--message", "m"],
+    ]) {
+      await expect(runControlOmb(args, { callTool: callTool as any, env })).rejects.toThrow(/is required/);
+    }
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
   it("rejects invalid bounds before the shared tool is called", async () => {
     const callTool = vi.fn();
     await expect(runControlOmb(["wait", "--bot", "bot-1", "--timeout", "0"], {

--- a/server/mcp-server.test.ts
+++ b/server/mcp-server.test.ts
@@ -318,6 +318,34 @@ describe("MCP tool execution", () => {
     expect(result.hits).toHaveLength(1);
   });
 
+  it("rewinds a thread by editing an earlier message, and refuses while busy", async () => {
+    // The composer rewind. It forks the conversation and answers again,
+    // which is the only mapped way to make the harness REBUILD context
+    // rather than resume the provider's own session.
+    const busyFetcher = vi.fn(async () => ({ bots: [{ id: "bot-1", busy: true }] }));
+    await expect(handleToolCall("edit_bot_message", {
+      bot_id: "bot-1", message_id: "m-9", text: "say that again",
+    }, busyFetcher)).rejects.toThrow("let it finish");
+
+    const fetcher = vi.fn(async (path: string) => {
+      if (path === "/api/bots?messages=0") return { bots: [{ id: "bot-1", busy: false }] };
+      return { threadId: "t-1", message: { id: "m-new" } };
+    });
+    const result: any = await handleToolCall("edit_bot_message", {
+      bot_id: "bot-1", message_id: "m-9", text: "say that again",
+    }, fetcher);
+    expect(fetcher).toHaveBeenCalledWith("/api/bots/bot-1/messages/m-9/edit", expect.objectContaining({ method: "POST" }));
+    expect(result).toMatchObject({ success: true, threadId: "t-1" });
+  });
+
+  it("will not rewind to an empty message", async () => {
+    const fetcher = vi.fn();
+    await expect(handleToolCall("edit_bot_message", {
+      bot_id: "bot-1", message_id: "m-9", text: "   ",
+    }, fetcher as never)).rejects.toThrow("text is required");
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
   it("requires an exact available model and refuses changes while busy", async () => {
     const busyFetcher = vi.fn(async () => ({ bots: [{ id: "bot-1", busy: true }] }));
     await expect(handleToolCall("set_bot_model", {


### PR DESCRIPTION
**Stacked on #759** — base is `feat/hybrid-context-runtime`, since this depends on the `context.prepared` event. Merge that first.

Compaction could only be proven in unit tests. `docs/verification/context-runtime.md` said so outright. This closes both reasons why.

## Reason one: the override never arrived

`control-omb launch` builds its child env from scratch so the fixture cannot inherit the user's shell — correct for isolation, but it meant `OMB_CONTEXT_WINDOW` never reached the server and no model could be made small enough to overflow on a short thread. It now forwards that and `FAKE_CLAUDE_MODE` when explicitly set, because without them whole features cannot be exercised here.

## Reason two: nothing could force a rebuild

A cleanly resumed turn never compacts — the vendor CLI owns its own context, by design. So compaction needs a turn that *rebuilds*, and nothing in the mapped surface could produce one.

Adds **`edit_bot_message`** and an **`omb edit`** command: the rewind a person performs in the composer, which forks the conversation and answers again. It was unmapped despite being an ordinary user action, and it is the only route to a replay path.

## Proven end to end

On a 12k window: 30 long turns, then an edit →

```
mode: "replay-required"   compacted: true
tokensBefore 5358 against a 4,800-token budget, one record written
```

## Two gotchas found while driving it

Both now in the doc, because both cost me a run:

- **Editing an early message does not work.** The edit forks the branch at that message, discarding the history you just built, so the shorter branch fits again and nothing compacts. Rewind at the *newest* user turn.
- **`compacted:false` on a resumed turn proves nothing.** No rebuild was attempted, so it is not evidence either way.

## Tests

Five new, covering the parts I would otherwise have shipped bare: command mapping, `edit` being treated as mutating (it forks a live conversation and starts a turn, so it must never reach a silently discovered app), argument validation, the handler refusing while the bot is busy, and refusing an empty rewind.

`vitest 3277 · broker 7 · electron 90/90 · packaged-server smoke · 0 lint errors` on Node 24.14.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)