### PR TITLE
fix(computer): make Auto explicit and side-effect free

### DIFF
--- a/server/box-turn.test.ts
+++ b/server/box-turn.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { boxTurnLifecycleAction } from "./box.ts";
+
+describe("Box turn lifecycle", () => {
+  it("keeps Auto mutation-free even when the box-native engine can mount Box", () => {
+    const auto = { explicitCloud: false, canMount: true };
+
+    expect(boxTurnLifecycleAction({ ...auto, state: null })).toBe("none");
+    expect(boxTurnLifecycleAction({ ...auto, state: "archived" })).toBe("none");
+    expect(boxTurnLifecycleAction({ ...auto, state: "provisioning" })).toBe("none");
+    expect(boxTurnLifecycleAction({ ...auto, state: "running" })).toBe("attach");
+  });
+
+  it("allows only explicit Cloud to provision or wake Box", () => {
+    const cloud = { explicitCloud: true, canMount: true };
+
+    expect(boxTurnLifecycleAction({ ...cloud, state: null })).toBe("provision");
+    expect(boxTurnLifecycleAction({ ...cloud, state: "archived" })).toBe("wake");
+    expect(boxTurnLifecycleAction({ ...cloud, state: "ready" })).toBe("attach");
+    expect(boxTurnLifecycleAction({ ...cloud, canMount: false, state: "ready" })).toBe("none");
+  });
+});

--- a/server/box.ts
+++ b/server/box.ts
@@ -24,6 +24,25 @@ const READY = new Set(["idle", "ready", "running"]);
 const DEFAULT_BOX_TTL_SECONDS = 8 * 60 * 60;
 const TRIAL_BOX_TTL_SECONDS = 2 * 60 * 60;
 
+export type BoxTurnLifecycleAction = "attach" | "provision" | "wake" | "none";
+
+/** Decide lifecycle work before a turn mounts Box. Auto may observe and
+ * attach an already-ready Box, but only explicit Cloud may create or wake. */
+export function boxTurnLifecycleAction({
+  explicitCloud,
+  canMount,
+  state,
+}: {
+  explicitCloud: boolean;
+  canMount: boolean;
+  state: string | null;
+}): BoxTurnLifecycleAction {
+  if (!canMount) return "none";
+  if (state && READY.has(state)) return "attach";
+  if (!explicitCloud) return "none";
+  return state ? "wake" : "provision";
+}
+
 function boxFetch(cfg: AppConfig, path: string, opts: RequestInit = {}) {
   return fetch(`${BOX_API}${path}`, {
     ...opts,

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -33,7 +33,6 @@ let child: ChildProcess;
 let boxStub: Server;
 let boxStubPort = 0;
 const boxRouteCalls: Array<{ method: string; path: string }> = [];
-let boxRouteListed: { id: string; name: string; state: string } | null = null;
 let home: string;
 let staticDir: string;
 let fakeClaudeDump: string;
@@ -473,16 +472,13 @@ beforeAll(async () => {
       boxRouteCalls.push({ method, path });
       res.writeHead(200, { "content-type": "application/json" });
       if (method === "GET" && path === "/boxes") {
-        return res.end(JSON.stringify({ ok: true, boxes: boxRouteListed ? [boxRouteListed] : [] }));
+        return res.end(JSON.stringify({ ok: true, boxes: [] }));
       }
       if (method === "POST" && path === "/boxes") {
-        return res.end(JSON.stringify({ ok: true, box: { id: "route-box", state: "running" } }));
+        return res.end(JSON.stringify({ ok: false, message: "fixture refused create" }));
       }
       if (method === "GET" && path === "/boxes/route-box") {
         return res.end(JSON.stringify({ ok: true, box: { id: "route-box", state: "running" } }));
-      }
-      if (method === "GET" && boxRouteListed && path === `/boxes/${boxRouteListed.id}`) {
-        return res.end(JSON.stringify({ ok: true, box: boxRouteListed }));
       }
       if (method === "POST" && path === "/boxes/route-box/commands") {
         return res.end(JSON.stringify({ ok: true, exitCode: 0, stdout: "", stderr: "" }));
@@ -1485,11 +1481,11 @@ describe("harness HTTP API", () => {
   });
 
   it("clears an explicit computer to Auto and refuses passive Auto Box provisioning", async () => {
-    const botIds: string[] = [];
+    let botId: string | undefined;
     try {
       expect((await api("PUT", "/api/config", { box: { token: "box_route" } })).status).toBe(200);
       const bot = (await api("POST", "/api/bots")).body.bot;
-      botIds.push(bot.id);
+      botId = bot.id;
       expect((await api("PATCH", `/api/bots/${bot.id}`, { computer: "cloud" })).body.bot.computer).toBe("cloud");
 
       const auto = await api("PATCH", `/api/bots/${bot.id}`, { computer: null });
@@ -1502,43 +1498,23 @@ describe("harness HTTP API", () => {
       expect(boxRouteCalls).toEqual([{ method: "GET", path: "/boxes" }]);
 
       // A stale renderer cannot turn that passive read into infrastructure:
-      // the server rejects Auto before any provider mutation is attempted.
+      // every Box verb is rejected before any provider mutation is attempted.
       const before = [...boxRouteCalls];
-      const blocked = await api("POST", `/api/bots/${bot.id}/computer/provision`, {});
-      expect(blocked.status).toBe(409);
-      expect(blocked.body.error).toMatch(/Choose Cloud/);
+      for (const action of ["provision", "join", "sleep", "exec", "screenshot", "remove"]) {
+        const blocked = await api("POST", `/api/bots/${bot.id}/computer/${action}`, {});
+        expect(blocked.status, action).toBe(409);
+        expect(blocked.body.error, action).toMatch(/Choose Cloud/);
+      }
       expect(boxRouteCalls).toEqual(before);
 
       // The same action is available after an explicit human Cloud choice.
       expect((await api("PATCH", `/api/bots/${bot.id}`, { computer: "cloud" })).status).toBe(200);
       const provisioned = await api("POST", `/api/bots/${bot.id}/computer/provision`, {});
-      expect(provisioned.status).toBe(200);
-      expect(provisioned.body).toMatchObject({ boxId: "route-box", state: "running" });
+      expect(provisioned.status).toBe(500);
+      expect(provisioned.body.error).toMatch(/fixture refused create/);
       expect(boxRouteCalls).toContainEqual({ method: "POST", path: "/boxes" });
-
-      // Running and archived Boxes are also observations in Auto. Each gets
-      // a fresh bot id so provider lookup cannot be satisfied from the cache.
-      for (const state of ["running", "archived"]) {
-        const observed = (await api("POST", "/api/bots")).body.bot;
-        botIds.push(observed.id);
-        const hash = createHash("sha256").update(observed.id).digest("hex").slice(0, 6);
-        boxRouteListed = {
-          id: `route-${state}`,
-          name: `ogb-${observed.id.slice(0, 8).toLowerCase().replace(/[^a-z0-9]/g, "")}-${hash}`,
-          state,
-        };
-        boxRouteCalls.length = 0;
-        const status = await api("GET", `/api/bots/${observed.id}/computer`);
-        expect(status.body.box).toMatchObject({ state });
-        expect(boxRouteCalls.length).toBeGreaterThan(0);
-        expect(boxRouteCalls.every((call) => call.method === "GET")).toBe(true);
-        const mutationCount = boxRouteCalls.length;
-        expect((await api("POST", `/api/bots/${observed.id}/computer/provision`, {})).status).toBe(409);
-        expect(boxRouteCalls).toHaveLength(mutationCount);
-      }
     } finally {
-      boxRouteListed = null;
-      for (const botId of botIds) await api("DELETE", `/api/bots/${botId}`);
+      if (botId) await api("DELETE", `/api/bots/${botId}`);
       await api("PUT", "/api/config", { box: { token: "" } });
       boxRouteCalls.length = 0;
     }

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -32,6 +32,8 @@ let child: ChildProcess;
 /** stands in for the box provider so config saving never touches the network */
 let boxStub: Server;
 let boxStubPort = 0;
+const boxRouteCalls: Array<{ method: string; path: string }> = [];
+let boxRouteListed: { id: string; name: string; state: string } | null = null;
 let home: string;
 let staticDir: string;
 let fakeClaudeDump: string;
@@ -464,6 +466,31 @@ beforeAll(async () => {
     }
     if (req.headers.authorization === "Bearer box_slow") {
       await new Promise((resolve) => setTimeout(resolve, 150));
+    }
+    if (req.headers.authorization === "Bearer box_route") {
+      const method = req.method ?? "GET";
+      const path = req.url ?? "/";
+      boxRouteCalls.push({ method, path });
+      res.writeHead(200, { "content-type": "application/json" });
+      if (method === "GET" && path === "/boxes") {
+        return res.end(JSON.stringify({ ok: true, boxes: boxRouteListed ? [boxRouteListed] : [] }));
+      }
+      if (method === "POST" && path === "/boxes") {
+        return res.end(JSON.stringify({ ok: true, box: { id: "route-box", state: "running" } }));
+      }
+      if (method === "GET" && path === "/boxes/route-box") {
+        return res.end(JSON.stringify({ ok: true, box: { id: "route-box", state: "running" } }));
+      }
+      if (method === "GET" && boxRouteListed && path === `/boxes/${boxRouteListed.id}`) {
+        return res.end(JSON.stringify({ ok: true, box: boxRouteListed }));
+      }
+      if (method === "POST" && path === "/boxes/route-box/commands") {
+        return res.end(JSON.stringify({ ok: true, exitCode: 0, stdout: "", stderr: "" }));
+      }
+      if (method === "POST" && path === "/boxes/route-box/desktop?vnc=1") {
+        return res.end(JSON.stringify({ ok: true, desktopUrl: "https://desktop.invalid/route-box" }));
+      }
+      return res.end(JSON.stringify({ ok: true }));
     }
     const ok = req.headers.authorization === "Bearer box_good" || req.headers.authorization === "Bearer box_slow";
     res.writeHead(ok ? 200 : 401, { "content-type": "application/json" });
@@ -1455,6 +1482,66 @@ describe("harness HTTP API", () => {
     expect(deleted.status).toBe(200);
     const after = await api("GET", "/api/bots");
     expect(after.body.bots.find((b: { id: string }) => b.id === bot.id)).toBeUndefined();
+  });
+
+  it("clears an explicit computer to Auto and refuses passive Auto Box provisioning", async () => {
+    const botIds: string[] = [];
+    try {
+      expect((await api("PUT", "/api/config", { box: { token: "box_route" } })).status).toBe(200);
+      const bot = (await api("POST", "/api/bots")).body.bot;
+      botIds.push(bot.id);
+      expect((await api("PATCH", `/api/bots/${bot.id}`, { computer: "cloud" })).body.bot.computer).toBe("cloud");
+
+      const auto = await api("PATCH", `/api/bots/${bot.id}`, { computer: null });
+      expect(auto.status).toBe(200);
+      expect(auto.body.bot).not.toHaveProperty("computer");
+
+      // Reading the panel status may inspect the provider, but it is GET-only.
+      boxRouteCalls.length = 0;
+      expect((await api("GET", `/api/bots/${bot.id}/computer`)).status).toBe(200);
+      expect(boxRouteCalls).toEqual([{ method: "GET", path: "/boxes" }]);
+
+      // A stale renderer cannot turn that passive read into infrastructure:
+      // the server rejects Auto before any provider mutation is attempted.
+      const before = [...boxRouteCalls];
+      const blocked = await api("POST", `/api/bots/${bot.id}/computer/provision`, {});
+      expect(blocked.status).toBe(409);
+      expect(blocked.body.error).toMatch(/Choose Cloud/);
+      expect(boxRouteCalls).toEqual(before);
+
+      // The same action is available after an explicit human Cloud choice.
+      expect((await api("PATCH", `/api/bots/${bot.id}`, { computer: "cloud" })).status).toBe(200);
+      const provisioned = await api("POST", `/api/bots/${bot.id}/computer/provision`, {});
+      expect(provisioned.status).toBe(200);
+      expect(provisioned.body).toMatchObject({ boxId: "route-box", state: "running" });
+      expect(boxRouteCalls).toContainEqual({ method: "POST", path: "/boxes" });
+
+      // Running and archived Boxes are also observations in Auto. Each gets
+      // a fresh bot id so provider lookup cannot be satisfied from the cache.
+      for (const state of ["running", "archived"]) {
+        const observed = (await api("POST", "/api/bots")).body.bot;
+        botIds.push(observed.id);
+        const hash = createHash("sha256").update(observed.id).digest("hex").slice(0, 6);
+        boxRouteListed = {
+          id: `route-${state}`,
+          name: `ogb-${observed.id.slice(0, 8).toLowerCase().replace(/[^a-z0-9]/g, "")}-${hash}`,
+          state,
+        };
+        boxRouteCalls.length = 0;
+        const status = await api("GET", `/api/bots/${observed.id}/computer`);
+        expect(status.body.box).toMatchObject({ state });
+        expect(boxRouteCalls.length).toBeGreaterThan(0);
+        expect(boxRouteCalls.every((call) => call.method === "GET")).toBe(true);
+        const mutationCount = boxRouteCalls.length;
+        expect((await api("POST", `/api/bots/${observed.id}/computer/provision`, {})).status).toBe(409);
+        expect(boxRouteCalls).toHaveLength(mutationCount);
+      }
+    } finally {
+      boxRouteListed = null;
+      for (const botId of botIds) await api("DELETE", `/api/bots/${botId}`);
+      await api("PUT", "/api/config", { box: { token: "" } });
+      boxRouteCalls.length = 0;
+    }
   });
 
   it("elects one Chief of Staff per section and preserves other section Chiefs", async () => {

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -1491,6 +1491,12 @@ describe("harness HTTP API", () => {
       const auto = await api("PATCH", `/api/bots/${bot.id}`, { computer: null });
       expect(auto.status).toBe(200);
       expect(auto.body.bot).not.toHaveProperty("computer");
+      const malformed = await api("PATCH", `/api/bots/${bot.id}`, { computer: ["cloud"] });
+      expect(malformed.status).toBe(400);
+      expect(malformed.body.error).toMatch(/computer must be null/);
+      expect((await api("GET", "/api/bots?messages=0")).body.bots.find(
+        (candidate: { id: string }) => candidate.id === bot.id,
+      )).not.toHaveProperty("computer");
 
       // Reading the panel status may inspect the provider, but it is GET-only.
       boxRouteCalls.length = 0;

--- a/server/index.ts
+++ b/server/index.ts
@@ -8303,8 +8303,23 @@ const server = createServer(async (req, res) => {
           else section = trimmed;
         }
       }
-      for (const key of ["unread", "computer", "cloudBackend", "color", "mascotExpression", "mascotBody", "pinned", "hidden"] as const) {
+      for (const key of ["unread", "cloudBackend", "color", "mascotExpression", "mascotBody", "pinned", "hidden"] as const) {
         if (body[key] !== undefined) patch[key] = body[key];
+      }
+      const computerSpecified = Object.prototype.hasOwnProperty.call(body, "computer");
+      let requestedComputer = existingBot?.computer;
+      if (computerSpecified) {
+        if (body.computer === null) {
+          // Auto is represented by an absent durable field. JSON needs a
+          // concrete clear value, so clients send null at the PATCH boundary.
+          requestedComputer = undefined;
+          patch.computer = undefined;
+        } else if (["cloud", "vm", "local", "browser", "off"].includes(String(body.computer))) {
+          requestedComputer = body.computer;
+          patch.computer = body.computer;
+        } else {
+          return json(res, 400, { error: "computer must be null (Auto), cloud, vm, local, browser, or off" });
+        }
       }
       if (normalizedSelection) patch.modelSelection = normalizedSelection;
       // one pinned message per thread; null/"" clears. The id is not
@@ -8347,12 +8362,6 @@ const server = createServer(async (req, res) => {
           patch.browserProfile = requestedProfile;
         } else return json(res, 400, { error: "browserProfile must name an existing browser profile" });
       }
-      if (
-        body.computer !== undefined &&
-        !["cloud", "vm", "local", "browser", "off"].includes(String(body.computer))
-      ) {
-        return json(res, 400, { error: "computer must be cloud, vm, local, browser, or off" });
-      }
       if (body.cloudBackend !== undefined && !["box", "vps"].includes(String(body.cloudBackend))) {
         return json(res, 400, { error: "cloudBackend must be box or vps" });
       }
@@ -8394,7 +8403,7 @@ const server = createServer(async (req, res) => {
       // create the combination — a bot curling the loopback API from a tool
       // call, a script, a stale client — is refused. The renderer dialog
       // alone is not a boundary; this check is.
-      const wantsComputer = body.computer !== undefined ? body.computer : existingBot?.computer;
+      const wantsComputer = computerSpecified ? requestedComputer : existingBot?.computer;
       const wantsAuto = body.autoApprove !== undefined ? body.autoApprove : existingBot?.autoApprove === true;
       const alreadyGranted = existingBot?.computer === "local" && existingBot?.autoApprove === true;
       if (wantsComputer === "local" && wantsAuto === true && !alreadyGranted && body.acknowledgeLocalAuto !== true) {
@@ -8414,7 +8423,7 @@ const server = createServer(async (req, res) => {
         }
         patch.alwaysAllow = [...new Set(body.alwaysAllow as string[])].slice(0, 200);
       }
-      if (existingBot?.computer === "local" && body.computer !== undefined && body.computer !== "local") {
+      if (existingBot?.computer === "local" && computerSpecified && requestedComputer !== "local") {
         cancelDirectTurnDispatch(existingBot.id, existingBot.threadId);
         await registry
           .get(existingBot.modelSelection.instanceId)
@@ -10080,6 +10089,11 @@ const server = createServer(async (req, res) => {
         if (m[2] === "screenshot") return json(res, 200, await vps.vpsComputerScreenshot(cfg, botId));
         const action = m[2] === "provision" ? "provision" : m[2] === "remove" ? "remove" : "stop";
         return json(res, 200, await vps.vpsComputerAction(action, cfg, botId));
+      }
+      if (m[2] === "provision" && bot.computer !== "cloud") {
+        return json(res, 409, {
+          error: "Choose Cloud before creating or waking this Box. Auto only checks existing computer state.",
+        });
       }
       if (m[2] === "remove") {
         // Boxes sleep and wake; only the VPS backend has a container to remove.

--- a/server/index.ts
+++ b/server/index.ts
@@ -3321,22 +3321,35 @@ async function startTurn(
           throw new Error("this model engine cannot use computer tools — choose Claude, an ACP engine, or the Computer engine");
         }
         let b = await box.findBox(cfg, bot.id).catch(() => null);
-        // Explicit Cloud and the box-native Computer engine provision on first
-        // use. Auto remains non-surprising and only reuses an existing box.
-        if (!b && mountsCloudComputer && (wants === "cloud" || instance.driverKind === "boxAgent")) {
+        let lifecycle = box.boxTurnLifecycleAction({
+          explicitCloud: wants === "cloud",
+          canMount: mountsCloudComputer,
+          state: typeof b?.state === "string" ? b.state : null,
+        });
+        if (lifecycle === "provision") {
           broadcast({ kind: "computer", botId: bot.id, state: "provisioning" });
           await box.provisionBox(cfg, bot.id, bot.name);
           b = await box.findBox(cfg, bot.id).catch(() => null);
+          lifecycle = box.boxTurnLifecycleAction({
+            explicitCloud: true,
+            canMount: mountsCloudComputer,
+            state: typeof b?.state === "string" ? b.state : null,
+          });
         }
         // an archived box answers every action with an error until it
         // resumes — wake it here, once, instead of letting the agent
-        // discover it one failed tool call at a time. Only worth the
-        // resume (~8s, and it un-pauses billing) when the bot can act.
-        if (b && mountsCloudComputer && !["idle", "ready", "running"].includes(b.state)) {
+        // discover it one failed tool call at a time. Explicit Cloud is the
+        // consent boundary for the resume (~8s, and it un-pauses billing).
+        if (lifecycle === "wake") {
           broadcast({ kind: "computer", botId: bot.id, state: "waking" });
           b = (await box.readyBox(cfg, bot.id).catch(() => null)) ?? b;
+          lifecycle = box.boxTurnLifecycleAction({
+            explicitCloud: true,
+            canMount: mountsCloudComputer,
+            state: typeof b?.state === "string" ? b.state : null,
+          });
         }
-        if (b) {
+        if (b && lifecycle === "attach") {
           previewCapture = () => box.screenshotBox(cfg, bot.id, b!.id);
           if (mountsCloudComputer) {
             integrations.computer = {
@@ -10090,6 +10103,19 @@ const server = createServer(async (req, res) => {
         const action = m[2] === "provision" ? "provision" : m[2] === "remove" ? "remove" : "stop";
         return json(res, 200, await vps.vpsComputerAction(action, cfg, botId));
       }
+      // Input validity is independent of destination authorization. Preserve
+      // the stable 400 contract for oversized commands without contacting the
+      // provider; a valid Auto request still reaches the 409 gate below.
+      let boxCommand: string | undefined;
+      if (m[2] === "exec") {
+        const body = await readBody(req);
+        boxCommand = String(body.command ?? "");
+        if (boxCommand.length > MAX_REMOTE_COMMAND_LENGTH) {
+          return json(res, 400, {
+            error: `command is too long (maximum ${MAX_REMOTE_COMMAND_LENGTH} characters)`,
+          });
+        }
+      }
       if (bot.computer !== "cloud") {
         return json(res, 409, {
           error: "Choose Cloud before changing or opening this Box. Auto only checks existing computer state.",
@@ -10106,16 +10132,8 @@ const server = createServer(async (req, res) => {
           return json(res, 200, await box.joinBox(cfg, botId));
         case "sleep":
           return json(res, 200, await box.sleepBox(cfg, botId));
-        case "exec": {
-          const body = await readBody(req);
-          const command = String(body.command ?? "");
-          if (command.length > MAX_REMOTE_COMMAND_LENGTH) {
-            return json(res, 400, {
-              error: `command is too long (maximum ${MAX_REMOTE_COMMAND_LENGTH} characters)`,
-            });
-          }
-          return json(res, 200, await box.execOnBox(cfg, botId, command));
-        }
+        case "exec":
+          return json(res, 200, await box.execOnBox(cfg, botId, boxCommand ?? ""));
         case "screenshot":
           return json(res, 200, await box.screenshotBox(cfg, botId));
       }

--- a/server/index.ts
+++ b/server/index.ts
@@ -8327,7 +8327,10 @@ const server = createServer(async (req, res) => {
           // concrete clear value, so clients send null at the PATCH boundary.
           requestedComputer = undefined;
           patch.computer = undefined;
-        } else if (["cloud", "vm", "local", "browser", "off"].includes(String(body.computer))) {
+        } else if (
+          typeof body.computer === "string" &&
+          ["cloud", "vm", "local", "browser", "off"].includes(body.computer)
+        ) {
           requestedComputer = body.computer;
           patch.computer = body.computer;
         } else {

--- a/server/index.ts
+++ b/server/index.ts
@@ -10090,9 +10090,9 @@ const server = createServer(async (req, res) => {
         const action = m[2] === "provision" ? "provision" : m[2] === "remove" ? "remove" : "stop";
         return json(res, 200, await vps.vpsComputerAction(action, cfg, botId));
       }
-      if (m[2] === "provision" && bot.computer !== "cloud") {
+      if (bot.computer !== "cloud") {
         return json(res, 409, {
-          error: "Choose Cloud before creating or waking this Box. Auto only checks existing computer state.",
+          error: "Choose Cloud before changing or opening this Box. Auto only checks existing computer state.",
         });
       }
       if (m[2] === "remove") {

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -1,10 +1,10 @@
 // The bot's computer, in the right-side slot. Where it runs decides the
-// whole flow: cloud → provision the box on open (idempotent) and preview
+// whole flow: explicit cloud → provision the box on open (idempotent) and preview
 // via SSE frames or a ~4s screenshot poll. macOS local mode keeps the legacy
 // in-panel capture. Linux local mode is an automation readiness state and its
-// separate preview remains explicitly user-initiated. Auto reuses but never
-// creates a Box (except for the box-native engine), and never selects a Linux
-// user's desktop.
+// separate preview remains explicitly user-initiated. Auto only reads an
+// existing Box's state: opening this panel never creates, wakes, bootstraps,
+// screenshots, or opens one, regardless of engine.
 import { useCallback, useEffect, useRef, useState } from "react";
 import { z } from "zod";
 import {
@@ -39,7 +39,6 @@ import { LocalScreenPreview } from "./LocalScreenPreview";
 import { LinuxLocalControl } from "./LinuxLocalControl";
 import { MacLocalControl } from "./MacLocalControl";
 import { LocalComputerAutoWarning } from "./LocalComputerAutoWarning";
-import { Switch } from "./SettingsPrimitives";
 import {
   autoSelectsLocalComputer,
   instanceSupportsLocalComputer,
@@ -76,6 +75,8 @@ type Phase =
   | "local"
   | "local-unavailable"
   | "auto-unavailable"
+  | "show-ready-box"
+  | "show-sleeping-box"
   | "browser"
   | "off"
   | "error";
@@ -303,7 +304,7 @@ export function ComputerPanel({
         ? "the built-in browser"
         : bot.computer === "off"
           ? null
-          : phase === "ready"
+          : phase === "ready" || phase === "show-ready-box"
             ? cloudBackend === "vps" ? "the self-hosted VPS selected by Auto" : "the cloud box selected by Auto"
             : "this computer selected by Auto";
 
@@ -469,9 +470,9 @@ export function ComputerPanel({
         alive = false;
       };
     }
-    // Cloud creates/wakes its Box. Auto may wake an existing Box but must not
-    // create one merely because this passive panel was opened. This mirrors
-    // turn routing, including the box-native engine's required exception.
+    // Explicit Cloud may create/wake its Box. Auto is observation-only here:
+    // even a ready Box and the box-native engine stay free of POSTs until the
+    // person deliberately chooses Cloud.
     api(`/api/bots/${bot.id}/computer`)
       .then((status) => {
         if (!alive) return;
@@ -483,13 +484,15 @@ export function ComputerPanel({
         });
         const action = resolveBoxPanelAction({
           computer: bot.computer,
-          driverKind: selectedInstance?.driverKind,
           configured: Boolean(status.configured),
-          hasExistingBox: Boolean(status.box),
+          boxState: typeof status.box?.state === "string" ? status.box.state : null,
           canUseCloud: cloudSupported,
           autoLocal,
         });
         if (action !== "ensure-box") {
+          if (action === "show-ready-box" || action === "show-sleeping-box") {
+            setBoxState(typeof status.box?.state === "string" ? status.box.state : null);
+          }
           setPhase(action);
           return;
         }
@@ -854,6 +857,8 @@ export function ComputerPanel({
     starting: "Starting your bot's computer…",
     unconfigured: "No cloud computer configured",
     "auto-unavailable": "Auto found no existing computer. Choose Cloud to create one, or pick another destination.",
+    "show-ready-box": "Auto found an existing cloud computer. It was not opened or changed.",
+    "show-sleeping-box": "Auto found a sleeping cloud computer. It was not woken or changed.",
     "vps-unconfigured": "No managed VPS computer is configured for this bot",
     "vps-incompatible": "This VPS computer belongs to an earlier OpenMausBot version",
     "vps-stopped": "The managed VPS computer is stopped",
@@ -966,6 +971,9 @@ export function ComputerPanel({
             <span>{bot.name}'s screen</span>
             {phase === "local" && <span className="text-[11px]">this computer</span>}
             {phase === "vm" && <span className="text-[11px]">Local VM</span>}
+            {(phase === "show-ready-box" || phase === "show-sleeping-box") && (
+              <span className="text-[11px]">cloud box · Auto · read-only</span>
+            )}
             {cloudBackend === "vps" && (phase === "ready" || phase === "starting") && <span className="text-[11px]">self-hosted VPS</span>}
         </div>
         <div className="flex aspect-[16/10] w-full items-center justify-center overflow-hidden rounded-xl bg-card">
@@ -1031,6 +1039,15 @@ export function ComputerPanel({
                   className="mt-1 rounded-lg bg-control px-3 py-1.5 text-[12px] text-ink hover:bg-raised-hover"
                 >
                   Open the Browser tab
+                </button>
+              )}
+              {(phase === "show-ready-box" || phase === "show-sleeping-box") && (
+                <button
+                  type="button"
+                  onClick={() => dispatch({ type: "updateBot", botId: bot.id, patch: { computer: "cloud" } })}
+                  className="mt-1 rounded-lg bg-control px-3 py-1.5 text-[12px] text-ink hover:bg-raised-hover"
+                >
+                  {phase === "show-sleeping-box" ? "Choose Cloud to wake" : "Choose Cloud to open"}
                 </button>
               )}
               {phase === "vm-unavailable" && (
@@ -1277,6 +1294,7 @@ export function ComputerPanel({
           <div className="mt-3 flex overflow-hidden rounded-lg border border-hairline/40">
             {(
               [
+                [null, "Auto"],
                 ["cloud", "Cloud"],
                 ["vm", "Local VM"],
                 ["local", "This computer"],
@@ -1302,11 +1320,11 @@ export function ComputerPanel({
                           : undefined;
                 return (
               <button
-                key={mode}
+                key={mode ?? "auto"}
                 disabled={disabled}
                 title={unavailableTitle}
                 onClick={() => {
-                  if (mode === bot.computer) return;
+                  if ((mode === null && bot.computer === undefined) || mode === bot.computer) return;
                   if (mode === "local" && bot.autoApprove) setLocalAutoWarning(true);
                   // a browser-only bot must actually have its browser: flip
                   // the per-bot switch on with the destination
@@ -1317,7 +1335,7 @@ export function ComputerPanel({
                   "flex-1 py-1.5 text-[13px]",
                   i > 0 && "border-l border-hairline/40",
                   disabled && "cursor-not-allowed opacity-40",
-                  bot.computer === mode
+                  (mode === null ? bot.computer === undefined : bot.computer === mode)
                     ? "bg-control text-ink"
                     : "text-ink-secondary hover:bg-control/60 hover:text-ink",
                 )}
@@ -1328,33 +1346,19 @@ export function ComputerPanel({
               })()
             ))}
           </div>
-          {(!bot.computer || bot.computer === "cloud") && (
+          {bot.computer === "cloud" && (
             <>
               <CloudBackendPicker
                 value={cloudBackend}
                 vpsSupported={vpsSupported}
                 onChange={(backend) => dispatch({ type: "updateBot", botId: bot.id, patch: { cloudBackend: backend } })}
               />
-              {!bot.computer && cloudBackend === "vps" && (
-                <div className="mt-3 flex items-center justify-between gap-4 rounded-lg bg-inset px-3 py-2.5">
-                  <div className="min-w-0">
-                    <div className="text-[13px] text-ink">Start VPS automatically</div>
-                    <div className="mt-0.5 text-[11.5px] text-ink-secondary">
-                      Off by default. When enabled, Auto may create or wake this bot's managed container.
-                    </div>
-                  </div>
-                  <Switch
-                    checked={Boolean(bot.autoStartVps)}
-                    aria-label="Start VPS automatically"
-                    onClick={() => dispatch({
-                      type: "updateBot",
-                      botId: bot.id,
-                      patch: { autoStartVps: !bot.autoStartVps },
-                    })}
-                  />
-                </div>
-              )}
             </>
+          )}
+          {!bot.computer && (
+            <div className="mt-3 rounded-lg bg-inset px-3 py-2.5 text-[11.5px] leading-relaxed text-ink-secondary">
+              Auto is selected. Opening this panel only checks for an existing computer; it never creates or wakes one. Choose Cloud to configure or start a cloud computer.
+            </div>
           )}
         </div>
 

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -24,6 +24,7 @@ import {
   X,
 } from "lucide-react";
 import { api, useStore, type Bot } from "@/state/store";
+import type { CloudBackend } from "../../server/contracts.ts";
 import type { Routine } from "@/lib/routines";
 import { ApiKeyRow } from "./ApiKeys";
 import { cn } from "@/lib/cn";
@@ -45,6 +46,7 @@ import {
   linuxAutoDescription,
   localComputerDisabledReason,
   localComputerSelectable,
+  persistedComputerSelectionMatches,
   resolveBoxPanelAction,
   shouldPollCloudPreview,
 } from "@/lib/local-computer";
@@ -183,7 +185,7 @@ export function ComputerPanel({
       /* storage blocked — width lives for this session */
     }
   };
-  const { state, dispatch } = useStore();
+  const { state, dispatch, flushBotPatches } = useStore();
   const { capabilities, ready: capabilitiesReady } = useDesktopCapabilities();
   const localAvailable = capabilities.localComputer.available;
   const isLinux = capabilities.host.platform === "linux";
@@ -192,13 +194,70 @@ export function ComputerPanel({
   const [localAutoWarning, setLocalAutoWarning] = useState(false);
   const localDisabledReason = localComputerDisabledReason({ capabilities, providerSupportsLocal });
   const [phase, setPhase] = useState<Phase>("checking");
-  const [cloudReadyBotId, setCloudReadyBotId] = useState<string | null>(null);
+  const [persistedComputerSelection, setPersistedComputerSelection] = useState<{
+    botId: string;
+    computer: Bot["computer"];
+    cloudBackend: CloudBackend;
+  } | null>(null);
+  const [resolvedComputerSelection, setResolvedComputerSelection] = useState<{
+    botId: string;
+    computer: Bot["computer"];
+    cloudBackend: CloudBackend;
+  } | null>(null);
+  const cloudBackend = bot.cloudBackend ?? "box";
+  const computerSelectionPersisted = Boolean(
+    persistedComputerSelection
+      && persistedComputerSelection.botId === bot.id
+      && persistedComputerSelection.computer === bot.computer
+      && persistedComputerSelection.cloudBackend === cloudBackend,
+  );
+  const computerStatusCurrent = Boolean(
+    resolvedComputerSelection
+      && resolvedComputerSelection.botId === bot.id
+      && resolvedComputerSelection.computer === bot.computer
+      && resolvedComputerSelection.cloudBackend === cloudBackend,
+  );
   const cloudPreviewReady = shouldPollCloudPreview({
     computer: bot.computer,
+    cloudBackend,
     phase,
     botId: bot.id,
-    resolvedBotId: cloudReadyBotId,
+    resolvedBotId: resolvedComputerSelection?.botId ?? null,
+    resolvedComputer: resolvedComputerSelection?.computer ?? null,
+    resolvedCloudBackend: resolvedComputerSelection?.cloudBackend ?? null,
   });
+  const updateComputerSelection = useCallback((patch: {
+    computer?: Bot["computer"] | null;
+    cloudBackend?: CloudBackend;
+    browser?: boolean;
+    acknowledgeLocalAuto?: boolean;
+  }) => {
+    // Clear old-provider UI in the same render as the optimistic profile
+    // change. The resolving effect waits for its PATCH before doing any work.
+    setResolvedComputerSelection(null);
+    setPhase("checking");
+    dispatch({ type: "updateBot", botId: bot.id, patch });
+  }, [bot.id, dispatch]);
+  useEffect(() => {
+    let alive = true;
+    setPersistedComputerSelection(null);
+    void flushBotPatches(bot.id).then((persistedBot) => {
+      if (!alive) return;
+      if (persistedBot && !persistedComputerSelectionMatches({
+        computer: bot.computer,
+        cloudBackend,
+        persistedBot,
+      })) return;
+      setPersistedComputerSelection({
+        botId: bot.id,
+        computer: bot.computer,
+        cloudBackend,
+      });
+    });
+    return () => {
+      alive = false;
+    };
+  }, [bot.id, bot.computer, cloudBackend, flushBotPatches]);
   const [boxState, setBoxState] = useState<string | null>(null);
   const [polledFrame, setPolledFrame] = useState<{ png: string; mime: string } | null>(null);
   const [vmFrame, setVmFrame] = useState<string | null>(null);
@@ -288,7 +347,6 @@ export function ComputerPanel({
   );
   const computerToolSupported = selectedInstance?.capabilities?.computerMcp === true;
   const vpsSupported = Boolean(computerToolSupported && selectedInstance?.driverKind !== "boxAgent");
-  const cloudBackend = bot.cloudBackend ?? "box";
   const cloudSupported = cloudBackend === "vps"
     ? vpsSupported
     : computerToolSupported || selectedInstance?.driverKind === "boxAgent";
@@ -324,7 +382,7 @@ export function ComputerPanel({
     // wake a box, or churn preview state behind either tab.
     if (panelView !== "computer") return;
     let alive = true;
-    setCloudReadyBotId(null);
+    setResolvedComputerSelection(null);
     setPhase("checking");
     setPolledFrame(null);
     setVmFrame(null);
@@ -333,6 +391,10 @@ export function ComputerPanel({
     setVpsStatus(null);
     setLocalFrame(null);
     setError(null);
+    // The selection may be optimistic for up to the profile debounce. Never
+    // let it choose a provider until the PATCH lane confirms server state.
+    if (!computerSelectionPersisted) return;
+
     if (bot.computer === "off") {
       setPhase("off");
       return;
@@ -425,6 +487,11 @@ export function ComputerPanel({
           if (!alive) return;
           const status: VpsComputerStatus = rawStatus;
           setVpsStatus(status);
+          setResolvedComputerSelection({
+            botId: bot.id,
+            computer: bot.computer,
+            cloudBackend,
+          });
           if (!status.configured) {
             if (autoLocal) setPhase("local");
             else {
@@ -435,7 +502,6 @@ export function ComputerPanel({
           }
           if (status.ready) {
             setBoxState(status.container ?? null);
-            if (bot.computer === "cloud") setCloudReadyBotId(bot.id);
             setPhase("ready");
             return;
           }
@@ -454,7 +520,11 @@ export function ComputerPanel({
               if (!alive) return;
               setBoxState(result.container ?? null);
               if (result.ready) {
-                setCloudReadyBotId(bot.id);
+                setResolvedComputerSelection({
+                  botId: bot.id,
+                  computer: bot.computer,
+                  cloudBackend,
+                });
                 setPhase("ready");
               }
               else {
@@ -503,6 +573,11 @@ export function ComputerPanel({
           canUseCloud: cloudSupported,
           autoLocal,
         });
+        setResolvedComputerSelection({
+          botId: bot.id,
+          computer: bot.computer,
+          cloudBackend,
+        });
         if (action !== "ensure-box") {
           if (action === "show-ready-box" || action === "show-sleeping-box" || action === "show-pending-box") {
             setBoxState(typeof status.box?.state === "string" ? status.box.state : null);
@@ -514,7 +589,11 @@ export function ComputerPanel({
         return api(`/api/bots/${bot.id}/computer/provision`, { method: "POST" }).then((r) => {
           if (!alive) return;
           setBoxState(r.state ?? null);
-          setCloudReadyBotId(bot.id);
+          setResolvedComputerSelection({
+            botId: bot.id,
+            computer: bot.computer,
+            cloudBackend,
+          });
           setPhase("ready");
         });
       })
@@ -542,6 +621,7 @@ export function ComputerPanel({
     vpsSupported,
     state.config?.vps?.sshAlias,
     panelView,
+    computerSelectionPersisted,
   ]);
 
   // cloud preview: SSE frames win while the bot works; otherwise poll.
@@ -779,7 +859,9 @@ export function ComputerPanel({
         if (kind === "provision") {
           setBoxState(result.container ?? null);
           if (result.ready) {
-            if (bot.computer === "cloud") setCloudReadyBotId(bot.id);
+            if (bot.computer === "cloud") {
+              setResolvedComputerSelection({ botId: bot.id, computer: bot.computer, cloudBackend });
+            }
             setPhase("ready");
           }
           else {
@@ -788,7 +870,7 @@ export function ComputerPanel({
           }
         }
         if (kind === "sleep") {
-          setCloudReadyBotId(null);
+          setResolvedComputerSelection(null);
           setBoxState(cloudBackend === "vps" ? "stopped" : "archived");
           if (cloudBackend === "vps") setPhase("vps-stopped");
         }
@@ -851,7 +933,9 @@ export function ComputerPanel({
       });
       setVpsStatus(result);
       setBoxState(result.container ?? null);
-      if (result.ready && bot.computer === "cloud") setCloudReadyBotId(bot.id);
+      if (result.ready && bot.computer === "cloud") {
+        setResolvedComputerSelection({ botId: bot.id, computer: bot.computer, cloudBackend });
+      }
       setPhase(result.ready ? "ready" : "error");
       if (!result.ready) setError(result.problem ?? "The replacement VPS Cua desktop is not ready yet");
     } catch (e) {
@@ -995,7 +1079,7 @@ export function ComputerPanel({
             {(phase === "show-ready-box" || phase === "show-sleeping-box" || phase === "show-pending-box") && (
               <span className="text-[11px]">cloud box · Auto · read-only</span>
             )}
-            {bot.computer === "cloud" && cloudBackend === "vps" && (phase === "ready" || phase === "starting") && <span className="text-[11px]">self-hosted VPS</span>}
+            {computerStatusCurrent && bot.computer === "cloud" && cloudBackend === "vps" && (phase === "ready" || phase === "starting") && <span className="text-[11px]">self-hosted VPS</span>}
         </div>
         <div className="flex aspect-[16/10] w-full items-center justify-center overflow-hidden rounded-xl bg-card">
           {frameSrc && previewOpensDesktop ? (
@@ -1067,7 +1151,7 @@ export function ComputerPanel({
               {(phase === "show-ready-box" || phase === "show-sleeping-box" || phase === "show-pending-box") && (
                 <button
                   type="button"
-                  onClick={() => dispatch({ type: "updateBot", botId: bot.id, patch: { computer: "cloud" } })}
+                  onClick={() => updateComputerSelection({ computer: "cloud" })}
                   className="mt-1 rounded-lg bg-control px-3 py-1.5 text-[12px] text-ink hover:bg-raised-hover"
                 >
                   {phase === "show-sleeping-box"
@@ -1098,7 +1182,7 @@ export function ComputerPanel({
                   </button>
                 )
               )}
-              {(phase === "vps-unconfigured" || phase === "vps-stopped") && (
+              {computerStatusCurrent && (phase === "vps-unconfigured" || phase === "vps-stopped") && (
                 <button
                   onClick={openConnectionSettings}
                   className="mt-1 rounded-lg bg-control px-3 py-1.5 text-[12px] text-ink hover:bg-raised-hover"
@@ -1106,7 +1190,7 @@ export function ComputerPanel({
                   Open VPS settings
                 </button>
               )}
-              {(phase === "vps-stopped" || (phase === "vps-unconfigured" && vpsStatus?.configured)) &&
+              {computerStatusCurrent && (phase === "vps-stopped" || (phase === "vps-unconfigured" && vpsStatus?.configured)) &&
                 (bot.computer === "cloud" || bot.autoStartVps) && (
                 <button
                   onClick={() => run("provision")}
@@ -1117,7 +1201,7 @@ export function ComputerPanel({
                   {phase === "vps-stopped" ? "Start VPS computer" : "Prepare VPS computer"}
                 </button>
               )}
-              {phase === "vps-incompatible" && vpsStatus?.managed &&
+              {computerStatusCurrent && phase === "vps-incompatible" && vpsStatus?.managed &&
                 (bot.computer === "cloud" || bot.autoStartVps) && (
                 <button
                   onClick={() => void replaceVpsComputer()}
@@ -1355,8 +1439,8 @@ export function ComputerPanel({
                   if (mode === "local" && bot.autoApprove) setLocalAutoWarning(true);
                   // a browser-only bot must actually have its browser: flip
                   // the per-bot switch on with the destination
-                  else if (mode === "browser") dispatch({ type: "updateBot", botId: bot.id, patch: { computer: mode, browser: true } });
-                  else dispatch({ type: "updateBot", botId: bot.id, patch: { computer: mode } });
+                  else if (mode === "browser") updateComputerSelection({ computer: mode, browser: true });
+                  else updateComputerSelection({ computer: mode });
                 }}
                 className={cn(
                   "flex-1 py-1.5 text-[13px]",
@@ -1378,7 +1462,7 @@ export function ComputerPanel({
               <CloudBackendPicker
                 value={cloudBackend}
                 vpsSupported={vpsSupported}
-                onChange={(backend) => dispatch({ type: "updateBot", botId: bot.id, patch: { cloudBackend: backend } })}
+                onChange={(backend) => updateComputerSelection({ cloudBackend: backend })}
               />
             </>
           )}
@@ -1475,7 +1559,7 @@ export function ComputerPanel({
       open={localAutoWarning}
       onCancel={() => setLocalAutoWarning(false)}
       onConfirm={() => {
-        dispatch({ type: "updateBot", botId: bot.id, patch: { computer: "local", acknowledgeLocalAuto: true } });
+        updateComputerSelection({ computer: "local", acknowledgeLocalAuto: true });
         setLocalAutoWarning(false);
       }}
     />

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -46,6 +46,7 @@ import {
   localComputerDisabledReason,
   localComputerSelectable,
   resolveBoxPanelAction,
+  shouldPollCloudPreview,
 } from "@/lib/local-computer";
 import {
   readComputerPanelView,
@@ -77,6 +78,7 @@ type Phase =
   | "auto-unavailable"
   | "show-ready-box"
   | "show-sleeping-box"
+  | "show-pending-box"
   | "browser"
   | "off"
   | "error";
@@ -190,6 +192,13 @@ export function ComputerPanel({
   const [localAutoWarning, setLocalAutoWarning] = useState(false);
   const localDisabledReason = localComputerDisabledReason({ capabilities, providerSupportsLocal });
   const [phase, setPhase] = useState<Phase>("checking");
+  const [cloudReadyBotId, setCloudReadyBotId] = useState<string | null>(null);
+  const cloudPreviewReady = shouldPollCloudPreview({
+    computer: bot.computer,
+    phase,
+    botId: bot.id,
+    resolvedBotId: cloudReadyBotId,
+  });
   const [boxState, setBoxState] = useState<string | null>(null);
   const [polledFrame, setPolledFrame] = useState<{ png: string; mime: string } | null>(null);
   const [vmFrame, setVmFrame] = useState<string | null>(null);
@@ -304,7 +313,7 @@ export function ComputerPanel({
         ? "the built-in browser"
         : bot.computer === "off"
           ? null
-          : phase === "ready" || phase === "show-ready-box"
+          : phase === "ready" || phase === "show-ready-box" || phase === "show-sleeping-box" || phase === "show-pending-box"
             ? cloudBackend === "vps" ? "the self-hosted VPS selected by Auto" : "the cloud box selected by Auto"
             : "this computer selected by Auto";
 
@@ -315,6 +324,7 @@ export function ComputerPanel({
     // wake a box, or churn preview state behind either tab.
     if (panelView !== "computer") return;
     let alive = true;
+    setCloudReadyBotId(null);
     setPhase("checking");
     setPolledFrame(null);
     setVmFrame(null);
@@ -425,6 +435,7 @@ export function ComputerPanel({
           }
           if (status.ready) {
             setBoxState(status.container ?? null);
+            if (bot.computer === "cloud") setCloudReadyBotId(bot.id);
             setPhase("ready");
             return;
           }
@@ -442,7 +453,10 @@ export function ComputerPanel({
             return api(`/api/bots/${bot.id}/computer/provision`, { method: "POST" }).then((result) => {
               if (!alive) return;
               setBoxState(result.container ?? null);
-              if (result.ready) setPhase("ready");
+              if (result.ready) {
+                setCloudReadyBotId(bot.id);
+                setPhase("ready");
+              }
               else {
                 setError(result.problem ?? "The VPS Cua desktop is not ready yet");
                 setPhase("error");
@@ -490,7 +504,7 @@ export function ComputerPanel({
           autoLocal,
         });
         if (action !== "ensure-box") {
-          if (action === "show-ready-box" || action === "show-sleeping-box") {
+          if (action === "show-ready-box" || action === "show-sleeping-box" || action === "show-pending-box") {
             setBoxState(typeof status.box?.state === "string" ? status.box.state : null);
           }
           setPhase(action);
@@ -500,6 +514,7 @@ export function ComputerPanel({
         return api(`/api/bots/${bot.id}/computer/provision`, { method: "POST" }).then((r) => {
           if (!alive) return;
           setBoxState(r.state ?? null);
+          setCloudReadyBotId(bot.id);
           setPhase("ready");
         });
       })
@@ -537,7 +552,7 @@ export function ComputerPanel({
   const sseFlowing = Boolean(bot.busy && live);
   const inFlight = useRef(false);
   useEffect(() => {
-    if (panelView !== "computer" || phase !== "ready" || sseFlowing || viewerOpen || !pageVisible) return;
+    if (panelView !== "computer" || !cloudPreviewReady || sseFlowing || viewerOpen || !pageVisible) return;
     let alive = true;
     const shoot = async () => {
       if (inFlight.current) return;
@@ -557,7 +572,7 @@ export function ComputerPanel({
       alive = false;
       clearInterval(timer);
     };
-  }, [panelView, phase, sseFlowing, bot.id, viewerOpen, pageVisible, bot.busy]);
+  }, [panelView, cloudPreviewReady, sseFlowing, bot.id, viewerOpen, pageVisible, bot.busy]);
 
   // Local VM preview comes directly from Cua Driver through the harness. It
   // does not use the password-protected noVNC viewer or cloud endpoints.
@@ -623,12 +638,12 @@ export function ComputerPanel({
       ? vmFrame
       : phase === "local" && !isLinux
       ? localFrame
-      : phase === "ready" || phase === "starting"
+      : cloudPreviewReady || (bot.computer === "cloud" && phase === "starting")
         ? cloudFrame && `data:${cloudFrame.mime};base64,${cloudFrame.png}`
         : null;
   const previewOpensDesktop = Boolean(
     frameSrc &&
-      ((phase === "vm" && vmViewerUrl) || phase === "ready"),
+      ((phase === "vm" && vmViewerUrl) || cloudPreviewReady),
   );
 
   // who-is-driving: SSE keeps this fresh; the mount fetch covers a panel
@@ -724,7 +739,7 @@ export function ComputerPanel({
       }
 
       let viewerUrl = vmViewerUrl;
-      if (phase === "ready") {
+      if (cloudPreviewReady) {
         const result = await api(`/api/bots/${bot.id}/computer/join`, { method: "POST" });
         viewerUrl = result.joinUrl?.constructor === String ? String(result.joinUrl) : null;
       }
@@ -746,7 +761,7 @@ export function ComputerPanel({
       // Release the bot before waiting on best-effort tunnel cleanup. A sick
       // SSH process must never leave the agent paused indefinitely.
       if (tookControl) await transitionControl("release").catch(() => {});
-      if (phase === "ready" && cloudBackend === "vps") {
+      if (cloudPreviewReady && cloudBackend === "vps") {
         await api(`/api/bots/${bot.id}/computer/viewer-close`, { method: "POST", body: "{}" }).catch(() => {});
       }
       setError(e instanceof Error ? e.message : String(e));
@@ -763,13 +778,17 @@ export function ComputerPanel({
       .then((result) => {
         if (kind === "provision") {
           setBoxState(result.container ?? null);
-          if (result.ready) setPhase("ready");
+          if (result.ready) {
+            if (bot.computer === "cloud") setCloudReadyBotId(bot.id);
+            setPhase("ready");
+          }
           else {
             setError(result.problem ?? "The VPS Cua desktop is not ready yet");
             setPhase("error");
           }
         }
         if (kind === "sleep") {
+          setCloudReadyBotId(null);
           setBoxState(cloudBackend === "vps" ? "stopped" : "archived");
           if (cloudBackend === "vps") setPhase("vps-stopped");
         }
@@ -832,6 +851,7 @@ export function ComputerPanel({
       });
       setVpsStatus(result);
       setBoxState(result.container ?? null);
+      if (result.ready && bot.computer === "cloud") setCloudReadyBotId(bot.id);
       setPhase(result.ready ? "ready" : "error");
       if (!result.ready) setError(result.problem ?? "The replacement VPS Cua desktop is not ready yet");
     } catch (e) {
@@ -859,6 +879,7 @@ export function ComputerPanel({
     "auto-unavailable": "Auto found no existing computer. Choose Cloud to create one, or pick another destination.",
     "show-ready-box": "Auto found an existing cloud computer. It was not opened or changed.",
     "show-sleeping-box": "Auto found a sleeping cloud computer. It was not woken or changed.",
+    "show-pending-box": "Auto found an existing cloud computer that is not ready. It was not changed.",
     "vps-unconfigured": "No managed VPS computer is configured for this bot",
     "vps-incompatible": "This VPS computer belongs to an earlier OpenMausBot version",
     "vps-stopped": "The managed VPS computer is stopped",
@@ -971,10 +992,10 @@ export function ComputerPanel({
             <span>{bot.name}'s screen</span>
             {phase === "local" && <span className="text-[11px]">this computer</span>}
             {phase === "vm" && <span className="text-[11px]">Local VM</span>}
-            {(phase === "show-ready-box" || phase === "show-sleeping-box") && (
+            {(phase === "show-ready-box" || phase === "show-sleeping-box" || phase === "show-pending-box") && (
               <span className="text-[11px]">cloud box · Auto · read-only</span>
             )}
-            {cloudBackend === "vps" && (phase === "ready" || phase === "starting") && <span className="text-[11px]">self-hosted VPS</span>}
+            {bot.computer === "cloud" && cloudBackend === "vps" && (phase === "ready" || phase === "starting") && <span className="text-[11px]">self-hosted VPS</span>}
         </div>
         <div className="flex aspect-[16/10] w-full items-center justify-center overflow-hidden rounded-xl bg-card">
           {frameSrc && previewOpensDesktop ? (
@@ -1013,8 +1034,10 @@ export function ComputerPanel({
                 <Monitor size={22} />
               )}
               <span className="text-[12px]">
-                {phase === "ready"
+                {cloudPreviewReady
                   ? "Waiting for the first frame…"
+                  : phase === "ready"
+                    ? "Auto found an existing cloud computer. Choose Cloud to open it."
                   : phase === "vm"
                     ? "Capturing the Local VM screen…"
                   : phase === "local"
@@ -1041,13 +1064,17 @@ export function ComputerPanel({
                   Open the Browser tab
                 </button>
               )}
-              {(phase === "show-ready-box" || phase === "show-sleeping-box") && (
+              {(phase === "show-ready-box" || phase === "show-sleeping-box" || phase === "show-pending-box") && (
                 <button
                   type="button"
                   onClick={() => dispatch({ type: "updateBot", botId: bot.id, patch: { computer: "cloud" } })}
                   className="mt-1 rounded-lg bg-control px-3 py-1.5 text-[12px] text-ink hover:bg-raised-hover"
                 >
-                  {phase === "show-sleeping-box" ? "Choose Cloud to wake" : "Choose Cloud to open"}
+                  {phase === "show-sleeping-box"
+                    ? "Choose Cloud to wake"
+                    : phase === "show-ready-box"
+                      ? "Choose Cloud to open"
+                      : "Choose Cloud to manage"}
                 </button>
               )}
               {phase === "vm-unavailable" && (
@@ -1152,7 +1179,7 @@ export function ComputerPanel({
           )}
 
         {/* Who is driving — take the wheel / hand it back */}
-        {(phase === "ready" || phase === "vm") && control.helpReason && !control.held && (
+        {(cloudPreviewReady || phase === "vm") && control.helpReason && !control.held && (
           <div className="mt-3 rounded-xl border border-warning/25 bg-warning/10 p-4">
             <div className="text-[13px] leading-relaxed text-warning">
               <b>{bot.name}</b> asked for your hands: {control.helpReason}
@@ -1160,7 +1187,7 @@ export function ComputerPanel({
             <div className="mt-2 flex gap-2">
               <button
                 onClick={() =>
-                  phase === "vm" || phase === "ready" ? void openDesktop() : controlAction("take")
+                  phase === "vm" || cloudPreviewReady ? void openDesktop() : controlAction("take")
                 }
                 disabled={controlPending || pending === "join"}
                 className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-accent py-2 text-[13px] font-medium text-white hover:brightness-110 disabled:opacity-50"
@@ -1178,11 +1205,11 @@ export function ComputerPanel({
             </div>
           </div>
         )}
-        {(phase === "ready" || phase === "vm") && control.held && (
+        {(cloudPreviewReady || phase === "vm") && control.held && (
           <div className="mt-3 rounded-xl border border-accent/25 bg-accent/10 p-4">
             <div className="text-[13px] leading-relaxed text-ink">
               You have the wheel — the bot's clicks and keystrokes are refused until you hand it back.
-              {phase === "ready" && " Use Open desktop to drive."}
+              {cloudPreviewReady && " Use Open desktop to drive."}
               {phase === "vm" && " Use Open desktop to drive — the preview here is watch-only."}
             </div>
             <button
@@ -1232,7 +1259,7 @@ export function ComputerPanel({
           </button>
         )}
         {/* Cloud-only actions */}
-        {phase === "ready" && (
+        {cloudPreviewReady && (
           <div className="mt-3 flex gap-2">
             {!control.held && !control.helpReason && (
               <button

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -552,7 +552,6 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
         | "title"
         | "description"
         | "notifications"
-        | "computer"
         | "cloudBackend"
         | "autoStartVps"
         | "color"
@@ -570,7 +569,7 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
         | "browser"
         | "modelSelection"
       >
-    > & { acknowledgeLocalAuto?: boolean },
+    > & { computer?: Bot["computer"] | null; acknowledgeLocalAuto?: boolean },
   ) => dispatch({ type: "updateBot", botId: bot.id, patch: p });
   const activeState = stateForBot(bot);
   const mascotMotion = state.mascotMotion?.botId === bot.id ? state.mascotMotion : null;
@@ -861,6 +860,7 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
             </div>
             <div className="mt-3 flex overflow-hidden rounded-lg border border-hairline/40">
               {([
+                [null, "Auto"],
                 ["cloud", "Cloud"],
                 ["vm", "Local VM"],
                 ["local", "This computer"],
@@ -868,7 +868,7 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
                 ["off", "Off"],
               ] as const).map(([mode, label], i) => (
                 <button
-                  key={mode}
+                  key={mode ?? "auto"}
                   disabled={(mode === "local" && !localSelectable) || (mode === "browser" && !browserSelectable)}
                   title={
                     mode === "local" && !localSelectable
@@ -878,7 +878,7 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
                         : undefined
                   }
                   onClick={() => {
-                    if (mode === bot.computer) return;
+                    if ((mode === null && bot.computer === undefined) || mode === bot.computer) return;
                     if (mode === "local" && bot.autoApprove) setLocalAutoWarning("local");
                     // a browser-only bot must actually have its browser: flip
                     // the per-bot switch on with the destination
@@ -889,7 +889,7 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
                     "flex-1 py-1.5 text-[13px] capitalize",
                     i > 0 && "border-l border-hairline/40",
                     ((mode === "local" && !localSelectable) || (mode === "browser" && !browserSelectable)) && "cursor-not-allowed opacity-40",
-                    bot.computer === mode
+                    (mode === null ? bot.computer === undefined : bot.computer === mode)
                       ? "bg-control text-ink"
                       : "text-ink-secondary hover:bg-control/60 hover:text-ink",
                   )}
@@ -900,6 +900,12 @@ export function SettingsPanel({ bot }: { bot: Bot }) {
             </div>
             {(!bot.computer || bot.computer === "cloud") && (
               <>
+                {!bot.computer && (
+                  <div className="mt-3 rounded-lg bg-inset px-3 py-2.5 text-[11.5px] leading-relaxed text-ink-secondary">
+                    <span className="font-medium text-ink">Auto cloud preference.</span>{" "}
+                    This chooses what Auto may reuse during a task; viewing settings does not create or wake a computer.
+                  </div>
+                )}
                 <CloudBackendPicker
                   value={bot.cloudBackend ?? "box"}
                   vpsSupported={canUseVps}

--- a/src/lib/local-computer.test.ts
+++ b/src/lib/local-computer.test.ts
@@ -6,6 +6,7 @@ import {
   linuxAutoDescription,
   localComputerDisabledReason,
   localComputerSelectable,
+  persistedComputerSelectionMatches,
   resolveBoxPanelAction,
   shouldPollCloudPreview,
 } from "./local-computer";
@@ -190,12 +191,41 @@ describe("local computer UI eligibility", () => {
   });
 
   it("refuses cloud preview polling when a stale ready phase belongs to Auto or another destination", () => {
-    const ready = { computer: "cloud" as const, phase: "ready", botId: "bot-a", resolvedBotId: "bot-a" };
+    const ready = {
+      computer: "cloud" as const,
+      cloudBackend: "box" as const,
+      phase: "ready",
+      botId: "bot-a",
+      resolvedBotId: "bot-a",
+      resolvedComputer: "cloud" as const,
+      resolvedCloudBackend: "box" as const,
+    };
     expect(shouldPollCloudPreview(ready)).toBe(true);
     expect(shouldPollCloudPreview({ ...ready, computer: undefined })).toBe(false);
     expect(shouldPollCloudPreview({ ...ready, computer: "local" })).toBe(false);
     expect(shouldPollCloudPreview({ ...ready, phase: "starting" })).toBe(false);
     expect(shouldPollCloudPreview({ ...ready, botId: "bot-b" })).toBe(false);
     expect(shouldPollCloudPreview({ ...ready, resolvedBotId: null })).toBe(false);
+    expect(shouldPollCloudPreview({ ...ready, resolvedComputer: undefined })).toBe(false);
+    expect(shouldPollCloudPreview({ ...ready, cloudBackend: "vps" })).toBe(false);
+    expect(shouldPollCloudPreview({ ...ready, resolvedCloudBackend: "vps" })).toBe(false);
+  });
+
+  it("rejects stale persisted selections in both cloud-backend switch directions", () => {
+    const expected = { computer: "cloud" as const, cloudBackend: "box" as const };
+    expect(persistedComputerSelectionMatches({ ...expected, persistedBot: expected })).toBe(true);
+    expect(persistedComputerSelectionMatches({
+      ...expected,
+      persistedBot: { computer: "cloud", cloudBackend: "vps" },
+    })).toBe(false);
+    expect(persistedComputerSelectionMatches({
+      computer: "cloud",
+      cloudBackend: "vps",
+      persistedBot: { computer: "cloud", cloudBackend: "box" },
+    })).toBe(false);
+    expect(persistedComputerSelectionMatches({
+      ...expected,
+      persistedBot: { computer: undefined, cloudBackend: "box" },
+    })).toBe(false);
   });
 });

--- a/src/lib/local-computer.test.ts
+++ b/src/lib/local-computer.test.ts
@@ -105,9 +105,8 @@ describe("local computer UI eligibility", () => {
     expect(
       resolveBoxPanelAction({
         computer: undefined,
-        driverKind: "claude",
         configured: true,
-        hasExistingBox: false,
+        boxState: null,
         canUseCloud: true,
         autoLocal: true,
       }),
@@ -115,54 +114,71 @@ describe("local computer UI eligibility", () => {
     expect(
       resolveBoxPanelAction({
         computer: undefined,
-        driverKind: "claude",
         configured: true,
-        hasExistingBox: false,
+        boxState: null,
         canUseCloud: true,
         autoLocal: false,
       }),
     ).toBe("auto-unavailable");
   });
 
-  it("reuses an existing Auto Box and provisions only for intentional cloud use", () => {
+  it("shows existing Auto Boxes without provisioning or waking them", () => {
     const base = {
       configured: true,
       canUseCloud: true,
       autoLocal: true,
+      computer: undefined,
     };
-    expect(
-      resolveBoxPanelAction({
-        ...base,
-        computer: undefined,
-        driverKind: "claude",
-        hasExistingBox: true,
-      }),
-    ).toBe("ensure-box");
-    expect(
-      resolveBoxPanelAction({
-        ...base,
-        computer: "cloud",
-        driverKind: "claude",
-        hasExistingBox: false,
-      }),
-    ).toBe("ensure-box");
-    expect(
-      resolveBoxPanelAction({
-        ...base,
-        computer: undefined,
-        driverKind: "boxAgent",
-        hasExistingBox: false,
-      }),
-    ).toBe("ensure-box");
+    for (const boxState of ["idle", "ready", "running"]) {
+      expect(resolveBoxPanelAction({ ...base, boxState })).toBe("show-ready-box");
+    }
+    for (const boxState of ["archived", "stopped", "provisioning"]) {
+      expect(resolveBoxPanelAction({ ...base, boxState })).toBe("show-sleeping-box");
+    }
+  });
+
+  it("provisions only after an explicit Cloud choice", () => {
+    expect(resolveBoxPanelAction({
+      computer: "cloud",
+      configured: true,
+      boxState: null,
+      canUseCloud: true,
+      autoLocal: true,
+    })).toBe("ensure-box");
+    expect(resolveBoxPanelAction({
+      computer: "cloud",
+      configured: true,
+      boxState: "archived",
+      canUseCloud: true,
+      autoLocal: true,
+    })).toBe("ensure-box");
+  });
+
+  it("never gives the box-native engine a passive Auto creation exception", () => {
+    // Engine kind intentionally is not an input: every engine follows the
+    // same read-only Auto rule, including boxAgent.
+    expect(resolveBoxPanelAction({
+      computer: undefined,
+      configured: true,
+      boxState: null,
+      canUseCloud: true,
+      autoLocal: false,
+    })).toBe("auto-unavailable");
+    expect(resolveBoxPanelAction({
+      computer: undefined,
+      configured: true,
+      boxState: "archived",
+      canUseCloud: true,
+      autoLocal: false,
+    })).toBe("show-sleeping-box");
   });
 
   it("falls back locally when the selected engine cannot use an existing Box", () => {
     expect(
       resolveBoxPanelAction({
         computer: undefined,
-        driverKind: "claude",
         configured: true,
-        hasExistingBox: true,
+        boxState: "running",
         canUseCloud: false,
         autoLocal: true,
       }),

--- a/src/lib/local-computer.test.ts
+++ b/src/lib/local-computer.test.ts
@@ -7,6 +7,7 @@ import {
   localComputerDisabledReason,
   localComputerSelectable,
   resolveBoxPanelAction,
+  shouldPollCloudPreview,
 } from "./local-computer";
 
 describe("local computer UI eligibility", () => {
@@ -132,8 +133,11 @@ describe("local computer UI eligibility", () => {
     for (const boxState of ["idle", "ready", "running"]) {
       expect(resolveBoxPanelAction({ ...base, boxState })).toBe("show-ready-box");
     }
-    for (const boxState of ["archived", "stopped", "provisioning"]) {
+    for (const boxState of ["archived", "stopped"]) {
       expect(resolveBoxPanelAction({ ...base, boxState })).toBe("show-sleeping-box");
+    }
+    for (const boxState of ["provisioning", "creating", "unknown-provider-state"]) {
+      expect(resolveBoxPanelAction({ ...base, boxState })).toBe("show-pending-box");
     }
   });
 
@@ -183,5 +187,15 @@ describe("local computer UI eligibility", () => {
         autoLocal: true,
       }),
     ).toBe("local");
+  });
+
+  it("refuses cloud preview polling when a stale ready phase belongs to Auto or another destination", () => {
+    const ready = { computer: "cloud" as const, phase: "ready", botId: "bot-a", resolvedBotId: "bot-a" };
+    expect(shouldPollCloudPreview(ready)).toBe(true);
+    expect(shouldPollCloudPreview({ ...ready, computer: undefined })).toBe(false);
+    expect(shouldPollCloudPreview({ ...ready, computer: "local" })).toBe(false);
+    expect(shouldPollCloudPreview({ ...ready, phase: "starting" })).toBe(false);
+    expect(shouldPollCloudPreview({ ...ready, botId: "bot-b" })).toBe(false);
+    expect(shouldPollCloudPreview({ ...ready, resolvedBotId: null })).toBe(false);
   });
 });

--- a/src/lib/local-computer.ts
+++ b/src/lib/local-computer.ts
@@ -59,35 +59,44 @@ export function linuxAutoDescription(): string {
   return "Auto reuses an existing cloud box; otherwise computer use stays off.";
 }
 
-export type BoxPanelAction = "ensure-box" | "local" | "unconfigured" | "auto-unavailable";
+export type BoxPanelAction =
+  | "ensure-box"
+  | "show-ready-box"
+  | "show-sleeping-box"
+  | "local"
+  | "unconfigured"
+  | "auto-unavailable";
+
+const READY_BOX_STATES = new Set(["idle", "ready", "running"]);
 
 /** Mirror the turn router's Box choice without letting a passive panel open
- * create infrastructure. Auto may wake an existing Box. The box-native
- * Computer engine is the sole creation exception because it cannot run
- * anywhere else; explicit Cloud is always an intentional creation request. */
+ * mutate infrastructure. Auto only reports an existing Box's current state;
+ * it never creates, wakes, bootstraps, or opens one. This is deliberately
+ * independent of the engine: even the box-native Computer engine needs an
+ * explicit Cloud choice before the panel may provision. */
 export function resolveBoxPanelAction({
   computer,
-  driverKind,
   configured,
-  hasExistingBox,
+  boxState,
   canUseCloud,
   autoLocal,
 }: {
   computer: Bot["computer"];
-  driverKind: string | undefined;
   configured: boolean;
-  hasExistingBox: boolean;
+  boxState: string | null;
   canUseCloud: boolean;
   autoLocal: boolean;
 }): BoxPanelAction {
   const explicitCloud = computer === "cloud";
-  const boxNative = driverKind === "boxAgent";
 
   if (!configured) {
-    if (explicitCloud || boxNative) return "unconfigured";
+    if (explicitCloud) return "unconfigured";
     return autoLocal ? "local" : "auto-unavailable";
   }
-  if (canUseCloud && (hasExistingBox || explicitCloud || boxNative)) return "ensure-box";
+  if (explicitCloud) return canUseCloud ? "ensure-box" : "auto-unavailable";
+  if (canUseCloud && boxState) {
+    return READY_BOX_STATES.has(boxState) ? "show-ready-box" : "show-sleeping-box";
+  }
   return autoLocal ? "local" : "auto-unavailable";
 }
 

--- a/src/lib/local-computer.ts
+++ b/src/lib/local-computer.ts
@@ -63,11 +63,13 @@ export type BoxPanelAction =
   | "ensure-box"
   | "show-ready-box"
   | "show-sleeping-box"
+  | "show-pending-box"
   | "local"
   | "unconfigured"
   | "auto-unavailable";
 
 const READY_BOX_STATES = new Set(["idle", "ready", "running"]);
+const SLEEPING_BOX_STATES = new Set(["archived", "stopped"]);
 
 /** Mirror the turn router's Box choice without letting a passive panel open
  * mutate infrastructure. Auto only reports an existing Box's current state;
@@ -95,9 +97,30 @@ export function resolveBoxPanelAction({
   }
   if (explicitCloud) return canUseCloud ? "ensure-box" : "auto-unavailable";
   if (canUseCloud && boxState) {
-    return READY_BOX_STATES.has(boxState) ? "show-ready-box" : "show-sleeping-box";
+    if (READY_BOX_STATES.has(boxState)) return "show-ready-box";
+    if (SLEEPING_BOX_STATES.has(boxState)) return "show-sleeping-box";
+    return "show-pending-box";
   }
   return autoLocal ? "local" : "auto-unavailable";
+}
+
+/** A stale ready phase can survive one render while the selected bot or its
+ * destination changes. Keep every cloud preview POST behind the durable,
+ * explicit Cloud choice as well as the resolved phase. */
+export function shouldPollCloudPreview(
+  {
+    computer,
+    phase,
+    botId,
+    resolvedBotId,
+  }: {
+    computer: Bot["computer"];
+    phase: string;
+    botId: string;
+    resolvedBotId: string | null;
+  },
+): boolean {
+  return computer === "cloud" && phase === "ready" && resolvedBotId === botId;
 }
 
 export function autoSelectsLocalComputer({

--- a/src/lib/local-computer.ts
+++ b/src/lib/local-computer.ts
@@ -110,17 +110,43 @@ export function resolveBoxPanelAction({
 export function shouldPollCloudPreview(
   {
     computer,
+    cloudBackend,
     phase,
     botId,
     resolvedBotId,
+    resolvedComputer,
+    resolvedCloudBackend,
   }: {
     computer: Bot["computer"];
+    cloudBackend: NonNullable<Bot["cloudBackend"]>;
     phase: string;
     botId: string;
     resolvedBotId: string | null;
+    resolvedComputer: Bot["computer"] | null;
+    resolvedCloudBackend: Bot["cloudBackend"] | null;
   },
 ): boolean {
-  return computer === "cloud" && phase === "ready" && resolvedBotId === botId;
+  return computer === "cloud"
+    && phase === "ready"
+    && resolvedBotId === botId
+    && resolvedComputer === "cloud"
+    && resolvedCloudBackend === cloudBackend;
+}
+
+/** A computer effect may render optimistic profile state while its PATCH is
+ * still in flight. Provider work is safe only when the settled server bot
+ * confirms the same destination and backend that this render expects. */
+export function persistedComputerSelectionMatches({
+  computer,
+  cloudBackend,
+  persistedBot,
+}: {
+  computer: Bot["computer"];
+  cloudBackend: NonNullable<Bot["cloudBackend"]>;
+  persistedBot: Pick<Bot, "computer" | "cloudBackend">;
+}): boolean {
+  return persistedBot.computer === computer
+    && (persistedBot.cloudBackend ?? "box") === cloudBackend;
 }
 
 export function autoSelectsLocalComputer({

--- a/src/state/bot-patch-queue.test.ts
+++ b/src/state/bot-patch-queue.test.ts
@@ -37,6 +37,29 @@ describe("bot patch queue", () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
+  it("flush waits for the PATCH and returns the server-authoritative computer selection", async () => {
+    const request = deferredBot();
+    const send = vi.fn(async () => request.promise);
+    const queue = createBotPatchQueue({
+      send,
+      reconcile: async () => bot(),
+      onAuthoritative: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    queue.enqueue("bot-1", { computer: "cloud", cloudBackend: "vps" }, bot());
+    const flushed = queue.flush("bot-1");
+    let settled = false;
+    void flushed.then(() => { settled = true; });
+    await Promise.resolve();
+
+    expect(send).toHaveBeenCalledOnce();
+    expect(settled).toBe(false);
+
+    request.resolve(bot({ computer: "cloud", cloudBackend: "vps" }));
+    await expect(flushed).resolves.toMatchObject({ computer: "cloud", cloudBackend: "vps" });
+  });
+
   it("coalesces upload then remove so an older avatar can never resurrect", async () => {
     const sent: BotUpdatePatch[] = [];
     const authoritative = vi.fn();

--- a/src/state/bot-patch-queue.test.ts
+++ b/src/state/bot-patch-queue.test.ts
@@ -43,7 +43,7 @@ describe("bot patch queue", () => {
     const queue = createBotPatchQueue({
       send: async (_botId, patch) => {
         sent.push(patch);
-        return bot({ ...patch });
+        return bot({ ...patch, computer: patch.computer ?? undefined });
       },
       reconcile: async () => bot(),
       onAuthoritative: authoritative,
@@ -220,6 +220,28 @@ describe("bot patch queue", () => {
 
     expect(sent).toEqual([{ computer: "local", acknowledgeLocalAuto: true, title: "Ops" }]);
     for (const overlay of overlays) expect(overlay).not.toHaveProperty("acknowledgeLocalAuto");
+  });
+
+  it("sends null to select Auto but normalizes it to an absent state field", async () => {
+    const sent: BotUpdatePatch[] = [];
+    const overlays: BotUpdatePatch[] = [];
+    const queue = createBotPatchQueue({
+      send: async (_botId, patch) => {
+        sent.push(patch);
+        return bot();
+      },
+      reconcile: async () => bot(),
+      onAuthoritative: (_bot, overlay) => overlays.push(overlay),
+      onError: vi.fn(),
+    });
+
+    queue.enqueue("bot-1", { computer: null }, bot({ computer: "cloud" }));
+    expect(queue.overlayFor("bot-1")).toEqual({ computer: undefined });
+    await vi.advanceTimersByTimeAsync(400);
+    await queue.flush("bot-1");
+
+    expect(sent).toEqual([{ computer: null }]);
+    expect(overlays).toEqual([{ computer: undefined }]);
   });
 
   it("revive undoes a dispose, so StrictMode's dev probe cannot kill saving", async () => {

--- a/src/state/bot-patch-queue.ts
+++ b/src/state/bot-patch-queue.ts
@@ -8,7 +8,6 @@ export type BotUpdatePatch = Partial<
     | "title"
     | "description"
     | "notifications"
-    | "computer"
     | "cloudBackend"
     | "autoStartVps"
     | "color"
@@ -30,11 +29,19 @@ export type BotUpdatePatch = Partial<
     | "modelSelection"
   >
 > & {
+  /** null is the wire representation for clearing an explicit destination
+   * and returning to Auto. Bot state itself keeps Auto as an absent field. */
+  computer?: Bot["computer"] | null;
   /** Rides the PATCH body only: the server's proof that the local-auto
    * warning dialog was shown (see server/index.ts's consent gate). It must
    * reach the wire inside the coalesced body and must never fold into bot
    * state — the queue strips it from every overlay it hands back. */
   acknowledgeLocalAuto?: boolean;
+};
+
+/** A wire patch after clear-only values have been normalized for Bot state. */
+export type BotStatePatch = Omit<BotUpdatePatch, "computer" | "acknowledgeLocalAuto"> & {
+  computer?: Bot["computer"];
 };
 
 interface BotPatchQueueEntry {
@@ -57,14 +64,14 @@ export interface BotPatchQueueOptions {
     signal: AbortSignal,
   ) => Promise<BotAnnouncement>;
   reconcile: (botId: string, signal: AbortSignal) => Promise<BotAnnouncement | null>;
-  onAuthoritative: (bot: BotAnnouncement, optimisticOverlay: BotUpdatePatch) => void;
+  onAuthoritative: (bot: BotAnnouncement, optimisticOverlay: BotStatePatch) => void;
   onError: (error: Error) => void;
 }
 
 export interface BotPatchQueue {
   enqueue: (botId: string, patch: BotUpdatePatch, fallback: BotAnnouncement) => void;
   flush: (botId: string) => Promise<void>;
-  overlayFor: (botId: string) => BotUpdatePatch;
+  overlayFor: (botId: string) => BotStatePatch;
   cancel: (botId: string) => void;
   /** Undo a dispose. Exists for React StrictMode, whose dev-mode mount probe
    * runs the effect cleanup once against the SAME memoized queue — without
@@ -77,9 +84,10 @@ const hasFields = (patch: BotUpdatePatch): boolean => Object.keys(patch).length 
 
 /** What may fold back into renderer bot state: everything except the consent
  * flag, which is wire-only. One strip point covers both overlay paths. */
-const stateOverlay = (patch: BotUpdatePatch): BotUpdatePatch => {
-  const { acknowledgeLocalAuto: _ack, ...fields } = patch;
-  return fields;
+const stateOverlay = (patch: BotUpdatePatch): BotStatePatch => {
+  const { acknowledgeLocalAuto: _ack, computer, ...fields } = patch;
+  if (computer === null) return { ...fields, computer: undefined };
+  return computer === undefined ? fields : { ...fields, computer };
 };
 
 /**

--- a/src/state/bot-patch-queue.ts
+++ b/src/state/bot-patch-queue.ts
@@ -53,7 +53,7 @@ interface BotPatchQueueEntry {
   running: boolean;
   controller: AbortController | null;
   cancelled: boolean;
-  idleWaiters: Array<() => void>;
+  idleWaiters: Array<(bot: BotAnnouncement | null) => void>;
 }
 
 export interface BotPatchQueueOptions {
@@ -70,7 +70,9 @@ export interface BotPatchQueueOptions {
 
 export interface BotPatchQueue {
   enqueue: (botId: string, patch: BotUpdatePatch, fallback: BotAnnouncement) => void;
-  flush: (botId: string) => Promise<void>;
+  /** Wait for the lane to settle and return the server-authoritative bot.
+   * null means there was no queued write (or the lane was cancelled). */
+  flush: (botId: string) => Promise<BotAnnouncement | null>;
   overlayFor: (botId: string) => BotStatePatch;
   cancel: (botId: string) => void;
   /** Undo a dispose. Exists for React StrictMode, whose dev-mode mount probe
@@ -103,7 +105,7 @@ export function createBotPatchQueue(options: BotPatchQueueOptions): BotPatchQueu
   const settleIfIdle = (entry: BotPatchQueueEntry) => {
     if (entry.running || entry.timer !== null || hasFields(entry.pending)) return;
     entries.delete(entry.botId);
-    for (const resolve of entry.idleWaiters.splice(0)) resolve();
+    for (const resolve of entry.idleWaiters.splice(0)) resolve(entry.fallback);
   };
 
   const drain = async (entry: BotPatchQueueEntry): Promise<void> => {
@@ -179,12 +181,12 @@ export function createBotPatchQueue(options: BotPatchQueueOptions): BotPatchQueu
 
     flush(botId) {
       const entry = entries.get(botId);
-      if (!entry) return Promise.resolve();
+      if (!entry) return Promise.resolve(null);
       if (entry.timer !== null) {
         clearTimeout(entry.timer);
         entry.timer = null;
       }
-      const idle = new Promise<void>((resolve) => entry.idleWaiters.push(resolve));
+      const idle = new Promise<BotAnnouncement | null>((resolve) => entry.idleWaiters.push(resolve));
       void drain(entry);
       settleIfIdle(entry);
       return idle;
@@ -202,7 +204,7 @@ export function createBotPatchQueue(options: BotPatchQueueOptions): BotPatchQueu
       if (entry.timer !== null) clearTimeout(entry.timer);
       entry.controller?.abort();
       entries.delete(botId);
-      for (const resolve of entry.idleWaiters.splice(0)) resolve();
+      for (const resolve of entry.idleWaiters.splice(0)) resolve(null);
     },
 
     revive() {
@@ -215,7 +217,7 @@ export function createBotPatchQueue(options: BotPatchQueueOptions): BotPatchQueu
         entry.cancelled = true;
         if (entry.timer !== null) clearTimeout(entry.timer);
         entry.controller?.abort();
-        for (const resolve of entry.idleWaiters.splice(0)) resolve();
+        for (const resolve of entry.idleWaiters.splice(0)) resolve(null);
       }
       entries.clear();
     },

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -623,6 +623,17 @@ describe("section Chiefs", () => {
     expect(next.bots.find((candidate) => candidate.id === workCandidate.id)?.chiefOfStaff).toBe(true);
     expect(next.bots.find((candidate) => candidate.id === personalChief.id)?.chiefOfStaff).toBe(true);
   });
+
+  it("optimistically clears an explicit computer when Auto is selected", () => {
+    const current = { ...bot("cloud-bot", "Work"), computer: "cloud" as const, messages: [] };
+    const next = reducer({ ...initialState, bots: [current] }, {
+      type: "updateBot",
+      botId: current.id,
+      patch: { computer: null },
+    });
+
+    expect(next.bots[0]?.computer).toBeUndefined();
+  });
 });
 
 describe("pending queued chip", () => {

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -1512,7 +1512,7 @@ const StoreContext = createContext<{
   state: AppState;
   dispatch: React.Dispatch<Action>;
   /** Commit any debounced profile edits before an operation reads the bot. */
-  flushBotPatches: (botId: string) => Promise<void>;
+  flushBotPatches: (botId: string) => Promise<BotAnnouncement | null>;
   /** Re-fetch engine availability — after an install, without a restart. */
   refreshInstances: () => Promise<void>;
   /** Explicit provider/network model discovery. */

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -1236,7 +1236,12 @@ export function reducer(state: AppState, action: Action): AppState {
             ),
           }
         : animated;
-      const { acknowledgeLocalAuto: _ack, ...botPatch } = action.patch;
+      const { acknowledgeLocalAuto: _ack, computer, ...rest } = action.patch;
+      const botPatch = computer === null
+        ? { ...rest, computer: undefined }
+        : computer === undefined
+          ? rest
+          : { ...rest, computer };
       return updateBot(next, action.botId, (b) => ({ ...b, ...botPatch }));
     }
     case "threadActive": {


### PR DESCRIPTION
## What changed
- add a real Auto option to both computer destination pickers
- make passive Auto inspection read-only for missing, ready, sleeping, and transitional Boxes
- require an explicit Cloud choice before any Box provision, join, wake, sleep, console, or screenshot mutation
- guard cloud preview polling against stale state when switching bots
- preserve Auto as an absent durable field while using `null` at the PATCH boundary

## Verification
- isolated real-server boundary test: all six Auto Box actions return 409 with zero provider calls; explicit Cloud reaches the provider
- 54 focused renderer/helper/state tests
- `pnpm typecheck`
- focused Oxlint and diff checks

Follow-up to #763.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an explicit **Auto** option for computer preferences.
  - Added clearer status views for existing boxes in Auto mode, including ready, sleeping, and pending states.
  - Added guidance and a **Choose Cloud** action when Cloud mode is required.

- **Bug Fixes**
  - Auto mode no longer creates or provisions Cloud boxes unexpectedly.
  - Invalid computer settings now return a clear validation error.
  - Cloud-only actions are blocked until Cloud mode is selected.
  - Clearing a computer preference now correctly returns it to Auto.
  - Computer preference changes now wait for confirmation before updating related controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->