### PR TITLE
fix(sidebar): restore the full Chief row hit area

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -659,7 +659,7 @@ function BotContextMenu({
   );
 }
 
-function BotListItem({
+export function BotListItem({
   bot,
   density,
   onMenu,
@@ -770,6 +770,7 @@ function BotListItem({
         role={renaming ? undefined : "button"}
         tabIndex={renaming ? undefined : 0}
         aria-label={!renaming && iconOnly ? bot.name : undefined}
+        data-sidebar-bot-row={bot.id}
         onClick={onSelect}
         onKeyDown={(event) => {
           if (renaming) return;
@@ -786,19 +787,14 @@ function BotListItem({
       {!renaming && iconOnly && bot.unread && (
         <span className="pointer-events-none absolute bottom-1.5 right-1.5 size-2 rounded-full border border-panel bg-accent" />
       )}
-      {!renaming && !iconOnly && <button
+      {/* Disabled buttons still own their pixels in Chromium, even at zero
+          opacity. Omit the unavailable action so the entire row stays live. */}
+      {!renaming && !iconOnly && !archiveDisabled && !bot.chiefOfStaff && <button
         type="button"
-        disabled={archiveDisabled}
         onClick={() => onArchive(bot)}
         aria-label={`Archive ${bot.name}`}
-        title={
-          bot.chiefOfStaff
-            ? "Choose another Chief of Staff first"
-            : archiveDisabled
-              ? "Keep at least one active bot"
-              : `Archive ${bot.name}`
-        }
-        className="absolute right-1 top-1/2 flex size-10 -translate-y-1/2 items-center justify-center rounded-lg bg-card/90 text-ink-secondary opacity-0 shadow-sm transition hover:bg-raised hover:text-ink focus:opacity-100 disabled:cursor-default disabled:opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 max-md:opacity-100"
+        title={`Archive ${bot.name}`}
+        className="absolute right-1 top-1/2 flex size-10 -translate-y-1/2 items-center justify-center rounded-lg bg-card/90 text-ink-secondary opacity-0 shadow-sm transition hover:bg-raised hover:text-ink focus:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100 max-md:opacity-100"
       >
         <Archive size={14} />
       </button>}

--- a/src/components/SidebarBotListItem.test.ts
+++ b/src/components/SidebarBotListItem.test.ts
@@ -1,0 +1,53 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { StoreProvider, type Bot } from "@/state/store";
+
+vi.mock("./DesktopCapabilities", () => ({
+  useDesktopCapabilities: () => ({}),
+}));
+
+import { BotListItem } from "./Sidebar";
+
+const bot = (overrides: Partial<Bot> = {}): Bot => ({
+  id: "atlas",
+  threadId: "thread-atlas",
+  name: "Atlas",
+  title: "",
+  description: "",
+  notifications: true,
+  color: "green",
+  unread: false,
+  modelSelection: { instanceId: "claude", model: "test" },
+  messages: [],
+  ...overrides,
+});
+
+function renderRow(candidate: Bot, archiveDisabled: boolean) {
+  return renderToStaticMarkup(createElement(
+    StoreProvider,
+    null,
+    createElement(BotListItem, {
+      bot: candidate,
+      density: "comfortable",
+      onMenu: vi.fn(),
+      onArchive: vi.fn(),
+      archiveDisabled,
+    }),
+  ));
+}
+
+describe("BotListItem", () => {
+  it("leaves the full Chief card as one selectable hit area", () => {
+    const markup = renderRow(bot({ chiefOfStaff: true }), false);
+
+    expect(markup).toContain('data-sidebar-bot-row="atlas"');
+    expect(markup).not.toContain('aria-label="Archive Atlas"');
+  });
+
+  it("renders the inline Archive action only when it is available", () => {
+    expect(renderRow(bot(), true)).not.toContain('aria-label="Archive Atlas"');
+    expect(renderRow(bot(), false)).toContain('aria-label="Archive Atlas"');
+  });
+});

--- a/src/lib/sidebar-selection.test.ts
+++ b/src/lib/sidebar-selection.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { botListItemPointerIntent } from "./sidebar-selection";
 
 describe("botListItemPointerIntent", () => {
-  it("keeps the bot row selectable while its name is being edited", () => {
+  it.each(["avatar", "body", "right edge"])("selects the bot from its %s", () => {
     expect(botListItemPointerIntent("click", false)).toBe("select");
   });
 


### PR DESCRIPTION
## What changed
- stop rendering unavailable inline Archive controls over Chief of Staff rows
- keep the entire Chief card clickable, including its right edge
- add renderer coverage for the selectable row and Archive visibility

## Verification
- `pnpm typecheck`
- focused Vitest: 7 passing
- focused Oxlint

Closes #722