### PR TITLE
fix(computer): keep Auto from creating Boxes

### DIFF
--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -2,8 +2,9 @@
 // whole flow: cloud → provision the box on open (idempotent) and preview
 // via SSE frames or a ~4s screenshot poll. macOS local mode keeps the legacy
 // in-panel capture. Linux local mode is an automation readiness state and its
-// separate preview remains explicitly user-initiated. Auto never selects a
-// Linux user's desktop.
+// separate preview remains explicitly user-initiated. Auto reuses but never
+// creates a Box (except for the box-native engine), and never selects a Linux
+// user's desktop.
 import { useCallback, useEffect, useRef, useState } from "react";
 import { z } from "zod";
 import {
@@ -45,6 +46,7 @@ import {
   linuxAutoDescription,
   localComputerDisabledReason,
   localComputerSelectable,
+  resolveBoxPanelAction,
 } from "@/lib/local-computer";
 import {
   readComputerPanelView,
@@ -73,6 +75,7 @@ type Phase =
   | "vps-stopped"
   | "local"
   | "local-unavailable"
+  | "auto-unavailable"
   | "browser"
   | "off"
   | "error";
@@ -466,7 +469,9 @@ export function ComputerPanel({
         alive = false;
       };
     }
-    // cloud, or auto (cloud box wins when one exists, else local in-app)
+    // Cloud creates/wakes its Box. Auto may wake an existing Box but must not
+    // create one merely because this passive panel was opened. This mirrors
+    // turn routing, including the box-native engine's required exception.
     api(`/api/bots/${bot.id}/computer`)
       .then((status) => {
         if (!alive) return;
@@ -476,12 +481,16 @@ export function ComputerPanel({
           capabilitiesReady,
           localSelectable,
         });
-        if (!status.configured) {
-          setPhase(autoLocal ? "local" : "unconfigured");
-          return;
-        }
-        if (!status.box && autoLocal) {
-          setPhase("local");
+        const action = resolveBoxPanelAction({
+          computer: bot.computer,
+          driverKind: selectedInstance?.driverKind,
+          configured: Boolean(status.configured),
+          hasExistingBox: Boolean(status.box),
+          canUseCloud: cloudSupported,
+          autoLocal,
+        });
+        if (action !== "ensure-box") {
+          setPhase(action);
           return;
         }
         setPhase("starting");
@@ -509,6 +518,7 @@ export function ComputerPanel({
     localSelectable,
     isLinux,
     providerSupportsLocal,
+    selectedInstance?.driverKind,
     vmSupported,
     cloudSupported,
     vpsSupported,
@@ -843,6 +853,7 @@ export function ComputerPanel({
     checking: "Checking…",
     starting: "Starting your bot's computer…",
     unconfigured: "No cloud computer configured",
+    "auto-unavailable": "Auto found no existing computer. Choose Cloud to create one, or pick another destination.",
     "vps-unconfigured": "No managed VPS computer is configured for this bot",
     "vps-incompatible": "This VPS computer belongs to an earlier OpenMausBot version",
     "vps-stopped": "The managed VPS computer is stopped",

--- a/src/lib/local-computer.test.ts
+++ b/src/lib/local-computer.test.ts
@@ -6,6 +6,7 @@ import {
   linuxAutoDescription,
   localComputerDisabledReason,
   localComputerSelectable,
+  resolveBoxPanelAction,
 } from "./local-computer";
 
 describe("local computer UI eligibility", () => {
@@ -98,5 +99,73 @@ describe("local computer UI eligibility", () => {
         localSelectable: true,
       }),
     ).toBe(false);
+  });
+
+  it("never creates a missing Box merely because an Auto panel opened", () => {
+    expect(
+      resolveBoxPanelAction({
+        computer: undefined,
+        driverKind: "claude",
+        configured: true,
+        hasExistingBox: false,
+        canUseCloud: true,
+        autoLocal: true,
+      }),
+    ).toBe("local");
+    expect(
+      resolveBoxPanelAction({
+        computer: undefined,
+        driverKind: "claude",
+        configured: true,
+        hasExistingBox: false,
+        canUseCloud: true,
+        autoLocal: false,
+      }),
+    ).toBe("auto-unavailable");
+  });
+
+  it("reuses an existing Auto Box and provisions only for intentional cloud use", () => {
+    const base = {
+      configured: true,
+      canUseCloud: true,
+      autoLocal: true,
+    };
+    expect(
+      resolveBoxPanelAction({
+        ...base,
+        computer: undefined,
+        driverKind: "claude",
+        hasExistingBox: true,
+      }),
+    ).toBe("ensure-box");
+    expect(
+      resolveBoxPanelAction({
+        ...base,
+        computer: "cloud",
+        driverKind: "claude",
+        hasExistingBox: false,
+      }),
+    ).toBe("ensure-box");
+    expect(
+      resolveBoxPanelAction({
+        ...base,
+        computer: undefined,
+        driverKind: "boxAgent",
+        hasExistingBox: false,
+      }),
+    ).toBe("ensure-box");
+  });
+
+  it("falls back locally when the selected engine cannot use an existing Box", () => {
+    expect(
+      resolveBoxPanelAction({
+        computer: undefined,
+        driverKind: "claude",
+        configured: true,
+        hasExistingBox: true,
+        canUseCloud: false,
+        autoLocal: true,
+      }),
+    ).toBe("local");
   });
 });

--- a/src/lib/local-computer.ts
+++ b/src/lib/local-computer.ts
@@ -56,7 +56,39 @@ export function localComputerDisabledReason({
 }
 
 export function linuxAutoDescription(): string {
-  return "Auto uses a cloud box when one is configured; otherwise computer use stays off.";
+  return "Auto reuses an existing cloud box; otherwise computer use stays off.";
+}
+
+export type BoxPanelAction = "ensure-box" | "local" | "unconfigured" | "auto-unavailable";
+
+/** Mirror the turn router's Box choice without letting a passive panel open
+ * create infrastructure. Auto may wake an existing Box. The box-native
+ * Computer engine is the sole creation exception because it cannot run
+ * anywhere else; explicit Cloud is always an intentional creation request. */
+export function resolveBoxPanelAction({
+  computer,
+  driverKind,
+  configured,
+  hasExistingBox,
+  canUseCloud,
+  autoLocal,
+}: {
+  computer: Bot["computer"];
+  driverKind: string | undefined;
+  configured: boolean;
+  hasExistingBox: boolean;
+  canUseCloud: boolean;
+  autoLocal: boolean;
+}): BoxPanelAction {
+  const explicitCloud = computer === "cloud";
+  const boxNative = driverKind === "boxAgent";
+
+  if (!configured) {
+    if (explicitCloud || boxNative) return "unconfigured";
+    return autoLocal ? "local" : "auto-unavailable";
+  }
+  if (canUseCloud && (hasExistingBox || explicitCloud || boxNative)) return "ensure-box";
+  return autoLocal ? "local" : "auto-unavailable";
 }
 
 export function autoSelectsLocalComputer({


### PR DESCRIPTION
## What changed
- make the Computer panel match the server's turn-routing semantics
- let Auto reuse an existing Box or fall back to this computer, but never create infrastructure just because the panel opened
- preserve intentional provisioning for explicit Cloud and the Box-native Computer engine
- show a clear unavailable state when Auto has nowhere safe to run

## Verification
- 8 focused computer-routing tests passed
- typecheck passed
- focused Oxlint passed
- isolated desktop check opened an Auto bot against a fake Box service: it listed twice, fell back locally, and sent zero provision requests
