### PR TITLE
feat(ios): securely provide credentials from phone

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -8,3 +8,6 @@ incorporated before the transition.
 The Google Antigravity ACP integration adapts release, installation, profile,
 and authentication behavior from T3 Code, Copyright 2026 T3 Tools Inc., used
 under the MIT License.
+
+The secure phone credential transport uses @hpke/core and @hpke/common from
+hpke-js, Copyright 2023-2024 Ajitomi Daisuke, used under the MIT License.

--- a/companion/README.md
+++ b/companion/README.md
@@ -19,7 +19,7 @@ carried across every release, and it is the patch that broke the first time
 upstream hardened its loopback gate.
 
 ```text
-  phone ──LAN/tailnet──▶ companion :8810 ──loopback──▶ harness :8799
+  phone ──HTTPS/LAN/tailnet──▶ companion :8810 ──loopback──▶ harness :8799
                           ▲                             ▲
                           │ token, allowlist,           │ unmodified,
                           │ Origin refused              │ loopback-only
@@ -34,20 +34,29 @@ upstream hardened its loopback gate.
 | **The allowlist** | Default deny, per method and path (`src/routes.ts`) — the list is every request the app makes, and nothing else. General bot/room PATCH routes stay closed; read state and approval grants use narrow verbs. A route that appears in the harness later is closed to devices until someone adds it here on purpose. |
 | **Scrubbing** | `resumeCursors` — the harness's own provider session ids — never reach a device, whether or not the harness still sends them. |
 | **Discovery** | Bonjour, so a phone finds the computer by name instead of by typed address. |
+| **Secure credential relay** | Carries an HPKE envelope for one pending, allowlisted credential card. The sidecar never receives the desktop private key or plaintext. |
 
 ## Transport security
 
-The device port speaks plain HTTP, and the device token travels in a header on
-every request. Where that is safe depends on how the phone reaches the
-computer, and the two routes are not equivalent:
+The optional hosted route uses certificate-validated HTTPS. Direct routes use
+plain HTTP, and the device token travels in a header on every request. Where a
+direct route is safe depends on how the phone reaches the computer:
 
-- **Over a tailnet** — the recommended route, and the only one that works away
-  from home — every packet is inside WireGuard before it touches a network, so
+- **Over hosted HTTPS** — the recommended remote route — TLS encrypts and
+  authenticates the connection through the outbound desktop connector.
+
+- **Over a tailnet** — the recommended direct route away from home — every
+  packet is inside WireGuard before it touches a network, so
   the connection is encrypted and authenticated end to end despite the `http`
   in the URL.
 - **Over a LAN** it is cleartext on that network. Trust it as far as you trust
   everyone on the wifi: fine at home, not fine on a café or conference network.
   Pair over the tailnet there instead.
+
+The phone never submits credential envelopes over LAN or Bonjour HTTP. That
+operation requires hosted HTTPS or Tailscale so its reusable device token is
+protected as well as the HPKE-encrypted value. Ordinary local chat and approval
+traffic keep the documented trusted-network behavior above.
 
 Turning on TLS is not a drop-in improvement. A certificate for a LAN address
 is one nothing can validate, so it would have to be pinned at pairing and
@@ -64,8 +73,11 @@ trusted-network-only rather than described as something it is not.
   request that carries one is a browser that has found this port. Refused
   before the token is even looked at — stricter than the harness's own rule,
   which allows loopback origins.
-- **Hold credentials, settings, or Local VM control.** Those stay on the
-  machine. See `src/routes.ts` for the exact refusals and why.
+- **Hold credentials, settings, or Local VM control.** Credential plaintext
+  remains transient on the phone and desktop only: the sidecar can carry one
+  QR-keyed HPKE envelope for an exact pending card, but cannot open or retain
+  it. General credential/configuration routes, settings, and Local VM control
+  remain unavailable. See `src/routes.ts` for the exact boundary.
 
 ## Running it
 

--- a/companion/src/control.ts
+++ b/companion/src/control.ts
@@ -24,6 +24,10 @@ export interface ControlOptions {
   devices: DeviceRegistry;
   /** Where a phone connects — for display, and for the pairing instructions. */
   companionPort: number;
+  /** HPKE recipient public key displayed in pairing QRs. Public by design;
+   * the matching private key never leaves Electron's encrypted store and
+   * private utility-process channel. */
+  secretPublicKey?: () => string | null;
   /** Stable HTTPS route provisioned for this computer, when available. */
   hostedUrl?: () => string | null;
   /** Electron alone uses this to publish a route after its connector health
@@ -176,6 +180,7 @@ export function companionState(options: ControlOptions) {
   const tailscale = tailscaleAddress(addresses);
   const name = tailnetName();
   const pairing = options.devices.pairing();
+  const secretPublicKey = options.secretPublicKey?.() ?? null;
   return {
     // Whoever starts this sidecar as a child process needs to be able to tell
     // it apart from an unrelated one that got to the control port first. An
@@ -197,6 +202,7 @@ export function companionState(options: ControlOptions) {
       name,
       currentHostedUrl(options),
     ),
+    ...(secretPublicKey ? { secretPublicKey } : {}),
     pairing: pairing ? { code: pairing.code, token: pairing.token, expiresAt: pairing.expiresAt } : null,
     devices: options.devices.list(),
     connectedDeviceIds: options.connectedDeviceIds?.() ?? [],

--- a/companion/src/index.ts
+++ b/companion/src/index.ts
@@ -37,6 +37,7 @@ import {
 } from "./mdns.ts";
 import { createProxyHandler } from "./proxy.ts";
 import { companionOriginSocket, listenCompanionOrigin } from "./origin.ts";
+import { normalizedPhoneSecretPublicKey } from "./phone-secret-key.ts";
 
 /** A port from the environment, or the default. Anything that is not a whole
  * number in range is the default — a typo'd port must not become port 0. */
@@ -52,6 +53,9 @@ const CONTROL_PORT = num(process.env.OMB_CONTROL_PORT, 8811);
 const SERVICE_TYPE = "_openmausbot._tcp";
 let hostedUrl = hostedCompanionUrl(process.env.OMB_COMPANION_HOSTED_URL);
 const PRIVATE_ORIGIN = companionOriginSocket(process.env.OMB_COMPANION_INTERNAL_ORIGIN);
+const SECRET_PUBLIC_KEY = normalizedPhoneSecretPublicKey(
+  process.env.OMB_PHONE_SECRET_PUBLIC_KEY ?? "",
+);
 
 /** Ports the harness takes for itself, and what it uses each for.
  *
@@ -153,6 +157,7 @@ const managedOrigin = PRIVATE_ORIGIN ? createServer(proxy) : null;
 const control = createControlServer({
   devices,
   companionPort: COMPANION_PORT,
+  secretPublicKey: () => SECRET_PUBLIC_KEY,
   hostedUrl: () => hostedUrl,
   setHostedUrl: (next) => {
     hostedUrl = next;

--- a/companion/src/phone-secret-key.ts
+++ b/companion/src/phone-secret-key.ts
@@ -1,0 +1,14 @@
+import { ECDH } from "node:crypto";
+
+/** Accept only a canonical, on-curve uncompressed P-256 public point. */
+export function normalizedPhoneSecretPublicKey(encoded: string): string | null {
+  if (!/^[A-Za-z0-9_-]{87}$/.test(encoded)) return null;
+  try {
+    const raw = Buffer.from(encoded, "base64url");
+    if (raw.length !== 65 || raw[0] !== 4 || raw.toString("base64url") !== encoded) return null;
+    const point = ECDH.convertKey(raw, "prime256v1", undefined, undefined, "uncompressed");
+    return Buffer.isBuffer(point) && point.equals(raw) ? encoded : null;
+  } catch {
+    return null;
+  }
+}

--- a/companion/src/proxy.ts
+++ b/companion/src/proxy.ts
@@ -67,6 +67,17 @@ export interface CompanionEndpointSnapshot {
  * that deliberately never ends, and a timeout that could not tell the
  * difference would cut every live stream at thirty seconds. */
 const HEADERS_TIMEOUT_MS = 30_000;
+// Secure credential saves include bounded provider validation before the
+// encrypted desktop store commits. Keep this beyond the server's 90-second
+// private-save deadline but comfortably inside the hosted proxy's deadline,
+// leaving time for the final card update and response to travel back.
+const PHONE_SECRET_HEADERS_TIMEOUT_MS = 105_000;
+const PHONE_SECRET_PROVIDE_PATH = /^\/api\/bots\/[\w-]+\/secret-cards\/[\w-]+\/provide(?:\?|$)/;
+
+export function proxyHeadersTimeoutMs(url: string, override?: number): number {
+  return override
+    ?? (PHONE_SECRET_PROVIDE_PATH.test(url) ? PHONE_SECRET_HEADERS_TIMEOUT_MS : HEADERS_TIMEOUT_MS);
+}
 
 /** A JSON response has to be buffered whole before it can be scrubbed, so the
  * buffer is the size of the response and nothing upstream promises that is
@@ -197,7 +208,7 @@ const endpointSnapshot = (options: ProxyOptions): CompanionEndpointSnapshot => {
  * blocklist: `host` and `origin` must not travel (see above), `authorization`
  * is the sidecar's credential and means nothing to the harness, and hop-by-hop
  * headers are by definition not ours to relay. */
-const forwardHeaders = (req: IncomingMessage): Record<string, string> => {
+const forwardHeaders = (req: IncomingMessage, authenticatedDeviceId?: string): Record<string, string> => {
   const out: Record<string, string> = {
     accept: String(req.headers.accept ?? "*/*"),
     // Lets a response whose URL is intentionally loopback-only (the VPS SSH
@@ -205,6 +216,12 @@ const forwardHeaders = (req: IncomingMessage): Record<string, string> => {
     // carries no authority; it only narrows behavior at the harness.
     "x-openmausbot-companion": "1",
   };
+  // Never forward a caller-supplied device header. This value comes only
+  // from the registry entry which authenticated the bearer above, allowing
+  // the harness to bind an encrypted credential to the same paired phone.
+  if (authenticatedDeviceId && /^[\w-]{1,128}$/.test(authenticatedDeviceId)) {
+    out["x-openmausbot-companion-device"] = authenticatedDeviceId;
+  }
   const contentType = req.headers["content-type"];
   if (contentType) out["content-type"] = String(contentType);
   // Preserve a trustworthy byte count for bounded raw uploads. Without it,
@@ -313,7 +330,7 @@ export function createProxyHandler(options: ProxyOptions) {
         port: options.harnessPort,
         path: req.url,
         method,
-        headers: forwardHeaders(req),
+        headers: forwardHeaders(req, device?.id),
       },
       (harness) => {
         clearTimeout(headersDeadline);
@@ -567,10 +584,11 @@ export function createProxyHandler(options: ProxyOptions) {
     // harness that accepts the connection and then says nothing holds the
     // device's request open until one side gives up, which neither does.
     let timedOut = false;
+    const headersTimeoutMs = proxyHeadersTimeoutMs(req.url ?? "", options.headersTimeoutMs);
     const headersDeadline = setTimeout(() => {
       timedOut = true;
       upstream.destroy(new Error("the harness sent no response headers"));
-    }, options.headersTimeoutMs ?? HEADERS_TIMEOUT_MS);
+    }, headersTimeoutMs);
     headersDeadline.unref?.();
 
     upstream.on("error", () => {

--- a/companion/src/routes.ts
+++ b/companion/src/routes.ts
@@ -83,6 +83,10 @@ const ALLOWED: ReadonlyArray<{ method: string; path: RegExp }> = [
   { method: "POST", path: /^\/api\/bots\/[\w-]+\/read$/ },
   { method: "POST", path: /^\/api\/bots\/[\w-]+\/always-allow$/ },
   { method: "POST", path: /^\/api\/bots\/[\w-]+\/messages\/[\w-]+\/edit$/ },
+  // A credential value crosses this one route only as an HPKE envelope. The
+  // server binds it to the authenticated device and exact pending card before
+  // Electron opens it into the OS-encrypted credential store.
+  { method: "POST", path: /^\/api\/bots\/[\w-]+\/secret-cards\/[\w-]+\/provide$/ },
   { method: "POST", path: /^\/api\/bots\/[\w-]+\/active-branch$/ },
   { method: "POST", path: /^\/api\/bots\/[\w-]+\/tasks$/ },
   { method: "POST", path: /^\/api\/bots\/[\w-]+\/tasks\/[\w-]+$/ },

--- a/companion/test/control.test.ts
+++ b/companion/test/control.test.ts
@@ -39,6 +39,7 @@ beforeAll(async () => {
   control = createControlServer({
     devices,
     companionPort: 8810,
+    secretPublicKey: () => "BIPBQ12_dWnF1DZLsTZO3Vg0NGjds5-jp9h3jhjr2To7bJelczS0LM82rfXV68PmSJhz2ePosj3fL974XckCpDU",
     hostedUrl: () => hostedUrl,
     setHostedUrl: (next) => {
       hostedUrl = next;
@@ -211,6 +212,7 @@ describe("hostCandidates", () => {
     expect(status).toBe(200);
     expect(Array.isArray(body.hosts)).toBe(true);
     expect(Array.isArray(body.endpoints)).toBe(true);
+    expect(body.secretPublicKey).toBe("BIPBQ12_dWnF1DZLsTZO3Vg0NGjds5-jp9h3jhjr2To7bJelczS0LM82rfXV68PmSJhz2ePosj3fL974XckCpDU");
     // Whatever this machine's interfaces are, the mDNS fallback is always
     // present and always last.
     expect(body.hosts.at(-1)).toMatch(/^openmausbot-[0-9a-f]{8}\.local$/);

--- a/companion/test/phone-secret-key.test.ts
+++ b/companion/test/phone-secret-key.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizedPhoneSecretPublicKey } from "../src/phone-secret-key.ts";
+
+const publicKey =
+  "BIPBQ12_dWnF1DZLsTZO3Vg0NGjds5-jp9h3jhjr2To7bJelczS0LM82rfXV68PmSJhz2ePosj3fL974XckCpDU";
+
+describe("phone secret public key", () => {
+  it("accepts a canonical on-curve P-256 point", () => {
+    expect(normalizedPhoneSecretPublicKey(publicKey)).toBe(publicKey);
+  });
+
+  it("rejects malformed and off-curve points", () => {
+    const offCurve = Buffer.alloc(65);
+    offCurve[0] = 4;
+
+    expect(normalizedPhoneSecretPublicKey(publicKey.slice(1))).toBeNull();
+    expect(normalizedPhoneSecretPublicKey(`${publicKey}=`)).toBeNull();
+    expect(normalizedPhoneSecretPublicKey(offCurve.toString("base64url"))).toBeNull();
+  });
+});

--- a/companion/test/proxy-response.test.ts
+++ b/companion/test/proxy-response.test.ts
@@ -7,7 +7,7 @@
 import { createServer, type Server, type ServerResponse } from "node:http";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { createProxyHandler } from "../src/proxy.ts";
+import { createProxyHandler, proxyHeadersTimeoutMs } from "../src/proxy.ts";
 import type { CompanionEndpoint } from "../src/endpoints.ts";
 import { scrub } from "../src/wire.ts";
 
@@ -26,6 +26,7 @@ let sidecar: Server;
 let sidecarPort = 0;
 let cloudDesktopAccess = true;
 let companionMarker = "";
+let companionDevice = "";
 let endpointCandidates: CompanionEndpoint[] = [];
 /** What the stub harness answers with next. Set per test. */
 let respond: (res: ServerResponse) => void = (res) => res.end();
@@ -56,6 +57,7 @@ const device = async (
 beforeAll(async () => {
   harness = createServer((req, res) => {
     companionMarker = String(req.headers["x-openmausbot-companion"] ?? "");
+    companionDevice = String(req.headers["x-openmausbot-companion-device"] ?? "");
     respond(res);
   });
   const harnessPort = await listen(harness);
@@ -63,7 +65,7 @@ beforeAll(async () => {
   sidecar = createServer(
     createProxyHandler({
       harnessPort,
-      authenticate: (t) => (t === TOKEN ? { cloudDesktopAccess } : null),
+      authenticate: (t) => (t === TOKEN ? { id: "phone-1", cloudDesktopAccess } : null),
       redeem: () => ({ error: "not used here" }),
       serverName: () => "Test computer",
       endpoints: () => endpointCandidates,
@@ -78,6 +80,12 @@ afterAll(async () => {
 });
 
 describe("preparing a harness response for a device", () => {
+  it("gives only transactional phone credential saves the longer deadline", () => {
+    expect(proxyHeadersTimeoutMs("/api/bots/b1/secret-cards/m1/provide")).toBe(105_000);
+    expect(proxyHeadersTimeoutMs("/api/bots/b1/messages")).toBe(30_000);
+    expect(proxyHeadersTimeoutMs("/api/bots/b1/secret-cards/m1/provide", 17)).toBe(17);
+  });
+
   it("drops an endpoint whose runtime URL is not a string", async () => {
     const malformed: CompanionEndpoint = { kind: "hosted", priority: 0, url: "https://ok.example" };
     Object.defineProperty(malformed, "url", { value: 42 });
@@ -112,6 +120,22 @@ describe("preparing a harness response for a device", () => {
     expect(status).toBe(200);
     expect(JSON.parse(text).joinUrl).toBe("https://desktop.example/session/fresh");
     expect(companionMarker).toBe("1");
+    expect(companionDevice).toBe("phone-1");
+  });
+
+  it("replaces a caller-supplied device identity with the authenticated one", async () => {
+    respond = (res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end("{}");
+    };
+    const response = await fetch(`http://127.0.0.1:${sidecarPort}/api/bots`, {
+      headers: {
+        authorization: `Bearer ${TOKEN}`,
+        "x-openmausbot-companion-device": "another-phone",
+      },
+    });
+    expect(response.status).toBe(200);
+    expect(companionDevice).toBe("phone-1");
   });
 
   it("never forwards a body it could not scrub", async () => {

--- a/companion/test/routes.test.ts
+++ b/companion/test/routes.test.ts
@@ -58,6 +58,7 @@ describe("what the app may do", () => {
     ["PATCH", "/api/bots/bot_123/model"],
     ["POST", "/api/bots/bot_123/avatar/generate"],
     ["POST", "/api/bots/bot_123/computer/join"],
+    ["POST", "/api/bots/bot_123/secret-cards/message_1/provide"],
     ["POST", "/api/groups/room-1/messages"],
     ["POST", "/api/groups/room-1/read"],
     ["POST", "/api/groups/room-1/tasks"],
@@ -159,6 +160,13 @@ describe("what it may not", () => {
     expect(allowed("POST", "/api/bots/bot_123/computer/sleep")).toBe(false);
     expect(allowed("POST", "/api/bots/bot_123/computer/exec")).toBe(false);
     expect(allowed("POST", "/api/bots/bot_123/computer/screenshot")).toBe(false);
+  });
+
+  it("allows only the exact encrypted credential submission verb", () => {
+    expect(allowed("POST", "/api/bots/bot_123/secret-cards/message_1/provide")).toBe(true);
+    expect(allowed("GET", "/api/bots/bot_123/secret-cards/message_1/provide")).toBe(false);
+    expect(allowed("POST", "/api/bots/bot_123/secret-cards/message_1/provided")).toBe(false);
+    expect(allowed("POST", "/api/bots/bot_123/secret-cards/message_1/provide/extra")).toBe(false);
   });
 
   // The method is part of the allowance, not decoration: reading the fleet

--- a/docs/ios-companion.md
+++ b/docs/ios-companion.md
@@ -1,7 +1,7 @@
 # iOS companion architecture
 
 The iOS app is a thin, native client for the OpenMausBot instance running on
-your Mac. The Mac remains the only machine that owns agent processes,
+your Mac. The Mac remains the only machine that persists agent processes,
 credentials, SQLite data, transcripts, and computers. The iPhone trusts a Mac
 by scanning the QR code shown in desktop **Settings → Phone**; it does not need
 an OpenMausBot account of its own.
@@ -26,6 +26,9 @@ The first version includes:
 - Resumable SSE, streamed reply text, reconnect hydration, and an opt-in live
   Box computer view. The loopback-only VPS SSH viewer remains desktop-only.
 - Markdown rendering and Keychain storage for the phone's pairing trust.
+- Secure completion of supported credential-request cards using iOS Password
+  AutoFill and QR-pinned HPKE encryption. Apple Passwords/iCloud Keychain is
+  sufficient; 1Password, Bitwarden, and other AutoFill providers are optional.
 
 Alerts work while the app is open or for the short period it remains connected
 after moving to the background. Once iOS suspends or closes the app, new alerts
@@ -44,7 +47,7 @@ transport.
 ## Runtime architecture
 
 ```text
- iPhone (pairing trust in Keychain)
+ iPhone (pairing trust in Keychain; credential plaintext only while editing)
        │                         │
        │ trusted LAN/Tailscale   │ optional hosted HTTPS
        ▼                         ▼
@@ -56,12 +59,16 @@ transport.
                                  └──────────────┐
                                                 ▼
  companion sidecar (pairing auth, default-deny allowlist,
- response/SSE scrubbing, authenticated endpoint refresh)
+ response/SSE scrubbing, authenticated endpoint refresh;
+ credential ciphertext only)
             │ loopback only
             ▼
  OpenMausBot harness :8799
    HTTP API + event stream
    agent processes and approvals
+            │ private Electron utility-process channel
+            ▼
+ OS-encrypted desktop credential store
             │
             ▼
  SQLite message store + local configuration
@@ -171,7 +178,10 @@ local port cannot inherit the public route.
 2. On the iPhone, choose **Connect my computer** and scan the QR.
 3. Confirm the computer name and the displayed transport — **HTTPS connection**,
    **Tailscale connection**, or **Trusted local connection**. The phone stores
-   its trust securely in Keychain; no iPhone account is required.
+   its trust securely in Keychain; no iPhone account is required. A camera QR
+   also pins that computer's public credential-encryption key. Manual and old
+   pairings can still chat, but must scan a fresh QR before entering a key on
+   the phone.
 4. If scanning is unavailable, open **Other ways to connect** for a nearby
    computer, manual address, or six-digit code.
 5. Revoking the phone on the Mac removes its access and lets it pair again.
@@ -196,6 +206,53 @@ An OpenMausBot account is not required for nearby, manual, or Tailscale
 connections. Only the desktop owner signs in when enabling the optional hosted
 HTTPS route; the iPhone always uses the same QR trust flow.
 
+### Secure credential entry
+
+This is Password AutoFill, not a password-vault integration. A native
+`SecureField` marked as a password lets the user explicitly choose Apple
+Passwords or any enabled third-party AutoFill provider. OpenMausMobile does
+not enumerate a vault, receive a provider token, or save the entered value in
+its own Keychain.
+
+The packaged desktop creates one stable P-256 recipient key pair and keeps the
+private JWK inside its operating-system-encrypted credential document. Only the
+65-byte uncompressed public point is added to a camera QR. The phone validates
+and pins that point with the connection; manual and older pairings remain fully
+usable for chat but cannot submit a credential until they scan a fresh QR.
+
+Credential submission is enabled only while the phone is using hosted HTTPS or
+a Tailscale route. Local and Bonjour chat pairing still work as before, but
+their cleartext HTTP transport would expose the reusable device token to anyone
+who could observe that Wi-Fi network, so the app directs the user to finish the
+credential request on the computer instead.
+
+Each submission uses RFC 9180 base-mode HPKE with P-256/HKDF-SHA256/AES-GCM-256
+and authenticates this exact newline-separated context:
+
+```text
+openmausbot-phone-credential-v1
+<key id>
+<authenticated companion device id>
+<bot id>
+<thread id>
+<message id>
+<credential target>
+<one-time request key>
+```
+
+The companion replaces any caller-supplied device header with the identity of
+the bearer token it authenticated. The harness accepts only an allowlisted
+target on the exact pending card, opens the ciphertext through its private
+Electron channel, and waits for the encrypted desktop store and live config to
+commit before it marks the card complete. Replays are idempotent; moving a
+ciphertext to another device, bot, task, card, target, or computer fails
+authentication. The native field is cleared immediately after local
+encryption. If the response is interrupted, the app retains only that exact
+ciphertext in memory and reuses it for Retry, so HPKE randomness cannot turn a
+network retry into a second credential write. Nothing is persisted on the
+phone. Development servers deliberately have no recipient key and fail closed
+instead of advertising an unusable secure-entry route.
+
 The device-facing socket rejects browser `Origin` headers before reading a
 token. Its route policy in `companion/src/routes.ts` is default-deny: a new
 harness route remains unreachable until it is deliberately added.
@@ -209,6 +266,11 @@ Allowed in the first release:
 - Send messages, interrupt bots, answer approvals/questions, and mark chats
   read.
 - Create a basic bot.
+- Submit a supported pending credential card as an RFC 9180 HPKE envelope
+  bound to the authenticated device, bot, task, message, request, and target.
+  Only the paired packaged desktop's embedded server and Electron private
+  process channel receive the private key or plaintext; the sidecar, hosted
+  relay, chat transcript, and SQLite store see ciphertext or status only.
 
 The write surface uses purpose-built `read` and `always-allow` endpoints. The
 general bot and room `PATCH` endpoints are not reachable through the sidecar.
@@ -218,7 +280,9 @@ to invent a broad execution grant.
 
 Intentionally refused:
 
-- API keys and provider configuration.
+- Reading credentials, arbitrary credential targets, and general provider
+  configuration. The only credential write is the exact pending-card envelope
+  above, and it feeds the existing desktop OS-encrypted save path.
 - Pairing, device revocation, or companion lifecycle control.
 - Local VM lifecycle, webhooks, connectors, routines, team import/export, and
   internal peer-agent routes.

--- a/docs/ios-privacy.md
+++ b/docs/ios-privacy.md
@@ -15,6 +15,23 @@ account. A user may separately sign in on the desktop to enable the optional
 - The computer remains the source of bots, transcripts, approvals, credentials,
   SQLite data, and screen images. OpenMausBot's hosted control plane does not
   store a copy of that content.
+- When a user completes a supported credential request on the phone, the value
+  exists only in the native secure field long enough to encrypt it with the
+  public key pinned by that computer's QR code. The app clears that field
+  immediately after encryption. It may keep the resulting ciphertext in memory
+  long enough to retry the exact same operation after an interrupted response;
+  that ciphertext is never persisted and is discarded when the app exits.
+  Submission is available only
+  through hosted HTTPS or Tailscale, not cleartext LAN or Bonjour HTTP. The
+  sidecar and optional hosted relay receive an HPKE ciphertext, not the value.
+  Only the paired packaged
+  desktop processes receive the private key: the embedded server decrypts and
+  passes the value over Electron's private process channel to commit through
+  the same operating-system-encrypted store used by Settings. The value is not
+  written to
+  iOS preferences or Keychain by OpenMausMobile, chat, SQLite, logs, or the
+  hosted control-plane database. The user's chosen Password AutoFill provider
+  may separately store it under that provider's own settings and privacy terms.
 - On a local Wi-Fi or Tailscale connection, phone traffic goes directly to the
   user's computer. Tailscale is a separate service with its own privacy terms.
 - If the desktop user enables optional hosted access, OpenMausBot stores the

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -60,6 +60,10 @@ extraResources:
     to: licenses/cloudflared-LICENSE.txt
   - from: third_party/cloudflared/README.md
     to: licenses/cloudflared-README.md
+  - from: third_party/hpke-js/core-LICENSE.txt
+    to: licenses/hpke-core-LICENSE.txt
+  - from: third_party/hpke-js/common-LICENSE.txt
+    to: licenses/hpke-common-LICENSE.txt
   - from: dist
     to: ui
   - from: dist-server

--- a/electron/companion.mjs
+++ b/electron/companion.mjs
@@ -187,7 +187,7 @@ export function stopCompanion() {
 }
 
 /** startCompanion's body, run inside the transition queue. */
-async function start({ resourcesPath, harnessPort, hostedUrl = null, log }) {
+async function start({ resourcesPath, harnessPort, hostedUrl = null, secretPublicKey = null, log }) {
   if (proc) return companionState();
   lastError = null;
   const resolved = entryPoint(resourcesPath);
@@ -223,8 +223,12 @@ async function start({ resourcesPath, harnessPort, hostedUrl = null, log }) {
   const childEnvironment = { ...process.env };
   delete childEnvironment.OMB_COMPANION_HOSTED_URL;
   delete childEnvironment.OMB_COMPANION_INTERNAL_ORIGIN;
+  delete childEnvironment.OMB_PHONE_SECRET_PUBLIC_KEY;
   if (hostedUrl) childEnvironment.OMB_COMPANION_HOSTED_URL = hostedUrl;
   childEnvironment.OMB_COMPANION_INTERNAL_ORIGIN = allocatedOrigin.socketPath;
+  if (/^[A-Za-z0-9_-]{87}$/.test(String(secretPublicKey ?? ""))) {
+    childEnvironment.OMB_PHONE_SECRET_PUBLIC_KEY = secretPublicKey;
+  }
 
   let child;
   try {

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -46,6 +46,14 @@ import {
   withoutManagedCompanionTunnelAccess,
 } from "./managed-companion-tunnel.mjs";
 import { createSecureCredentialState } from "./secure-credential-state.mjs";
+import {
+  createPhoneSecretSaveCoordinator,
+  createPhoneSecretIdentity,
+  decodePhoneSecretSaveRequest,
+  phoneSecretPrivateKeyMessage,
+  readPhoneSecretIdentity,
+  withPhoneSecretIdentity,
+} from "./phone-secret-identity.mjs";
 import { isKnownSkin } from "./skin-overlay.cjs";
 import { readSecureCredentials } from "./secure-credentials.mjs";
 import { createControlPlaneClient } from "./control-plane-client.mjs";
@@ -268,6 +276,7 @@ async function stopUtilityServer(proc, timeoutMs = UTILITY_SERVER_STOP_TIMEOUT_M
     }),
   ]).finally(() => clearTimeout(timer));
 }
+let phoneSecretIdentity = null;
 
 const CREDENTIALS_FILE = path.join(app.getPath("userData"), "credentials.bin");
 
@@ -525,6 +534,29 @@ export async function updateSecureCredentialDocument(derive, afterPersist) {
   }
 }
 
+async function ensurePhoneSecretIdentity() {
+  const existing = readPhoneSecretIdentity(secureCredentialState?.read() ?? secureCredentials);
+  if (existing) {
+    phoneSecretIdentity = existing;
+    return existing;
+  }
+  try {
+    const created = await createPhoneSecretIdentity();
+    await updateSecureCredentialDocument((credentials) =>
+      withPhoneSecretIdentity(credentials, created),
+    );
+    phoneSecretIdentity = created;
+    return created;
+  } catch (error) {
+    // Companion chat remains available. Pairing simply omits the public key,
+    // and mobile cards explain that secure entry needs the desktop until the
+    // OS credential store is available on a later launch.
+    phoneSecretIdentity = null;
+    slog(`phone credential key unavailable: ${error?.message ?? error}`);
+    return null;
+  }
+}
+
 function publicManagedCompanionState() {
   const access = managedCompanionTunnelAccess(secureCredentials);
   const status = managedCompanionConnector?.getStatus();
@@ -560,6 +592,10 @@ function companionLaunchOptions(hostedUrl = null) {
     resourcesPath: process.resourcesPath,
     harnessPort: SERVER_PORT,
     hostedUrl,
+    // Only an embedded server receives the private half over its utility
+    // port. A dev server launched in another terminal cannot decrypt, so it
+    // must not advertise a public key and strand the phone on a dead path.
+    secretPublicKey: app.isPackaged && serverProc ? phoneSecretIdentity?.publicKey ?? null : null,
     log: slog,
   };
 }
@@ -882,6 +918,33 @@ function receiveBrowserLifecycleCleanup(proc, rawMessage) {
   return true;
 }
 
+function syncPhoneSecretKey(proc) {
+  const message = phoneSecretPrivateKeyMessage(phoneSecretIdentity);
+  if (!message) return;
+  try {
+    proc.postMessage(message);
+  } catch (error) {
+    slog(`phone credential key sync failed: ${error?.message ?? error}`);
+  }
+}
+
+const savePhoneSecretOnce = createPhoneSecretSaveCoordinator((target, value) =>
+  saveWorkspaceCredential(target, value),
+);
+
+function receivePhoneSecretSave(proc, rawMessage) {
+  const request = decodePhoneSecretSaveRequest(rawMessage);
+  if (!request) return false;
+  void savePhoneSecretOnce(request).then((result) => {
+    try {
+      proc.postMessage(result);
+    } catch (error) {
+      slog(`phone credential save result failed: ${error?.message ?? error}`);
+    }
+  });
+  return true;
+}
+
 async function startServerOn(port) {
   const entry = path.join(process.resourcesPath, "server", "index.js");
   const childEnv = managedComposioChildEnvironment(composioBrokerUrl(), secureCredentials, {
@@ -928,13 +991,15 @@ async function startServerOn(port) {
     try {
       if (receiveBrowserControlHold(message)) return;
       if (receiveBrowserLifecycleCleanup(proc, message)) return;
+      if (receivePhoneSecretSave(proc, message)) return;
     } catch (error) {
-      slog(`browser private sync rejected: ${error?.message ?? error}`);
+      slog(`desktop private sync rejected: ${error?.message ?? error}`);
     }
   });
   proc.once("spawn", () => {
     slog(`spawned pid=${proc.pid}`);
     syncBrowserConnection(proc);
+    syncPhoneSecretKey(proc);
   });
   let exited = false;
   proc.once("exit", (code) => {
@@ -2118,7 +2183,7 @@ const CREDENTIAL_PATCH = {
   openaiImageApiKey: (value) => ({ imageGen: { key: value } }),
 };
 
-ipcMain.handle("credential:set", localOnly("credential:set", async (_event, name, value) => {
+async function saveWorkspaceCredential(name, value) {
   const patchFor = CREDENTIAL_PATCH[name];
   if (!patchFor || typeof value !== "string") {
     throw new Error("Unsupported credential");
@@ -2154,7 +2219,11 @@ ipcMain.handle("credential:set", localOnly("credential:set", async (_event, name
     },
     applyToHarness,
   );
-}));
+}
+
+ipcMain.handle("credential:set", localOnly("credential:set", (_event, name, value) =>
+  saveWorkspaceCredential(name, value),
+));
 
 async function broadcastDesktopCapabilities() {
   const capabilities = desktopCapabilities({
@@ -2207,6 +2276,7 @@ app.whenReady().then(async () => {
     writable: !credentialStoreUnavailable,
   });
   secureCredentials = secureCredentialState.read();
+  if (app.isPackaged) await ensurePhoneSecretIdentity();
   const hostedAccount = ensureCompanionAccountService();
   // Display capture remains user-initiated. The renderer first sends a
   // short-lived one-shot intent, then calls getDisplayMedia in the same click.

--- a/electron/phone-secret-identity.mjs
+++ b/electron/phone-secret-identity.mjs
@@ -1,0 +1,237 @@
+import { createECDH, createHash, createHmac, randomBytes, webcrypto } from "node:crypto";
+
+export const PHONE_SECRET_PROTOCOL_VERSION = 1;
+export const PHONE_SECRET_CREDENTIAL_KEY = "phoneSecretHpke";
+
+const BASE64URL = /^[A-Za-z0-9_-]+$/;
+
+const encodeBase64URL = (bytes) => Buffer.from(bytes).toString("base64url");
+
+const decodeBase64URL = (value, bytes) => {
+  if (typeof value !== "string" || !BASE64URL.test(value)) return null;
+  try {
+    const decoded = Buffer.from(value, "base64url");
+    if (decoded.length !== bytes || encodeBase64URL(decoded) !== value) return null;
+    return decoded;
+  } catch {
+    return null;
+  }
+};
+
+export function phoneSecretKeyId(publicKey) {
+  const raw = decodeBase64URL(publicKey, 65);
+  if (!raw || raw[0] !== 4) return null;
+  return createHash("sha256").update(raw).digest().subarray(0, 16).toString("base64url");
+}
+
+/**
+ * Read the desktop's HPKE recipient identity from the OS-encrypted credential
+ * document. The public point is reconstructed from the private JWK before the
+ * record is trusted, so a partial/corrupt write can never advertise a key the
+ * desktop cannot actually open.
+ */
+export function readPhoneSecretIdentity(credentials) {
+  const candidate = credentials?.[PHONE_SECRET_CREDENTIAL_KEY];
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
+  if (candidate.version !== PHONE_SECRET_PROTOCOL_VERSION) return null;
+
+  const privateKey = candidate.privateKey;
+  if (!privateKey || typeof privateKey !== "object" || Array.isArray(privateKey)) return null;
+  if (privateKey.kty !== "EC" || privateKey.crv !== "P-256") return null;
+  const x = decodeBase64URL(privateKey.x, 32);
+  const y = decodeBase64URL(privateKey.y, 32);
+  const d = decodeBase64URL(privateKey.d, 32);
+  if (!x || !y || !d) return null;
+
+  // Derive the point directly from the scalar instead of round-tripping a
+  // JWK. Some OpenSSL builds preserve the JWK-supplied x/y on re-export even
+  // when they do not match d, so that round-trip is not a portable proof.
+  try {
+    const ecdh = createECDH("prime256v1");
+    ecdh.setPrivateKey(d);
+    const derivedPublicKey = ecdh.getPublicKey(undefined, "uncompressed");
+    const suppliedPublicKey = Buffer.concat([Buffer.from([4]), x, y]);
+    if (!derivedPublicKey.equals(suppliedPublicKey)) return null;
+  } catch {
+    return null;
+  }
+
+  const publicKey = encodeBase64URL(Buffer.concat([Buffer.from([4]), x, y]));
+  const keyId = phoneSecretKeyId(publicKey);
+  if (!keyId || candidate.publicKey !== publicKey || candidate.keyId !== keyId) return null;
+
+  return {
+    version: PHONE_SECRET_PROTOCOL_VERSION,
+    keyId,
+    publicKey,
+    privateKey: {
+      kty: "EC",
+      crv: "P-256",
+      x: privateKey.x,
+      y: privateKey.y,
+      d: privateKey.d,
+    },
+  };
+}
+
+export async function createPhoneSecretIdentity() {
+  const pair = await webcrypto.subtle.generateKey(
+    { name: "ECDH", namedCurve: "P-256" },
+    true,
+    ["deriveBits"],
+  );
+  const [publicBytes, exportedPrivate] = await Promise.all([
+    webcrypto.subtle.exportKey("raw", pair.publicKey),
+    webcrypto.subtle.exportKey("jwk", pair.privateKey),
+  ]);
+  const publicKey = encodeBase64URL(publicBytes);
+  const keyId = phoneSecretKeyId(publicKey);
+  if (
+    !keyId ||
+    exportedPrivate.kty !== "EC" ||
+    exportedPrivate.crv !== "P-256" ||
+    !exportedPrivate.x ||
+    !exportedPrivate.y ||
+    !exportedPrivate.d
+  ) {
+    throw new Error("The operating system could not create a phone credential key");
+  }
+  const identity = {
+    version: PHONE_SECRET_PROTOCOL_VERSION,
+    keyId,
+    publicKey,
+    privateKey: {
+      kty: "EC",
+      crv: "P-256",
+      x: exportedPrivate.x,
+      y: exportedPrivate.y,
+      d: exportedPrivate.d,
+    },
+  };
+  if (!readPhoneSecretIdentity({ [PHONE_SECRET_CREDENTIAL_KEY]: identity })) {
+    throw new Error("The phone credential key could not be verified");
+  }
+  return identity;
+}
+
+export function withPhoneSecretIdentity(credentials, identity) {
+  const verified = readPhoneSecretIdentity({ [PHONE_SECRET_CREDENTIAL_KEY]: identity });
+  if (!verified) throw new Error("The phone credential key is invalid");
+  return { ...credentials, [PHONE_SECRET_CREDENTIAL_KEY]: verified };
+}
+
+/** Only the embedded server receives the private half, through Electron's
+ * in-memory utility-process port. It never enters argv, environment, logs,
+ * renderer IPC, companion state, or a pairing QR. */
+export function phoneSecretPrivateKeyMessage(identity) {
+  const verified = readPhoneSecretIdentity({ [PHONE_SECRET_CREDENTIAL_KEY]: identity });
+  if (!verified) return null;
+  return {
+    type: "openmausbot:phone-secret-key",
+    version: verified.version,
+    keyId: verified.keyId,
+    privateKey: verified.privateKey,
+  };
+}
+
+export function decodePhoneSecretSaveRequest(rawMessage) {
+  const message = rawMessage?.data ?? rawMessage;
+  if (!message || typeof message !== "object" || Array.isArray(message)) return null;
+  if (message.type !== "openmausbot:phone-secret-save") return null;
+  if (typeof message.requestId !== "string" || !/^[A-Za-z0-9_-]{1,80}$/.test(message.requestId)) return null;
+  if (typeof message.target !== "string" || !/^[A-Za-z][A-Za-z0-9]{0,63}$/.test(message.target)) return null;
+  if (typeof message.value !== "string") return null;
+  const value = message.value.trim();
+  if (!value || Buffer.byteLength(value) > 4_096) return null;
+  return { requestId: message.requestId, target: message.target, value };
+}
+
+export function phoneSecretSaveResult(requestId, ok, error) {
+  const result = {
+    type: "openmausbot:phone-secret-save-result",
+    requestId,
+    ok: ok === true,
+  };
+  if (!result.ok && typeof error === "string" && error.trim()) {
+    result.error = error.trim().slice(0, 180);
+  }
+  return result;
+}
+
+/**
+ * Deduplicate the private desktop save by the stable envelope operation id.
+ * This matters when the credential committed but a phone, tunnel, or proxy
+ * lost the success response: the retry receives the cached result and never
+ * starts a second provider validation/write. Only the non-secret target and
+ * status are retained; the plaintext value falls out of scope as soon as the
+ * save settles.
+ */
+export function createPhoneSecretSaveCoordinator(save, maximumCompleted = 512) {
+  const active = new Map();
+  const completed = new Map();
+  const limit = Math.max(1, Number.isSafeInteger(maximumCompleted) ? maximumCompleted : 512);
+  // The private IPC operation id is already the hash of the exact HPKE
+  // envelope. Keep a process-random-keyed fingerprint only while a save is
+  // active so a malformed duplicate cannot join with another plaintext.
+  // Completed entries retain target + status only, never a stable derivative
+  // of the user's secret.
+  const activeSignatureKey = randomBytes(32);
+  const signature = (request) => createHmac("sha256", activeSignatureKey)
+    .update(request.target)
+    .update("\0")
+    .update(request.value)
+    .digest("base64url");
+
+  return async (request) => {
+    const running = active.get(request.requestId);
+    if (running) {
+      const requestSignature = signature(request);
+      if (running.signature !== requestSignature) {
+        return phoneSecretSaveResult(request.requestId, false, "The credential save retry did not match");
+      }
+      return running.promise;
+    }
+
+    const prior = completed.get(request.requestId);
+    if (prior) {
+      if (prior.target !== request.target) {
+        return phoneSecretSaveResult(request.requestId, false, "The credential save retry did not match");
+      }
+      // Refresh insertion order so a genuinely retried operation is the last
+      // bounded cache entry to be evicted.
+      completed.delete(request.requestId);
+      completed.set(request.requestId, prior);
+      return prior.result;
+    }
+
+    const requestSignature = signature(request);
+    const operation = {
+      signature: requestSignature,
+      promise: Promise.resolve()
+        .then(() => save(request.target, request.value))
+        .then(
+          () => phoneSecretSaveResult(request.requestId, true),
+          (error) => phoneSecretSaveResult(
+            request.requestId,
+            false,
+            error instanceof Error ? error.message : String(error),
+          ),
+        )
+        .then((result) => {
+          active.delete(request.requestId);
+          // A committed save is safe to replay forever within the bounded
+          // cache: this is the lost-response case the operation id exists to
+          // cover. A failure is retryable (provider outage, locked keychain,
+          // validation timeout), so retaining it would strand this exact
+          // encrypted envelope until hundreds of unrelated saves evicted it.
+          if (result.ok) {
+            completed.set(request.requestId, { target: request.target, result });
+            while (completed.size > limit) completed.delete(completed.keys().next().value);
+          }
+          return result;
+        }),
+    };
+    active.set(request.requestId, operation);
+    return operation.promise;
+  };
+}

--- a/electron/phone-secret-identity.node-test.mjs
+++ b/electron/phone-secret-identity.node-test.mjs
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  PHONE_SECRET_CREDENTIAL_KEY,
+  createPhoneSecretIdentity,
+  createPhoneSecretSaveCoordinator,
+  decodePhoneSecretSaveRequest,
+  phoneSecretKeyId,
+  phoneSecretPrivateKeyMessage,
+  phoneSecretSaveResult,
+  readPhoneSecretIdentity,
+  withPhoneSecretIdentity,
+} from "./phone-secret-identity.mjs";
+
+test("creates and validates one P-256 phone credential identity", async () => {
+  const identity = await createPhoneSecretIdentity();
+  assert.equal(identity.version, 1);
+  assert.equal(Buffer.from(identity.publicKey, "base64url").length, 65);
+  assert.equal(Buffer.from(identity.privateKey.d, "base64url").length, 32);
+  assert.equal(phoneSecretKeyId(identity.publicKey), identity.keyId);
+  assert.deepEqual(
+    readPhoneSecretIdentity({ [PHONE_SECRET_CREDENTIAL_KEY]: identity }),
+    identity,
+  );
+});
+
+test("rejects a mismatched or malformed stored identity", async () => {
+  const identity = await createPhoneSecretIdentity();
+  assert.equal(readPhoneSecretIdentity({
+    [PHONE_SECRET_CREDENTIAL_KEY]: { ...identity, keyId: "AAAAAAAAAAAAAAAAAAAAAA" },
+  }), null);
+  assert.equal(readPhoneSecretIdentity({
+    [PHONE_SECRET_CREDENTIAL_KEY]: {
+      ...identity,
+      privateKey: { ...identity.privateKey, d: "not-base64" },
+    },
+  }), null);
+  const other = await createPhoneSecretIdentity();
+  assert.equal(readPhoneSecretIdentity({
+    [PHONE_SECRET_CREDENTIAL_KEY]: {
+      ...identity,
+      privateKey: { ...identity.privateKey, d: other.privateKey.d },
+    },
+  }), null);
+});
+
+test("adds the identity without changing other secure credentials", async () => {
+  const identity = await createPhoneSecretIdentity();
+  const next = withPhoneSecretIdentity({ xaiApiKey: "kept" }, identity);
+  assert.equal(next.xaiApiKey, "kept");
+  assert.deepEqual(next[PHONE_SECRET_CREDENTIAL_KEY], identity);
+});
+
+test("private key messages never contain the public pairing URL shape", async () => {
+  const identity = await createPhoneSecretIdentity();
+  assert.deepEqual(phoneSecretPrivateKeyMessage(identity), {
+    type: "openmausbot:phone-secret-key",
+    version: 1,
+    keyId: identity.keyId,
+    privateKey: identity.privateKey,
+  });
+});
+
+test("accepts only bounded private save requests", () => {
+  assert.deepEqual(decodePhoneSecretSaveRequest({
+    type: "openmausbot:phone-secret-save",
+    requestId: "request_1",
+    target: "xaiApiKey",
+    value: "  secret  ",
+  }), { requestId: "request_1", target: "xaiApiKey", value: "secret" });
+  assert.equal(decodePhoneSecretSaveRequest({
+    type: "openmausbot:phone-secret-save",
+    requestId: "request_1",
+    target: "xaiApiKey",
+    value: " ",
+  }), null);
+  assert.equal(decodePhoneSecretSaveRequest({
+    type: "openmausbot:phone-secret-save",
+    requestId: "request_1",
+    target: "xaiApiKey",
+    value: "x".repeat(4_097),
+  }), null);
+  assert.equal(decodePhoneSecretSaveRequest({
+    type: "openmausbot:phone-secret-save",
+    requestId: 123,
+    target: "xaiApiKey",
+    value: "secret",
+  }), null);
+});
+
+test("save results expose only a bounded error", () => {
+  assert.deepEqual(phoneSecretSaveResult("request_1", true), {
+    type: "openmausbot:phone-secret-save-result",
+    requestId: "request_1",
+    ok: true,
+  });
+  assert.equal(phoneSecretSaveResult("request_1", false, "x".repeat(400)).error.length, 180);
+});
+
+test("joins and caches an exact private save retry", async () => {
+  let calls = 0;
+  let finish;
+  const blocked = new Promise((resolve) => { finish = resolve; });
+  const save = createPhoneSecretSaveCoordinator(async () => {
+    calls += 1;
+    await blocked;
+  });
+  const request = { requestId: "operation_1", target: "xaiApiKey", value: "secret" };
+
+  const first = save(request);
+  const concurrentRetry = save(request);
+  await Promise.resolve();
+  assert.equal(calls, 1);
+  finish();
+  assert.deepEqual(await first, phoneSecretSaveResult("operation_1", true));
+  assert.deepEqual(await concurrentRetry, phoneSecretSaveResult("operation_1", true));
+  assert.deepEqual(await save(request), phoneSecretSaveResult("operation_1", true));
+  assert.equal(calls, 1);
+});
+
+test("rejects reuse of a completed operation id for another credential target", async () => {
+  let calls = 0;
+  const save = createPhoneSecretSaveCoordinator(async () => { calls += 1; });
+  const first = { requestId: "operation_1", target: "xaiApiKey", value: "secret" };
+  assert.equal((await save(first)).ok, true);
+  const mismatch = await save({ ...first, target: "ttsKey", value: "different" });
+  assert.equal(mismatch.ok, false);
+  assert.match(mismatch.error, /did not match/i);
+  assert.equal(calls, 1);
+});
+
+test("rejects a mismatched plaintext while an operation is active", async () => {
+  let finish;
+  const blocked = new Promise((resolve) => { finish = resolve; });
+  const save = createPhoneSecretSaveCoordinator(async () => { await blocked; });
+  const first = { requestId: "operation_1", target: "xaiApiKey", value: "secret" };
+  const pending = save(first);
+
+  const mismatch = await save({ ...first, value: "different" });
+  assert.equal(mismatch.ok, false);
+  assert.match(mismatch.error, /did not match/i);
+  finish();
+  assert.equal((await pending).ok, true);
+});
+
+test("does not cache a failed save for an exact encrypted retry", async () => {
+  let calls = 0;
+  const save = createPhoneSecretSaveCoordinator(async () => {
+    calls += 1;
+    if (calls === 1) throw new Error("credential store was temporarily locked");
+  });
+  const request = { requestId: "operation_1", target: "xaiApiKey", value: "secret" };
+
+  const [failed, concurrentWaiter] = await Promise.all([save(request), save(request)]);
+  for (const result of [failed, concurrentWaiter]) {
+    assert.equal(result.ok, false);
+    assert.match(result.error, /temporarily locked/i);
+  }
+  assert.equal(calls, 1);
+  assert.deepEqual(await save(request), phoneSecretSaveResult("operation_1", true));
+  assert.equal(calls, 2);
+});

--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -1517,14 +1517,33 @@ struct ActivityChip: View {
     }
 }
 
-/// A host credential is intentionally entered on the computer, where
-/// Electron can commit it through the operating system's encrypted store.
-/// The phone still needs a real row: an invisible blocker makes the bot look
-/// confused and encourages people to paste a key into ordinary chat.
+/// A credential entered here is encrypted for the exact computer whose
+/// public key was pinned by the pairing QR. Password AutoFill remains
+/// provider-neutral: Apple Passwords works without another subscription,
+/// while 1Password, Bitwarden and other enabled providers work as usual.
 struct CredentialRequestCardView: View {
     let chat: Chat
     let message: Message
     let secret: SecretRequestCardData
+    @EnvironmentObject private var session: Session
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var value = ""
+    @State private var fieldID = UUID()
+    @State private var preparedSubmission: PreparedPhoneCredential?
+    @State private var submissionTask: Task<Void, Never>?
+    @State private var activeSubmissionID: UUID?
+    @State private var submitting = false
+    @State private var submitted = false
+    @State private var submissionError: String?
+
+    private struct RequestIdentity: Equatable {
+        let connectionID: String?
+        let botID: String?
+        let threadID: String
+        let messageID: String
+        let target: String?
+        let requestKey: String?
+    }
 
     private var tint: Color { MausPalette.color(message.from?.color ?? chat.color) }
     private var requester: String { message.from?.name ?? chat.name }
@@ -1534,7 +1553,10 @@ struct CredentialRequestCardView: View {
             return secret.resumed == true ? "Saved securely. The task resumed." : "Saved securely on your computer."
         }
         if secret.dismissed == true { return "Not provided." }
-        return "Finish this credential request on your computer."
+        if submitted { return "Encrypted and sent to your computer." }
+        if canEnterOnPhone { return "Enter it securely on this phone." }
+        if !hasSecurePairing { return "Pair again by QR code, or finish on your computer." }
+        return "Use secure phone access or Tailscale, or finish on your computer."
     }
 
     private func visible(_ value: String?) -> String? {
@@ -1551,6 +1573,45 @@ struct CredentialRequestCardView: View {
               url.password == nil
         else { return nil }
         return url
+    }
+
+    private var hasSecurePairing: Bool {
+        guard secret.isPending,
+              visible(secret.target) != nil,
+              visible(secret.requestKey) != nil,
+              let connection = session.connection
+        else { return false }
+        return connection.secretPublicKey != nil && connection.companionDeviceId != nil
+    }
+
+    private var hasProtectedTransport: Bool {
+        session.phoneCredentialTransportIsProtected
+    }
+
+    private var canEnterOnPhone: Bool { hasSecurePairing && hasProtectedTransport }
+
+    private var placeholder: String { visible(secret.placeholder) ?? label }
+
+    private var canSubmit: Bool {
+        guard canEnterOnPhone, !submitting, !submitted else { return false }
+        return preparedSubmission != nil
+            || !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var requestIdentity: RequestIdentity {
+        let botID: String?
+        switch chat {
+        case let .bot(bot): botID = bot.id
+        case .room: botID = message.from?.botId
+        }
+        return RequestIdentity(
+            connectionID: session.connection?.id,
+            botID: botID,
+            threadID: chat.threadId,
+            messageID: message.id,
+            target: secret.target,
+            requestKey: secret.requestKey
+        )
     }
 
     var body: some View {
@@ -1580,20 +1641,94 @@ struct CredentialRequestCardView: View {
             }
 
             if secret.provided == true {
-                Label(
-                    secret.resumed == true ? "Saved securely. The task resumed." : "Saved securely on your computer.",
-                    systemImage: "checkmark.shield.fill"
-                )
-                .foregroundStyle(.green)
+                VStack(alignment: .leading, spacing: 8) {
+                    Label(
+                        secret.resumed == true ? "Saved securely. The task resumed." : "Saved securely on your computer.",
+                        systemImage: "checkmark.shield.fill"
+                    )
+                    .foregroundStyle(.green)
+
+                    if secret.resumed != true, let preparedSubmission {
+                        Button(action: { send(preparedSubmission) }) {
+                            HStack(spacing: 7) {
+                                if submitting { ProgressView() }
+                                Image(systemName: "arrow.clockwise")
+                                Text(submitting ? "Resuming…" : "Try resuming the task")
+                            }
+                            .font(.system(size: 13, weight: .semibold))
+                        }
+                        .disabled(submitting || !hasProtectedTransport)
+                    }
+                }
             } else if secret.dismissed == true {
                 Label("Not provided", systemImage: "xmark.circle")
                     .foregroundStyle(Color.secondary)
-            } else {
+            } else if submitted {
+                Label("Encrypted and saved on your computer", systemImage: "checkmark.shield.fill")
+                    .foregroundStyle(.green)
+            } else if canEnterOnPhone {
                 VStack(alignment: .leading, spacing: 5) {
-                    Label("Finish on your computer", systemImage: "desktopcomputer")
+                    Label("Enter securely on this phone", systemImage: "lock.shield.fill")
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundStyle(tint)
-                    Text("Open this chat in OpenMausBot on your computer to enter the key. It is stored there securely and is never added to chat.")
+
+                    if preparedSubmission == nil {
+                        SecureField(placeholder, text: $value)
+                            .id(fieldID)
+                            .textContentType(.password)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                            .privacySensitive()
+                            .disabled(submitting)
+                            .submitLabel(.done)
+                            .onSubmit { submit() }
+                            .padding(.horizontal, 12)
+                            .frame(minHeight: 44)
+                            .background(
+                                Color.secondary.opacity(0.1),
+                                in: RoundedRectangle(cornerRadius: 11, style: .continuous)
+                            )
+                            .accessibilityLabel(label)
+                    } else {
+                        Label(
+                            submitting ? "Encrypted and saving…" : "Encrypted and ready to retry",
+                            systemImage: "lock.fill"
+                        )
+                        .font(.system(size: 13))
+                        .foregroundStyle(Color.secondary)
+                        .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                        .padding(.horizontal, 12)
+                        .background(
+                            Color.secondary.opacity(0.1),
+                            in: RoundedRectangle(cornerRadius: 11, style: .continuous)
+                        )
+                    }
+
+                    Button(action: submit) {
+                        HStack(spacing: 7) {
+                            if submitting { ProgressView().tint(.white) }
+                            Image(systemName: "lock.fill")
+                            Text(
+                                submitting
+                                    ? "Saving securely…"
+                                    : preparedSubmission == nil ? "Save securely" : "Try again securely"
+                            )
+                        }
+                        .font(.system(size: 14, weight: .semibold))
+                        .frame(maxWidth: .infinity, minHeight: 42)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(tint)
+                    .disabled(!canSubmit)
+
+                    if preparedSubmission != nil, !submitting, submissionError != nil {
+                        Button("Enter a different value") {
+                            discardPreparedSubmission()
+                        }
+                        .font(.system(size: 13, weight: .medium))
+                    }
+
+                    Text("Use Apple Passwords, 1Password, Bitwarden, or paste. The value is encrypted for your computer and never added to chat.")
                         .font(.system(size: 13))
                         .foregroundStyle(Color.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -1601,6 +1736,39 @@ struct CredentialRequestCardView: View {
                 .padding(11)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 13, style: .continuous))
+            } else if !hasSecurePairing {
+                VStack(alignment: .leading, spacing: 5) {
+                    Label("Pair again to enter here", systemImage: "qrcode")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(tint)
+                    Text("This pairing predates secure phone entry. Scan a fresh QR from OpenMausBot, or finish this request on your computer.")
+                        .font(.system(size: 13))
+                        .foregroundStyle(Color.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(11)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 13, style: .continuous))
+            } else {
+                VStack(alignment: .leading, spacing: 5) {
+                    Label("Secure connection required", systemImage: "lock.shield.fill")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(tint)
+                    Text("Switch to Secure phone access (HTTPS) or Tailscale, then try again. You can still finish this request on your computer.")
+                        .font(.system(size: 13))
+                        .foregroundStyle(Color.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(11)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 13, style: .continuous))
+            }
+
+            if let submissionError = visible(submissionError) {
+                Label(submissionError, systemImage: "exclamationmark.triangle.fill")
+                    .font(.system(size: 12.5))
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             if let error = visible(secret.error) {
@@ -1627,9 +1795,133 @@ struct CredentialRequestCardView: View {
             RoundedRectangle(cornerRadius: 22, style: .continuous)
                 .strokeBorder(secret.isPending ? tint.opacity(0.65) : Color.clear, lineWidth: 1.25)
         }
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: canEnterOnPhone ? .contain : .combine)
         .accessibilityLabel("\(label). \(accessibilityStatus)")
+        .onAppear {
+            preparedSubmission = session.preparedCredential(
+                chat: chat,
+                message: message,
+                secret: secret
+            )
+        }
+        .onChange(of: requestIdentity) { _, _ in
+            resetSensitiveState(clearPrepared: true)
+            preparedSubmission = session.preparedCredential(
+                chat: chat,
+                message: message,
+                secret: secret
+            )
+            submitted = false
+        }
+        .onChange(of: session.credentialEntryResetGeneration) { _, _ in
+            suspendSensitiveEntry()
+        }
+        .onChange(of: session.status) { _, status in
+            if status != .live { suspendSensitiveEntry() }
+        }
+        .onChange(of: scenePhase) { _, phase in
+            // Password AutoFill and its Face ID sheet temporarily make the
+            // scene inactive. Removing the SecureField at that point breaks
+            // the very fill operation the user requested. A true background
+            // transition (including locking the phone) still scrubs it.
+            if phase == .background { suspendSensitiveEntry() }
+        }
+        .onDisappear {
+            // The async request owns only ciphertext and is safe to finish.
+            // Its envelope stays in Session so returning to this card can
+            // retry the exact same operation after an ambiguous response.
+            clearPlaintext()
+            submissionError = nil
+        }
     }
+
+    private func submit() {
+        guard canSubmit else { return }
+        submissionError = nil
+        if let preparedSubmission {
+            send(preparedSubmission)
+            return
+        }
+
+        do {
+            // Encryption happens synchronously. No task closure ever captures
+            // the cleartext, and the native field is replaced immediately.
+            let prepared = try session.prepareCredential(
+                value,
+                chat: chat,
+                message: message,
+                secret: secret
+            )
+            clearPlaintext()
+            preparedSubmission = prepared
+            send(prepared)
+        } catch {
+            clearPlaintext()
+            submissionError = error.localizedDescription
+            Haptics.notification(.error)
+        }
+    }
+
+    private func send(_ prepared: PreparedPhoneCredential) {
+        submissionTask?.cancel()
+        let submissionID = UUID()
+        activeSubmissionID = submissionID
+        submissionError = nil
+        submitting = true
+
+        submissionTask = Task { @MainActor in
+            do {
+                try await session.provideCredential(prepared)
+                guard !Task.isCancelled, activeSubmissionID == submissionID else { return }
+                submitted = true
+                Haptics.success()
+            } catch {
+                guard !Task.isCancelled, activeSubmissionID == submissionID else { return }
+                // Keep only the exact ciphertext so Retry is the same
+                // idempotent operation. The cleartext field is already gone.
+                submissionError = error.localizedDescription
+                Haptics.notification(.error)
+            }
+
+            guard activeSubmissionID == submissionID else { return }
+            activeSubmissionID = nil
+            submissionTask = nil
+            submitting = false
+        }
+    }
+
+    private func clearPlaintext() {
+        value.removeAll(keepingCapacity: false)
+        // Replacing the SecureField also clears UIKit's backing control,
+        // including text inserted by Password AutoFill.
+        fieldID = UUID()
+    }
+
+    private func suspendSensitiveEntry() {
+        clearPlaintext()
+        activeSubmissionID = nil
+        submissionTask?.cancel()
+        submissionTask = nil
+        submitting = false
+        submissionError = nil
+        // Keep an already-encrypted envelope. If the request reached the
+        // computer before iOS suspended it, foreground Retry must send the
+        // exact same operation instead of generating fresh HPKE randomness.
+    }
+
+    private func resetSensitiveState(clearPrepared: Bool) {
+        suspendSensitiveEntry()
+        if clearPrepared, let preparedSubmission {
+            session.discardPreparedCredential(preparedSubmission)
+            self.preparedSubmission = nil
+        }
+    }
+
+    private func discardPreparedSubmission() {
+        resetSensitiveState(clearPrepared: true)
+        submitted = false
+    }
+
 }
 
 /// An option card. When it still has a request behind it, this is the

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -27,6 +27,18 @@ private final class CachedAttachmentDownload: NSObject {
     }
 }
 
+/// An immutable, ciphertext-only credential write prepared on the main
+/// actor before any asynchronous work begins. HPKE uses fresh randomness for
+/// every seal, so retries must reuse this exact value rather than encrypting
+/// the same credential again after an ambiguous network failure.
+struct PreparedPhoneCredential: Equatable, Sendable {
+    fileprivate let requestIdentity: String
+    fileprivate let connectionID: String
+    fileprivate let botID: String
+    fileprivate let messageID: String
+    fileprivate let envelope: PhoneSecretEnvelope
+}
+
 @MainActor
 final class Session: ObservableObject {
     enum Status: Equatable {
@@ -55,12 +67,20 @@ final class Session: ObservableObject {
     /// Pairing can be opened while another computer remains connected. The
     /// working session is only replaced after the new credential commits.
     @Published private(set) var pairingRequested = false
+    /// Views with sensitive input observe this value so an explicit runtime
+    /// disconnect clears the field even when the selected connection itself
+    /// has not changed.
+    @Published private(set) var credentialEntryResetGeneration = 0
 
     /// A notification response that should be pushed by the roster's
     /// NavigationStack after the exact detached task has been activated.
     @Published private(set) var notificationChat: Chat?
 
     private var client: CompanionClient?
+    /// Ciphertext-only operations survive navigation and transient
+    /// disconnects so a retry cannot accidentally reseal the same value with
+    /// a different HPKE operation id. Nothing here is persisted to disk.
+    private var preparedPhoneCredentials: [String: PreparedPhoneCredential] = [:]
     /// The device token, kept in memory so the client can be rebuilt when the
     /// dial moves to another stored host. The keychain remains the only place
     /// it is persisted.
@@ -117,6 +137,11 @@ final class Session: ObservableObject {
     /// is available. Retain the last explicitly tapped destination until the
     /// paired client can be rebuilt after unlock.
     private var pendingNotification: NotificationTarget?
+
+    /// The exact route the current client will use for a credential write.
+    var phoneCredentialTransportIsProtected: Bool {
+        client?.connection.activeEndpoint?.protectsCredentials == true
+    }
 
     private struct AttachmentDraftKey: Hashable {
         let destination: MessageDestination
@@ -257,6 +282,7 @@ final class Session: ObservableObject {
         // prefer the name the computer calls itself over the Bonjour label
         var stored = outcome.connection
         if !paired.serverName.isEmpty { stored.name = paired.serverName }
+        stored.companionDeviceId = paired.device.id
         // The computer knows every address it answers on, but redemption may
         // not widen the explicit route consent carried by the invite.
         stored.applyPairingAdvertisement(hosts: paired.hosts, endpoints: paired.endpoints)
@@ -381,6 +407,7 @@ final class Session: ObservableObject {
         guard registry.connection(id: id) != nil else { return }
         let wasActive = registry.activeConnectionID == id
         if wasActive { stopActiveRuntime() }
+        preparedPhoneCredentials = preparedPhoneCredentials.filter { $0.value.connectionID != id }
         Keychain.remove(id)
         registry.remove(id: id)
         persistRegistry()
@@ -414,6 +441,7 @@ final class Session: ObservableObject {
     }
 
     private func clearActiveConnection() {
+        resetCredentialEntry()
         streamTask?.cancel()
         streamTask = nil
         endpointRefreshTask?.cancel()
@@ -450,6 +478,7 @@ final class Session: ObservableObject {
     }
 
     private func stopActiveRuntime() {
+        resetCredentialEntry()
         streamGeneration += 1
         streamTask?.cancel()
         streamTask = nil
@@ -556,11 +585,16 @@ final class Session: ObservableObject {
     /// anyway; dropping it deliberately means the cursor is written down at
     /// a known point instead of wherever the socket happened to die.
     func disconnect() {
+        resetCredentialEntry()
         streamTask?.cancel()
         streamTask = nil
         endpointRefreshTask?.cancel()
         endpointRefreshTask = nil
         endLinger()
+    }
+
+    private func resetCredentialEntry() {
+        credentialEntryResetGeneration &+= 1
     }
 
     private var lingerTask: UIBackgroundTaskIdentifier = .invalid
@@ -1102,6 +1136,157 @@ final class Session: ObservableObject {
             isPermission: card.isPermission,
             reviewedSha256: card.skillRequest?.reviewedSha256
         )
+    }
+
+    /// Synchronously seal a credential before the caller starts an async
+    /// request. The caller can then erase its input immediately and retain
+    /// only this ciphertext value for an exact, idempotent retry.
+    func prepareCredential(
+        _ value: String,
+        chat: Chat,
+        message: Message,
+        secret: SecretRequestCardData
+    ) throws -> PreparedPhoneCredential {
+        guard let client, let connection else {
+            throw APIError.transport("This computer is offline.")
+        }
+        guard let publicKey = connection.secretPublicKey,
+              let deviceId = connection.companionDeviceId,
+              let target = secret.target,
+              let requestKey = secret.requestKey
+        else { throw PhoneSecretError.unavailable }
+        guard client.connection.activeEndpoint?.protectsCredentials == true else {
+            throw PhoneSecretError.insecureTransport
+        }
+
+        let botId = try credentialBotID(chat: chat, message: message)
+        let context = PhoneSecretRequestContext(
+            deviceId: deviceId,
+            botId: botId,
+            threadId: chat.threadId,
+            messageId: message.id,
+            target: target,
+            requestKey: requestKey
+        )
+        let keyId = try PhoneSecretCrypto.publicKeyId(publicKey)
+        let requestIdentity = phoneCredentialRequestIdentity(
+            connectionID: connection.id,
+            botID: botId,
+            context: context,
+            keyID: keyId
+        )
+        if let prepared = preparedPhoneCredentials[requestIdentity] {
+            return prepared
+        }
+        let envelope = try PhoneSecretCrypto.encrypt(
+            value,
+            publicKey: publicKey,
+            context: context
+        )
+
+        let prepared = PreparedPhoneCredential(
+            requestIdentity: requestIdentity,
+            connectionID: connection.id,
+            botID: botId,
+            messageID: message.id,
+            envelope: envelope
+        )
+        preparedPhoneCredentials[requestIdentity] = prepared
+        return prepared
+    }
+
+    /// Recover an ambiguous ciphertext-only operation when a card view is
+    /// recreated. This is deliberately in-memory: a force-quit forgets it,
+    /// while ordinary navigation, AutoFill, and reconnects do not.
+    func preparedCredential(
+        chat: Chat,
+        message: Message,
+        secret: SecretRequestCardData
+    ) -> PreparedPhoneCredential? {
+        guard let connection,
+              let publicKey = connection.secretPublicKey,
+              let deviceId = connection.companionDeviceId,
+              let target = secret.target,
+              let requestKey = secret.requestKey,
+              let botId = try? credentialBotID(chat: chat, message: message),
+              let keyId = try? PhoneSecretCrypto.publicKeyId(publicKey)
+        else { return nil }
+        let context = PhoneSecretRequestContext(
+            deviceId: deviceId,
+            botId: botId,
+            threadId: chat.threadId,
+            messageId: message.id,
+            target: target,
+            requestKey: requestKey
+        )
+        return preparedPhoneCredentials[phoneCredentialRequestIdentity(
+            connectionID: connection.id,
+            botID: botId,
+            context: context,
+            keyID: keyId
+        )]
+    }
+
+    func discardPreparedCredential(_ prepared: PreparedPhoneCredential) {
+        if preparedPhoneCredentials[prepared.requestIdentity] == prepared {
+            preparedPhoneCredentials.removeValue(forKey: prepared.requestIdentity)
+        }
+    }
+
+    private func credentialBotID(chat: Chat, message: Message) throws -> String {
+        switch chat {
+        case let .bot(bot): return bot.id
+        case .room:
+            guard let sender = message.from?.botId else {
+                throw PhoneSecretError.invalidRequest
+            }
+            return sender
+        }
+    }
+
+    private func phoneCredentialRequestIdentity(
+        connectionID: String,
+        botID: String,
+        context: PhoneSecretRequestContext,
+        keyID: String
+    ) -> String {
+        [
+            connectionID,
+            keyID,
+            botID,
+            context.threadId,
+            context.messageId,
+            context.target,
+            context.requestKey,
+        ].joined(separator: "\u{0}")
+    }
+
+    /// Send one already-sealed operation. A retry deliberately reuses the
+    /// same HPKE envelope; the desktop derives its idempotency key from these
+    /// bytes, so a lost response cannot cause a second provider save.
+    func provideCredential(_ prepared: PreparedPhoneCredential) async throws {
+        guard let client, let connection else {
+            throw APIError.transport("This computer is offline.")
+        }
+        guard connection.id == prepared.connectionID,
+              connection.companionDeviceId == prepared.envelope.deviceId,
+              let publicKey = connection.secretPublicKey,
+              (try? PhoneSecretCrypto.publicKeyId(publicKey)) == prepared.envelope.keyId
+        else { throw PhoneSecretError.unavailable }
+        guard client.connection.activeEndpoint?.protectsCredentials == true else {
+            throw PhoneSecretError.insecureTransport
+        }
+
+        do {
+            try await client.provideCredential(
+                botId: prepared.botID,
+                messageId: prepared.messageID,
+                envelope: prepared.envelope
+            )
+        } catch let error as APIError where error.isUnauthorized {
+            status = .unauthorized
+            throw error
+        }
     }
 
     /// The same answer, from something that only has the ids — the Live

--- a/ios/AppStore/RELEASE.md
+++ b/ios/AppStore/RELEASE.md
@@ -19,7 +19,7 @@ The app is native Swift and uses XcodeGen; EAS commands do not apply.
 4. Increment `CURRENT_PROJECT_VERSION` for every upload. Update `MARKETING_VERSION` only for a new App Store version.
 5. Archive a generic iOS device build and validate it in Xcode Organizer.
 6. Upload to App Store Connect and distribute to internal TestFlight testers first.
-7. Complete a real-iPhone pass for pairing, Bonjour permission, Keychain restore and upgrade migration, Tailscale, optional hosted HTTPS, approvals, background/foreground reconciliation, sign-out/revocation, transcript sharing, and Share-sheet delivery of text, a link, an image, and a document. Repeat Share-sheet delivery after force-quitting the containing app.
+7. Complete a real-iPhone pass for pairing, Bonjour permission, Keychain restore and upgrade migration, Tailscale, optional hosted HTTPS, approvals, secure credential entry through Apple Passwords and by paste, background/foreground reconciliation, sign-out/revocation, transcript sharing, and Share-sheet delivery of text, a link, an image, and a document. Repeat Share-sheet delivery after force-quitting the containing app.
 8. After internal testing, submit to an external TestFlight group before App Review.
 
 ## App Store Connect

--- a/ios/AppStore/en-US/description.txt
+++ b/ios/AppStore/en-US/description.txt
@@ -3,6 +3,7 @@ OpenMausMobile is the private iPhone companion for OpenMausBot on your computer.
 Keep your AI team moving when you step away from your desk:
 
 • Answer approvals and questions
+• Securely provide requested API keys with Password AutoFill
 • Follow replies as they stream
 • Send messages to bots and rooms
 • Switch and manage task contexts
@@ -14,6 +15,8 @@ Keep your AI team moving when you step away from your desk:
 YOUR COMPUTER STAYS IN CHARGE
 
 OpenMausMobile connects to the companion service on your own computer. Your bot transcripts remain in OpenMausBot’s local storage; the optional hosted connection transports them to your computer without creating a developer-hosted transcript copy.
+
+When a bot requests a supported API key, the phone can send it over Secure phone access or Tailscale, encrypted for the paired computer. Apple Passwords is built in, and other enabled Password AutoFill providers work too. The value is never added to chat or retained by OpenMausMobile.
 
 PAIR ONCE, REVOKE ANY TIME
 

--- a/ios/AppStore/en-US/release_notes.txt
+++ b/ios/AppStore/en-US/release_notes.txt
@@ -1,6 +1,7 @@
 Welcome to OpenMausMobile 1.0.
 
 • Pair securely with your OpenMausBot computer
+• Fill a requested API key from Apple Passwords or another AutoFill provider and send it encrypted over Secure phone access or Tailscale
 • Default QR pairing now stays on hosted HTTPS; Tailscale and local routes remain explicit choices
 • Chat with bots and rooms
 • Answer approvals and questions

--- a/ios/AppStore/privacy-answers.md
+++ b/ios/AppStore/privacy-answers.md
@@ -24,6 +24,14 @@ production hosted service still match this repository.
   developer's control plane. Confirm the current App Store Connect definition
   of ephemeral processing when answering the collection question for the
   submitted build.
+- A credential entered into a pending secure card is encrypted on the phone
+  for the QR-paired computer and is submitted only over hosted HTTPS or
+  Tailscale. The hosted route and companion sidecar can see only ciphertext;
+  the developer cannot decrypt or retain the value.
+  The phone clears its transient field immediately after local encryption. It
+  may keep only the exact ciphertext in memory for an interrupted-request
+  retry; that ciphertext is not persisted. The value is not added to chat,
+  preferences, Keychain, diagnostics, or analytics.
 - Privacy policy URL:
   `https://github.com/milind-soni/OpenMausBot/blob/main/docs/ios-privacy.md`
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -3,10 +3,10 @@
 Your bots keep running on the laptop. This is the phone you watch them from,
 answer their approvals on, and send them the next thing.
 
-The laptop stays the only machine that owns agent processes, credentials,
-transcripts and computers. The phone owns nothing — it is a second client of the
-same harness the desktop app talks to, through the restricted sidecar described in
-[`docs/ios-companion.md`](../docs/ios-companion.md).
+The laptop stays the only machine that persists agent processes, credentials,
+transcripts and computers. The phone owns no copy — it is a second client of
+the same harness the desktop app talks to, through the restricted sidecar
+described in [`docs/ios-companion.md`](../docs/ios-companion.md).
 
 ## Status
 
@@ -14,6 +14,17 @@ Built and verified against a real harness on both a simulator and an iPhone:
 QR handoff, Bonjour discovery, manual LAN and Tailscale pairing, the roster, paged chat,
 streaming replies, shared sidebar sections, the computer view, and — the one that matters — an approval
 raised by a bot on the Mac, answered on the phone, with the bot carrying on.
+
+Pending API-key cards can also be completed on a freshly QR-paired phone.
+The native secure field supports iOS Password AutoFill (Apple Passwords is the
+free built-in option; enabled third-party providers work too), then CryptoKit
+encrypts the value for the paired computer before it enters the network. The
+phone clears the native field immediately; it may retain only the exact
+ciphertext in memory for an idempotent retry, and never persists it. The
+sidecar, hosted relay, transcript and SQLite database retain no plaintext copy.
+Submission requires Secure phone access (HTTPS) or Tailscale; local Wi-Fi chat
+still works, but the app does not send a reusable device token with a credential
+request over cleartext LAN HTTP.
 
 The app also installs an iOS Share extension. From any app's Share sheet, a
 person can choose **OpenMausBot**, review the paired computer and destination,

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -2,9 +2,10 @@
 //
 // Everything the phone can do to the harness, in one place. The rules it
 // encodes come from the default-deny policy in `companion/src/routes.ts`: a
-// paired phone may chat, answer approvals, and read rooms — it may not touch
-// credentials, pairing, or the Local VM. Those routes are simply absent here
-// rather than present and failing at runtime.
+// paired phone may chat, answer approvals, and read rooms. Credential values
+// are the narrow exception: this client can transport an HPKE envelope whose
+// plaintext only the QR-paired Electron process can open. Pairing management
+// and the Local VM remain absent rather than failing at runtime.
 import Foundation
 
 /// Where a companion connects, and with what. The token is *not* held here
@@ -38,6 +39,12 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
     /// LAN or Bonjour origin for local pairing. Absent alongside a nil kind
     /// policy on connections saved before route consent existed.
     public var allowedLocalRouteURLs: Set<String>?
+    /// P-256 HPKE recipient point learned only from the camera-scanned QR.
+    /// It is public key material; the phone never receives the private key.
+    public var secretPublicKey: String?
+    /// Sidecar device identity returned after redemption. Bound into every
+    /// credential envelope and checked against the authenticated bearer.
+    public var companionDeviceId: String?
 
     public init(
         id: String = UUID().uuidString,
@@ -48,7 +55,9 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
         activeEndpoint: CompanionEndpoint? = nil,
         endpoints: [CompanionEndpoint]? = nil,
         allowedRouteKinds: Set<CompanionEndpointKind>? = nil,
-        allowedLocalRouteURLs: Set<String>? = nil
+        allowedLocalRouteURLs: Set<String>? = nil,
+        secretPublicKey: String? = nil,
+        companionDeviceId: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -59,6 +68,8 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
         self.endpoints = endpoints
         self.allowedRouteKinds = allowedRouteKinds
         self.allowedLocalRouteURLs = allowedLocalRouteURLs
+        self.secretPublicKey = secretPublicKey
+        self.companionDeviceId = companionDeviceId
     }
 
     /// The representation `URLComponents.host` accepts for a literal IPv6
@@ -234,6 +245,10 @@ public struct PairingInvite: Equatable, Sendable {
             guard let endpoints = Self.decodeEndpoints(encoded) else { return nil }
             connection.endpoints = endpoints
             connection = connection.dialing(endpoints[0])
+        }
+        if let secretKey = values["secretKey"] {
+            guard let normalized = PhoneSecretCrypto.normalizedPublicKey(secretKey) else { return nil }
+            connection.secretPublicKey = normalized
         }
         connection.establishRoutePolicyFromInvite()
         return PairingInvite(connection: connection, credential: credential)
@@ -1324,6 +1339,25 @@ public struct CompanionClient: Sendable {
 
     public func interrupt(botId: String) async throws {
         try await send(try makeRequest("POST", "/api/bots/\(botId)/interrupt"))
+    }
+
+    public func provideCredential(
+        botId: String,
+        messageId: String,
+        envelope: PhoneSecretEnvelope
+    ) async throws {
+        var request = try makeRequest(
+            "POST",
+            "/api/bots/\(botId)/secret-cards/\(messageId)/provide",
+            encodedBody: envelope
+        )
+        // Saving is transactional: the desktop validates provider access,
+        // commits its OS-encrypted credential document, and updates the live
+        // server before replying. Those provider checks have bounded network
+        // deadlines of their own, so this one operation deliberately gets
+        // longer than the normal twenty-second chat API timeout.
+        request.timeoutInterval = 115
+        try await send(request)
     }
 
     /// Mint a fresh interactive viewer for an existing cloud computer. The

--- a/ios/Sources/CompanionCore/Models.swift
+++ b/ios/Sources/CompanionCore/Models.swift
@@ -108,9 +108,8 @@ public struct ToolActivity: Codable, Hashable, Sendable {
 
 /// A credential request created by the desktop for one paused task.
 ///
-/// Paired phones deliberately cannot write host credentials. Keeping the
-/// payload lets the companion render an honest handoff card instead of
-/// turning this newer message kind into an invisible row.
+/// The phone may fill this request only through the QR-pinned HPKE transport.
+/// The payload contains identifiers and display copy, never the credential.
 public struct SecretRequestCardData: Codable, Hashable, Sendable {
     public var target: String?
     public var label: String?

--- a/ios/Sources/CompanionCore/PhoneSecret.swift
+++ b/ios/Sources/CompanionCore/PhoneSecret.swift
@@ -1,0 +1,202 @@
+import CryptoKit
+import Foundation
+
+public enum PhoneSecretError: Error, LocalizedError, Equatable, Sendable {
+    case unavailable
+    case insecureTransport
+    case invalidRequest
+    case invalidPublicKey
+    case invalidCredential
+    case encryptionFailed
+
+    public var errorDescription: String? {
+        switch self {
+        case .unavailable:
+            return "Pair this phone again by QR code to enable secure credential entry."
+        case .insecureTransport:
+            return "Use secure phone access or Tailscale before sending a credential from this phone."
+        case .invalidRequest:
+            return "This credential request is no longer valid."
+        case .invalidPublicKey:
+            return "This computer’s secure pairing key is invalid. Pair it again."
+        case .invalidCredential:
+            return "Enter a credential between 1 and 4096 bytes."
+        case .encryptionFailed:
+            return "The credential could not be encrypted for this computer. Pair it again and retry."
+        }
+    }
+}
+
+/// The only phone-to-desktop credential wire format. It uses the RFC 9180
+/// suite built into CryptoKit on iOS 17: P-256, HKDF-SHA256 and AES-GCM-256.
+/// The companion relay receives these fields but cannot open `ciphertext`.
+public struct PhoneSecretEnvelope: Codable, Equatable, Sendable {
+    public let version: Int
+    public let threadId: String
+    public let keyId: String
+    public let deviceId: String
+    public let target: String
+    public let requestKey: String
+    public let encapsulatedKey: String
+    public let ciphertext: String
+}
+
+public struct PhoneSecretRequestContext: Equatable, Sendable {
+    public let deviceId: String
+    public let botId: String
+    public let threadId: String
+    public let messageId: String
+    public let target: String
+    public let requestKey: String
+
+    public init(
+        deviceId: String,
+        botId: String,
+        threadId: String,
+        messageId: String,
+        target: String,
+        requestKey: String
+    ) {
+        self.deviceId = deviceId
+        self.botId = botId
+        self.threadId = threadId
+        self.messageId = messageId
+        self.target = target
+        self.requestKey = requestKey
+    }
+}
+
+public enum PhoneSecretCrypto {
+    public static let version = 1
+    public static let maximumCredentialBytes = 4_096
+    public static let info = "OpenMausBot phone credential v1"
+
+    /// Validate and return the canonical unpadded base64url P-256 point used
+    /// in a QR. This function deliberately works below the HPKE availability
+    /// floor so pairing/model tests can still run with CompanionCore's macOS
+    /// 13 package target; the app itself deploys to iOS 17.
+    public static func normalizedPublicKey(_ encoded: String) -> String? {
+        guard let raw = decodeBase64URL(encoded),
+              raw.count == 65,
+              raw.first == 4,
+              (try? P256.KeyAgreement.PublicKey(x963Representation: raw)) != nil,
+              encodeBase64URL(raw) == encoded
+        else { return nil }
+        return encoded
+    }
+
+    public static func publicKeyId(_ encoded: String) throws -> String {
+        guard let normalized = normalizedPublicKey(encoded),
+              let raw = decodeBase64URL(normalized)
+        else { throw PhoneSecretError.invalidPublicKey }
+        return encodeBase64URL(Data(SHA256.hash(data: raw).prefix(16)))
+    }
+
+    public static func authenticatedData(
+        keyId: String,
+        context: PhoneSecretRequestContext
+    ) throws -> Data {
+        guard isBase64URL(keyId, count: 22),
+              [context.deviceId, context.botId, context.threadId, context.messageId, context.requestKey]
+                .allSatisfy({ isRouteID($0) }),
+              isTargetID(context.target)
+        else { throw PhoneSecretError.invalidRequest }
+        return Data([
+            "openmausbot-phone-credential-v1",
+            keyId,
+            context.deviceId,
+            context.botId,
+            context.threadId,
+            context.messageId,
+            context.target,
+            context.requestKey,
+        ].joined(separator: "\n").utf8)
+    }
+
+    @available(iOS 17.0, macOS 14.0, *)
+    public static func encrypt(
+        _ rawValue: String,
+        publicKey encodedPublicKey: String,
+        context: PhoneSecretRequestContext
+    ) throws -> PhoneSecretEnvelope {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let plaintext = Data(value.utf8)
+        guard !plaintext.isEmpty, plaintext.count <= maximumCredentialBytes else {
+            throw PhoneSecretError.invalidCredential
+        }
+        guard let normalized = normalizedPublicKey(encodedPublicKey),
+              let publicKeyData = decodeBase64URL(normalized)
+        else { throw PhoneSecretError.invalidPublicKey }
+
+        do {
+            let key = try P256.KeyAgreement.PublicKey(x963Representation: publicKeyData)
+            let keyId = try publicKeyId(normalized)
+            let aad = try authenticatedData(keyId: keyId, context: context)
+            var sender = try HPKE.Sender(
+                recipientKey: key,
+                ciphersuite: .P256_SHA256_AES_GCM_256,
+                info: Data(info.utf8)
+            )
+            let ciphertext = try sender.seal(plaintext, authenticating: aad)
+            return PhoneSecretEnvelope(
+                version: version,
+                threadId: context.threadId,
+                keyId: keyId,
+                deviceId: context.deviceId,
+                target: context.target,
+                requestKey: context.requestKey,
+                encapsulatedKey: encodeBase64URL(sender.encapsulatedKey),
+                ciphertext: encodeBase64URL(ciphertext)
+            )
+        } catch let error as PhoneSecretError {
+            throw error
+        } catch {
+            throw PhoneSecretError.encryptionFailed
+        }
+    }
+
+    private static func isRouteID(_ value: String) -> Bool {
+        guard !value.isEmpty, value.utf8.count <= 128 else { return false }
+        return value.utf8.allSatisfy { byte in
+            (48...57).contains(byte) || (65...90).contains(byte) ||
+                (97...122).contains(byte) || byte == 45 || byte == 95
+        }
+    }
+
+    private static func isTargetID(_ value: String) -> Bool {
+        let bytes = Array(value.utf8)
+        guard let first = bytes.first, bytes.count <= 64,
+              (65...90).contains(first) || (97...122).contains(first)
+        else { return false }
+        return bytes.dropFirst().allSatisfy { byte in
+            (48...57).contains(byte) || (65...90).contains(byte) || (97...122).contains(byte)
+        }
+    }
+
+    private static func isBase64URL(_ value: String, count: Int) -> Bool {
+        value.utf8.count == count && value.utf8.allSatisfy { byte in
+            (48...57).contains(byte) || (65...90).contains(byte) ||
+                (97...122).contains(byte) || byte == 45 || byte == 95
+        }
+    }
+
+    private static func encodeBase64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    private static func decodeBase64URL(_ value: String) -> Data? {
+        guard !value.isEmpty,
+              value.utf8.allSatisfy({ byte in
+                  (48...57).contains(byte) || (65...90).contains(byte) ||
+                      (97...122).contains(byte) || byte == 45 || byte == 95
+              })
+        else { return nil }
+        var base64 = value.replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        base64 += String(repeating: "=", count: (4 - base64.count % 4) % 4)
+        return Data(base64Encoded: base64)
+    }
+}

--- a/ios/Tests/CompanionCoreTests/ConnectionTests.swift
+++ b/ios/Tests/CompanionCoreTests/ConnectionTests.swift
@@ -67,12 +67,21 @@ final class ConnectionTests: XCTestCase {
 
     func testParsesADesktopPairingInvite() throws {
         let token = "omb_pair_" + String(repeating: "a", count: 43)
-        let url = try XCTUnwrap(URL(string: "openmausbot://pair?address=macbook.tail1234.ts.net%3A8810&token=\(token)&code=004209&name=Milind%27s%20Mac"))
+        let secretKey = "BIPBQ12_dWnF1DZLsTZO3Vg0NGjds5-jp9h3jhjr2To7bJelczS0LM82rfXV68PmSJhz2ePosj3fL974XckCpDU"
+        let url = try XCTUnwrap(URL(string: "openmausbot://pair?address=macbook.tail1234.ts.net%3A8810&token=\(token)&code=004209&name=Milind%27s%20Mac&secretKey=\(secretKey)"))
         let invite = try XCTUnwrap(PairingInvite.parse(url))
         XCTAssertEqual(invite.connection.host, "macbook.tail1234.ts.net")
         XCTAssertEqual(invite.connection.port, 8810)
         XCTAssertEqual(invite.connection.name, "Milind's Mac")
+        XCTAssertEqual(invite.connection.secretPublicKey, secretKey)
         XCTAssertEqual(invite.credential, token)
+    }
+
+    func testRejectsAPresentButInvalidSecureEntryKey() throws {
+        let token = "omb_pair_" + String(repeating: "a", count: 43)
+        let invalid = try XCTUnwrap(URL(string:
+            "openmausbot://pair?address=mac.local&token=\(token)&secretKey=not-a-p256-key"))
+        XCTAssertNil(PairingInvite.parse(invalid))
     }
 
     func testPairingConsentShowsNormalizedOriginInsteadOfTrustingQRName() throws {
@@ -174,6 +183,8 @@ final class ConnectionTests: XCTestCase {
         XCTAssertNil(saved.hosts)
         XCTAssertNil(saved.allowedRouteKinds)
         XCTAssertNil(saved.allowedLocalRouteURLs)
+        XCTAssertNil(saved.secretPublicKey)
+        XCTAssertNil(saved.companionDeviceId)
         XCTAssertEqual(saved.orderedHosts, ["mac.tail1234.ts.net"])
     }
 

--- a/ios/Tests/CompanionCoreTests/PhoneSecretTests.swift
+++ b/ios/Tests/CompanionCoreTests/PhoneSecretTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import XCTest
+@testable import CompanionCore
+
+private final class PhoneSecretRequestStub: URLProtocol {
+    static var request: URLRequest?
+    static var body: Data?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.request = request
+        Self.body = Self.readBody(from: request)
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(#"{"provided":true,"resumed":true}"#.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func readBody(from request: URLRequest) -> Data? {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 1_024)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count >= 0 else { return nil }
+            if count == 0 { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+}
+
+final class PhoneSecretTests: XCTestCase {
+    private let publicKey = "BIPBQ12_dWnF1DZLsTZO3Vg0NGjds5-jp9h3jhjr2To7bJelczS0LM82rfXV68PmSJhz2ePosj3fL974XckCpDU"
+    private let context = PhoneSecretRequestContext(
+        deviceId: "paired-device-1",
+        botId: "bot-1",
+        threadId: "thread-1",
+        messageId: "message-1",
+        target: "ttsKey",
+        requestKey: "credential-request-1"
+    )
+
+    func testExplainsWhenCredentialTransportIsNotProtected() {
+        XCTAssertEqual(
+            PhoneSecretError.insecureTransport.errorDescription,
+            "Use secure phone access or Tailscale before sending a credential from this phone."
+        )
+    }
+
+    func testValidatesThePairingKeyAndUsesStableCrossPlatformAAD() throws {
+        XCTAssertEqual(PhoneSecretCrypto.normalizedPublicKey(publicKey), publicKey)
+        XCTAssertEqual(try PhoneSecretCrypto.publicKeyId(publicKey), "taWSR_nZ7ojlH_0Z3tar6Q")
+        XCTAssertEqual(
+            String(decoding: try PhoneSecretCrypto.authenticatedData(
+                keyId: "taWSR_nZ7ojlH_0Z3tar6Q",
+                context: context
+            ), as: UTF8.self),
+            [
+                "openmausbot-phone-credential-v1",
+                "taWSR_nZ7ojlH_0Z3tar6Q",
+                "paired-device-1",
+                "bot-1",
+                "thread-1",
+                "message-1",
+                "ttsKey",
+                "credential-request-1",
+            ].joined(separator: "\n")
+        )
+        XCTAssertNil(PhoneSecretCrypto.normalizedPublicKey(String(publicKey.dropLast())))
+    }
+
+    @available(macOS 14.0, *)
+    func testEncryptsWithoutPuttingPlaintextInTheEnvelope() throws {
+        let envelope = try PhoneSecretCrypto.encrypt(
+            "swift-secret-that-must-not-leak",
+            publicKey: publicKey,
+            context: context
+        )
+        let wire = String(decoding: try JSONEncoder().encode(envelope), as: UTF8.self)
+
+        XCTAssertEqual(envelope.version, 1)
+        XCTAssertEqual(envelope.keyId, "taWSR_nZ7ojlH_0Z3tar6Q")
+        XCTAssertEqual(Data(base64URLEncoded: envelope.encapsulatedKey)?.count, 65)
+        XCTAssertFalse(wire.contains("swift-secret-that-must-not-leak"))
+    }
+
+    func testClientPostsOnlyTheEnvelopeToTheExactCard() async throws {
+        PhoneSecretRequestStub.request = nil
+        PhoneSecretRequestStub.body = nil
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [PhoneSecretRequestStub.self]
+        let session = URLSession(configuration: configuration)
+        defer { session.invalidateAndCancel() }
+        let client = CompanionClient(
+            connection: Connection(name: "Mac", host: "127.0.0.1", port: 8810),
+            token: "paired-token",
+            session: session
+        )
+        let envelope = PhoneSecretEnvelope(
+            version: 1,
+            threadId: "thread-1",
+            keyId: "taWSR_nZ7ojlH_0Z3tar6Q",
+            deviceId: "paired-device-1",
+            target: "ttsKey",
+            requestKey: "credential-request-1",
+            encapsulatedKey: String(repeating: "A", count: 87),
+            ciphertext: String(repeating: "B", count: 32)
+        )
+
+        try await client.provideCredential(botId: "bot-1", messageId: "message-1", envelope: envelope)
+
+        XCTAssertEqual(PhoneSecretRequestStub.request?.httpMethod, "POST")
+        XCTAssertEqual(
+            PhoneSecretRequestStub.request?.url?.path,
+            "/api/bots/bot-1/secret-cards/message-1/provide"
+        )
+        XCTAssertEqual(
+            PhoneSecretRequestStub.request?.value(forHTTPHeaderField: "Authorization"),
+            "Bearer paired-token"
+        )
+        XCTAssertEqual(PhoneSecretRequestStub.request?.timeoutInterval, 115)
+        let body = try XCTUnwrap(PhoneSecretRequestStub.body)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(object["threadId"] as? String, "thread-1")
+        XCTAssertEqual(object["ciphertext"] as? String, String(repeating: "B", count: 32))
+        XCTAssertNil(object["value"])
+    }
+}
+
+private extension Data {
+    init?(base64URLEncoded value: String) {
+        var base64 = value.replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        base64 += String(repeating: "=", count: (4 - base64.count % 4) % 4)
+        self.init(base64Encoded: base64)
+    }
+}

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "control-plane:dry-run": "pnpm --filter @openmausbot/control-plane dry-run"
   },
   "dependencies": {
+    "@hpke/core": "1.9.0",
     "@trycua/cua-driver": "0.20.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.539.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hpke/core':
+        specifier: 1.9.0
+        version: 1.9.0
       '@trycua/cua-driver':
         specifier: 0.20.0
         version: 0.20.0
@@ -889,6 +892,14 @@ packages:
 
   '@fumari/image-size@0.1.0':
     resolution: {integrity: sha512-x2o9u6P8uKUK15B8XgEoRhR3PgLoLSbQKK6FUCd14JzumEw+e8FXZPelij/dZ4VQVMp4r61VD3DcvSo3aEhLAA==}
+
+  '@hpke/common@1.10.1':
+    resolution: {integrity: sha512-moJwhmtLtuxiUzzNp1jpfBfx8yefKoO9D/RCR9dmwrnc7qjJqId1rEtQz+lSlU5cabX8daToMSx/7HayXOiaFw==}
+    engines: {node: '>=16.0.0'}
+
+  '@hpke/core@1.9.0':
+    resolution: {integrity: sha512-pFxWl1nNJeQCSUFs7+GAblHvXBCjn9EPN65vdKlYQil2aURaRxfGMO6vBKGqm1YHTKwiAxJQNEI70PbSowMP9Q==}
+    engines: {node: '>=16.0.0'}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -4848,6 +4859,12 @@ snapshots:
       tailwindcss: 4.3.3
 
   '@fumari/image-size@0.1.0': {}
+
+  '@hpke/common@1.10.1': {}
+
+  '@hpke/core@1.9.0':
+    dependencies:
+      '@hpke/common': 1.10.1
 
   '@img/colour@1.1.0': {}
 

--- a/server/drivers/agents-proxy.test.ts
+++ b/server/drivers/agents-proxy.test.ts
@@ -264,8 +264,8 @@ describe("agents-proxy MCP surface", () => {
     expect(delegate.description).toContain("DEFAULT FOR ASSIGNING WORK");
     expect(delegate.description).toContain("delivered automatically");
     expect(wait.description).toContain("Never call it in the same turn as delegate_bot");
-    expect(credential.description).toContain("on mobile it only shows a handoff");
-    expect(credential.description).toContain("Never claim a secure field opened on mobile");
+    expect(credential.description).toContain("freshly QR-paired mobile app show a secure entry card");
+    expect(credential.description).toContain("Never claim a secure field opened unless this request succeeds");
   });
 
   it("publishes a flat routine schedule schema that survives provider conversion", async () => {
@@ -490,8 +490,8 @@ describe("agents-proxy MCP surface", () => {
       reason: "The selected model needs it.",
     });
     expect(res.result.content[0].text).toContain("secure OpenCode API key request");
-    expect(res.result.content[0].text).toContain("mobile app only shows a handoff");
-    expect(res.result.content[0].text).toContain("Do not claim a secure field opened on mobile");
+    expect(res.result.content[0].text).toContain("freshly QR-paired mobile app show its secure entry card");
+    expect(res.result.content[0].text).toContain("older mobile pairings explain how to pair again");
     expect(res.result.content[0].text).toContain("End this turn");
     expect(lastCredentialBody).toEqual({
       fromBotId: "bot-asker",

--- a/server/drivers/agents-proxy.ts
+++ b/server/drivers/agents-proxy.ts
@@ -324,7 +324,7 @@ const TOOLS = [
   {
     name: "request_credential",
     description:
-      "Ask the user for a supported API key through OpenMausBot's secure credential flow. On desktop this shows a secure entry card; on mobile it only shows a handoff telling the user to open the conversation on their computer, because credentials cannot be entered from the mobile app. Never claim a secure field opened on mobile, and never ask the user to paste a secret into chat. The secret is saved by the desktop app and is never returned to you. After calling this tool, end the turn; OpenMausBot resumes the task after the user saves or declines.",
+      "Ask the user for a supported API key through OpenMausBot's secure credential flow. The desktop app and a freshly QR-paired mobile app show a secure entry card; older mobile pairings show how to pair again or finish on the computer. Never claim a secure field opened unless this request succeeds, and never ask the user to paste a secret into chat. The secret is saved by the desktop app and is never returned to you. After calling this tool, end the turn; OpenMausBot resumes the task after the user saves or declines.",
     inputSchema: {
       type: "object",
       properties: {
@@ -678,7 +678,7 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
       return { text: `${r.label ?? CREDENTIAL_TARGETS[credentialId].label} is already configured. Continue the task.` };
     }
     return {
-      text: `A secure ${r.label ?? CREDENTIAL_TARGETS[credentialId].label} request is ready. The desktop app shows its secure entry card; the mobile app only shows a handoff to open this conversation on the computer and does not accept the credential. End this turn; OpenMausBot will resume the task after the user saves or declines. Do not claim a secure field opened on mobile, and never ask them to paste the key into chat.`,
+      text: `A secure ${r.label ?? CREDENTIAL_TARGETS[credentialId].label} request is ready. The desktop app and a freshly QR-paired mobile app show its secure entry card; older mobile pairings explain how to pair again or finish on the computer. End this turn; OpenMausBot will resume the task after the user saves or declines. Never ask them to paste the key into chat.`,
     };
   }
   if (name === "list_routines") {

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -6,11 +6,17 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
 import { createServer, request, type Server } from "node:http";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { DatabaseSync } from "node:sqlite";
+import {
+  Aes256Gcm,
+  CipherSuite,
+  DhkemP256HkdfSha256,
+  HkdfSha256,
+} from "@hpke/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { z } from "zod";
 
@@ -18,6 +24,11 @@ import { removeTempDir, waitForExit } from "./testing/cleanup.ts";
 import { freePortBlock } from "./testing/ports.ts";
 import { openSse } from "./testing/sse.ts";
 import { FILE_MAX_BYTES, IMAGE_MAX_BYTES } from "./attachments.ts";
+import {
+  PHONE_SECRET_INFO,
+  phoneSecretAAD,
+  type PhoneSecretContext,
+} from "./phone-secret.ts";
 
 const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(SERVER_DIR, "..");
@@ -27,6 +38,48 @@ const PORT = 18800 + Math.floor(Math.random() * 10_000);
 const BASE = `http://127.0.0.1:${PORT}`;
 const WEBHOOK_PORT = 39000 + Math.floor(Math.random() * 10_000);
 const WEBHOOK_BASE = `http://127.0.0.1:${WEBHOOK_PORT}`;
+
+const PHONE_SECRET_TEST_IDENTITY = {
+  type: "openmausbot:phone-secret-key",
+  version: 1,
+  keyId: "taWSR_nZ7ojlH_0Z3tar6Q",
+  privateKey: {
+    kty: "EC",
+    crv: "P-256",
+    x: "g8FDXb91acXUNkuxNk7dWDQ0aN2zn6On2HeOGOvZOjs",
+    y: "bJelczS0LM82rfXV68PmSJhz2ePosj3fL974XckCpDU",
+    d: "5B-SwYLGXc04u4v7YLpzFrwj2JjysBFaJevOPl3h3Zg",
+  },
+} as const;
+const phoneSecretTestSuite = new CipherSuite({
+  kem: new DhkemP256HkdfSha256(),
+  kdf: new HkdfSha256(),
+  aead: new Aes256Gcm(),
+});
+
+async function sealPhoneSecretForTest(
+  context: Omit<PhoneSecretContext, "encapsulatedKey" | "ciphertext">,
+  value: string,
+): Promise<PhoneSecretContext> {
+  const publicKey = await phoneSecretTestSuite.kem.deserializePublicKey(Buffer.concat([
+    Buffer.from([4]),
+    Buffer.from(PHONE_SECRET_TEST_IDENTITY.privateKey.x, "base64url"),
+    Buffer.from(PHONE_SECRET_TEST_IDENTITY.privateKey.y, "base64url"),
+  ]));
+  const encrypted = await phoneSecretTestSuite.seal(
+    {
+      recipientPublicKey: publicKey,
+      info: new TextEncoder().encode(PHONE_SECRET_INFO),
+    },
+    new TextEncoder().encode(value),
+    phoneSecretAAD(context),
+  );
+  return {
+    ...context,
+    encapsulatedKey: Buffer.from(encrypted.enc).toString("base64url"),
+    ciphertext: Buffer.from(encrypted.ct).toString("base64url"),
+  };
+}
 
 let child: ChildProcess;
 /** stands in for the box provider so config saving never touches the network */
@@ -3410,16 +3463,77 @@ describe("harness HTTP API", () => {
       });
       expect(requested.status).toBe(201);
       const { messageId } = (await requested.json()) as { messageId: string };
-      const directCard = (await api("GET", "/api/bots?messages=20")).body.bots
-        .find((candidate: { id: string }) => candidate.id === bot.id)?.messages
+      const directState = (await api("GET", "/api/bots?messages=20")).body.bots
+        .find((candidate: { id: string }) => candidate.id === bot.id);
+      const directCard = directState?.messages
         .find((message: { id: string }) => message.id === messageId);
       expect(directCard).toMatchObject({
         kind: "secret",
-        text: "Open this conversation in OpenMausBot on your computer to securely enter the OpenAI API key. Credential entry is not available in the mobile app.",
+        text: "Securely provide the OpenAI API key from OpenMausBot on your phone or computer. It is never added to chat.",
       });
       expect(directCard).not.toHaveProperty("from");
 
+      const encryptedEnvelope = {
+        version: 1,
+        threadId: bot.threadId,
+        keyId: "A".repeat(22),
+        deviceId: "phone-1",
+        target: "openaiImageApiKey",
+        requestKey: directCard.secret.requestKey,
+        encapsulatedKey: "A".repeat(87),
+        ciphertext: "A".repeat(23),
+      };
+      const directProvision = await fetch(
+        `${BASE}/api/bots/${bot.id}/secret-cards/${messageId}/provide`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(encryptedEnvelope),
+        },
+      );
+      expect(directProvision.status).toBe(403);
+
+      const developmentProvision = await fetch(
+        `${BASE}/api/bots/${bot.id}/secret-cards/${messageId}/provide`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-openmausbot-companion": "1",
+            "x-openmausbot-companion-device": "phone-1",
+          },
+          body: JSON.stringify(encryptedEnvelope),
+        },
+      );
+      expect(developmentProvision.status).toBe(503);
+
       expect((await api("POST", `/api/bots/${bot.id}/interrupt`)).status).toBe(200);
+      await expect.poll(async () => {
+        const current = (await api("GET", "/api/bots?messages=0")).body.bots
+          .find((candidate: { id: string }) => candidate.id === bot.id);
+        return current?.busy;
+      }).toBe(false);
+      const originalUserMessage = directState?.messages.find(
+        (message: { role?: string; kind?: string; text?: string }) =>
+          message.role === "user" && message.kind === "text" && message.text === "stay active",
+      );
+      expect(originalUserMessage?.id).toEqual(expect.any(String));
+      expect((await api("POST", `/api/bots/${bot.id}/messages/${originalUserMessage.id}/edit`, {
+        text: "take another branch",
+      })).status).toBe(202);
+      expect((await api("POST", `/api/bots/${bot.id}/secret-cards/${messageId}/dismiss`, {
+        threadId: bot.threadId,
+      })).status).toBe(404);
+      expect((await api("POST", `/api/bots/${bot.id}/interrupt`)).status).toBe(200);
+      await expect.poll(async () => {
+        const current = (await api("GET", "/api/bots?messages=0")).body.bots
+          .find((candidate: { id: string }) => candidate.id === bot.id);
+        return current?.busy;
+      }).toBe(false);
+      expect((await api("POST", `/api/bots/${bot.id}/active-branch`, {
+        messageId,
+      })).status).toBe(200);
+
       expect((await api("PATCH", `/api/bots/${bot.id}`, { computer: "cloud" })).status).toBe(200);
       expect((await api("POST", `/api/bots/${bot.id}/secret-cards/${messageId}/dismiss`, {
         threadId: bot.threadId,
@@ -3441,6 +3555,318 @@ describe("harness HTTP API", () => {
       rmSync(fakeClaudeDump, { force: true });
     }
   });
+
+  it("keeps credential-card ownership stable while an encrypted phone save is in flight", async () => {
+    const isolatedHome = mkdtempSync(join(tmpdir(), "omb-phone-secret-races-"));
+    const isolatedData = join(isolatedHome, ".openmausbot");
+    const isolatedStatic = join(isolatedHome, "static");
+    const isolatedGate = join(isolatedHome, "credential-gate");
+    const isolatedPort = await freePortBlock([0, 1]);
+    const isolatedDump = join(isolatedHome, "fake-claude-dump.json");
+    const releaseFile = join(isolatedGate, "release");
+    mkdirSync(join(isolatedStatic, "assets"), { recursive: true });
+    mkdirSync(isolatedData, { recursive: true });
+    mkdirSync(isolatedGate, { recursive: true });
+    writeFileSync(join(isolatedStatic, "index.html"), "<!doctype html><title>Phone secret race test</title>");
+    writeFileSync(join(isolatedStatic, "assets", "smoke.css"), "body{}");
+    writeFileSync(join(isolatedData, "config.json"), JSON.stringify({
+      instances: {
+        claude: { driver: "claudeAgent", displayName: "Fixture Claude", config: { cli: FAKE_CLAUDE_CLI } },
+      },
+    }));
+
+    // Model Electron's private utility-process bridge. Both encrypted saves
+    // pause after decryption, before the external credential config commit,
+    // so the public routes below exercise their real in-flight guards.
+    const desktopPrelude = `data:text/javascript,${encodeURIComponent(`
+      const { existsSync, writeFileSync } = await import("node:fs");
+      const { join } = await import("node:path");
+      const identity = ${JSON.stringify(PHONE_SECRET_TEST_IDENTITY)};
+      const gate = ${JSON.stringify(isolatedGate)};
+      const release = ${JSON.stringify(releaseFile)};
+      let listener;
+      let saves = Promise.resolve();
+      const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+      Object.defineProperty(process, "parentPort", {
+        value: {
+          on(event, callback) {
+            if (event !== "message") return;
+            listener = callback;
+            queueMicrotask(() => listener?.({ data: identity }));
+          },
+          postMessage(message) {
+            if (message?.type !== "openmausbot:phone-secret-save") return;
+            writeFileSync(join(gate, message.requestId + ".started"), message.target);
+            saves = saves.then(async () => {
+              while (!existsSync(release)) await delay(10);
+              try {
+                const patch = message.target === "openaiImageApiKey"
+                  ? { imageGen: { key: message.value } }
+                  : null;
+                if (!patch) throw new Error("unsupported test credential target");
+                const response = await fetch(
+                  "http://127.0.0.1:" + process.env.OMB_PORT + "/api/config?secretStorage=external",
+                  {
+                    method: "PUT",
+                    headers: { "content-type": "application/json" },
+                    body: JSON.stringify(patch),
+                  },
+                );
+                const body = await response.json().catch(() => null);
+                if (!response.ok) throw new Error(body?.error || "credential config failed");
+                listener?.({ data: {
+                  type: "openmausbot:phone-secret-save-result",
+                  requestId: message.requestId,
+                  ok: true,
+                } });
+              } catch (error) {
+                listener?.({ data: {
+                  type: "openmausbot:phone-secret-save-result",
+                  requestId: message.requestId,
+                  ok: false,
+                  error: error instanceof Error ? error.message : String(error),
+                } });
+              }
+            });
+          },
+        },
+      });
+    `)}`;
+    let isolatedStderr = "";
+    const isolatedChild = spawn(
+      process.execPath,
+      ["--import", desktopPrelude, join(SERVER_DIR, "index.ts")],
+      {
+        cwd: ROOT,
+        env: {
+          ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
+          ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
+          HOME: isolatedHome,
+          USERPROFILE: isolatedHome,
+          OMB_PORT: String(isolatedPort),
+          OMB_WEBHOOK_PORT: String(isolatedPort + 1),
+          OMB_STATIC_DIR: isolatedStatic,
+          FAKE_CLAUDE_MODE: "hang",
+          FAKE_CLAUDE_DUMP: isolatedDump,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    isolatedChild.stderr!.on("data", (chunk) => (isolatedStderr += chunk));
+    const isolatedApi = async (method: string, path: string, body?: unknown): Promise<{
+      status: number;
+      body: any;
+    }> => {
+      const response = await fetch(`http://127.0.0.1:${isolatedPort}${path}`, {
+        method,
+        headers: body ? { "content-type": "application/json" } : undefined,
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      return { status: response.status, body: await response.json() };
+    };
+    const requestCredential = async (
+      token: string,
+      botId: string,
+      threadId: string,
+    ): Promise<{ messageId: string }> => {
+      const response = await fetch(`http://127.0.0.1:${isolatedPort}/api/internal/request-credential`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          fromBotId: botId,
+          fromThreadId: threadId,
+          credentialId: "openaiImageApiKey",
+          reason: "needed for this task",
+        }),
+      });
+      expect(response.status).toBe(201);
+      return response.json() as Promise<{ messageId: string }>;
+    };
+    const provideRequests: Array<Promise<Response>> = [];
+    const earlyProvisionStatuses: number[] = [];
+
+    try {
+      await waitForIsolatedServer(isolatedChild, isolatedPort, () => isolatedStderr);
+      const createBot = async () => (await isolatedApi("POST", "/api/bots", {
+        modelSelection: { instanceId: "claude", model: "claude-sonnet-5" },
+        requireAvailableModel: true,
+      })).body.bot;
+      const direct = await createBot();
+      const channelOwner = await createBot();
+      const channelPeer = await createBot();
+
+      const directOriginalThread = direct.threadId as string;
+      const directAlternate = await isolatedApi("POST", `/api/bots/${direct.id}/tasks`, { title: "Alternate" });
+      expect(directAlternate.status).toBe(201);
+      expect((await isolatedApi(
+        "POST",
+        `/api/bots/${direct.id}/tasks/${directOriginalThread}`,
+      )).status).toBe(200);
+
+      const group = (await isolatedApi("POST", "/api/groups", {
+        name: "Credential ownership",
+        memberIds: [channelOwner.id, channelPeer.id],
+        setup: { bulletin: "", defaultResponder: { kind: "member", botId: channelOwner.id } },
+      })).body.group;
+      const groupOriginalThread = group.threadId as string;
+      const groupAlternate = await isolatedApi("POST", `/api/groups/${group.id}/tasks`, { title: "Alternate" });
+      expect(groupAlternate.status).toBe(201);
+      expect((await isolatedApi(
+        "POST",
+        `/api/groups/${group.id}/tasks/${groupOriginalThread}`,
+      )).status).toBe(200);
+
+      expect((await isolatedApi(
+        "POST",
+        `/api/bots/${direct.id}/messages`,
+        { text: "request a private key" },
+      )).status).toBe(202);
+      const dump = await readJsonFileWhenReady<{
+        mcpConfig: { mcpServers: { agents: { env: { OMB_COMMS_TOKEN: string } } } };
+      }>(isolatedDump);
+      const token = dump.mcpConfig.mcpServers.agents.env.OMB_COMMS_TOKEN;
+      const directRequest = await requestCredential(token, direct.id, directOriginalThread);
+      expect((await isolatedApi("POST", `/api/bots/${direct.id}/interrupt`, {})).status).toBe(200);
+      await expect.poll(async () => {
+        const state = (await isolatedApi("GET", "/api/bots?messages=0")).body;
+        return state.bots.find((bot: { id: string }) => bot.id === direct.id)?.busy;
+      }).toBe(false);
+      const groupRequest = await requestCredential(token, channelOwner.id, groupOriginalThread);
+
+      const state = (await isolatedApi("GET", "/api/bots?messages=20")).body;
+      const directState = state.bots.find((bot: { id: string }) => bot.id === direct.id);
+      const directCard = directState.messages.find(
+        (message: { id: string }) => message.id === directRequest.messageId,
+      );
+      const directUser = directState.messages.find(
+        (message: { role: string; text?: string }) => message.role === "user" && message.text === "request a private key",
+      );
+      const groupCard = state.groups
+        .find((candidate: { id: string }) => candidate.id === group.id).messages
+        .find((message: { id: string }) => message.id === groupRequest.messageId);
+      expect(directCard?.secret?.requestKey).toEqual(expect.any(String));
+      expect(directUser?.id).toEqual(expect.any(String));
+      expect(groupCard).toMatchObject({ from: { botId: channelOwner.id } });
+
+      const deviceId = "paired-phone";
+      const directEnvelope = await sealPhoneSecretForTest({
+        version: 1,
+        keyId: PHONE_SECRET_TEST_IDENTITY.keyId,
+        deviceId,
+        botId: direct.id,
+        threadId: directOriginalThread,
+        messageId: directRequest.messageId,
+        target: "openaiImageApiKey",
+        requestKey: directCard.secret.requestKey,
+      }, "sk-test-direct");
+      const groupEnvelope = await sealPhoneSecretForTest({
+        version: 1,
+        keyId: PHONE_SECRET_TEST_IDENTITY.keyId,
+        deviceId,
+        botId: channelOwner.id,
+        threadId: groupOriginalThread,
+        messageId: groupRequest.messageId,
+        target: "openaiImageApiKey",
+        requestKey: groupCard.secret.requestKey,
+      }, "sk-test-channel");
+      const provide = (botId: string, messageId: string, envelope: PhoneSecretContext) => fetch(
+        `http://127.0.0.1:${isolatedPort}/api/bots/${botId}/secret-cards/${messageId}/provide`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-openmausbot-companion": "1",
+            "x-openmausbot-companion-device": deviceId,
+          },
+          body: JSON.stringify(Object.fromEntries(
+            Object.entries(envelope).filter(([key]) => key !== "botId" && key !== "messageId"),
+          )),
+        },
+      );
+      provideRequests.push(...[
+        provide(direct.id, directRequest.messageId, directEnvelope),
+        provide(channelOwner.id, groupRequest.messageId, groupEnvelope),
+      ].map((request) => request.then((response) => {
+        earlyProvisionStatuses.push(response.status);
+        return response;
+      })));
+      await expect.poll(
+        () => ({
+          started: readdirSync(isolatedGate).filter((name) => name.endsWith(".started")).length,
+          earlyProvisionStatuses,
+        }),
+        { timeout: 20_000 },
+      ).toEqual({ started: 2, earlyProvisionStatuses: [] });
+
+      const expectLocked = async (result: Promise<{ status: number; body: any }>) => {
+        const response = await result;
+        expect(response.status).toBe(409);
+        expect(response.body.error).toMatch(/securely saving a credential/i);
+      };
+      await expectLocked(isolatedApi("POST", `/api/bots/${direct.id}/messages/${directUser.id}/edit`, {
+        text: "rewind under the save",
+      }));
+      await expectLocked(isolatedApi("POST", `/api/bots/${direct.id}/active-branch`, {
+        messageId: directRequest.messageId,
+      }));
+      await expectLocked(isolatedApi("POST", `/api/bots/${direct.id}/tasks`, { title: "Race" }));
+      await expectLocked(isolatedApi(
+        "POST",
+        `/api/bots/${direct.id}/tasks/${directAlternate.body.task.threadId}`,
+      ));
+      await expectLocked(isolatedApi("DELETE", `/api/bots/${direct.id}/tasks/${directOriginalThread}`));
+      await expectLocked(isolatedApi("DELETE", `/api/bots/${direct.id}`));
+
+      await expectLocked(isolatedApi("POST", `/api/groups/${group.id}/tasks`, { title: "Race" }));
+      await expectLocked(isolatedApi(
+        "POST",
+        `/api/groups/${group.id}/tasks/${groupAlternate.body.task.threadId}`,
+      ));
+      await expectLocked(isolatedApi("DELETE", `/api/groups/${group.id}/tasks/${groupOriginalThread}`));
+      await expectLocked(isolatedApi("PATCH", `/api/groups/${group.id}`, {
+        memberIds: [channelPeer.id],
+      }));
+      await expectLocked(isolatedApi("DELETE", `/api/groups/${group.id}`));
+      await expectLocked(isolatedApi("DELETE", `/api/bots/${channelOwner.id}`));
+      await expectLocked(isolatedApi("DELETE", `/api/bots/${channelPeer.id}`));
+
+      writeFileSync(releaseFile, "release");
+      const completed = await Promise.all(provideRequests);
+      for (const response of completed) {
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ provided: true, resumed: true });
+      }
+
+      // A lost HTTP response may replay the exact randomized envelope, but a
+      // new envelope could contain a different value and must never inherit
+      // the first save's success result.
+      const exactRetry = await provide(direct.id, directRequest.messageId, directEnvelope);
+      expect(exactRetry.status).toBe(200);
+      expect(await exactRetry.json()).toEqual({ provided: true, resumed: true });
+      const replacementEnvelope = await sealPhoneSecretForTest({
+        version: 1,
+        keyId: PHONE_SECRET_TEST_IDENTITY.keyId,
+        deviceId,
+        botId: direct.id,
+        threadId: directOriginalThread,
+        messageId: directRequest.messageId,
+        target: "openaiImageApiKey",
+        requestKey: directCard.secret.requestKey,
+      }, "sk-test-replacement");
+      const replacement = await provide(direct.id, directRequest.messageId, replacementEnvelope);
+      expect(replacement.status).toBe(409);
+      expect(await replacement.json()).toMatchObject({ error: expect.stringMatching(/already completed/i) });
+    } finally {
+      writeFileSync(releaseFile, "release");
+      await Promise.allSettled(provideRequests);
+      await waitForExit(isolatedChild, { signal: "SIGTERM" });
+      await removeTempDir(isolatedHome);
+    }
+    expectStoppedTestServerCleanly(isolatedChild, isolatedStderr);
+  }, 45_000);
 
   it("reports a failed routine once, not twice", async () => {
     // A routine reaches the same dispatch catch as an interactive turn and
@@ -5611,9 +6037,39 @@ describe("harness HTTP API", () => {
         .find((message: { id: string }) => message.id === messageId);
       expect(roomCard).toMatchObject({
         kind: "secret",
-        text: "Open this conversation in OpenMausBot on your computer to securely enter the OpenAI API key. Credential entry is not available in the mobile app.",
+        text: "Securely provide the OpenAI API key from OpenMausBot on your phone or computer. It is never added to chat.",
         from: { botId: second.id, name: second.name, color: second.color },
       });
+
+      // Every channel member shares the same thread, but the card remains
+      // owned by the member that requested it. Another member cannot dismiss
+      // it (and likewise cannot bind a phone ciphertext to itself).
+      const wrongOwner = await api("POST", `/api/bots/${first.id}/secret-cards/${messageId}/dismiss`, {
+        threadId: room.threadId,
+      });
+      expect(wrongOwner.status).toBe(404);
+      const wrongOwnerPhone = await fetch(
+        `${BASE}/api/bots/${first.id}/secret-cards/${messageId}/provide`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-openmausbot-companion": "1",
+            "x-openmausbot-companion-device": "phone-1",
+          },
+          body: JSON.stringify({
+            version: 1,
+            threadId: room.threadId,
+            keyId: "A".repeat(22),
+            deviceId: "phone-1",
+            target: "openaiImageApiKey",
+            requestKey: roomCard.secret.requestKey,
+            encapsulatedKey: "A".repeat(87),
+            ciphertext: "A".repeat(23),
+          }),
+        },
+      );
+      expect(wrongOwnerPhone.status).toBe(404);
 
       const resumed = await api("POST", `/api/bots/${second.id}/secret-cards/${messageId}/dismiss`, {
         threadId: room.threadId,

--- a/server/index.ts
+++ b/server/index.ts
@@ -287,6 +287,15 @@ import {
 } from "./request-auth.ts";
 import { formatPairingCode, SESSION_TTL_MS, SessionRegistry, type Scope } from "./sessions.ts";
 import { describeBrand, loadBrand } from "./brand.ts";
+import {
+  PHONE_SECRET_PROTOCOL_VERSION,
+  PhoneSecretBridge,
+  PhoneSecretError,
+  PhoneSecretSubmissionRegistry,
+  assertPhoneSecretRequestMatches,
+  phoneSecretOperationId,
+  type PhoneSecretContext,
+} from "./phone-secret.ts";
 
 const PORT = Number(process.env.OMB_PORT || process.env.OGB_PORT || 8799);
 const WEBHOOK_PORT = Number(process.env.OMB_WEBHOOK_PORT || PORT + 1);
@@ -353,6 +362,11 @@ type DesktopPrivateMessage = BrowserCleanupWireRequest | {
   type: "openmausbot:browser-control";
   botId: string;
   held: true;
+} | {
+  type: "openmausbot:phone-secret-save";
+  requestId: string;
+  target: string;
+  value: string;
 };
 function postDesktopPrivateMessage(message: DesktopPrivateMessage): boolean {
   if (!utilityParentPort) return false;
@@ -368,10 +382,12 @@ const browserCleanup = new BrowserCleanupCoordinator({
   file: join(DATA_DIR, "browser-cleanups.json"),
   send: postDesktopPrivateMessage,
 });
+const phoneSecrets = new PhoneSecretBridge(postDesktopPrivateMessage);
 utilityParentPort?.on("message", (event) => {
   const message = event?.data;
   try {
     if (browserCleanup.receive(message)) return;
+    if (phoneSecrets.receive(message)) return;
     if (!applyDesktopBrowserConnectionMessage(message)) composio.applyManagedBrokerMessage(message);
   } catch (error) {
     console.error(`[desktop-sync] rejected private parent message: ${error instanceof Error ? error.message : String(error)}`);
@@ -404,6 +420,16 @@ const createSidebarSectionSchema = z.object({
   botIds: z.array(z.string().regex(/^[\w-]+$/)).min(1).max(MAX_WORKSPACE_BOTS),
 }).strict();
 const createGroupTaskRequestSchema = z.object({ title: z.string().optional() });
+const phoneSecretEnvelopeSchema = z.object({
+  version: z.literal(PHONE_SECRET_PROTOCOL_VERSION),
+  threadId: z.string().regex(/^[\w-]{1,128}$/),
+  keyId: z.string().regex(/^[A-Za-z0-9_-]{22}$/),
+  deviceId: z.string().regex(/^[\w-]{1,128}$/),
+  target: z.string().regex(/^[A-Za-z][A-Za-z0-9]{0,63}$/),
+  requestKey: z.string().regex(/^[\w-]{1,128}$/),
+  encapsulatedKey: z.string().regex(/^[A-Za-z0-9_-]{87}$/),
+  ciphertext: z.string().regex(/^[A-Za-z0-9_-]{23,5483}$/),
+}).strict();
 // Resolved from the server root — see server/proxy-paths.ts. This descending
 // path happened to survive bundling, but it goes through the same anchor so
 // there is exactly one way proxies are located.
@@ -3635,7 +3661,7 @@ async function startTurn(
           ? peerRosterSystemPrompt(sectionPeers)
           : "";
       const credentialPrompt = integrations.agents
-        ? " If a supported API key is missing, use request_credential to create a secure credential request. The desktop app shows the entry card; the mobile app only shows a handoff to the computer and never accepts the credential. Never claim a secure field opened on mobile, and never ask the user to paste credentials into chat."
+        ? " If a supported API key is missing, use request_credential to create a secure credential request. A freshly QR-paired mobile app or the desktop app can show the secure entry card. Never claim it opened unless the request succeeded, and never ask the user to paste credentials into chat."
         : "";
       const routinePrompt = integrations.agents
         ? " If the user explicitly asks to list or review, schedule, run, or change routines, use list_routines and propose_routine or propose_routine_action. A proposal is not applied until the user confirms its in-app card, so never claim the action completed before that confirmation."
@@ -4571,7 +4597,7 @@ async function runGroupMemberTurn(
     group.bulletin.trim() && `Room bulletin (shared instructions for everyone):\n${group.bulletin.trim()}`,
     `Reply as yourself, briefly and conversationally. To bring a teammate in, mention them like @Name — they'll see the conversation and respond.`,
     integrations.agents &&
-      "If a supported API key is missing, use request_credential to create a secure credential request. The desktop app shows the entry card; the mobile app only shows a handoff to the computer and never accepts the credential. Never claim a secure field opened on mobile, and never ask the user to paste credentials into chat.",
+      "If a supported API key is missing, use request_credential to create a secure credential request. A freshly QR-paired mobile app or the desktop app can show the secure entry card. Never claim it opened unless the request succeeded, and never ask the user to paste credentials into chat.",
     integrations.agents &&
       "If the user explicitly asks to list or review, schedule, run, or change routines, use list_routines and propose_routine or propose_routine_action. A proposal is not applied until the user confirms its in-app card, so never claim the action completed before that confirmation.",
     skillAuthoring &&
@@ -5952,15 +5978,56 @@ type SecretResumeEntry = {
   outcome: "provided" | "dismissed";
 };
 const pendingSecretResumes = new Map<string, SecretResumeEntry>();
+const phoneSecretSubmissions = new PhoneSecretSubmissionRegistry();
+
+function claimPhoneSecretBotDeletion(botId: string): (() => void) | null {
+  const scopes = [
+    { botId },
+    ...store.groups
+      .filter((group) => group.memberIds.includes(botId))
+      .map((group) => ({ groupId: group.id })),
+  ];
+  const releases: Array<() => void> = [];
+  for (const scope of scopes) {
+    const release = phoneSecretSubmissions.claimMutation(scope);
+    if (!release) {
+      for (const undo of releases.reverse()) undo();
+      return null;
+    }
+    releases.push(release);
+  }
+  return () => {
+    for (const release of releases.reverse()) release();
+  };
+}
+
+function phoneSecretSubmissionKey(threadId: string, messageId: string, requestKey: string): string {
+  return `${threadId}:${messageId}:${requestKey}`;
+}
 
 function credentialDesktopHandoff(label: string): string {
-  return `Open this conversation in OpenMausBot on your computer to securely enter the ${label}. Credential entry is not available in the mobile app.`;
+  return `Securely provide the ${label} from OpenMausBot on your phone or computer. It is never added to chat.`;
 }
 
 function secretMessage(botId: string, threadId: string, messageId: string): Message | null {
-  if (!connectorThread(botId, threadId)) return null;
-  const message = store.messagesFor(threadId).find((candidate) => candidate.id === messageId);
+  const owner = connectorThread(botId, threadId);
+  if (!owner) return null;
+  // A credential card is actionable only while it is visible on the chosen
+  // conversation branch. In a channel, the sender attribution is also the
+  // durable owner: any member may share the thread, but only the bot that
+  // requested this credential may bind it into HPKE AAD or resume its turn.
+  const message = store.activePath(threadId).find((candidate) => candidate.id === messageId);
+  if (owner.group && message?.from?.botId !== botId) return null;
   return message?.kind === "secret" && message.secret ? message : null;
+}
+
+function currentSecretState(botId: string, threadId: string, messageId: string) {
+  const message = secretMessage(botId, threadId, messageId);
+  if (!message?.secret) return null;
+  return {
+    provided: message.secret.provided === true,
+    resumed: message.secret.resumed === true,
+  };
 }
 
 function markSecretResumeFailed(threadId: string, messageId: string, error: string) {
@@ -6049,6 +6116,102 @@ function resumeSecretCard(botId: string, threadId: string, messageId: string, ou
   });
   dispatchSecretResume({ botId, threadId, messageId, label: message.secret.label, outcome });
   return true;
+}
+
+async function provideSecretFromPhone(
+  context: PhoneSecretContext,
+  authenticatedDeviceId: string,
+): Promise<{ provided: boolean; resumed: boolean }> {
+  const owner = connectorThread(context.botId, context.threadId);
+  const message = secretMessage(context.botId, context.threadId, context.messageId);
+  if (!owner || !message?.secret) throw new PhoneSecretError("No such credential request", 404);
+  if (message.secret.dismissed) throw new PhoneSecretError("This credential request was dismissed", 409);
+  assertPhoneSecretRequestMatches(context, authenticatedDeviceId, {
+    target: message.secret.target,
+    requestKey: message.secret.requestKey,
+  });
+  const operationId = phoneSecretOperationId(context);
+  if (message.secret.phoneOperationId && message.secret.phoneOperationId !== operationId) {
+    throw new PhoneSecretError(
+      "This credential request was already completed by another submission",
+      409,
+    );
+  }
+  // The encrypted store may have committed immediately before a process
+  // interruption. Recording the winning operation precedes completing the
+  // card, so the exact retry can repair that tiny window without writing the
+  // credential again. A different randomized envelope was rejected above.
+  if (message.secret.phoneOperationId === operationId && !message.secret.provided) {
+    if (!credentialIsConfigured(cfg, message.secret.target)) {
+      throw new PhoneSecretError(`${message.secret.label} is no longer configured`, 409);
+    }
+    if (!resumeSecretCard(context.botId, context.threadId, context.messageId, "provided")) {
+      throw new PhoneSecretError("This credential request is no longer available", 409);
+    }
+    const recovered = currentSecretState(context.botId, context.threadId, context.messageId);
+    if (!recovered) throw new PhoneSecretError("This credential request is no longer available", 409);
+    return recovered;
+  }
+  if (message.secret.provided) {
+    if (message.secret.phoneOperationId !== operationId) {
+      throw new PhoneSecretError(
+        "This credential request was already completed by another submission",
+        409,
+      );
+    }
+    if (!credentialIsConfigured(cfg, message.secret.target)) {
+      throw new PhoneSecretError(`${message.secret.label} is no longer configured`, 409);
+    }
+    // A crash or older build may have committed the credential and marked
+    // the card provided without dispatching its continuation. An exact phone
+    // retry repairs that state instead of silently claiming it resumed.
+    if (!message.secret.resumed && !resumeSecretCard(
+      context.botId,
+      context.threadId,
+      context.messageId,
+      "provided",
+    )) {
+      throw new PhoneSecretError("This credential request is no longer available", 409);
+    }
+    const recovered = currentSecretState(context.botId, context.threadId, context.messageId);
+    if (!recovered) throw new PhoneSecretError("This credential request is no longer available", 409);
+    return recovered;
+  }
+
+  const submissionKey = phoneSecretSubmissionKey(context.threadId, context.messageId, context.requestKey);
+  await phoneSecretSubmissions.run({
+    cardKey: submissionKey,
+    botId: context.botId,
+    threadId: context.threadId,
+    ...(owner.group ? { groupId: owner.group.id } : {}),
+  }, operationId, async () => {
+    await phoneSecrets.provide(context);
+    const current = secretMessage(context.botId, context.threadId, context.messageId);
+    if (!current?.secret || current.secret.requestKey !== context.requestKey) {
+      throw new PhoneSecretError("This credential request is no longer available", 409);
+    }
+    if (current.secret.dismissed) {
+      throw new PhoneSecretError("This credential request was dismissed", 409);
+    }
+    // Electron acknowledges only after credentials.bin and the server's
+    // external-secret config update both commit. Keep this assertion at the
+    // boundary so a future parent handler cannot accidentally resume first.
+    if (!credentialIsConfigured(cfg, current.secret.target)) {
+      throw new PhoneSecretError(`${current.secret.label} was not saved yet`, 409);
+    }
+    // Persist the winning randomized envelope id before completing the card.
+    // A later exact retry can recover a lost response, while a newly sealed
+    // value can never be reported as though it were the value already saved.
+    store.patchMessage(context.threadId, current.id, {
+      secret: { ...current.secret, phoneOperationId: operationId },
+    });
+    if (!resumeSecretCard(context.botId, context.threadId, context.messageId, "provided")) {
+      throw new PhoneSecretError("This credential request is no longer available", 409);
+    }
+  });
+  const settled = currentSecretState(context.botId, context.threadId, context.messageId);
+  if (!settled) throw new PhoneSecretError("This credential request is no longer available", 409);
+  return settled;
 }
 
 function drainSecretResumes() {
@@ -6300,7 +6463,7 @@ function json(res: ServerResponse, status: number, body: unknown) {
   res.end(data);
 }
 
-function readBody(req: IncomingMessage): Promise<any> {
+function readBody(req: IncomingMessage, limit = 1_000_000): Promise<any> {
   return new Promise((resolve, reject) => {
     let data = "";
     let bytes = 0;
@@ -6314,7 +6477,7 @@ function readBody(req: IncomingMessage): Promise<any> {
     req.on("data", (c) => {
       if (done) return;
       bytes += typeof c === "string" ? Buffer.byteLength(c) : c.length;
-      if (bytes > 1_000_000) {
+      if (bytes > limit) {
         // Keep draining the socket, but stop retaining attacker-controlled
         // bytes. Destroying the request here prevents the caller from
         // receiving the useful 413 response.
@@ -7096,7 +7259,7 @@ const server = createServer(async (req, res) => {
         if (credentialIsConfigured(cfg, credentialId)) {
           return json(res, 200, { alreadyConfigured: true, label: target.label });
         }
-        const existing = store.messagesFor(fromThreadId).find((message) =>
+        const existing = store.activePath(fromThreadId).find((message) =>
           isReusableCredentialRequest(message, credentialId, from.id, Boolean(owner.group))
         );
         if (existing) {
@@ -8238,6 +8401,9 @@ const server = createServer(async (req, res) => {
         return json(res, 409, { error: "this channel is working or waiting on you — finish that turn first" });
       }
       const body = await readBody(req);
+      if (phoneSecretSubmissions.hasGroup(group.id)) {
+        return json(res, 409, { error: "this channel is securely saving a credential — try again when it finishes" });
+      }
       if (!body || typeof body !== "object" || Array.isArray(body)) {
         return json(res, 400, { error: "body must be a JSON object" });
       }
@@ -8255,6 +8421,9 @@ const server = createServer(async (req, res) => {
       const group = store.group(m[1]);
       if (!group) return json(res, 404, { error: "no such channel" });
       if (group.dm) return json(res, 400, { error: "bot-to-bot channels keep one canonical conversation" });
+      if (phoneSecretSubmissions.hasGroup(group.id)) {
+        return json(res, 409, { error: "this channel is securely saving a credential — try again when it finishes" });
+      }
       if (channelTaskSwitchBlocked(group, m[2])) {
         return json(res, 409, { error: "this channel is working or waiting on you in another task" });
       }
@@ -8286,6 +8455,9 @@ const server = createServer(async (req, res) => {
       const group = store.group(m[1]);
       if (!group) return json(res, 404, { error: "no such channel" });
       if (group.dm) return json(res, 400, { error: "bot-to-bot channels keep one canonical conversation" });
+      if (phoneSecretSubmissions.hasThread(m[2])) {
+        return json(res, 409, { error: "this task is securely saving a credential — try again when it finishes" });
+      }
       if (channelTaskBlocked(group)) {
         return json(res, 409, { error: "this channel is working or waiting on you — finish that turn first" });
       }
@@ -8308,6 +8480,9 @@ const server = createServer(async (req, res) => {
       }
       const existing = store.group(m[1]);
       if (!existing) return json(res, 404, { error: "no such room" });
+      if (body.memberIds !== undefined && phoneSecretSubmissions.hasGroup(existing.id)) {
+        return json(res, 409, { error: "this channel is securely saving a credential — try again when it finishes" });
+      }
       if (
         channelTaskBlocked(existing) &&
         (body.memberIds !== undefined || body.defaultResponder !== undefined || body.bulletin !== undefined)
@@ -8408,6 +8583,9 @@ const server = createServer(async (req, res) => {
     if (m && method === "DELETE") {
       const group = store.group(m[1]);
       if (!group) return json(res, 404, { error: "no such room" });
+      if (phoneSecretSubmissions.hasGroup(group.id)) {
+        return json(res, 409, { error: "this channel is securely saving a credential — try again when it finishes" });
+      }
       if (groupIsWorking(group)) {
         return json(res, 409, { error: "this channel is working — stop that turn first" });
       }
@@ -9060,7 +9238,17 @@ const server = createServer(async (req, res) => {
           error: "finish reconciling this bot's pending cloud computer creation before deleting it — check ascii.dev, then retry Box setup",
         });
       }
+      // Bot deletion awaits VM/browser/provider cleanup. Claim the bot and
+      // every channel it belongs to before that first await so a phone save
+      // cannot begin halfway through teardown (or vice versa). The computer
+      // lifecycle claim is synchronous too, so either both claims are held or
+      // neither survives this request.
       const releaseComputerLifecycle = claimBotComputerLifecycle(bot.id);
+      const releasePhoneSecretMutation = claimPhoneSecretBotDeletion(bot.id);
+      if (!releasePhoneSecretMutation) {
+        releaseComputerLifecycle();
+        return json(res, 409, { error: "this bot or one of its channels is securely saving a credential" });
+      }
       try {
         if (localVmMode(cfg) === "per-bot") {
           const target = perBotLocalVmTarget(bot.id);
@@ -9181,6 +9369,7 @@ const server = createServer(async (req, res) => {
         return json(res, 200, { ok: true });
       } finally {
         releaseComputerLifecycle();
+        releasePhoneSecretMutation();
       }
     }
 
@@ -9530,6 +9719,9 @@ const server = createServer(async (req, res) => {
       // never both get past this check: startTurn flips busy before the
       // next request is handled
       if (bot.busy) return json(res, 409, { error: "the bot is working — stop it before editing" });
+      if (phoneSecretSubmissions.hasThread(bot.threadId)) {
+        return json(res, 409, { error: "this task is securely saving a credential — try again when it finishes" });
+      }
       const source = store.messagesFor(bot.threadId).find((msg) => msg.id === messageId);
       if (!source || source.role !== "user" || source.kind !== "text") {
         return json(res, 404, { error: "only user messages can be edited" });
@@ -9554,6 +9746,9 @@ const server = createServer(async (req, res) => {
       if (!bot) return json(res, 404, { error: "no such bot" });
       if (bot.busy) return json(res, 409, { error: "the bot is working — stop it before switching versions" });
       const body = await readBody(req);
+      if (phoneSecretSubmissions.hasThread(bot.threadId)) {
+        return json(res, 409, { error: "this task is securely saving a credential — try again when it finishes" });
+      }
       const leaf = store.setActiveLeaf(bot.threadId, String(body.messageId ?? ""));
       if (!leaf) return json(res, 404, { error: "no such message" });
       // provider sessions still hold the other branch — next turn replays
@@ -9729,6 +9924,9 @@ const server = createServer(async (req, res) => {
       if (!bot) return json(res, 404, { error: "no such bot" });
       if (bot.busy) return json(res, 409, { error: "this bot is working — let it finish before starting a task" });
       const body = await readBody(req);
+      if (phoneSecretSubmissions.hasBot(bot.id)) {
+        return json(res, 409, { error: "this bot is securely saving a credential — try again when it finishes" });
+      }
       const task = store.createTask(bot.id, typeof body.title === "string" ? body.title : undefined);
       if (!task) return json(res, 500, { error: "couldn't create that task" });
       const fresh = botWithThread(store.bot(bot.id)!);
@@ -9739,6 +9937,9 @@ const server = createServer(async (req, res) => {
     if (m && method === "POST") {
       const bot = store.bot(m[1]);
       if (!bot) return json(res, 404, { error: "no such bot" });
+      if (phoneSecretSubmissions.hasBot(bot.id)) {
+        return json(res, 409, { error: "this bot is securely saving a credential — try again when it finishes" });
+      }
       // Switching the active thread while its provider turn is still running
       // loses ownership of the process and can make a later interrupt target
       // the wrong task. Keep this mutation atomic at the HTTP boundary; an
@@ -9763,6 +9964,12 @@ const server = createServer(async (req, res) => {
     }
     if (m && method === "DELETE") {
       const bot = store.bot(m[1]);
+      if (!bot || !store.taskByThread(bot.id, m[2])) {
+        return json(res, 404, { error: "no such task" });
+      }
+      if (phoneSecretSubmissions.hasThread(m[2])) {
+        return json(res, 409, { error: "this task is securely saving a credential — try again when it finishes" });
+      }
       if (bot?.busy && (bot.threadId === m[2] || routines!.isActiveThread(m[2]))) {
         return json(res, 409, { error: "this task is running — stop it first" });
       }
@@ -10743,22 +10950,61 @@ const server = createServer(async (req, res) => {
     m = path.match(/^\/api\/connectors\/([\w-]+)$/);
     if (m && method === "DELETE") return json(res, 200, await composio.removeService(cfg, m[1]));
 
-    // Inline credential cards never receive the credential value. Electron
-    // saves it through the OS-backed store first; this route only verifies
-    // configured state, updates card metadata, and resumes the paused turn.
+    // Phone credential entry arrives as an HPKE envelope bound to the exact
+    // paired device, bot, task, card and allowlisted target. The companion
+    // authenticates the bearer and supplies the device id; only the embedded
+    // Electron server has the private key needed to open the envelope.
+    m = path.match(/^\/api\/bots\/([\w-]+)\/secret-cards\/([\w-]+)\/provide$/);
+    if (m && method === "POST") {
+      if (req.headers["x-openmausbot-companion"] !== "1") {
+        return json(res, 403, { error: "Secure phone entry must come from a paired phone" });
+      }
+      const rawDeviceId = req.headers["x-openmausbot-companion-device"];
+      const authenticatedDeviceId = Array.isArray(rawDeviceId) ? "" : String(rawDeviceId ?? "");
+      if (!/^[\w-]{1,128}$/.test(authenticatedDeviceId)) {
+        return json(res, 401, { error: "This paired phone could not be verified" });
+      }
+      if (!String(req.headers["content-type"] ?? "").toLowerCase().startsWith("application/json")) {
+        return json(res, 415, { error: "content-type must be application/json" });
+      }
+      const parsed = phoneSecretEnvelopeSchema.safeParse(await readBody(req, 16_384));
+      if (!parsed.success || !isCredentialTargetId(parsed.data?.target)) {
+        return json(res, 400, { error: "The encrypted credential request is invalid" });
+      }
+      const state = await provideSecretFromPhone({
+        ...parsed.data,
+        botId: m[1],
+        messageId: m[2],
+        target: parsed.data.target,
+      }, authenticatedDeviceId);
+      return json(res, 200, state);
+    }
+
+    // Desktop credential cards never send the credential through this route.
+    // Electron saves it through the OS-backed store first; these actions only
+    // verify configured state, update card metadata, and resume the turn.
     m = path.match(/^\/api\/bots\/([\w-]+)\/secret-cards\/([\w-]+)\/(provided|resume|dismiss)$/);
     if (m && method === "POST") {
       const body = await readBody(req);
       const threadId = String(body.threadId ?? "");
       const message = secretMessage(m[1], threadId, m[2]);
       if (!message?.secret) return json(res, 404, { error: "no such credential request" });
+      if (phoneSecretSubmissions.has(
+        phoneSecretSubmissionKey(threadId, message.id, message.secret.requestKey),
+      )) {
+        return json(res, 409, { error: "this credential is currently being saved from a phone" });
+      }
       if (m[3] === "provided") {
         if (message.secret.dismissed) return json(res, 409, { error: "this credential request was dismissed" });
         if (!credentialIsConfigured(cfg, message.secret.target)) {
           return json(res, 409, { error: `${message.secret.label} was not saved yet` });
         }
-        resumeSecretCard(m[1], threadId, message.id, "provided");
-        return json(res, 200, { provided: true, resumed: true });
+        if (!resumeSecretCard(m[1], threadId, message.id, "provided")) {
+          return json(res, 409, { error: "this credential request is no longer available" });
+        }
+        const state = currentSecretState(m[1], threadId, message.id);
+        if (!state) return json(res, 409, { error: "this credential request is no longer available" });
+        return json(res, 200, state);
       }
       if (m[3] === "resume") {
         const outcome = credentialResumeOutcome(message.secret);
@@ -10768,11 +11014,19 @@ const server = createServer(async (req, res) => {
         if (outcome === "provided" && !credentialIsConfigured(cfg, message.secret.target)) {
           return json(res, 409, { error: `${message.secret.label} is no longer configured` });
         }
-        resumeSecretCard(m[1], threadId, message.id, outcome);
-        return json(res, 200, { resumed: true });
+        if (!resumeSecretCard(m[1], threadId, message.id, outcome)) {
+          return json(res, 409, { error: "this credential request is no longer available" });
+        }
+        const state = currentSecretState(m[1], threadId, message.id);
+        if (!state) return json(res, 409, { error: "this credential request is no longer available" });
+        return json(res, 200, { resumed: state.resumed });
       }
-      if (!message.secret.provided) resumeSecretCard(m[1], threadId, message.id, "dismissed");
-      return json(res, 200, { dismissed: true, resumed: true });
+      if (!message.secret.provided && !resumeSecretCard(m[1], threadId, message.id, "dismissed")) {
+        return json(res, 409, { error: "this credential request is no longer available" });
+      }
+      const state = currentSecretState(m[1], threadId, message.id);
+      if (!state) return json(res, 409, { error: "this credential request is no longer available" });
+      return json(res, 200, { dismissed: true, resumed: state.resumed });
     }
 
     // Inline connection cards are bound to both the bot and the exact task

--- a/server/phone-secret.test.ts
+++ b/server/phone-secret.test.ts
@@ -1,0 +1,334 @@
+import { createHash, webcrypto } from "node:crypto";
+
+import {
+  Aes256Gcm,
+  CipherSuite,
+  DhkemP256HkdfSha256,
+  HkdfSha256,
+} from "@hpke/core";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  PHONE_SECRET_INFO,
+  PhoneSecretBridge,
+  PhoneSecretError,
+  PhoneSecretSubmissionRegistry,
+  assertPhoneSecretRequestMatches,
+  phoneSecretAAD,
+  phoneSecretOperationId,
+  type PhoneSecretContext,
+} from "./phone-secret.ts";
+
+const suite = new CipherSuite({
+  kem: new DhkemP256HkdfSha256(),
+  kdf: new HkdfSha256(),
+  aead: new Aes256Gcm(),
+});
+
+async function keyMaterial() {
+  const pair = await webcrypto.subtle.generateKey(
+    { name: "ECDH", namedCurve: "P-256" },
+    true,
+    ["deriveBits"],
+  );
+  const raw = Buffer.from(await webcrypto.subtle.exportKey("raw", pair.publicKey));
+  const privateKey = await webcrypto.subtle.exportKey("jwk", pair.privateKey);
+  const keyId = createHash("sha256").update(raw).digest().subarray(0, 16).toString("base64url");
+  return {
+    publicKey: await suite.kem.deserializePublicKey(raw),
+    message: { type: "openmausbot:phone-secret-key", version: 1, keyId, privateKey },
+    keyId,
+  };
+}
+
+const baseContext = (keyId: string): Omit<PhoneSecretContext, "encapsulatedKey" | "ciphertext"> => ({
+  version: 1,
+  keyId,
+  deviceId: "paired-device-1",
+  botId: "bot-1",
+  threadId: "thread-1",
+  messageId: "message-1",
+  target: "ttsKey",
+  requestKey: "credential-request-1",
+});
+
+async function seal(
+  context: Omit<PhoneSecretContext, "encapsulatedKey" | "ciphertext">,
+  publicKey: CryptoKey,
+  value = "elevenlabs-secret",
+): Promise<PhoneSecretContext> {
+  const encrypted = await suite.seal(
+    { recipientPublicKey: publicKey, info: new TextEncoder().encode(PHONE_SECRET_INFO) },
+    new TextEncoder().encode(value),
+    phoneSecretAAD(context),
+  );
+  return {
+    ...context,
+    encapsulatedKey: Buffer.from(encrypted.enc).toString("base64url"),
+    ciphertext: Buffer.from(encrypted.ct).toString("base64url"),
+  };
+}
+
+describe("PhoneSecretBridge", () => {
+  it("opens an envelope produced by Apple's CryptoKit HPKE implementation", async () => {
+    let bridge!: PhoneSecretBridge;
+    const send = vi.fn((message: { requestId: string; value: string }) => {
+      expect(message.value).toBe("swift-to-node-secret");
+      queueMicrotask(() => bridge.receive({
+        type: "openmausbot:phone-secret-save-result",
+        requestId: message.requestId,
+        ok: true,
+      }));
+      return true;
+    });
+    bridge = new PhoneSecretBridge(send, 200);
+    bridge.receive({
+      type: "openmausbot:phone-secret-key",
+      version: 1,
+      keyId: "taWSR_nZ7ojlH_0Z3tar6Q",
+      privateKey: {
+        kty: "EC",
+        crv: "P-256",
+        x: "g8FDXb91acXUNkuxNk7dWDQ0aN2zn6On2HeOGOvZOjs",
+        y: "bJelczS0LM82rfXV68PmSJhz2ePosj3fL974XckCpDU",
+        d: "5B-SwYLGXc04u4v7YLpzFrwj2JjysBFaJevOPl3h3Zg",
+      },
+    });
+
+    await expect(bridge.provide({
+      version: 1,
+      keyId: "taWSR_nZ7ojlH_0Z3tar6Q",
+      deviceId: "paired-device-1",
+      botId: "bot-1",
+      threadId: "thread-1",
+      messageId: "message-1",
+      target: "ttsKey",
+      requestKey: "credential-request-1",
+      encapsulatedKey: "BDhy_5hMSvVIy3zGSmBwBECAedYBAwwFLvbWoXCGTJyLRH1cItoQXo9NBcEG0cTQV_VwaEf5judXcsJlh2jfW7Q",
+      ciphertext: "CjM0CnBT8NYd_BHAXJRKFrbYrSw6OgMIlJLAKs8VUPSSCsa2",
+    })).resolves.toBeUndefined();
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the card-bound envelope and saves through the private parent", async () => {
+    const material = await keyMaterial();
+    let bridge!: PhoneSecretBridge;
+    const send = vi.fn((message: { requestId: string; value: string; target: string }) => {
+      expect(message.value).toBe("elevenlabs-secret");
+      expect(message.target).toBe("ttsKey");
+      queueMicrotask(() => bridge.receive({
+        type: "openmausbot:phone-secret-save-result",
+        requestId: message.requestId,
+        ok: true,
+      }));
+      return true;
+    });
+    bridge = new PhoneSecretBridge(send, 200);
+    expect(bridge.receive(material.message)).toBe(true);
+
+    await expect(bridge.provide(await seal(baseContext(material.keyId), material.publicKey))).resolves.toBeUndefined();
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses metadata tampering before plaintext reaches the private parent", async () => {
+    const material = await keyMaterial();
+    const send = vi.fn(() => true);
+    const bridge = new PhoneSecretBridge(send, 50);
+    bridge.receive(material.message);
+    const envelope = await seal(baseContext(material.keyId), material.publicKey);
+
+    await expect(bridge.provide({ ...envelope, botId: "another-bot" })).rejects.toMatchObject({
+      message: "The encrypted credential could not be verified",
+    });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("requires the exact pinned desktop key", async () => {
+    const material = await keyMaterial();
+    const bridge = new PhoneSecretBridge(() => true, 50);
+    bridge.receive(material.message);
+    const envelope = await seal(baseContext(material.keyId), material.publicKey);
+
+    await expect(bridge.provide({
+      ...envelope,
+      keyId: "AAAAAAAAAAAAAAAAAAAAAA",
+    })).rejects.toMatchObject({ status: 409 });
+  });
+
+  it("fails closed when no embedded Electron parent supplied a key", async () => {
+    const bridge = new PhoneSecretBridge(() => true, 50);
+    await expect(bridge.provide({
+      ...baseContext("AAAAAAAAAAAAAAAAAAAAAA"),
+      encapsulatedKey: "A".repeat(87),
+      ciphertext: "A".repeat(24),
+    })).rejects.toEqual(expect.objectContaining<Partial<PhoneSecretError>>({ status: 503 }));
+  });
+
+  it("rejects a private scalar that does not match the advertised public point", async () => {
+    const material = await keyMaterial();
+    const other = await keyMaterial();
+    const bridge = new PhoneSecretBridge(() => true, 50);
+    bridge.receive({
+      ...material.message,
+      privateKey: {
+        ...material.message.privateKey,
+        d: other.message.privateKey.d,
+      },
+    });
+
+    await expect(bridge.provide({
+      ...baseContext(material.keyId),
+      encapsulatedKey: "A".repeat(87),
+      ciphertext: "A".repeat(24),
+    })).rejects.toMatchObject({ status: 503 });
+  });
+
+  it("turns a private-store refusal into a bounded client error", async () => {
+    const material = await keyMaterial();
+    let bridge!: PhoneSecretBridge;
+    bridge = new PhoneSecretBridge((message) => {
+      queueMicrotask(() => bridge.receive({
+        type: "openmausbot:phone-secret-save-result",
+        requestId: message.requestId,
+        ok: false,
+        error: "The operating-system credential store is unavailable",
+      }));
+      return true;
+    }, 200);
+    bridge.receive(material.message);
+
+    await expect(bridge.provide(await seal(baseContext(material.keyId), material.publicKey))).rejects.toMatchObject({
+      status: 503,
+      message: "The operating-system credential store is unavailable",
+    });
+  });
+
+  it("bounds the entire decrypt-and-save operation under concurrent load", async () => {
+    const material = await keyMaterial();
+    const envelope = await seal(baseContext(material.keyId), material.publicKey);
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => { markStarted = resolve; });
+    let firstRequestId = "";
+    const bridge = new PhoneSecretBridge((message) => {
+      firstRequestId = message.requestId;
+      markStarted();
+      return true;
+    }, 200, 1);
+    bridge.receive(material.message);
+
+    const first = bridge.provide(envelope);
+    await started;
+    await expect(bridge.provide(envelope)).rejects.toMatchObject({ status: 429 });
+    bridge.receive({
+      type: "openmausbot:phone-secret-save-result",
+      requestId: firstRequestId,
+      ok: true,
+    });
+    await expect(first).resolves.toBeUndefined();
+  });
+});
+
+describe("phoneSecretAAD", () => {
+  it("has the exact stable cross-platform serialization", () => {
+    expect(new TextDecoder().decode(phoneSecretAAD(baseContext("AAAAAAAAAAAAAAAAAAAAAA")))).toBe([
+      "openmausbot-phone-credential-v1",
+      "AAAAAAAAAAAAAAAAAAAAAA",
+      "paired-device-1",
+      "bot-1",
+      "thread-1",
+      "message-1",
+      "ttsKey",
+      "credential-request-1",
+    ].join("\n"));
+  });
+
+  it("binds an envelope to the authenticated phone and pending card", () => {
+    const context = baseContext("AAAAAAAAAAAAAAAAAAAAAA");
+    expect(() => assertPhoneSecretRequestMatches(context, "paired-device-1", {
+      target: "ttsKey",
+      requestKey: "credential-request-1",
+    })).not.toThrow();
+    for (const candidate of [
+      { ...context, deviceId: "another-device" },
+      { ...context, target: "xaiApiKey" },
+      { ...context, requestKey: "another-request" },
+    ]) {
+      expect(() => assertPhoneSecretRequestMatches(candidate, "paired-device-1", {
+        target: "ttsKey",
+        requestKey: "credential-request-1",
+      })).toThrow(expect.objectContaining({ status: 409 }));
+    }
+  });
+
+  it("gives an exact encrypted retry one stable desktop operation id", async () => {
+    const material = await keyMaterial();
+    const envelope = await seal(baseContext(material.keyId), material.publicKey);
+    const operationId = phoneSecretOperationId(envelope);
+    expect(operationId).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(phoneSecretOperationId({ ...envelope })).toBe(operationId);
+    expect(phoneSecretOperationId({
+      ...envelope,
+      ciphertext: `${envelope.ciphertext.slice(0, -1)}${envelope.ciphertext.endsWith("A") ? "B" : "A"}`,
+    })).not.toBe(operationId);
+  });
+});
+
+describe("PhoneSecretSubmissionRegistry", () => {
+  it("joins only an exact retry and locks the card transition until commit", async () => {
+    const registry = new PhoneSecretSubmissionRegistry();
+    const scope = {
+      cardKey: "thread:message:request",
+      botId: "bot-1",
+      threadId: "thread-1",
+      groupId: "group-1",
+    };
+    let release!: () => void;
+    const blocked = new Promise<void>((resolve) => { release = resolve; });
+    const work = vi.fn(async () => { await blocked; });
+    const duplicateWork = vi.fn(async () => {});
+
+    const first = registry.run(scope, "operation-1", work);
+    await vi.waitFor(() => expect(work).toHaveBeenCalledTimes(1));
+    expect(registry.has("thread:message:request")).toBe(true);
+    expect(registry.hasBot("bot-1")).toBe(true);
+    expect(registry.hasThread("thread-1")).toBe(true);
+    expect(registry.hasGroup("group-1")).toBe(true);
+    expect(registry.claimMutation({ botId: "bot-1" })).toBeNull();
+    expect(registry.claimMutation({ threadId: "thread-1" })).toBeNull();
+    expect(registry.claimMutation({ groupId: "group-1" })).toBeNull();
+    const exactRetry = registry.run(scope, "operation-1", duplicateWork);
+    await expect(registry.run(
+      scope,
+      "operation-2",
+      duplicateWork,
+    )).rejects.toMatchObject({ status: 409 });
+    expect(duplicateWork).not.toHaveBeenCalled();
+
+    release();
+    await expect(Promise.all([first, exactRetry])).resolves.toEqual([undefined, undefined]);
+    expect(registry.has("thread:message:request")).toBe(false);
+    expect(registry.hasBot("bot-1")).toBe(false);
+    expect(registry.hasThread("thread-1")).toBe(false);
+    expect(registry.hasGroup("group-1")).toBe(false);
+  });
+
+  it("refuses a submission while an overlapping structural mutation is claimed", async () => {
+    const registry = new PhoneSecretSubmissionRegistry();
+    const release = registry.claimMutation({ threadId: "thread-1" });
+    expect(release).toBeTypeOf("function");
+    expect(registry.claimMutation({ threadId: "thread-1" })).toBeNull();
+
+    await expect(registry.run({
+      cardKey: "thread:message:request",
+      botId: "bot-1",
+      threadId: "thread-1",
+    }, "operation-1", async () => {})).rejects.toMatchObject({ status: 409 });
+
+    release?.();
+    await expect(registry.run({
+      cardKey: "thread:message:request",
+      botId: "bot-1",
+      threadId: "thread-1",
+    }, "operation-1", async () => {})).resolves.toBeUndefined();
+  });
+});

--- a/server/phone-secret.ts
+++ b/server/phone-secret.ts
@@ -1,0 +1,464 @@
+import { createECDH, createHash, type webcrypto } from "node:crypto";
+
+import {
+  Aes256Gcm,
+  CipherSuite,
+  DhkemP256HkdfSha256,
+  HkdfSha256,
+} from "@hpke/core";
+
+export const PHONE_SECRET_PROTOCOL_VERSION = 1 as const;
+export const PHONE_SECRET_INFO = "OpenMausBot phone credential v1";
+export const PHONE_SECRET_MAX_BYTES = 4_096;
+
+const BASE64URL = /^[A-Za-z0-9_-]+$/;
+const ROUTE_ID = /^[\w-]{1,128}$/;
+const TARGET_ID = /^[A-Za-z][A-Za-z0-9]{0,63}$/;
+
+export interface PhoneSecretEnvelope {
+  version: 1;
+  keyId: string;
+  deviceId: string;
+  target: string;
+  requestKey: string;
+  encapsulatedKey: string;
+  ciphertext: string;
+}
+
+export interface PhoneSecretContext extends PhoneSecretEnvelope {
+  botId: string;
+  threadId: string;
+  messageId: string;
+}
+
+interface PhoneSecretIdentity {
+  keyId: string;
+  privateKey: CryptoKey;
+}
+
+type SendPrivateMessage = (message: {
+  type: "openmausbot:phone-secret-save";
+  requestId: string;
+  target: string;
+  value: string;
+}) => boolean;
+
+type PendingSave = {
+  resolve: () => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+export class PhoneSecretError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status = 400) {
+    super(message);
+    this.name = "PhoneSecretError";
+    this.status = status;
+  }
+}
+
+const suite = new CipherSuite({
+  kem: new DhkemP256HkdfSha256(),
+  kdf: new HkdfSha256(),
+  aead: new Aes256Gcm(),
+});
+const INFO = new TextEncoder().encode(PHONE_SECRET_INFO);
+
+const decodeBase64URL = (value: unknown, expectedBytes?: number): Uint8Array | null => {
+  if (typeof value !== "string" || !BASE64URL.test(value)) return null;
+  try {
+    const decoded = Buffer.from(value, "base64url");
+    if (
+      (expectedBytes !== undefined && decoded.length !== expectedBytes) ||
+      decoded.toString("base64url") !== value
+    ) {
+      return null;
+    }
+    return decoded;
+  } catch {
+    return null;
+  }
+};
+
+export function phoneSecretKeyIdFromJwk(jwk: webcrypto.JsonWebKey): string | null {
+  const x = decodeBase64URL(jwk.x, 32);
+  const y = decodeBase64URL(jwk.y, 32);
+  if (!x || !y) return null;
+  return createHash("sha256")
+    .update(Buffer.concat([Buffer.from([4]), x, y]))
+    .digest()
+    .subarray(0, 16)
+    .toString("base64url");
+}
+
+/** A single canonical string is used by Swift and TypeScript. Every dynamic
+ * field is route-safe ASCII and therefore cannot contain the newline
+ * separator. Authenticating this metadata prevents a relay from moving one
+ * ciphertext to another bot, conversation, card, device, or credential. */
+export function phoneSecretAAD(context: Pick<
+  PhoneSecretContext,
+  "keyId" | "deviceId" | "botId" | "threadId" | "messageId" | "target" | "requestKey"
+>): Uint8Array {
+  const fields = [
+    "openmausbot-phone-credential-v1",
+    context.keyId,
+    context.deviceId,
+    context.botId,
+    context.threadId,
+    context.messageId,
+    context.target,
+    context.requestKey,
+  ];
+  if (
+    !/^[A-Za-z0-9_-]{22}$/.test(context.keyId) ||
+    !fields.slice(2, 6).every((value) => ROUTE_ID.test(value)) ||
+    !TARGET_ID.test(context.target) ||
+    !ROUTE_ID.test(context.requestKey)
+  ) {
+    throw new PhoneSecretError("The credential request metadata is invalid");
+  }
+  return new TextEncoder().encode(fields.join("\n"));
+}
+
+/**
+ * A stable, non-secret operation id for one exact HPKE envelope. Electron
+ * uses it to join a retry whose HTTP response was lost instead of validating
+ * and writing the same credential twice. A freshly encrypted submission has
+ * a different encapsulated key/ciphertext and therefore a different id.
+ */
+export function phoneSecretOperationId(context: PhoneSecretContext): string {
+  const aad = phoneSecretAAD(context);
+  return createHash("sha256")
+    .update(aad)
+    .update("\0")
+    .update(String(context.version))
+    .update("\n")
+    .update(context.encapsulatedKey)
+    .update("\n")
+    .update(context.ciphertext)
+    .digest("base64url");
+}
+
+export function assertPhoneSecretRequestMatches(
+  context: Pick<PhoneSecretContext, "deviceId" | "target" | "requestKey">,
+  authenticatedDeviceId: string,
+  expected: { target: string; requestKey: string },
+): void {
+  if (
+    context.deviceId !== authenticatedDeviceId ||
+    context.target !== expected.target ||
+    context.requestKey !== expected.requestKey
+  ) {
+    throw new PhoneSecretError("This encrypted credential does not belong to this request", 409);
+  }
+}
+
+/** Serializes the state transition for one pending credential card. Exact
+ * retransmissions join the original operation; a separately encrypted value
+ * cannot be mistaken for that retry, and callers can block dismiss/resume
+ * while the operating-system store is committing. */
+export class PhoneSecretSubmissionRegistry {
+  private readonly active = new Map<
+    string,
+    {
+      operationId: string;
+      promise: Promise<void>;
+      resources: ReadonlySet<string>;
+    }
+  >();
+  private readonly mutations = new Set<string>();
+
+  private resources(scope: {
+    botId?: string;
+    threadId?: string;
+    groupId?: string;
+  }): Set<string> {
+    return new Set([
+      ...(scope.botId ? [`bot:${scope.botId}`] : []),
+      ...(scope.threadId ? [`thread:${scope.threadId}`] : []),
+      ...(scope.groupId ? [`group:${scope.groupId}`] : []),
+    ]);
+  }
+
+  private hasActiveResource(resources: ReadonlySet<string>): boolean {
+    return [...this.active.values()].some((entry) =>
+      [...resources].some((resource) => entry.resources.has(resource))
+    );
+  }
+
+  has(cardKey: string): boolean {
+    return this.active.has(cardKey);
+  }
+
+  hasBot(botId: string): boolean {
+    return this.hasActiveResource(this.resources({ botId }));
+  }
+
+  hasThread(threadId: string): boolean {
+    return this.hasActiveResource(this.resources({ threadId }));
+  }
+
+  hasGroup(groupId: string): boolean {
+    return this.hasActiveResource(this.resources({ groupId }));
+  }
+
+  /** Claim a structural mutation before its first await. A submission and a
+   * destructive/rewind mutation can then never both pass their preflight
+   * checks and invalidate each other while the OS credential store is slow. */
+  claimMutation(scope: {
+    botId?: string;
+    threadId?: string;
+    groupId?: string;
+  }): (() => void) | null {
+    const resources = this.resources(scope);
+    if (
+      resources.size === 0 ||
+      this.hasActiveResource(resources) ||
+      [...resources].some((resource) => this.mutations.has(resource))
+    ) {
+      return null;
+    }
+    for (const resource of resources) this.mutations.add(resource);
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      for (const resource of resources) this.mutations.delete(resource);
+    };
+  }
+
+  async run(
+    scope: { cardKey: string; botId: string; threadId: string; groupId?: string },
+    operationId: string,
+    work: () => Promise<void>,
+  ): Promise<void> {
+    const running = this.active.get(scope.cardKey);
+    if (running) {
+      if (running.operationId !== operationId) {
+        throw new PhoneSecretError("Another credential submission is already being saved", 409);
+      }
+      await running.promise;
+      return;
+    }
+
+    const resources = this.resources(scope);
+    if ([...resources].some((resource) => this.mutations.has(resource))) {
+      throw new PhoneSecretError("This credential request is being changed. Try again.", 409);
+    }
+
+    // Deferring work by one microtask lets the registry publish the active
+    // entry before decrypt/save begins, so no synchronous callback can slip a
+    // competing state transition through the gap.
+    const promise = Promise.resolve().then(work);
+    const entry = { operationId, promise, resources };
+    this.active.set(scope.cardKey, entry);
+    try {
+      await promise;
+    } finally {
+      if (this.active.get(scope.cardKey) === entry) this.active.delete(scope.cardKey);
+    }
+  }
+}
+
+async function importIdentity(message: Record<string, unknown>): Promise<PhoneSecretIdentity> {
+  if (message.version !== PHONE_SECRET_PROTOCOL_VERSION) {
+    throw new PhoneSecretError("The desktop credential key version is unsupported", 503);
+  }
+  const keyId = String(message.keyId ?? "");
+  const candidate = message.privateKey;
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+    throw new PhoneSecretError("The desktop credential key is unavailable", 503);
+  }
+  const privateKey = candidate as webcrypto.JsonWebKey;
+  const x = decodeBase64URL(privateKey.x, 32);
+  const y = decodeBase64URL(privateKey.y, 32);
+  const d = decodeBase64URL(privateKey.d, 32);
+  if (
+    privateKey.kty !== "EC" ||
+    privateKey.crv !== "P-256" ||
+    !x ||
+    !y ||
+    !d ||
+    phoneSecretKeyIdFromJwk(privateKey) !== keyId
+  ) {
+    throw new PhoneSecretError("The desktop credential key is invalid", 503);
+  }
+  try {
+    const ecdh = createECDH("prime256v1");
+    ecdh.setPrivateKey(d);
+    if (!ecdh.getPublicKey(undefined, "uncompressed").equals(
+      Buffer.concat([Buffer.from([4]), x, y]),
+    )) {
+      throw new Error("mismatched public point");
+    }
+  } catch {
+    throw new PhoneSecretError("The desktop credential key is invalid", 503);
+  }
+  const imported = await suite.kem.importKey("jwk", {
+    kty: "EC",
+    crv: "P-256",
+    x: privateKey.x,
+    y: privateKey.y,
+    d: privateKey.d,
+    ext: true,
+    key_ops: ["deriveBits"],
+  }, false);
+  return { keyId, privateKey: imported };
+}
+
+function decodeSaveResult(raw: unknown): { requestId: string; ok: boolean; error?: string } | null {
+  const message = (raw as { data?: unknown } | null)?.data ?? raw;
+  if (!message || typeof message !== "object" || Array.isArray(message)) return null;
+  const value = message as Record<string, unknown>;
+  if (value.type !== "openmausbot:phone-secret-save-result") return null;
+  if (typeof value.requestId !== "string" || !ROUTE_ID.test(value.requestId) || typeof value.ok !== "boolean") {
+    return null;
+  }
+  return {
+    requestId: value.requestId,
+    ok: value.ok,
+    ...(typeof value.error === "string" ? { error: value.error.slice(0, 180) } : {}),
+  };
+}
+
+/**
+ * Owns the narrow private bridge between the embedded server and Electron's
+ * OS-encrypted credential document. The phone-facing HTTP route gives this
+ * class ciphertext only. Plaintext exists only after HPKE opens it on the
+ * desktop and is immediately handed to the already-existing credential save
+ * path; it is never returned to HTTP, chat, SQLite, SSE, or logs.
+ */
+export class PhoneSecretBridge {
+  private identity: Promise<PhoneSecretIdentity> | null = null;
+  private readonly pending = new Map<string, PendingSave>();
+  private active = 0;
+  private readonly send: SendPrivateMessage;
+  private readonly timeoutMs: number;
+  private readonly maximumPending: number;
+
+  constructor(
+    send: SendPrivateMessage,
+    // Provider validation is part of the encrypted-store transaction and can
+    // legitimately take tens of seconds. This remains bounded, but outlives
+    // every provider's own deadline so a late successful save is not reported
+    // as a failure and then repeated underneath the user.
+    // Stay materially below the outer HTTPS proxy and phone deadlines. This
+    // leaves enough time for their JSON response to travel after a slow
+    // provider validation instead of turning a committed save into a client
+    // timeout at Cloudflare's boundary.
+    timeoutMs = 90_000,
+    maximumPending = 8,
+  ) {
+    this.send = send;
+    this.timeoutMs = timeoutMs;
+    this.maximumPending = maximumPending;
+  }
+
+  receive(raw: unknown): boolean {
+    const message = (raw as { data?: unknown } | null)?.data ?? raw;
+    if (!message || typeof message !== "object" || Array.isArray(message)) return false;
+    const record = message as Record<string, unknown>;
+    if (record.type === "openmausbot:phone-secret-key") {
+      // Keep the rejection inside the promise. A request receives a bounded
+      // 503; an invalid parent message must never become an unhandled reject.
+      this.identity = importIdentity(record);
+      void this.identity.catch(() => {});
+      return true;
+    }
+    const result = decodeSaveResult(record);
+    if (!result) return false;
+    const pending = this.pending.get(result.requestId);
+    if (!pending) return true;
+    this.pending.delete(result.requestId);
+    clearTimeout(pending.timer);
+    if (result.ok) pending.resolve();
+    else pending.reject(new PhoneSecretError(result.error || "The credential could not be saved", 503));
+    return true;
+  }
+
+  async provide(context: PhoneSecretContext): Promise<void> {
+    if (this.active >= this.maximumPending) {
+      throw new PhoneSecretError("Another secure credential is still being saved. Try again.", 429);
+    }
+    this.active += 1;
+    try {
+      await this.provideWithinLimit(context);
+    } finally {
+      this.active -= 1;
+    }
+  }
+
+  private async provideWithinLimit(context: PhoneSecretContext): Promise<void> {
+    if (!this.identity) {
+      throw new PhoneSecretError(
+        "Secure phone entry is not ready on this computer. Reopen OpenMausBot and try again.",
+        503,
+      );
+    }
+    const identity = await this.identity.catch(() => {
+      throw new PhoneSecretError(
+        "Secure phone entry is not ready on this computer. Reopen OpenMausBot and try again.",
+        503,
+      );
+    });
+    if (context.version !== PHONE_SECRET_PROTOCOL_VERSION || context.keyId !== identity.keyId) {
+      throw new PhoneSecretError("This phone was paired with an older security key. Pair it again by QR code.", 409);
+    }
+
+    const encapsulatedKey = decodeBase64URL(context.encapsulatedKey, 65);
+    const ciphertext = decodeBase64URL(context.ciphertext);
+    if (
+      !encapsulatedKey ||
+      !ciphertext ||
+      ciphertext.length <= 16 ||
+      ciphertext.length > PHONE_SECRET_MAX_BYTES + 16
+    ) {
+      throw new PhoneSecretError("The encrypted credential is invalid");
+    }
+
+    let opened: ArrayBuffer;
+    try {
+      opened = await suite.open(
+        { recipientKey: identity.privateKey, enc: encapsulatedKey, info: INFO },
+        ciphertext,
+        phoneSecretAAD(context),
+      );
+    } catch {
+      throw new PhoneSecretError("The encrypted credential could not be verified");
+    }
+
+    const openedBytes = new Uint8Array(opened);
+    let value: string;
+    try {
+      value = new TextDecoder("utf-8", { fatal: true }).decode(openedBytes).trim();
+    } catch {
+      throw new PhoneSecretError("The encrypted credential is not valid text");
+    } finally {
+      openedBytes.fill(0);
+    }
+    if (!value || Buffer.byteLength(value) > PHONE_SECRET_MAX_BYTES) {
+      throw new PhoneSecretError("The credential must be between 1 and 4096 bytes");
+    }
+
+    const requestId = phoneSecretOperationId(context);
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(requestId);
+        reject(new PhoneSecretError("The operating-system credential store did not respond. Try again.", 504));
+      }, this.timeoutMs);
+      timer.unref?.();
+      this.pending.set(requestId, { resolve, reject, timer });
+      if (this.send({
+        type: "openmausbot:phone-secret-save",
+        requestId,
+        target: context.target,
+        value,
+      })) return;
+      clearTimeout(timer);
+      this.pending.delete(requestId);
+      reject(new PhoneSecretError("Secure phone entry is unavailable in this build.", 503));
+    });
+  }
+}

--- a/server/store.ts
+++ b/server/store.ts
@@ -86,6 +86,9 @@ export interface SecretRequestCardData {
   placeholder: string;
   helpUrl: string;
   requestKey: string;
+  /** Exact successful HPKE operation. This contains no plaintext and prevents
+   * a freshly sealed value from being mistaken for a lost-response retry. */
+  phoneOperationId?: string;
   provided?: boolean;
   dismissed?: boolean;
   resumed?: boolean;

--- a/src/components/PhoneSetupFlow.tsx
+++ b/src/components/PhoneSetupFlow.tsx
@@ -78,6 +78,7 @@ export interface CompanionState {
   lan?: string | null;
   hosts?: string[];
   endpoints?: CompanionEndpoint[];
+  secretPublicKey?: string;
   discovery?: { advertising: boolean; name: string };
   error?: string;
 }
@@ -790,6 +791,7 @@ export function usePhoneSetupController(profileEmail = ""): PhoneSetupController
       code: state.pairing.code,
       token: state.pairing.token,
       name: state.discovery?.name,
+      secretPublicKey: state.secretPublicKey,
     });
   }, [pairingRoute, state]);
 

--- a/src/lib/companion-pairing.test.ts
+++ b/src/lib/companion-pairing.test.ts
@@ -8,6 +8,7 @@ import {
 
 describe("companionPairingLink", () => {
   const token = `omb_pair_${"a".repeat(43)}`;
+  const secretPublicKey = "BIPBQ12_dWnF1DZLsTZO3Vg0NGjds5-jp9h3jhjr2To7bJelczS0LM82rfXV68PmSJhz2ePosj3fL974XckCpDU";
 
   const decodedEndpoints = (link: string) => {
     const encoded = new URL(link).searchParams.get("endpoints");
@@ -23,6 +24,7 @@ describe("companionPairingLink", () => {
       code: "004209",
       token,
       name: "Milind's Mac",
+      secretPublicKey,
     });
 
     const url = new URL(link!);
@@ -32,6 +34,15 @@ describe("companionPairingLink", () => {
     expect(url.searchParams.get("token")).toBe(token);
     expect(url.searchParams.get("code")).toBe("004209");
     expect(url.searchParams.get("name")).toBe("Milind's Mac");
+    expect(url.searchParams.get("secretKey")).toBe(secretPublicKey);
+  });
+
+  it("omits malformed secure-entry keys instead of advertising an unusable key", () => {
+    const base = { address: "mac.local", port: 8810, code: "123456", token };
+    expect(new URL(companionPairingLink({ ...base, secretPublicKey: secretPublicKey.slice(1) })!)
+      .searchParams.get("secretKey")).toBeNull();
+    expect(new URL(companionPairingLink({ ...base, secretPublicKey: `A${secretPublicKey.slice(1)}` })!)
+      .searchParams.get("secretKey")).toBeNull();
   });
 
   it("refuses to make a link from an invalid pairing window", () => {

--- a/src/lib/companion-pairing.ts
+++ b/src/lib/companion-pairing.ts
@@ -12,6 +12,9 @@ interface CompanionPairingLinkOptions {
   /** Complete base URLs for current mobile builds. Encoded separately from
    * the legacy address/hosts fields so HTTPS and port 443 stay unambiguous. */
   endpoints?: CompanionEndpoint[];
+  /** P-256 HPKE recipient key pinned by the camera scan. Its private half
+   * remains in the desktop's OS-encrypted credential store. */
+  secretPublicKey?: string;
 }
 
 export type CompanionEndpointKind = "hosted" | "tailnet" | "lan" | "bonjour";
@@ -286,6 +289,22 @@ function encodeEndpoints(endpoints: CompanionEndpoint[]): string {
   return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
 }
 
+function validSecretPublicKey(value: string | undefined): string | null {
+  if (!value || !/^[A-Za-z0-9_-]{87}$/.test(value)) return null;
+  try {
+    const base64 = value.replaceAll("-", "+").replaceAll("_", "/") + "=";
+    const decoded = atob(base64);
+    if (decoded.length !== 65 || decoded.charCodeAt(0) !== 4) return null;
+    let binary = "";
+    for (let index = 0; index < decoded.length; index += 1) binary += decoded[index];
+    return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "") === value
+      ? value
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * A short-lived handoff from the trusted desktop pairing panel to the mobile
  * app. The code still has to be redeemed with the companion; putting it in
@@ -299,6 +318,7 @@ export function companionPairingLink({
   name,
   hosts,
   endpoints,
+  secretPublicKey,
 }: CompanionPairingLinkOptions): string | null {
   const host = address.trim();
   if (
@@ -329,5 +349,7 @@ export function companionPairingLink({
   if (candidates.length) url.searchParams.set("hosts", candidates.join(","));
   const routes = qrEndpoints(endpoints);
   if (routes.length) url.searchParams.set("endpoints", encodeEndpoints(routes));
+  const secretKey = validSecretPublicKey(secretPublicKey);
+  if (secretKey) url.searchParams.set("secretKey", secretKey);
   return url.toString();
 }

--- a/third_party/hpke-js/common-LICENSE.txt
+++ b/third_party/hpke-js/common-LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Ajitomi Daisuke
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/hpke-js/core-LICENSE.txt
+++ b/third_party/hpke-js/core-LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Ajitomi Daisuke
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- Add a native masked credential field to pending iOS credential cards, with provider-neutral Password AutoFill for Apple Passwords, 1Password, Bitwarden, or paste.
- Pin a stable per-desktop P-256 public key in the pairing QR and encrypt each value on the phone with RFC 9180 HPKE.
- Bind ciphertext to the authenticated paired device and exact bot, active thread branch, card, target, and one-time request.
- Keep the relay and companion sidecar ciphertext-only; decrypt only inside the paired packaged desktop and commit through the existing OS-encrypted credential store.
- Allow credential submission only over hosted HTTPS or Tailscale so both the HPKE-encrypted value and reusable phone token are protected. Local Wi-Fi pairing remains available for chat and approvals.
- Clear the native plaintext field immediately after local encryption while preserving Password AutoFill/Face ID behavior. Interrupted requests retain only the exact ciphertext in memory for an idempotent retry.
- Record the exact winning encrypted operation on the card. Lost-response retries recover safely; a newly encrypted replacement can never inherit an earlier save's success.
- Lock bot, channel, task, and branch mutations during the narrow desktop save transaction so card ownership cannot change under a credential write.
- Preserve chat compatibility for old/manual pairings while asking them to scan one fresh QR before phone credential entry.
- Update privacy, App Store, companion, licensing, and rollout documentation.

## Product decision

This does not add a 1Password SDK, subscription, provider account, or OpenMausBot phone vault. It uses the standard iOS Password AutoFill surface, so Apple Passwords/iCloud Keychain works out of the box and third-party providers remain optional.

## Verification

- 320 Swift tests pass.
- All 158 server HTTP API tests pass, including isolated end-to-end HPKE save, retry, ownership, and mutation-race coverage.
- The iOS app, widgets, and Share extension build successfully for the simulator.
- Focused sidecar, server, credential transport, Electron identity, malformed-key, and off-curve-key tests pass.
- Typecheck, production build, companion build, Electron tests, lint, diff check, and production dependency audit pass.
- Two independent final correctness/security reviews reported no remaining blockers.

## Rollout

Secure phone entry is deliberately advertised only by the packaged Electron app, where the desktop private key and encrypted credential store are available. Existing pairings remain usable for chat, but need one fresh QR scan to pin the new public key. Credential submission requires Secure phone access (hosted HTTPS) or Tailscale; a cleartext LAN/Bonjour route directs the user to switch routes or finish on the computer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure phone-based entry for requested API keys using iOS Password AutoFill and encrypted submission to the paired computer.
  * Added secure credential cards with retry support and automatic task resumption.
  * Pairing links now support secure-entry setup, with re-pairing guidance for older pairings.
  * Added protected credential submission through hosted HTTPS or Tailscale.
  * Credential values are not retained in chat, logs, or app storage.
* **Documentation**
  * Updated privacy, security, setup, and App Store materials with secure credential handling and transport requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->