### PR TITLE
feat(local-vm): show and manage per-bot desktops

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -4455,6 +4455,28 @@ describe("harness HTTP API", () => {
     expect(firstStatus.body.container_name).not.toBe(secondStatus.body.container_name);
     expect(firstStatus.body.workspace_path).not.toBe(secondStatus.body.workspace_path);
 
+    const inventory = await fetch(`${BASE}/api/local-computer/instances`);
+    expect(inventory.status).toBe(200);
+    expect(inventory.headers.get("cache-control")).toBe("private, no-store");
+    const inventoryBody = await inventory.json() as any;
+    expect(inventoryBody).toMatchObject({
+      maxInstances: 3,
+      instances: expect.any(Array),
+      available: expect.any(Boolean),
+    });
+    for (const instance of inventoryBody.instances) {
+      expect(Object.keys(instance).sort()).toEqual([
+        "botId",
+        "container",
+        "destination",
+        "inUse",
+        "name",
+        "problem",
+        "ready",
+      ]);
+    }
+    expect(JSON.stringify(inventoryBody)).not.toMatch(/viewer_url|workspace_path|container_name|target_key/);
+
     const invalid = await api("PATCH", "/api/config", { localVm: { maxInstances: 5 } });
     expect(invalid.status).toBe(400);
     expect(invalid.body.error).toContain("localVm.maxInstances");

--- a/server/index.ts
+++ b/server/index.ts
@@ -215,6 +215,10 @@ import { fetchSkillFromSource } from "./skill-fetch.ts";
 import { expandLearnTurnText, learnSource } from "./skill-learn.ts";
 import type { SkillRequestCardData } from "../shared/skill-request.ts";
 import { readCuaConnection } from "./local-computer.ts";
+import {
+  discoverExistingPerBotLocalVms,
+  localVmInventoryEntry,
+} from "./local-vm-inventory.ts";
 import { LocalVmIdleTimer } from "./local-vm-idle.ts";
 import { LocalVmLease, LocalVmLeasePool } from "./local-vm-lease.ts";
 import { RepeatDetector, callKey } from "./repeat-detector.ts";
@@ -1890,16 +1894,53 @@ function releaseLocalVmThread(threadId: string): void {
 }
 
 // A running VM may have survived an app/server restart. Start its idle
-// backstop even if nobody opens Settings or begins a turn this session.
+// backstop even if nobody opens Settings or begins a turn this session. The
+// bot's current destination is intentionally ignored: moving a bot to Cloud,
+// Browser, This computer, Auto, or Off does not delete its old Local VM.
 void (async () => {
-  const targets = localVmMode(cfg) === "per-bot"
-    ? store.bots.filter((bot) => bot.computer === "vm").map((bot) => perBotLocalVmTarget(bot.id))
-    : [SHARED_LOCAL_VM_TARGET];
-  for (const target of targets) {
-    const status = await containerComputerStatus(undefined, undefined, target).catch(() => null);
-    if (status?.container === "running") localVmIdleFor(target).touch();
+  if (localVmMode(cfg) !== "per-bot") {
+    const status = await containerComputerStatus(undefined, undefined, SHARED_LOCAL_VM_TARGET).catch(() => null);
+    if (status?.container === "running") localVmIdleFor(SHARED_LOCAL_VM_TARGET).touch();
+    return;
   }
-})();
+  const runtime = await containerRuntimeStatus().catch(() => null);
+  if (!runtime?.runtime || !runtime.daemonUp) return;
+  const existing = await discoverExistingPerBotLocalVms(store.bots, runtime.runtime).catch(() => []);
+  const statuses = await Promise.all(existing.map(({ target }) =>
+    containerComputerStatus(undefined, undefined, target).catch(() => null),
+  ));
+  existing.forEach(({ target }, index) => {
+    if (statuses[index]?.container === "running") localVmIdleFor(target).touch();
+  });
+})().catch(() => {
+  // Startup inspection is a backstop, not a reason to keep the app offline.
+  // The Settings inventory remains available for a later explicit retry.
+});
+
+async function localVmInventoryPayload() {
+  const runtime = await containerRuntimeStatus();
+  if (!runtime.runtime || !runtime.daemonUp) {
+    return {
+      instances: [],
+      maxInstances: localVmMaxInstances(cfg),
+      available: false,
+      problem: runtime.runtime ? `Start ${runtime.runtime} first` : "Install a supported container runtime first",
+    };
+  }
+  const existing = await discoverExistingPerBotLocalVms(store.bots, runtime.runtime);
+  const statuses = await Promise.all(existing.map(({ target }) =>
+    containerComputerStatus(undefined, undefined, target),
+  ));
+  const instances = existing.flatMap(({ bot, target }, index) => {
+    const status = statuses[index];
+    if (!status) return [];
+    const inUse = localVmActiveThreads.has(target.key) ||
+      localVmLeaseFor(target).current(localVmOwnerBusy) !== null;
+    const entry = localVmInventoryEntry(bot, status, inUse);
+    return entry ? [entry] : [];
+  });
+  return { instances, maxInstances: localVmMaxInstances(cfg), available: true, problem: null };
+}
 
 bus.subscribe((event: RuntimeEvent) => {
   if (shouldIgnoreProviderEvent(event)) return;
@@ -5689,12 +5730,7 @@ async function localVmPayload(target: LocalVmTarget) {
 }
 
 async function existingPerBotLocalVmCount(runtime: Runtime) {
-  const targets = [...new Map(store.bots.map((bot) => {
-    const target = perBotLocalVmTarget(bot.id);
-    return [target.key, target] as const;
-  })).values()];
-  const existing = await Promise.all(targets.map((target) => containerComputerExists(runtime, target)));
-  return existing.filter(Boolean).length;
+  return (await discoverExistingPerBotLocalVms(store.bots, runtime)).length;
 }
 
 async function perBotLocalVmCountForModeChange(): Promise<number | null> {
@@ -8986,6 +9022,10 @@ const server = createServer(async (req, res) => {
     // its daemon is up, and whether the desktop image and container exist
     if (method === "GET" && path === "/api/local-computer") {
       return json(res, 200, await localVmPayload(SHARED_LOCAL_VM_TARGET));
+    }
+    if (method === "GET" && path === "/api/local-computer/instances") {
+      res.setHeader("cache-control", "private, no-store");
+      return json(res, 200, await localVmInventoryPayload());
     }
     m = path.match(/^\/api\/local-computer\/(pull|run|start|stop|remove)$/);
     if (m && method === "POST") {

--- a/server/local-vm-inventory.test.ts
+++ b/server/local-vm-inventory.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  discoverExistingPerBotLocalVms,
+  localVmInventoryEntry,
+} from "./local-vm-inventory.ts";
+import {
+  perBotLocalVmTarget,
+  type ContainerComputerStatus,
+} from "./container-computer.ts";
+
+describe("Local VM inventory", () => {
+  it("finds existing VMs even after their bots move away from Local VM", async () => {
+    const bots = [
+      { id: "vm", name: "VM bot", computer: "vm" as const },
+      { id: "cloud", name: "Cloud bot", computer: "cloud" as const },
+      { id: "off", name: "Off bot", computer: "off" as const },
+      { id: "auto", name: "Auto bot" },
+    ];
+    const existingNames = new Set([
+      perBotLocalVmTarget("cloud").containerName,
+      perBotLocalVmTarget("off").containerName,
+    ]);
+    const exists = vi.fn(async (_runtime, target) => existingNames.has(target.containerName));
+
+    const found = await discoverExistingPerBotLocalVms(bots, "docker", exists);
+
+    expect(found.map(({ bot }) => bot.id)).toEqual(["cloud", "off"]);
+    expect(exists).toHaveBeenCalledTimes(4);
+  });
+
+  it("publishes only the safe allow-listed fields and omits missing VMs", () => {
+    const status = {
+      container: "running",
+      ready: true,
+      problem: null,
+      viewer_url: "http://127.0.0.1:5000/vnc.html#password=secret",
+      workspace_path: "/Users/person/.openmausbot/vm-homes/private",
+      commands: { remove: "docker rm private-container" },
+    } as unknown as ContainerComputerStatus;
+
+    const entry = localVmInventoryEntry(
+      { id: "bot-1", name: "Research", computer: "cloud" },
+      status,
+      true,
+    );
+
+    expect(entry).toEqual({
+      botId: "bot-1",
+      name: "Research",
+      destination: "cloud",
+      container: "running",
+      ready: true,
+      problem: null,
+      inUse: true,
+    });
+    expect(JSON.stringify(entry)).not.toMatch(/secret|workspace|command|target/i);
+    expect(localVmInventoryEntry(
+      { id: "bot-2", name: "Missing" },
+      { ...status, container: "missing" } as ContainerComputerStatus,
+      false,
+    )).toBeNull();
+  });
+});

--- a/server/local-vm-inventory.ts
+++ b/server/local-vm-inventory.ts
@@ -1,0 +1,71 @@
+import {
+  containerComputerExists,
+  perBotLocalVmTarget,
+  type ContainerComputerStatus,
+  type LocalVmTarget,
+  type Runtime,
+} from "./container-computer.ts";
+
+export type LocalVmDestination = "auto" | "cloud" | "vm" | "local" | "browser" | "off";
+
+export interface LocalVmInventoryBot {
+  id: string;
+  name: string;
+  computer?: Exclude<LocalVmDestination, "auto">;
+}
+
+export interface ExistingPerBotLocalVm {
+  bot: LocalVmInventoryBot;
+  target: LocalVmTarget;
+}
+
+export interface LocalVmInventoryEntry {
+  botId: string;
+  name: string;
+  destination: LocalVmDestination;
+  container: "running" | "stopped";
+  ready: boolean;
+  problem: string | null;
+  inUse: boolean;
+}
+
+/** Discover only exact, bot-derived container identities. Bot destination is
+ * deliberately irrelevant: an existing VM must stay visible after its bot is
+ * moved to Cloud, Browser, This computer, Auto, or Off. */
+export async function discoverExistingPerBotLocalVms(
+  bots: LocalVmInventoryBot[],
+  runtime: Runtime,
+  exists: (
+    runtime: Runtime,
+    target: LocalVmTarget,
+  ) => Promise<boolean> = containerComputerExists,
+): Promise<ExistingPerBotLocalVm[]> {
+  const candidates = [...new Map(bots.map((bot) => {
+    const target = perBotLocalVmTarget(bot.id);
+    return [target.key, { bot, target }] as const;
+  })).values()];
+  const existing = await Promise.all(
+    candidates.map(({ target }) => exists(runtime, target)),
+  );
+  return candidates.filter((_, index) => existing[index]);
+}
+
+/** The public inventory is an explicit allow-list. In particular, it cannot
+ * leak viewer passwords/URLs, host workspace paths, runtime commands, or
+ * target hashes from the full Local VM status object. */
+export function localVmInventoryEntry(
+  bot: LocalVmInventoryBot,
+  status: ContainerComputerStatus,
+  inUse: boolean,
+): LocalVmInventoryEntry | null {
+  if (status.container === "missing") return null;
+  return {
+    botId: bot.id,
+    name: bot.name,
+    destination: bot.computer ?? "auto",
+    container: status.container,
+    ready: status.ready,
+    problem: status.problem,
+    inUse,
+  };
+}

--- a/src/components/LocalComputerSection.test.ts
+++ b/src/components/LocalComputerSection.test.ts
@@ -1,0 +1,77 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  LocalVmInventoryCard,
+  localVmInventoryState,
+  type LocalVmInventoryInstance,
+} from "./LocalComputerSection";
+
+const cloudVm: LocalVmInventoryInstance = {
+  botId: "cloud-bot",
+  name: "Research",
+  destination: "cloud",
+  container: "running",
+  ready: true,
+  problem: null,
+  inUse: false,
+};
+
+describe("Local VM inventory UI", () => {
+  it("shows capacity, current destinations, health, and an in-use deletion guard", () => {
+    const markup = renderToStaticMarkup(createElement(LocalVmInventoryCard, {
+      instances: [
+        cloudVm,
+        {
+          botId: "off-bot",
+          name: "Archive",
+          destination: "off",
+          container: "stopped",
+          ready: false,
+          problem: "This desktop image cannot safely resume; recreate the Local VM",
+          inUse: true,
+        },
+      ],
+      maxInstances: 4,
+      loading: false,
+      deletingBotId: null,
+      error: null,
+      unavailableReason: null,
+      onRefresh: vi.fn(),
+      onDelete: vi.fn(),
+    }));
+
+    expect(markup).toContain("2/4 created");
+    expect(markup).toContain("Current destination: Cloud");
+    expect(markup).toContain("Current destination: Off");
+    expect(markup).toContain("In use");
+    expect(markup).toContain("Stop this bot&#x27;s turn before deleting its desktop.");
+    expect(markup).toContain("disabled=\"\"");
+    expect(markup).not.toMatch(/viewer_url|workspace_path|password=/);
+  });
+
+  it("keeps state labels honest", () => {
+    expect(localVmInventoryState(cloudVm)).toBe("Running");
+    expect(localVmInventoryState({ ...cloudVm, ready: false })).toBe("Needs attention");
+    expect(localVmInventoryState({ ...cloudVm, container: "stopped", ready: false })).toBe("Stopped");
+    expect(localVmInventoryState({ ...cloudVm, inUse: true })).toBe("In use");
+  });
+
+  it("does not claim there are no VMs when the runtime cannot be inspected", () => {
+    const markup = renderToStaticMarkup(createElement(LocalVmInventoryCard, {
+      instances: [],
+      maxInstances: 4,
+      loading: false,
+      deletingBotId: null,
+      error: null,
+      unavailableReason: "Start docker first",
+      onRefresh: vi.fn(),
+      onDelete: vi.fn(),
+    }));
+
+    expect(markup).toContain("Inventory unavailable");
+    expect(markup).toContain("Start docker first");
+    expect(markup).not.toContain("No per-bot desktops have been created");
+  });
+});

--- a/src/components/LocalComputerSection.tsx
+++ b/src/components/LocalComputerSection.tsx
@@ -53,6 +53,146 @@ interface Status {
   };
 }
 
+export interface LocalVmInventoryInstance {
+  botId: string;
+  name: string;
+  destination: "auto" | "cloud" | "vm" | "local" | "browser" | "off";
+  container: "running" | "stopped";
+  ready: boolean;
+  problem: string | null;
+  inUse: boolean;
+}
+
+interface LocalVmInventoryPayload {
+  instances: LocalVmInventoryInstance[];
+  maxInstances: number;
+  available: boolean;
+  problem: string | null;
+}
+
+const destinationLabels: Record<LocalVmInventoryInstance["destination"], string> = {
+  auto: "Auto",
+  cloud: "Cloud",
+  vm: "Local VM",
+  local: "This computer",
+  browser: "Browser",
+  off: "Off",
+};
+
+export function localVmInventoryState(instance: LocalVmInventoryInstance): string {
+  if (instance.inUse) return "In use";
+  if (instance.container === "stopped") return "Stopped";
+  if (instance.ready) return "Running";
+  return "Needs attention";
+}
+
+export function LocalVmInventoryCard({
+  instances,
+  maxInstances,
+  loading,
+  deletingBotId,
+  error,
+  unavailableReason,
+  onRefresh,
+  onDelete,
+}: {
+  instances: LocalVmInventoryInstance[];
+  maxInstances: number;
+  loading: boolean;
+  deletingBotId: string | null;
+  error: string | null;
+  unavailableReason: string | null;
+  onRefresh: () => void;
+  onDelete: (instance: LocalVmInventoryInstance) => void;
+}) {
+  return (
+    <Card
+      title="Per-bot desktops"
+      subtitle={`${unavailableReason ? "Inventory unavailable." : `${instances.length}/${maxInstances} created.`} This list includes old desktops even when their bot now uses another destination.`}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-[12px] text-ink-secondary">
+          Delete desktops you no longer need to free a slot. Durable workspace files remain.
+        </div>
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={loading || deletingBotId !== null}
+          aria-label="Refresh per-bot desktops"
+          className="flex shrink-0 items-center gap-1.5 rounded-lg border border-hairline/40 px-2.5 py-1.5 text-[12px] text-ink-secondary hover:bg-control hover:text-ink disabled:opacity-40"
+        >
+          <RefreshCw size={12} className={cn(loading && "animate-spin")} /> Refresh
+        </button>
+      </div>
+
+      {error && <div className="mt-3 rounded-lg bg-danger/10 px-3 py-2 text-[12px] text-danger">{error}</div>}
+
+      <div className="mt-3 overflow-hidden rounded-xl border border-hairline/40">
+        {loading && instances.length === 0 ? (
+          <div className="flex items-center gap-2 px-3 py-4 text-[13px] text-ink-secondary">
+            <Loader2 size={13} className="animate-spin" /> Checking existing desktops…
+          </div>
+        ) : unavailableReason ? (
+          <div className="flex items-center gap-2 px-3 py-4 text-[13px] text-ink-secondary">
+            <AlertTriangle size={14} className="shrink-0 text-warning" /> {unavailableReason}
+          </div>
+        ) : instances.length === 0 ? (
+          <div className="px-3 py-4 text-[13px] text-ink-secondary">No per-bot desktops have been created.</div>
+        ) : instances.map((instance, index) => {
+          const state = localVmInventoryState(instance);
+          const deleting = deletingBotId === instance.botId;
+          return (
+            <div
+              key={instance.botId}
+              className={cn(
+                "flex items-start justify-between gap-3 px-3 py-3",
+                index > 0 && "border-t border-hairline/35",
+              )}
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="truncate text-[13.5px] font-medium text-ink">{instance.name}</span>
+                  <span
+                    className={cn(
+                      "rounded-full px-2 py-0.5 text-[11px]",
+                      instance.inUse || instance.ready
+                        ? "bg-success/15 text-success"
+                        : instance.container === "stopped"
+                          ? "bg-control text-ink-secondary"
+                          : "bg-warning/15 text-warning",
+                    )}
+                  >
+                    {state}
+                  </span>
+                </div>
+                <div className="mt-1 text-[11.5px] text-ink-secondary">
+                  Current destination: {destinationLabels[instance.destination]}
+                </div>
+                {instance.problem && !instance.inUse && (
+                  <div className="mt-1 text-[11.5px] text-warning">{instance.problem}</div>
+                )}
+                {instance.inUse && (
+                  <div className="mt-1 text-[11.5px] text-ink-secondary">Stop this bot's turn before deleting its desktop.</div>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => onDelete(instance)}
+                disabled={instance.inUse || deletingBotId !== null}
+                title={instance.inUse ? "Stop this bot's turn before deleting its Local VM" : `Delete ${instance.name}'s Local VM`}
+                className="flex shrink-0 items-center gap-1.5 rounded-lg bg-danger/10 px-2.5 py-1.5 text-[12px] font-medium text-danger hover:bg-danger/15 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {deleting ? <Loader2 size={12} className="animate-spin" /> : <Trash2 size={12} />}
+                Delete
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}
+
 function Step({ n, title, done, children }: { n: number; title: string; done: boolean; children?: React.ReactNode }) {
   return (
     <div className="flex gap-3">
@@ -107,6 +247,13 @@ export function LocalComputerSection() {
   const [error, setError] = useState<string | null>(null);
   const [policyPending, setPolicyPending] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [inventory, setInventory] = useState<LocalVmInventoryInstance[]>([]);
+  const [inventoryMax, setInventoryMax] = useState(2);
+  const [inventoryLoading, setInventoryLoading] = useState(false);
+  const [inventoryError, setInventoryError] = useState<string | null>(null);
+  const [inventoryUnavailableReason, setInventoryUnavailableReason] = useState<string | null>(null);
+  const [deletingBotId, setDeletingBotId] = useState<string | null>(null);
+  const [inventoryRefreshKey, setInventoryRefreshKey] = useState(0);
 
   const refresh = useCallback(async (signal?: AbortSignal) => {
     const response = await fetch("/api/local-computer", { signal });
@@ -114,6 +261,17 @@ export function LocalComputerSection() {
     if (!response.ok) throw new Error(body.error ?? `Status request failed (${response.status})`);
     setStatus(body as Status);
     setError(null);
+  }, []);
+
+  const refreshInventory = useCallback(async (signal?: AbortSignal) => {
+    const response = await fetch("/api/local-computer/instances", { signal });
+    const body = await response.json().catch(() => ({}));
+    if (!response.ok) throw new Error(body.error ?? `Inventory request failed (${response.status})`);
+    const payload = body as LocalVmInventoryPayload;
+    setInventory(payload.instances);
+    setInventoryMax(payload.maxInstances);
+    setInventoryUnavailableReason(payload.available ? null : (payload.problem ?? "Container runtime unavailable"));
+    setInventoryError(null);
   }, []);
 
   useEffect(() => {
@@ -143,6 +301,28 @@ export function LocalComputerSection() {
       if (timer !== undefined) window.clearTimeout(timer);
     };
   }, [refresh, refreshKey]);
+
+  useEffect(() => {
+    if (status?.mode !== "per-bot") {
+      setInventory([]);
+      setInventoryLoading(false);
+      setInventoryError(null);
+      setInventoryUnavailableReason(null);
+      return;
+    }
+    const controller = new AbortController();
+    setInventoryLoading(true);
+    void refreshInventory(controller.signal)
+      .catch((e) => {
+        if (!(e instanceof DOMException && e.name === "AbortError")) {
+          setInventoryError(e instanceof Error ? e.message : String(e));
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setInventoryLoading(false);
+      });
+    return () => controller.abort();
+  }, [inventoryRefreshKey, refreshInventory, status?.mode]);
 
   const post = async (action: Exclude<Action, "recreate">) => {
     const response = await fetch(`/api/local-computer/${action}`, {
@@ -203,6 +383,26 @@ export function LocalComputerSection() {
     }
   };
 
+  const deletePerBotVm = async (instance: LocalVmInventoryInstance) => {
+    if (!window.confirm(`Delete ${instance.name}'s Local VM? Its durable workspace files will remain.`)) return;
+    setDeletingBotId(instance.botId);
+    setInventoryError(null);
+    try {
+      const response = await fetch(`/api/bots/${instance.botId}/local-computer/remove`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      });
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(body.error ?? "Could not delete this Local VM");
+      await refreshInventory();
+    } catch (e) {
+      setInventoryError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setDeletingBotId(null);
+    }
+  };
+
   const c = status?.commands;
   const ready = status?.ready === true;
   const existing = status?.container !== "missing";
@@ -253,6 +453,7 @@ export function LocalComputerSection() {
             onClick={() => {
               setLoading(true);
               setRefreshKey((key) => key + 1);
+              setInventoryRefreshKey((key) => key + 1);
             }}
             disabled={loading || pending !== null}
             className="flex items-center gap-1.5 rounded-lg border border-hairline/40 px-2.5 py-1 text-[12.5px] text-ink-secondary hover:bg-control hover:text-ink disabled:opacity-40"
@@ -384,6 +585,19 @@ export function LocalComputerSection() {
           </Step>
         </div>
       </Card>
+
+      {perBot && (
+        <LocalVmInventoryCard
+          instances={inventory}
+          maxInstances={inventoryMax || status?.max_instances || 2}
+          loading={inventoryLoading}
+          deletingBotId={deletingBotId}
+          error={inventoryError}
+          unavailableReason={inventoryUnavailableReason}
+          onRefresh={() => setInventoryRefreshKey((key) => key + 1)}
+          onDelete={(instance) => void deletePerBotVm(instance)}
+        />
+      )}
 
       {unavailable && (
         <Card>


### PR DESCRIPTION
## Summary
- add a safe per-bot Local VM inventory to Settings
- show which bot owns each desktop, its current destination, and runtime state
- allow guarded deletion of stale or broken desktops through the existing bot-scoped endpoint
- restart idle cleanup for every existing per-bot VM, even after its bot moved to Cloud, Auto, Off, or another destination
- report an unavailable container runtime honestly instead of showing a false empty state
- prevent browser caching of the authenticated inventory response

## Verification
- focused UI/helper and server route tests passed
- typecheck passed
- lint passed with pre-existing warnings only
- diff check passed
- isolated desktop check switched to per-bot mode and verified the new inventory reports “Start docker first” rather than falsely claiming there are no desktops


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Local Computer inventory for per-bot mode, showing capacity, destinations, and each virtual machine’s status.
  - Added status details such as Running, Stopped, Needs attention, and In use.
  - Added the ability to refresh inventory and remove eligible virtual machines directly from the interface.
  - Added messaging when inventory is unavailable or a machine cannot be removed because it is in use.
  - Inventory responses now protect sensitive virtual machine details.

- **Bug Fixes**
  - Existing per-bot virtual machines are now discovered and counted even when bot destinations have changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->