### PR TITLE
fix(connectors): explain managed Twitter limitation

### DIFF
--- a/server/composio.test.ts
+++ b/server/composio.test.ts
@@ -328,6 +328,19 @@ describe.sequential("Composio Sessions", () => {
     });
   });
 
+  it("does not offer Twitter through the official managed broker without an owned OAuth app", async () => {
+    setManagedBrokerAccess({
+      url: "https://broker.openmausbot.test",
+      token: "a".repeat(64),
+    });
+    try {
+      await expect(authorizeService({} as AppConfig, "twitter")).rejects.toThrow(/X Developer app/i);
+      await expect(authorizeService({} as AppConfig, "x")).rejects.toThrow(/self-hosted connected apps/i);
+    } finally {
+      setManagedBrokerAccess(null);
+    }
+  });
+
   it("validates account aliases before sending them upstream", () => {
     expect(normalizeAccountAlias("  personal gmail  ")).toBe("personal gmail");
     expect(() => normalizeAccountAlias("bad\nalias")).toThrow(/printable/i);

--- a/server/composio.ts
+++ b/server/composio.ts
@@ -4,6 +4,7 @@ import { saveConfig, type AppConfig } from "./config.ts";
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import { SPAWNED_PROXIES } from "./proxy-paths.ts";
+import { managedConnectorUnavailableReason } from "../shared/connector-availability.ts";
 
 const DEFAULT_BACKEND_ORIGIN = "https://backend.composio.dev";
 
@@ -808,7 +809,10 @@ export async function removeAccount(cfg: AppConfig, slug: string, accountId: str
 /** Mint a browser auth link for one service. Returns { url } or throws. */
 export async function authorizeService(cfg: AppConfig, slug: string, requestedAlias?: string | null) {
   const alias = normalizeAccountAlias(requestedAlias);
-  if (brokerAccess() || !cfg.composio?.apiKey) {
+  const broker = brokerAccess();
+  const unavailable = managedConnectorUnavailableReason(broker ? "managed" : connectionMode(cfg), slug);
+  if (unavailable) throw inputError(unavailable, 409);
+  if (broker || !cfg.composio?.apiKey) {
     const request: RequestInit = { method: "POST" };
     if (alias) request.body = JSON.stringify({ alias });
     const response = await brokerRequest(`/v1/connectors/${encodeURIComponent(slug)}/authorize`, request);

--- a/shared/connector-availability.ts
+++ b/shared/connector-availability.ts
@@ -1,0 +1,17 @@
+export type ConnectedAppsMode = "managed" | "self-hosted" | "unavailable";
+
+const MANAGED_CUSTOM_AUTH_TOOLKITS = new Set(["twitter", "x"]);
+
+/**
+ * Some Composio toolkits no longer include provider-managed credentials.
+ * The official OpenMausBot broker cannot offer those connections until its
+ * project owns the corresponding OAuth app. Self-hosted Composio projects can
+ * still supply their own auth config, so keep this restriction mode-specific.
+ */
+export function managedConnectorUnavailableReason(
+  mode: ConnectedAppsMode,
+  slug: string,
+): string | null {
+  if (mode !== "managed" || !MANAGED_CUSTOM_AUTH_TOOLKITS.has(slug.trim().toLowerCase())) return null;
+  return "Twitter/X needs your own X Developer app and Composio auth config. Use self-hosted connected apps for now.";
+}

--- a/src/components/PluginsPanel.test.ts
+++ b/src/components/PluginsPanel.test.ts
@@ -10,8 +10,13 @@ import {
   onlyLatestConnectorResponses,
   type ConnectorStatus,
 } from "./PluginsPanel";
+import { managedConnectorUnavailableReason } from "../../shared/connector-availability";
 
 describe("connected-app status races", () => {
+  it("does not render a dead Twitter connect action for managed installs", () => {
+    expect(managedConnectorUnavailableReason("managed", "twitter")).toMatch(/self-hosted/i);
+    expect(managedConnectorUnavailableReason("self-hosted", "twitter")).toBeNull();
+  });
   it("does not let an older not_connected response erase a newer OAuth attempt", async () => {
     const generations = new Map([["gmail", 0]]);
     const initialRequestGenerations = new Map(generations);

--- a/src/components/PluginsPanel.tsx
+++ b/src/components/PluginsPanel.tsx
@@ -7,6 +7,7 @@ import { Check, Loader2, RefreshCw, Search, TriangleAlert, X } from "lucide-reac
 import { api, useStore } from "@/state/store";
 import { cn } from "@/lib/cn";
 import { readCachedInventory, writeCachedInventory } from "@/lib/connected-apps-cache";
+import { managedConnectorUnavailableReason } from "../../shared/connector-availability";
 import { McpServersPanel } from "./McpServersPanel";
 
 interface ToolkitCard {
@@ -636,6 +637,7 @@ export function PluginsPanel() {
                 || (serviceStatus?.connected === true && !accounts.length && !pending && !failed);
               const addingAccount = aliasSlug === card.slug;
               const busy = busySlug === card.slug;
+              const unavailableReason = managedConnectorUnavailableReason(mode, card.slug);
               return (
                 <div
                   key={card.slug}
@@ -645,13 +647,23 @@ export function PluginsPanel() {
                     <ServiceIcon card={card} />
                     <div className="min-w-0 flex-1">
                       <div className="truncate text-[14px] font-medium text-ink">{card.label}</div>
-                      <div className="mt-0.5 truncate text-[12.5px] text-ink-secondary">
-                        {pending ? "Finish setup in your browser" : failed && !accounts.length ? "Authorization expired — try again" : card.blurb}
+                      <div
+                        className="mt-0.5 truncate text-[12.5px] text-ink-secondary"
+                        title={unavailableReason ?? undefined}
+                      >
+                        {unavailableReason ?? (
+                          pending
+                            ? "Finish setup in your browser"
+                            : failed && !accounts.length
+                              ? "Authorization expired — try again"
+                              : card.blurb
+                        )}
                       </div>
                     </div>
                     <button
                       type="button"
-                      disabled={!configured || inventoryPhase !== "ready" || busy || included}
+                      disabled={!configured || inventoryPhase !== "ready" || busy || included || Boolean(unavailableReason)}
+                      title={unavailableReason ?? undefined}
                       onClick={() => {
                         if (pending && pendingUrls[card.slug]) {
                           setError(null);
@@ -663,7 +675,9 @@ export function PluginsPanel() {
                       }}
                       className="flex min-w-[88px] items-center justify-center gap-1.5 rounded-full bg-raised px-3 py-2 text-[12.5px] text-ink transition-colors hover:bg-raised-hover disabled:opacity-40"
                     >
-                      {busy ? (
+                      {unavailableReason ? (
+                        "Self-host only"
+                      ) : busy ? (
                         <Loader2 size={13} className="mx-auto animate-spin" />
                       ) : (
                         connectorActionLabel(inventoryPhase, {


### PR DESCRIPTION
## What changed
- show Twitter/X as **Self-host only** for official managed connected apps
- keep Twitter available for self-hosted Composio projects with custom X credentials
- reject direct/chat authorization attempts with the same actionable explanation instead of Composio's raw auth_config_override error

Composio removed managed Twitter credentials, so official builds cannot complete this OAuth flow until OpenMausBot owns an X Developer app and auth config. This prevents a dead Connect button without pretending the provider limitation is fixed.

Closes #689

## Verification
- `pnpm exec vitest run src/components/PluginsPanel.test.ts server/composio.test.ts` (28 passed)
- `pnpm typecheck`
- focused Oxlint
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Twitter and X connectors now indicate when they require a self-hosted connected app.
  * Connect actions are disabled for unavailable connectors, with explanatory messaging and a “Self-host only” label.
  * Authorization now clearly reports unavailable connector errors before proceeding.

* **Bug Fixes**
  * Prevented unsupported managed authorization attempts for Twitter and X.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->