### PR TITLE
fix(composio): honor user projects and repair X connections

### DIFF
--- a/apps/docs/content/docs/connected-apps/index.mdx
+++ b/apps/docs/content/docs/connected-apps/index.mdx
@@ -24,6 +24,19 @@ The installation identity is stored using Electron's operating-system-backed sec
 
 The managed service is a convenience for official packaged builds. A source build can use your own Composio project and `COMPOSIO_API_KEY`; see [Self-hosted Composio](./self-hosted-composio.mdx).
 
+You can also use your own Composio project in the packaged app. Open **App Settings → Connections → Self-host connected apps** and paste its project key. A saved project key takes priority over the managed service for the marketplace, connection management, and bot tools. Clear the key to return to the managed service.
+
+## Connect X (Twitter)
+
+Composio does not provide managed credentials for its `twitter` toolkit. To connect an X account:
+
+1. Create an app in the X Developer Portal.
+2. Create a `twitter` auth config in your Composio project using that app's credentials.
+3. Save the project's key under **Self-host connected apps**.
+4. Return to **Connected apps** and connect **X (Twitter)**.
+
+The official managed OpenMausBot service keeps X disabled until it owns an appropriate X OAuth app. Older OpenMausBot tasks that refer to the connector as `x` continue to work; OpenMausBot translates that alias to Composio's `twitter` toolkit automatically.
+
 ## Multiple accounts
 
 Connect more than one account for the same toolkit and give each a clear alias such as `work`, `personal`, or `client-acme`. When several accounts could perform an action, OpenMausBot requires explicit selection instead of silently replacing the first connection.

--- a/server/composio.test.ts
+++ b/server/composio.test.ts
@@ -1,5 +1,5 @@
 import { createServer, type Server } from "node:http";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import type { AppConfig } from "./config.ts";
 import {
@@ -8,15 +8,18 @@ import {
   connectedServices,
   connectionMode,
   connectionStatus,
+  listToolkits,
   mcpIntegration,
   normalizeAccountAlias,
   prepareProjectSession,
   removeAccount,
   removeService,
+  relayMcp,
   setManagedBrokerAccess,
 } from "./composio.ts";
 
 let api: Server;
+let origin = "";
 let base = "";
 const calls: Array<{ method: string; path: string; query: string; body: any }> = [];
 let malformedConnectedAccounts = false;
@@ -35,6 +38,45 @@ beforeAll(async () => {
     const body = raw ? JSON.parse(raw) : null;
     calls.push({ method: req.method ?? "GET", path: url.pathname, query: url.search, body });
 
+    if (url.pathname.startsWith("/broker/")) {
+      if (req.headers.authorization !== `Bearer ${"a".repeat(64)}`) {
+        res.writeHead(401, { "content-type": "application/json" });
+        return res.end(JSON.stringify({ error: "invalid broker token" }));
+      }
+      if (req.method === "GET" && url.pathname === "/broker/v1/connectors") {
+        const services = Object.fromEntries(
+          (url.searchParams.get("services") ?? "").split(",").filter(Boolean).map((slug) => [
+            slug,
+            { connected: slug === "github", status: slug === "github" ? "ACTIVE" : "not_connected" },
+          ]),
+        );
+        res.writeHead(200, { "content-type": "application/json" });
+        return res.end(JSON.stringify({ services }));
+      }
+      if (req.method === "GET" && url.pathname === "/broker/v1/connectors/connected") {
+        res.writeHead(200, { "content-type": "application/json" });
+        return res.end(JSON.stringify({ services: { github: { connected: true, status: "ACTIVE" } } }));
+      }
+      if (req.method === "POST" && url.pathname.endsWith("/authorize")) {
+        res.writeHead(200, { "content-type": "application/json" });
+        return res.end(JSON.stringify({ url: "https://connect.composio.dev/managed" }));
+      }
+      if (req.method === "DELETE" && url.pathname.startsWith("/broker/v1/connectors/")) {
+        res.writeHead(200, { "content-type": "application/json" });
+        return res.end(JSON.stringify({ removed: 1 }));
+      }
+      if (req.method === "GET" && url.pathname === "/broker/v1/catalog") {
+        res.writeHead(200, { "content-type": "application/json" });
+        return res.end(JSON.stringify({ items: [{ slug: "github", name: "GitHub" }] }));
+      }
+      if (req.method === "POST" && url.pathname === "/broker/v1/mcp") {
+        res.writeHead(200, { "content-type": "application/json" });
+        return res.end(JSON.stringify({ source: "broker" }));
+      }
+      res.writeHead(404, { "content-type": "application/json" });
+      return res.end(JSON.stringify({ error: "unknown broker route" }));
+    }
+
     if (req.headers["x-api-key"] !== "ak_test") {
       res.writeHead(401, { "content-type": "application/json" });
       return res.end(JSON.stringify({ error: { message: "invalid project key" } }));
@@ -48,6 +90,10 @@ beforeAll(async () => {
         mcp: { type: "http", url: "https://app.composio.dev/tool_router/v3/trs_test/mcp" },
         config: { user_id: body.user_id, multi_account: body.multi_account, auth_configs: sessionAuthConfigs },
       }));
+    }
+    if (req.method === "GET" && url.pathname === "/api/v3/toolkits") {
+      res.writeHead(200, { "content-type": "application/json" });
+      return res.end(JSON.stringify({ items: [{ slug: "x", name: "X (Twitter)" }, { slug: "github", name: "GitHub" }] }));
     }
     if (req.method === "GET" && url.pathname === "/api/v3.1/tool_router/session/trs_test") {
       res.writeHead(200, { "content-type": "application/json" });
@@ -146,13 +192,16 @@ beforeAll(async () => {
     res.end(JSON.stringify({ error: "not found" }));
   });
   await new Promise<void>((resolve) => api.listen(0, "127.0.0.1", resolve));
-  base = `http://127.0.0.1:${(api.address() as { port: number }).port}/api/v3.1`;
+  origin = `http://127.0.0.1:${(api.address() as { port: number }).port}`;
+  base = `${origin}/api/v3.1`;
   process.env.OMB_COMPOSIO_API = base;
+  process.env.OMB_COMPOSIO_TOOLKITS_API = `${origin}/api/v3`;
 });
 
 afterAll(async () => {
   setManagedBrokerAccess(null);
   delete process.env.OMB_COMPOSIO_API;
+  delete process.env.OMB_COMPOSIO_TOOLKITS_API;
   await new Promise<void>((resolve) => api.close(() => resolve()));
 });
 
@@ -205,6 +254,111 @@ describe.sequential("Composio Sessions", () => {
     expect(applyManagedBrokerMessage({ type: messageType, access: null })).toBe(true);
     expect(connectionMode({})).toBe("unavailable");
   });
+
+  it("uses a user-owned project for every connector operation even when the managed broker is available", async () => {
+    const cfg: AppConfig = {
+      composio: { apiKey: "ak_test", userId: "openmausbot_existing", sessionId: "trs_test" },
+    };
+    setManagedBrokerAccess({ url: `${origin}/broker`, token: "a".repeat(64) });
+    const before = calls.length;
+    const realFetch = globalThis.fetch;
+    const mcpRequests: Array<{ url: string; apiKey: string | null }> = [];
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = typeof input === "string" || input instanceof URL ? String(input) : input.url;
+      if (url.startsWith("https://app.composio.dev/tool_router/")) {
+        mcpRequests.push({ url, apiKey: new Headers(init?.headers).get("x-api-key") });
+        return new Response(JSON.stringify({ source: "project" }), {
+          status: 200,
+          headers: { "content-type": "application/json", "mcp-session-id": "mcp_project" },
+        });
+      }
+      return realFetch(input, init);
+    });
+
+    try {
+      expect(connectionMode(cfg)).toBe("self-hosted");
+      await expect(listToolkits(cfg)).resolves.toMatchObject({
+        source: "api",
+        cards: [{ slug: "twitter" }, { slug: "github" }],
+      });
+      await expect(connectedServices(cfg)).resolves.toHaveProperty("github.connected", true);
+      await expect(connectionStatus(cfg, ["slack"])).resolves.toHaveProperty("slack.connected", false);
+      await expect(authorizeService(cfg, "slack")).resolves.toEqual({
+        url: "https://connect.composio.dev/link/slack",
+      });
+      await expect(removeAccount(cfg, "github", "ca_github_personal")).resolves.toEqual({ removed: 1 });
+      await expect(removeService(cfg, "github")).resolves.toEqual({ removed: 1 });
+      const relayed = await relayMcp(cfg, { jsonrpc: "2.0", id: 1, method: "tools/list" });
+      expect(JSON.parse(new TextDecoder().decode(relayed.bytes))).toEqual({ source: "project" });
+      expect(relayed.transportSessionId).toBe("mcp_project");
+
+      expect(mcpRequests).toEqual([{
+        url: "https://app.composio.dev/tool_router/v3/trs_test/mcp",
+        apiKey: "ak_test",
+      }]);
+      const since = calls.slice(before);
+      expect(since.some((call) => call.path === "/api/v3.1/tool_router/session/trs_test")).toBe(true);
+      expect(since.some((call) => call.path.startsWith("/broker/"))).toBe(false);
+    } finally {
+      fetchSpy.mockRestore();
+      setManagedBrokerAccess(null);
+    }
+  });
+
+  it("accepts the legacy x alias but authorizes Composio's twitter toolkit", async () => {
+    const cfg: AppConfig = {
+      composio: { apiKey: "ak_test", userId: "openmausbot_existing", sessionId: "trs_test" },
+    };
+    sessionAuthConfigs = { twitter: "ac_twitter" };
+    setManagedBrokerAccess({ url: `${origin}/broker`, token: "a".repeat(64) });
+    const before = calls.length;
+    try {
+      await expect(authorizeService(cfg, "x")).resolves.toEqual({
+        url: "https://connect.composio.dev/link/twitter",
+      });
+      await expect(connectionStatus(cfg, ["x"])).resolves.toHaveProperty("x.connected", false);
+      await expect(removeService(cfg, "x")).resolves.toEqual({ removed: 0 });
+      const catalog = await listToolkits(cfg);
+      expect(catalog.cards).toContainEqual(expect.objectContaining({ slug: "twitter" }));
+
+      const since = calls.slice(before);
+      expect(since.filter((call) => call.method === "POST" && call.path.endsWith("/link")).at(-1)?.body).toEqual({
+        toolkit: "twitter",
+      });
+      expect(since.some((call) => call.query.includes("toolkits=twitter"))).toBe(true);
+      expect(since.some((call) => call.path.startsWith("/broker/"))).toBe(false);
+    } finally {
+      sessionAuthConfigs = {};
+      setManagedBrokerAccess(null);
+    }
+  });
+
+  it("falls back to the managed broker immediately after the project key is cleared", async () => {
+    const cfg: AppConfig = { composio: { apiKey: "" } };
+    setManagedBrokerAccess({ url: `${origin}/broker`, token: "a".repeat(64) });
+    const before = calls.length;
+    try {
+      expect(connectionMode(cfg)).toBe("managed");
+      await expect(connectionStatus(cfg, ["github"])).resolves.toHaveProperty("github.connected", true);
+      await expect(authorizeService(cfg, "github")).resolves.toEqual({
+        url: "https://connect.composio.dev/managed",
+      });
+      await expect(listToolkits(cfg)).resolves.toMatchObject({ source: "api", cards: [{ slug: "github" }] });
+      const relayed = await relayMcp(cfg, { jsonrpc: "2.0", id: 2, method: "tools/list" });
+      expect(JSON.parse(new TextDecoder().decode(relayed.bytes))).toEqual({ source: "broker" });
+
+      const brokerCalls = calls.slice(before).filter((call) => call.path.startsWith("/broker/"));
+      expect(brokerCalls.map((call) => `${call.method} ${call.path}`)).toEqual([
+        "GET /broker/v1/connectors",
+        "POST /broker/v1/connectors/github/authorize",
+        "GET /broker/v1/catalog",
+        "POST /broker/v1/mcp",
+      ]);
+    } finally {
+      setManagedBrokerAccess(null);
+    }
+  });
+
   it("accepts only project API keys", async () => {
     await expect(prepareProjectSession("old_key")).rejects.toThrow(/start with ak_/i);
     await expect(prepareProjectSession("ak_wrong")).rejects.toThrow(/invalid project key/i);

--- a/server/composio.test.ts
+++ b/server/composio.test.ts
@@ -21,7 +21,14 @@ import {
 let api: Server;
 let origin = "";
 let base = "";
-const calls: Array<{ method: string; path: string; query: string; body: any }> = [];
+const calls: Array<{
+  method: string;
+  path: string;
+  query: string;
+  body: any;
+  apiKey: string;
+  transportSessionId: string;
+}> = [];
 let malformedConnectedAccounts = false;
 let connectedAccountsUnavailable = false;
 // The project's own auth configs, and the ones the stub Session was created
@@ -36,7 +43,14 @@ beforeAll(async () => {
     let raw = "";
     for await (const chunk of req) raw += chunk;
     const body = raw ? JSON.parse(raw) : null;
-    calls.push({ method: req.method ?? "GET", path: url.pathname, query: url.search, body });
+    calls.push({
+      method: req.method ?? "GET",
+      path: url.pathname,
+      query: url.search,
+      body,
+      apiKey: String(req.headers["x-api-key"] ?? ""),
+      transportSessionId: String(req.headers["mcp-session-id"] ?? ""),
+    });
 
     if (url.pathname.startsWith("/broker/")) {
       if (req.headers.authorization !== `Bearer ${"a".repeat(64)}`) {
@@ -70,14 +84,15 @@ beforeAll(async () => {
         return res.end(JSON.stringify({ items: [{ slug: "github", name: "GitHub" }] }));
       }
       if (req.method === "POST" && url.pathname === "/broker/v1/mcp") {
-        res.writeHead(200, { "content-type": "application/json" });
+        res.writeHead(200, { "content-type": "application/json", "mcp-session-id": "mcp_broker" });
         return res.end(JSON.stringify({ source: "broker" }));
       }
       res.writeHead(404, { "content-type": "application/json" });
       return res.end(JSON.stringify({ error: "unknown broker route" }));
     }
 
-    if (req.headers["x-api-key"] !== "ak_test") {
+    const apiKey = String(req.headers["x-api-key"] ?? "");
+    if (!["ak_test", "ak_catalog_a", "ak_catalog_b"].includes(apiKey)) {
       res.writeHead(401, { "content-type": "application/json" });
       return res.end(JSON.stringify({ error: { message: "invalid project key" } }));
     }
@@ -93,6 +108,12 @@ beforeAll(async () => {
     }
     if (req.method === "GET" && url.pathname === "/api/v3/toolkits") {
       res.writeHead(200, { "content-type": "application/json" });
+      if (apiKey === "ak_catalog_a") {
+        return res.end(JSON.stringify({ items: [{ slug: "notion", name: "Catalog A" }] }));
+      }
+      if (apiKey === "ak_catalog_b") {
+        return res.end(JSON.stringify({ items: [{ slug: "linear", name: "Catalog B" }] }));
+      }
       return res.end(JSON.stringify({ items: [{ slug: "x", name: "X (Twitter)" }, { slug: "github", name: "GitHub" }] }));
     }
     if (req.method === "GET" && url.pathname === "/api/v3.1/tool_router/session/trs_test") {
@@ -253,6 +274,88 @@ describe.sequential("Composio Sessions", () => {
 
     expect(applyManagedBrokerMessage({ type: messageType, access: null })).toBe(true);
     expect(connectionMode({})).toBe("unavailable");
+  });
+
+  it("does not reuse a self-hosted catalog after the project key changes", async () => {
+    const before = calls.length;
+    const first = await listToolkits({ composio: { apiKey: "ak_catalog_a" } });
+    const second = await listToolkits({ composio: { apiKey: "ak_catalog_b" } });
+
+    expect(first.cards).toEqual([expect.objectContaining({ slug: "notion", label: "Catalog A" })]);
+    expect(second.cards).toEqual([expect.objectContaining({ slug: "linear", label: "Catalog B" })]);
+    expect(calls.slice(before).filter((call) => call.path === "/api/v3/toolkits").map((call) => call.apiKey)).toEqual([
+      "ak_catalog_a",
+      "ak_catalog_b",
+    ]);
+  });
+
+  it("drops a managed MCP session when routing switches to a user project", async () => {
+    setManagedBrokerAccess({ url: `${origin}/broker`, token: "a".repeat(64) });
+    const projectSessions: string[] = [];
+    const realFetch = globalThis.fetch;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = typeof input === "string" || input instanceof URL ? String(input) : input.url;
+      if (url.startsWith("https://app.composio.dev/tool_router/")) {
+        projectSessions.push(new Headers(init?.headers).get("mcp-session-id") ?? "");
+        return new Response(JSON.stringify({ source: "project" }), {
+          status: 200,
+          headers: { "content-type": "application/json", "mcp-session-id": "mcp_project_after_managed" },
+        });
+      }
+      return realFetch(input, init);
+    });
+    try {
+      const managed = await relayMcp({}, { jsonrpc: "2.0", id: 101, method: "tools/list" });
+      expect(managed.transportSessionId).toBe("mcp_broker");
+      await relayMcp(
+        {},
+        { jsonrpc: "2.0", id: 105, method: "tools/list" },
+        managed.transportSessionId,
+      );
+      expect(calls.findLast((call) => call.path === "/broker/v1/mcp" && call.body?.id === 105)?.transportSessionId)
+        .toBe("mcp_broker");
+      const project = await relayMcp(
+        { composio: { apiKey: "ak_test", userId: "openmausbot_existing", sessionId: "trs_test" } },
+        { jsonrpc: "2.0", id: 102, method: "tools/list" },
+        managed.transportSessionId,
+      );
+      expect(project.transportSessionId).toBe("mcp_project_after_managed");
+      expect(projectSessions).toEqual([""]);
+    } finally {
+      fetchSpy.mockRestore();
+      setManagedBrokerAccess(null);
+    }
+  });
+
+  it("drops a project MCP session when routing switches to the managed broker", async () => {
+    setManagedBrokerAccess({ url: `${origin}/broker`, token: "a".repeat(64) });
+    const realFetch = globalThis.fetch;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = typeof input === "string" || input instanceof URL ? String(input) : input.url;
+      if (url.startsWith("https://app.composio.dev/tool_router/")) {
+        return new Response(JSON.stringify({ source: "project" }), {
+          status: 200,
+          headers: { "content-type": "application/json", "mcp-session-id": "mcp_project_before_managed" },
+        });
+      }
+      return realFetch(input, init);
+    });
+    try {
+      const project = await relayMcp(
+        { composio: { apiKey: "ak_test", userId: "openmausbot_existing", sessionId: "trs_test" } },
+        { jsonrpc: "2.0", id: 103, method: "tools/list" },
+      );
+      expect(project.transportSessionId).toBe("mcp_project_before_managed");
+      await relayMcp(
+        {},
+        { jsonrpc: "2.0", id: 104, method: "tools/list" },
+        project.transportSessionId,
+      );
+      expect(calls.findLast((call) => call.path === "/broker/v1/mcp" && call.body?.id === 104)?.transportSessionId).toBe("");
+    } finally {
+      fetchSpy.mockRestore();
+      setManagedBrokerAccess(null);
+    }
   });
 
   it("uses a user-owned project for every connector operation even when the managed broker is available", async () => {

--- a/server/composio.ts
+++ b/server/composio.ts
@@ -1,7 +1,7 @@
 // A project API key (ak_…) creates/reuses one Composio Session. That
 // Session owns connection state, auth links and the MCP endpoint.
 import { saveConfig, type AppConfig } from "./config.ts";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { z } from "zod";
 import { SPAWNED_PROXIES } from "./proxy-paths.ts";
 import { managedConnectorUnavailableReason } from "../shared/connector-availability.ts";
@@ -206,6 +206,31 @@ function projectApiKey(cfg: AppConfig): string | null {
 function canonicalToolkitSlug(slug: string): string {
   const normalized = slug.trim().toLowerCase();
   return normalized === "x" ? "twitter" : normalized;
+}
+
+/** Keep credential-backed caches and transport sessions separated without
+ * retaining another plaintext copy of the credential as their identity. */
+function backendFingerprint(kind: string, endpoint: string, credential: string): string {
+  return createHash("sha256")
+    .update(kind)
+    .update("\0")
+    .update(endpoint)
+    .update("\0")
+    .update(credential)
+    .digest("hex");
+}
+
+const MAX_TRACKED_TRANSPORT_SESSIONS = 512;
+const transportSessionBackends = new Map<string, string>();
+
+function rememberTransportSession(sessionId: string, identity: string): void {
+  transportSessionBackends.delete(sessionId);
+  transportSessionBackends.set(sessionId, identity);
+  while (transportSessionBackends.size > MAX_TRACKED_TRANSPORT_SESSIONS) {
+    const oldest = transportSessionBackends.keys().next().value;
+    if (oldest === undefined) break;
+    transportSessionBackends.delete(oldest);
+  }
 }
 
 function canonicalServiceRecord<T>(services: Record<string, T>): Record<string, T> {
@@ -538,20 +563,32 @@ export async function relayMcp(
 ): Promise<{ status: number; bytes: Uint8Array; contentType: string; transportSessionId?: string }> {
   const apiKey = projectApiKey(cfg);
   let url: string;
+  let identity: string;
   const headers = new Headers({
     "content-type": "application/json",
     accept: "application/json, text/event-stream",
   });
-  if (transportSessionId) headers.set("mcp-session-id", transportSessionId);
   if (apiKey) {
     const session = await ensureProjectSession(cfg);
     url = session.mcp.url;
     headers.set("x-api-key", apiKey);
+    identity = backendFingerprint("project-mcp", url, apiKey);
   } else {
     const broker = brokerAccess();
     if (!broker) throw new Error("Connected apps are unavailable");
     url = `${broker.url}/v1/mcp`;
     headers.set("authorization", `Bearer ${broker.token}`);
+    identity = backendFingerprint("managed-mcp", url, broker.token);
+  }
+  const knownIdentity = transportSessionId
+    ? transportSessionBackends.get(transportSessionId)
+    : undefined;
+  const forwardedTransportSessionId = transportSessionId
+    && knownIdentity === identity
+    ? transportSessionId
+    : undefined;
+  if (forwardedTransportSessionId) {
+    headers.set("mcp-session-id", forwardedTransportSessionId);
   }
   const response = await fetch(url, {
     method: "POST",
@@ -563,11 +600,14 @@ export async function relayMcp(
   if (declared > 20 * 1024 * 1024) throw new Error("Connected-app response exceeded 20 MB");
   const bytes = new Uint8Array(await response.arrayBuffer());
   if (bytes.byteLength > 20 * 1024 * 1024) throw new Error("Connected-app response exceeded 20 MB");
+  if (forwardedTransportSessionId) rememberTransportSession(forwardedTransportSessionId, identity);
+  const nextTransportSessionId = response.headers.get("mcp-session-id") ?? undefined;
+  if (nextTransportSessionId) rememberTransportSession(nextTransportSessionId, identity);
   return {
     status: response.status,
     bytes,
     contentType: response.headers.get("content-type") ?? "application/json",
-    transportSessionId: response.headers.get("mcp-session-id") ?? undefined,
+    transportSessionId: nextTransportSessionId,
   };
 }
 
@@ -967,7 +1007,7 @@ const CURATED: ToolkitCard[] = [
   { slug: "stripe", label: "Stripe", blurb: "Payments and customers", domain: "stripe.com", logo: null },
 ];
 
-let toolkitCache: { at: number; cards: ToolkitCard[]; mode: "managed" | "self-hosted" } | null = null;
+let toolkitCache: { at: number; cards: ToolkitCard[]; identity: string } | null = null;
 
 /**
  * Marketplace catalog. Tries the v3 toolkits API (official names,
@@ -976,8 +1016,12 @@ let toolkitCache: { at: number; cards: ToolkitCard[]; mode: "managed" | "self-ho
 export async function listToolkits(cfg: AppConfig): Promise<{ cards: ToolkitCard[]; source: "api" | "curated" }> {
   const backendKey = projectApiKey(cfg);
   const broker = backendKey ? null : brokerAccess();
-  const mode = backendKey ? "self-hosted" : broker ? "managed" : null;
-  if (mode && toolkitCache?.mode === mode && Date.now() - toolkitCache.at < 10 * 60_000) {
+  const identity = backendKey
+    ? backendFingerprint("project-catalog", toolkitBase(), backendKey)
+    : broker
+      ? backendFingerprint("managed-catalog", broker.url, broker.token)
+      : null;
+  if (identity && toolkitCache?.identity === identity && Date.now() - toolkitCache.at < 10 * 60_000) {
     return { cards: toolkitCache.cards, source: "api" };
   }
   if (backendKey || broker) {
@@ -1003,7 +1047,7 @@ export async function listToolkits(cfg: AppConfig): Promise<{ cards: ToolkitCard
           const uniqueCards = cards.filter(
             (card, index) => card.slug && cards.findIndex((candidate) => candidate.slug === card.slug) === index,
           );
-          toolkitCache = { at: Date.now(), cards: uniqueCards, mode: mode! };
+          toolkitCache = { at: Date.now(), cards: uniqueCards, identity: identity! };
           return { cards: uniqueCards, source: "api" };
         }
       }

--- a/server/composio.ts
+++ b/server/composio.ts
@@ -193,9 +193,43 @@ function brokerAccess(): { url: string; token: string } | null {
   return { url: normalizeManagedBrokerUrl(url), token };
 }
 
+/** A user-owned project is an explicit choice and must win over the packaged
+ * app's managed broker. An empty key means that choice was cleared, so the
+ * managed service may take over again without a restart. */
+function projectApiKey(cfg: AppConfig): string | null {
+  const apiKey = cfg.composio?.apiKey?.trim();
+  return apiKey || null;
+}
+
+/** Composio's toolkit slug is `twitter`. Keep accepting the old `x` alias at
+ * every local boundary so saved connector cards and model calls keep working. */
+function canonicalToolkitSlug(slug: string): string {
+  const normalized = slug.trim().toLowerCase();
+  return normalized === "x" ? "twitter" : normalized;
+}
+
+function canonicalServiceRecord<T>(services: Record<string, T>): Record<string, T> {
+  return Object.fromEntries(
+    Object.entries(services).map(([slug, state]) => [canonicalToolkitSlug(slug), state]),
+  );
+}
+
+/** Preserve the caller's key (`x` included) while speaking canonical toolkit
+ * slugs upstream. Old connector cards index status with their saved slug. */
+function requestedServiceRecord<T>(services: Record<string, T>, requested: string[]): Record<string, T> {
+  const canonical = canonicalServiceRecord(services);
+  return Object.fromEntries(
+    requested.flatMap((slug) => {
+      const state = canonical[canonicalToolkitSlug(slug)];
+      return state === undefined ? [] : [[slug, state]];
+    }),
+  );
+}
+
 export function connectionMode(cfg: AppConfig): "managed" | "self-hosted" | "unavailable" {
+  if (projectApiKey(cfg)) return "self-hosted";
   if (brokerAccess()) return "managed";
-  return cfg.composio?.apiKey ? "self-hosted" : "unavailable";
+  return "unavailable";
 }
 
 export function configured(cfg: AppConfig): boolean {
@@ -333,7 +367,7 @@ export async function listCustomAuthConfigs(apiKey: string): Promise<AuthConfigM
     if (!res.ok) throw new Error(await responseError(res, `Composio auth configs: HTTP ${res.status}`));
     const body = authConfigsPageSchema.parse(await res.json());
     for (const item of body.items ?? []) {
-      const slug = item.toolkit?.slug?.toLowerCase();
+      const slug = item.toolkit?.slug ? canonicalToolkitSlug(item.toolkit.slug) : "";
       if (!slug || !item.id || item.is_composio_managed === true) continue;
       if (item.is_enabled_for_tool_router === false) continue;
       if (item.status && /^(disabled|inactive|expired|deleted)$/i.test(item.status)) continue;
@@ -353,7 +387,7 @@ export async function listCustomAuthConfigs(apiKey: string): Promise<AuthConfigM
  *  missing or different one means the Session predates the config. */
 function sessionCoversAuthConfigs(session: SessionResponse, wanted: AuthConfigMap): boolean {
   const have = session.config?.auth_configs ?? {};
-  const haveLower = Object.fromEntries(Object.entries(have).map(([slug, id]) => [slug.toLowerCase(), id]));
+  const haveLower = Object.fromEntries(Object.entries(have).map(([slug, id]) => [canonicalToolkitSlug(slug), id]));
   return Object.entries(wanted).every(([slug, id]) => haveLower[slug] === id);
 }
 
@@ -425,21 +459,22 @@ export async function prepareProjectSession(
 
 async function ensureProjectSession(cfg: AppConfig): Promise<SessionResponse> {
   const composio = cfg.composio;
-  if (!composio?.apiKey) throw new Error("No Composio project key configured");
+  const apiKey = projectApiKey(cfg);
+  if (!composio || !apiKey) throw new Error("No Composio project key configured");
   if (composio.sessionId) {
-    const existing = await getProjectSession(composio.apiKey, composio.sessionId);
+    const existing = await getProjectSession(apiKey, composio.sessionId);
     if (existing && (supportsMultiAccount(existing) || multiAccountUpgradeAttempted.has(existing.session_id))) {
       return existing;
     }
   }
   // A missing/deleted session is recreated and its non-secret identifiers are
   // persisted so an edited config/env setup does not recreate it every launch.
-  const prepared = await prepareProjectSession(composio.apiKey, composio);
+  const prepared = await prepareProjectSession(apiKey, composio);
   multiAccountUpgradeAttempted.add(prepared.sessionId);
   composio.userId = prepared.userId;
   composio.sessionId = prepared.sessionId;
   saveConfig({ composio: { userId: prepared.userId, sessionId: prepared.sessionId } });
-  const created = await getProjectSession(composio.apiKey, prepared.sessionId);
+  const created = await getProjectSession(apiKey, prepared.sessionId);
   if (!created) throw new Error("Composio Session disappeared after creation");
   return created;
 }
@@ -453,17 +488,18 @@ async function recreateProjectSession(
   authConfigs: AuthConfigMap,
 ): Promise<SessionResponse> {
   const composio = cfg.composio;
-  if (!composio?.apiKey) throw new Error("No Composio project key configured");
+  const apiKey = projectApiKey(cfg);
+  if (!composio || !apiKey) throw new Error("No Composio project key configured");
   const prepared = await prepareProjectSession(
-    composio.apiKey,
-    { apiKey: composio.apiKey, userId },
+    apiKey,
+    { apiKey, userId },
     authConfigs,
   );
   multiAccountUpgradeAttempted.add(prepared.sessionId);
   composio.userId = prepared.userId;
   composio.sessionId = prepared.sessionId;
   saveConfig({ composio: { userId: prepared.userId, sessionId: prepared.sessionId } });
-  const created = await getProjectSession(composio.apiKey, prepared.sessionId);
+  const created = await getProjectSession(apiKey, prepared.sessionId);
   if (!created) throw new Error("Composio Session disappeared after creation");
   return created;
 }
@@ -500,21 +536,22 @@ export async function relayMcp(
   payload: JsonValue,
   transportSessionId?: string,
 ): Promise<{ status: number; bytes: Uint8Array; contentType: string; transportSessionId?: string }> {
-  const broker = brokerAccess();
+  const apiKey = projectApiKey(cfg);
   let url: string;
   const headers = new Headers({
     "content-type": "application/json",
     accept: "application/json, text/event-stream",
   });
   if (transportSessionId) headers.set("mcp-session-id", transportSessionId);
-  if (broker) {
-    url = `${broker.url}/v1/mcp`;
-    headers.set("authorization", `Bearer ${broker.token}`);
-  } else {
-    if (!cfg.composio?.apiKey) throw new Error("Connected apps are unavailable");
+  if (apiKey) {
     const session = await ensureProjectSession(cfg);
     url = session.mcp.url;
-    headers.set("x-api-key", cfg.composio.apiKey);
+    headers.set("x-api-key", apiKey);
+  } else {
+    const broker = brokerAccess();
+    if (!broker) throw new Error("Connected apps are unavailable");
+    url = `${broker.url}/v1/mcp`;
+    headers.set("authorization", `Bearer ${broker.token}`);
   }
   const response = await fetch(url, {
     method: "POST",
@@ -598,10 +635,10 @@ async function listSessionToolkits(
 }
 
 function summarizeAccounts(accounts: ConnectedAccountResponse[], slugs: string[]) {
-  const requested = new Set(slugs.map((slug) => slug.toLowerCase()));
+  const requested = new Set(slugs.map(canonicalToolkitSlug));
   const bySlug = new Map<string, Array<ConnectedAccountSummary & { updatedAt: string }>>();
   for (const account of accounts) {
-    const slug = account.toolkit?.slug?.toLowerCase();
+    const slug = account.toolkit?.slug ? canonicalToolkitSlug(account.toolkit.slug) : "";
     if (!slug || (requested.size && !requested.has(slug)) || !validAccountId(account.id)) continue;
     const alias = account.alias?.trim() ?? "";
     const summary: ConnectedAccountSummary & { updatedAt: string } = {
@@ -646,7 +683,7 @@ function allServiceStates(
     [...accountsBySlug].map(([slug, accounts]) => [slug, serviceStateFromAccounts(accounts)]),
   );
   for (const toolkit of toolkits) {
-    const slug = toolkit.slug?.toLowerCase();
+    const slug = toolkit.slug ? canonicalToolkitSlug(toolkit.slug) : "";
     const selected = toolkit.connected_account;
     const selectedId = validAccountId(selected?.id) ? selected.id : undefined;
     if (!slug || (!toolkit.is_no_auth && !selectedId)) continue;
@@ -672,12 +709,14 @@ function allServiceStates(
  * on marketplace ordering or catalog pagination.
  */
 export async function connectedServices(cfg: AppConfig): Promise<Record<string, ConnectorServiceState>> {
-  if (brokerAccess()) {
+  const apiKey = projectApiKey(cfg);
+  if (!apiKey) {
     const response = await brokerRequest("/v1/connectors/connected");
     if (!response.ok) await throwBrokerError(response, `Connected apps: HTTP ${response.status}`);
     const body = connectorServicesResponseSchema.parse(await response.json());
+    const services = canonicalServiceRecord(body.services ?? {});
     return Object.fromEntries(
-      Object.entries(body.services ?? {}).map(([slug, state]) => [slug, {
+      Object.entries(services).map(([slug, state]) => [slug, {
         connected: state.connected,
         pending: state.pending ?? false,
         status: state.status ?? (state.connected ? "ACTIVE" : "not_connected"),
@@ -685,34 +724,35 @@ export async function connectedServices(cfg: AppConfig): Promise<Record<string, 
       }]),
     );
   }
-  if (!cfg.composio?.apiKey) throw new Error("Connected apps are unavailable");
   const session = await ensureProjectSession(cfg);
-  const userId = session.config?.user_id ?? cfg.composio.userId;
+  const userId = session.config?.user_id ?? cfg.composio?.userId;
   if (!userId) throw new Error("Composio Session returned no user ID");
   const [toolkits, accounts] = await Promise.all([
-    listSessionToolkits(cfg.composio.apiKey, session.session_id),
+    listSessionToolkits(apiKey, session.session_id),
     // Scoped project keys can grant Session reads without granting the raw
     // connected-account list. The Session still proves which selected/no-auth
     // toolkits belong to this installation, so retain that safe fallback.
-    listConnectedAccounts(cfg.composio.apiKey, userId, []).catch(() => []),
+    listConnectedAccounts(apiKey, userId, []).catch(() => []),
   ]);
   return allServiceStates(summarizeAccounts(accounts, []), toolkits);
 }
 
 export async function connectionStatus(cfg: AppConfig, slugs: string[]) {
-  if (brokerAccess() || !cfg.composio?.apiKey) {
-    const response = await brokerRequest(`/v1/connectors?${new URLSearchParams({ services: slugs.join(",") })}`);
+  const canonicalSlugs = [...new Set(slugs.map(canonicalToolkitSlug))];
+  const apiKey = projectApiKey(cfg);
+  if (!apiKey) {
+    const response = await brokerRequest(`/v1/connectors?${new URLSearchParams({ services: canonicalSlugs.join(",") })}`);
     if (!response.ok) await throwBrokerError(response, `Connected apps: HTTP ${response.status}`);
     const body = connectorServicesResponseSchema.parse(await response.json());
-    return body.services ?? {};
+    return requestedServiceRecord(body.services ?? {}, slugs);
   }
   const session = await ensureProjectSession(cfg);
   const params = new URLSearchParams({ limit: "50" });
-  if (slugs.length) params.set("toolkits", slugs.join(","));
-  const userId = session.config?.user_id ?? cfg.composio.userId;
+  if (canonicalSlugs.length) params.set("toolkits", canonicalSlugs.join(","));
+  const userId = session.config?.user_id ?? cfg.composio?.userId;
   const [res, accounts] = await Promise.all([
     fetch(`${apiBase()}/tool_router/session/${encodeURIComponent(session.session_id)}/toolkits?${params}`, {
-      headers: projectHeaders(cfg.composio.apiKey),
+      headers: projectHeaders(apiKey),
       signal: AbortSignal.timeout(15_000),
     }),
     // Session toolkits only include an account once it is usable. Read the
@@ -721,17 +761,20 @@ export async function connectionStatus(cfg: AppConfig, slugs: string[]) {
     // keys may omit connected-account read permission, so this is additive:
     // the normal session result remains the fallback.
     userId
-      ? listConnectedAccounts(cfg.composio.apiKey, userId, slugs).catch(() => [])
+      ? listConnectedAccounts(apiKey, userId, canonicalSlugs).catch(() => [])
       : Promise.resolve([]),
   ]);
   if (!res.ok) throw new Error(await responseError(res, `Composio toolkits: HTTP ${res.status}`));
   const body = toolkitPageSchema.parse(await res.json());
-  const bySlug = new Map((body.items ?? []).map((item) => [item.slug?.toLowerCase(), item]));
-  const accountsBySlug = summarizeAccounts(accounts, slugs);
+  const bySlug = new Map(
+    (body.items ?? []).flatMap((item) => item.slug ? [[canonicalToolkitSlug(item.slug), item] as const] : []),
+  );
+  const accountsBySlug = summarizeAccounts(accounts, canonicalSlugs);
   return Object.fromEntries(
     slugs.map((slug) => {
-      const item = bySlug.get(slug.toLowerCase());
-      const serviceAccounts = accountsBySlug.get(slug.toLowerCase()) ?? [];
+      const canonicalSlug = canonicalToolkitSlug(slug);
+      const item = bySlug.get(canonicalSlug);
+      const serviceAccounts = accountsBySlug.get(canonicalSlug) ?? [];
       // Mirror allServiceStates: a scoped key can be denied the raw account
       // list while the Session still names its selected account. Synthesize
       // that account here too, so a status poll never wipes the row the
@@ -756,24 +799,26 @@ export async function connectionStatus(cfg: AppConfig, slugs: string[]) {
 
 /** Backward-compatible service disconnect: removes the Session-selected account. */
 export async function removeService(cfg: AppConfig, slug: string) {
-  if (brokerAccess() || !cfg.composio?.apiKey) {
-    const response = await brokerRequest(`/v1/connectors/${encodeURIComponent(slug)}`, { method: "DELETE" });
+  const toolkit = canonicalToolkitSlug(slug);
+  const apiKey = projectApiKey(cfg);
+  if (!apiKey) {
+    const response = await brokerRequest(`/v1/connectors/${encodeURIComponent(toolkit)}`, { method: "DELETE" });
     if (!response.ok) await throwBrokerError(response, `Connected apps: HTTP ${response.status}`);
     return removalResponseSchema.parse(await response.json());
   }
   const session = await ensureProjectSession(cfg);
-  const params = new URLSearchParams({ limit: "50", toolkits: slug });
+  const params = new URLSearchParams({ limit: "50", toolkits: toolkit });
   const list = await fetch(
     `${apiBase()}/tool_router/session/${encodeURIComponent(session.session_id)}/toolkits?${params}`,
-    { headers: projectHeaders(cfg.composio.apiKey), signal: AbortSignal.timeout(15_000) },
+    { headers: projectHeaders(apiKey), signal: AbortSignal.timeout(15_000) },
   );
   if (!list.ok) throw new Error(await responseError(list, `Composio toolkits: HTTP ${list.status}`));
   const body = toolkitPageSchema.parse(await list.json());
-  const id = body.items?.find((item) => item.slug?.toLowerCase() === slug.toLowerCase())?.connected_account?.id;
+  const id = body.items?.find((item) => item.slug && canonicalToolkitSlug(item.slug) === toolkit)?.connected_account?.id;
   if (!id) return { removed: 0 };
   const removed = await fetch(
     `${apiBase()}/connected_accounts/${encodeURIComponent(id)}?revoke_on_delete=true`,
-    { method: "DELETE", headers: projectHeaders(cfg.composio.apiKey), signal: AbortSignal.timeout(30_000) },
+    { method: "DELETE", headers: projectHeaders(apiKey), signal: AbortSignal.timeout(30_000) },
   );
   if (!removed.ok) throw new Error(await responseError(removed, `Composio disconnect: HTTP ${removed.status}`));
   return { removed: 1 };
@@ -782,25 +827,29 @@ export async function removeService(cfg: AppConfig, slug: string) {
 /** Disconnect exactly one account after proving it belongs to this user/toolkit. */
 export async function removeAccount(cfg: AppConfig, slug: string, accountId: string) {
   if (!validAccountId(accountId)) throw inputError("Invalid connected-account ID");
-  if (brokerAccess() || !cfg.composio?.apiKey) {
+  const toolkit = canonicalToolkitSlug(slug);
+  const apiKey = projectApiKey(cfg);
+  if (!apiKey) {
     const response = await brokerRequest(
-      `/v1/connectors/${encodeURIComponent(slug)}/accounts/${encodeURIComponent(accountId)}`,
+      `/v1/connectors/${encodeURIComponent(toolkit)}/accounts/${encodeURIComponent(accountId)}`,
       { method: "DELETE" },
     );
     if (!response.ok) await throwBrokerError(response, `Connected apps: HTTP ${response.status}`);
     return removalResponseSchema.parse(await response.json());
   }
   const session = await ensureProjectSession(cfg);
-  const userId = session.config?.user_id ?? cfg.composio.userId;
+  const userId = session.config?.user_id ?? cfg.composio?.userId;
   if (!userId) throw new Error("Composio Session has no user ID");
-  const accounts = await listConnectedAccounts(cfg.composio.apiKey, userId, [slug]);
+  const accounts = await listConnectedAccounts(apiKey, userId, [toolkit]);
   const owned = accounts.some((account) =>
-    account.id === accountId && account.toolkit?.slug?.toLowerCase() === slug.toLowerCase()
+    account.id === accountId
+      && account.toolkit?.slug !== undefined
+      && canonicalToolkitSlug(account.toolkit.slug) === toolkit
   );
   if (!owned) return { removed: 0 };
   const removed = await fetch(
     `${apiBase()}/connected_accounts/${encodeURIComponent(accountId)}?revoke_on_delete=true`,
-    { method: "DELETE", headers: projectHeaders(cfg.composio.apiKey), signal: AbortSignal.timeout(30_000) },
+    { method: "DELETE", headers: projectHeaders(apiKey), signal: AbortSignal.timeout(30_000) },
   );
   if (!removed.ok) throw new Error(await responseError(removed, `Composio disconnect: HTTP ${removed.status}`));
   return { removed: 1 };
@@ -809,38 +858,41 @@ export async function removeAccount(cfg: AppConfig, slug: string, accountId: str
 /** Mint a browser auth link for one service. Returns { url } or throws. */
 export async function authorizeService(cfg: AppConfig, slug: string, requestedAlias?: string | null) {
   const alias = normalizeAccountAlias(requestedAlias);
-  const broker = brokerAccess();
-  const unavailable = managedConnectorUnavailableReason(broker ? "managed" : connectionMode(cfg), slug);
+  const toolkit = canonicalToolkitSlug(slug);
+  const mode = connectionMode(cfg);
+  const unavailable = managedConnectorUnavailableReason(mode, toolkit);
   if (unavailable) throw inputError(unavailable, 409);
-  if (broker || !cfg.composio?.apiKey) {
+  const apiKey = projectApiKey(cfg);
+  if (!apiKey) {
     const request: RequestInit = { method: "POST" };
     if (alias) request.body = JSON.stringify({ alias });
-    const response = await brokerRequest(`/v1/connectors/${encodeURIComponent(slug)}/authorize`, request);
+    const response = await brokerRequest(`/v1/connectors/${encodeURIComponent(toolkit)}/authorize`, request);
     if (!response.ok) await throwBrokerError(response, `Connected apps: HTTP ${response.status}`);
     const body = authUrlResponseSchema.parse(await response.json());
-    return { url: trustedAuthUrl(body.url, slug) };
+    return { url: trustedAuthUrl(body.url, toolkit) };
   }
   const session = await ensureProjectSession(cfg);
-  const userId = session.config?.user_id ?? cfg.composio.userId;
+  const userId = session.config?.user_id ?? cfg.composio?.userId;
   if (!userId) throw new Error("Composio Session has no user ID");
   // A scoped key may be denied account listing — authorization must still
   // work (it always did pre-multi-account), so the alias guardrails degrade
   // to first-account behavior, the same fallback every inventory path takes.
-  const accounts = await listConnectedAccounts(cfg.composio.apiKey, userId, [slug]).catch(() => []);
-  const serviceAccounts = accounts.filter((account) => account.toolkit?.slug?.toLowerCase() === slug.toLowerCase());
+  const accounts = await listConnectedAccounts(apiKey, userId, [toolkit]).catch(() => []);
+  const serviceAccounts = accounts.filter((account) =>
+    account.toolkit?.slug !== undefined && canonicalToolkitSlug(account.toolkit.slug) === toolkit
+  );
   const usableAccounts = serviceAccounts.filter((account) => /^(active|initiated|initializing|pending)$/i.test(account.status ?? ""));
   if (usableAccounts.length >= MULTI_ACCOUNT_CONFIG.max_accounts_per_toolkit) {
-    throw inputError(`${slug} already has the maximum of ${MULTI_ACCOUNT_CONFIG.max_accounts_per_toolkit} accounts`, 409);
+    throw inputError(`${toolkit} already has the maximum of ${MULTI_ACCOUNT_CONFIG.max_accounts_per_toolkit} accounts`, 409);
   }
   if (usableAccounts.length > 0 && !alias) {
     throw inputError("Add an account alias so the existing connection is not replaced");
   }
   if (alias && serviceAccounts.some((account) => account.alias?.trim().toLowerCase() === alias.toLowerCase())) {
-    throw inputError(`Account alias "${alias}" is already in use for ${slug}`, 409);
+    throw inputError(`Account alias "${alias}" is already in use for ${toolkit}`, 409);
   }
-  const linkRequest: AccountLinkRequest = { toolkit: slug };
+  const linkRequest: AccountLinkRequest = { toolkit };
   if (alias) linkRequest.alias = alias;
-  const apiKey = cfg.composio.apiKey;
   const link = (sessionId: string) =>
     fetch(`${apiBase()}/tool_router/session/${encodeURIComponent(sessionId)}/link`, {
       method: "POST",
@@ -857,12 +909,11 @@ export async function authorizeService(cfg: AppConfig, slug: string, requestedAl
     // the Session existed is invisible to it: rebuild the Session once and
     // retry. If the project has no config for this toolkit, say what to do
     // instead of echoing Composio's "auth_config_override" hint.
-    const slugLower = slug.toLowerCase();
     const authConfigs = await listCustomAuthConfigs(apiKey);
-    const covered = Object.keys(authConfigs).some((key) => key.toLowerCase() === slugLower);
+    const covered = Object.keys(authConfigs).some((key) => canonicalToolkitSlug(key) === toolkit);
     if (!covered) {
       throw inputError(
-        `${slug} has no Composio-managed sign-in. In your Composio project, create an auth config for "${slug}" `
+        `${toolkit} has no Composio-managed sign-in. In your Composio project, create an auth config for "${toolkit}" `
           + "(Auth Configs → Create) with your own app credentials, then click Connect again.",
       );
     }
@@ -871,7 +922,7 @@ export async function authorizeService(cfg: AppConfig, slug: string, requestedAl
     if (!res.ok) throw new Error(await responseError(res, `Composio authorization: HTTP ${res.status}`));
   }
   const body = linkResponseSchema.parse(await res.json());
-  return { url: trustedAuthUrl(body.redirect_url, slug) };
+  return { url: trustedAuthUrl(body.redirect_url, toolkit) };
 }
 
 // ── marketplace catalog ────────────────────────────────────────────────
@@ -902,7 +953,7 @@ const CURATED: ToolkitCard[] = [
   { slug: "sentry", label: "Sentry", blurb: "Errors and alerts", domain: "sentry.io", logo: null },
   { slug: "posthog", label: "PostHog", blurb: "Analytics, feature flags, experiments", domain: "posthog.com", logo: null },
   { slug: "discord", label: "Discord", blurb: "Messages and channels", domain: "discord.com", logo: null },
-  { slug: "x", label: "X (Twitter)", blurb: "Post and read on X", domain: "x.com", logo: null },
+  { slug: "twitter", label: "X (Twitter)", blurb: "Post and read on X", domain: "x.com", logo: null },
   { slug: "reddit", label: "Reddit", blurb: "Browse and post", domain: "reddit.com", logo: null },
   { slug: "zapier", label: "Zapier", blurb: "Connect 9,000+ apps", domain: "zapier.com", logo: null },
   { slug: "hubspot", label: "HubSpot", blurb: "CRM search & updates", domain: "hubspot.com", logo: null },
@@ -916,18 +967,20 @@ const CURATED: ToolkitCard[] = [
   { slug: "stripe", label: "Stripe", blurb: "Payments and customers", domain: "stripe.com", logo: null },
 ];
 
-let toolkitCache: { at: number; cards: ToolkitCard[] } | null = null;
+let toolkitCache: { at: number; cards: ToolkitCard[]; mode: "managed" | "self-hosted" } | null = null;
 
 /**
  * Marketplace catalog. Tries the v3 toolkits API (official names,
  * descriptions, logos — cached 10 min); falls back to the curated list.
  */
 export async function listToolkits(cfg: AppConfig): Promise<{ cards: ToolkitCard[]; source: "api" | "curated" }> {
-  if (toolkitCache && Date.now() - toolkitCache.at < 10 * 60_000) {
+  const backendKey = projectApiKey(cfg);
+  const broker = backendKey ? null : brokerAccess();
+  const mode = backendKey ? "self-hosted" : broker ? "managed" : null;
+  if (mode && toolkitCache?.mode === mode && Date.now() - toolkitCache.at < 10 * 60_000) {
     return { cards: toolkitCache.cards, source: "api" };
   }
-  const backendKey = brokerAccess() ? undefined : cfg.composio?.apiKey;
-  if (backendKey || brokerAccess()) {
+  if (backendKey || broker) {
     try {
       const res = backendKey
         ? await fetch(`${toolkitBase()}/toolkits?limit=500&sort_by=usage`, {
@@ -940,15 +993,18 @@ export async function listToolkits(cfg: AppConfig): Promise<{ cards: ToolkitCard
         const items = json.items ?? json.data ?? [];
         if (Array.isArray(items) && items.length) {
           const cards: ToolkitCard[] = items.map((t: any) => ({
-            slug: (t.slug ?? t.key ?? t.name ?? "").toLowerCase(),
+            slug: canonicalToolkitSlug(String(t.slug ?? t.key ?? t.name ?? "")),
             label: t.name ?? t.slug ?? "",
             blurb: (t.meta?.description ?? t.description ?? "").slice(0, 90),
             logo: t.meta?.logo ?? t.logo ?? null,
             noAuth: t.no_auth === true,
             domain: null,
           }));
-          toolkitCache = { at: Date.now(), cards };
-          return { cards, source: "api" };
+          const uniqueCards = cards.filter(
+            (card, index) => card.slug && cards.findIndex((candidate) => candidate.slug === card.slug) === index,
+          );
+          toolkitCache = { at: Date.now(), cards: uniqueCards, mode: mode! };
+          return { cards: uniqueCards, source: "api" };
         }
       }
     } catch {
@@ -959,7 +1015,7 @@ export async function listToolkits(cfg: AppConfig): Promise<{ cards: ToolkitCard
 }
 
 export async function toolkitCard(cfg: AppConfig, slug: string): Promise<ToolkitCard> {
-  const normalized = slug.toLowerCase();
+  const normalized = canonicalToolkitSlug(slug);
   const { cards } = await listToolkits(cfg);
   return cards.find((card) => card.slug.toLowerCase() === normalized)
     ?? CURATED.find((card) => card.slug === normalized)


### PR DESCRIPTION
## What changed
- prefer an explicitly supplied Composio project over the packaged managed broker for every connector operation
- use Composio’s real `twitter` toolkit slug while keeping old `x` aliases compatible
- explain the required user-owned X Developer/Auth Config setup and keep managed X unavailable
- isolate catalog caches and MCP transport sessions when connection credentials change

## Verification
- focused Composio suite: 22 passing
- `pnpm typecheck`
- focused Oxlint
- docs production build

Closes #689