### PR TITLE
fix(local-vm): recreate an idle-removed Local VM instead of failing the turn

### DIFF
--- a/server/container-computer.test.ts
+++ b/server/container-computer.test.ts
@@ -24,9 +24,11 @@ import {
   containerComputerStatus,
   containerRuntimeStatus,
   containerRunArgs,
+  localVmRecreatableOnDemand,
   managedImageDockerfile,
   perBotLocalVmTarget,
   podmanSecurityIsHardened,
+  SHARED_LOCAL_VM_TARGET,
   setupCommands,
   type CommandRunner,
   type LocalVmTarget,
@@ -781,5 +783,70 @@ describe("setupCommands", () => {
 
   it("offers the supported Podman Desktop installer on Windows", () => {
     expect(setupCommands(null, "win32").install).toBe("winget install -e --id RedHat.Podman-Desktop");
+  });
+});
+
+describe("localVmRecreatableOnDemand", () => {
+  const linuxPodman = {
+    "/usr/bin/which docker": new Error("missing"),
+    "/usr/bin/which podman": "podman\n",
+    "podman info --format json": '{"host":{"arch":"amd64"}}\n',
+  };
+
+  it("recreates a Local VM the idle timer removed", async () => {
+    const target = SHARED_LOCAL_VM_TARGET;
+    const fake = runner({
+      ...linuxPodman,
+      [`podman image inspect ${IMAGE}`]: preparedImageInspect(),
+      [`podman inspect ${target.containerName}`]: new Error("no such container"),
+    });
+
+    const status = await containerComputerStatus(fake.run, "linux", target);
+
+    expect(status.container).toBe("missing");
+    expect(status.problem).toBe("Create the Local VM");
+    expect(localVmRecreatableOnDemand(status)).toBe(true);
+  });
+
+  it("leaves a stopped container alone, because it is asked to be recreated not started", async () => {
+    const target = SHARED_LOCAL_VM_TARGET;
+    const detail = JSON.parse(readyInspect())[0];
+    detail.State = { Running: false, Status: "exited" };
+    const fake = runner({
+      ...linuxPodman,
+      [`podman image inspect ${IMAGE}`]: preparedImageInspect(),
+      [`podman inspect ${target.containerName}`]: JSON.stringify([detail]),
+    });
+
+    const status = await containerComputerStatus(fake.run, "linux", target);
+
+    expect(status.container).toBe("stopped");
+    expect(localVmRecreatableOnDemand(status)).toBe(false);
+  });
+
+  it("does not create anything when no container runtime is installed", async () => {
+    const fake = runner({
+      "/usr/bin/which docker": new Error("missing"),
+      "/usr/bin/which podman": new Error("missing"),
+    });
+
+    const status = await containerComputerStatus(fake.run, "linux", SHARED_LOCAL_VM_TARGET);
+
+    expect(status.runtime).toBeNull();
+    expect(localVmRecreatableOnDemand(status)).toBe(false);
+  });
+
+  it("does not create anything before the desktop image has been prepared", async () => {
+    const target = SHARED_LOCAL_VM_TARGET;
+    const fake = runner({
+      ...linuxPodman,
+      [`podman image inspect ${IMAGE}`]: new Error("no such image"),
+      [`podman inspect ${target.containerName}`]: new Error("no such container"),
+    });
+
+    const status = await containerComputerStatus(fake.run, "linux", target);
+
+    expect(status.image).toBe(false);
+    expect(localVmRecreatableOnDemand(status)).toBe(false);
   });
 });

--- a/server/container-computer.ts
+++ b/server/container-computer.ts
@@ -327,6 +327,31 @@ function emptyStatus(platform: NodeJS.Platform, target: LocalVmTarget): Containe
   };
 }
 
+/** Whether a turn may recreate this Local VM itself instead of failing.
+ *
+ * True for exactly one state: the container is gone, and a plain `run` is all
+ * that is needed to bring it back. That is what `LocalVmIdleTimer` leaves
+ * behind — it removes an unused Local VM rather than pausing it — so a turn
+ * arriving after an idle period should not have to send the person to App
+ * Settings for a container the app itself deleted.
+ *
+ * Every other problem in `statusProblem` stays the person's call and returns
+ * false here: no runtime, daemon down, image never prepared, `create_supported`
+ * false, and any existing container — stale image, unmanaged, unsafe network,
+ * security or persistence. A stopped container is excluded deliberately, since
+ * `statusProblem` says this desktop image cannot safely resume and asks for a
+ * recreate rather than a start.
+ */
+export function localVmRecreatableOnDemand(
+  status: ContainerComputerStatus,
+): status is ContainerComputerStatus & { runtime: Runtime } {
+  return Boolean(status.runtime)
+    && status.daemonUp
+    && status.image
+    && status.container === "missing"
+    && status.create_supported;
+}
+
 function statusProblem(status: ContainerComputerStatus): string | null {
   if (!status.runtime) return "Install a supported container runtime first";
   if (!status.daemonUp) return `Start ${status.runtime} first`;

--- a/server/index.ts
+++ b/server/index.ts
@@ -71,6 +71,7 @@ import {
   containerComputerScreenshot,
   containerComputerStatus,
   containerRuntimeStatus,
+  localVmRecreatableOnDemand,
   perBotLocalVmTarget,
   SHARED_LOCAL_VM_TARGET,
   setupCommands,
@@ -1837,6 +1838,10 @@ const activeVpsThreads = new Map<string, string>();
 // entire async Git operation so a turn cannot start in that folder midway.
 const checkpointRestoreLeases = new Set<string>();
 const LOCAL_VM_IDLE_MS = 8 * 60 * 60_000;
+/** How long a turn waits for Cua Driver after starting the container itself.
+ * A cold XFCE desktop needs some seconds; past this the turn reports the
+ * status it has rather than hanging on a container that will not come up. */
+const LOCAL_VM_DESKTOP_WAIT_MS = 90_000;
 const localVmIdles = new Map<string, LocalVmIdleTimer>();
 
 function localVmTargetForBot(botId: string): LocalVmTarget {
@@ -3134,7 +3139,7 @@ async function startTurn(
         localVmThreadTargets.set(threadId, localVmTarget);
         localVmActiveThreads.set(localVmTarget.key, threadId);
         localVmIdleFor(localVmTarget).touch();
-        const localVm = await containerComputerStatus(undefined, undefined, localVmTarget);
+        const localVm = await readyLocalVmForTurn(bot.id, localVmTarget);
         if (!localVm.ready || !localVm.runtime) {
           throw new Error(`${localVm.problem ?? "the Local VM is not ready"} (App Settings → Local VM)`);
         }
@@ -5642,6 +5647,63 @@ async function localVmPayload(target: LocalVmTarget) {
     mode: localVmMode(cfg),
     max_instances: localVmMaxInstances(cfg),
   };
+}
+
+/** The Local VM a turn is about to use, recreated if the idle timer took it.
+ *
+ * `LocalVmIdleTimer` REMOVES an unused Local VM rather than pausing it. The
+ * turn then failed with "Create the Local VM (App Settings → Local VM)" —
+ * which reads like a fault the person must repair by hand, for a container the
+ * app itself deleted eight hours earlier. Someone who steps away overnight
+ * comes back to an error on their first message.
+ *
+ * The cloud branch below already does the opposite: an absent box is
+ * provisioned on first use behind a `provisioning` broadcast. This gives the
+ * Local VM the same lifecycle for the same reason.
+ *
+ * Only `missing` is recovered, and only when a fresh `run` is all it takes.
+ * Every other problem still surfaces: no runtime installed, no image pulled,
+ * `create_supported` false, or an existing container that is stale, unmanaged
+ * or unsafe. Those need a decision — install podman, download 1.4 GB, replace
+ * a container someone else made — and a stopped container is deliberately not
+ * resumed here, because `localVmProblem` says this desktop image cannot safely
+ * resume and asks for a recreate rather than a start. Per-bot mode keeps its
+ * instance cap; creating past it would quietly do what the lifecycle route
+ * refuses.
+ */
+async function readyLocalVmForTurn(botId: string, target: LocalVmTarget) {
+  let status = await containerComputerStatus(undefined, undefined, target);
+  if (status.ready || !localVmRecreatableOnDemand(status)) return status;
+
+  if (target.key !== SHARED_LOCAL_VM_TARGET.key) {
+    const count = await existingPerBotLocalVmCount(status.runtime);
+    if (count >= localVmMaxInstances(cfg)) return status;
+  }
+
+  broadcast({ kind: "computer", botId, state: "provisioning" });
+  localVmLifecycleBusy.add(target.key);
+  localVmProvisionBusy = true;
+  try {
+    status = await containerComputerAction("run", undefined, undefined, target);
+  } catch {
+    // Keep the inspected status: its `problem` names the real obstacle, which
+    // is more use to the person than "podman run exited non-zero".
+    return status;
+  } finally {
+    localVmProvisionBusy = false;
+    localVmLifecycleBusy.delete(target.key);
+  }
+  localVmIdleFor(target).touch();
+
+  // The container is up before Cua Driver is. Waiting here rather than failing
+  // the turn is the whole point: a person who has been away eight hours should
+  // not have to send their message twice.
+  const deadline = Date.now() + LOCAL_VM_DESKTOP_WAIT_MS;
+  while (!status.ready && status.container === "running" && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+    status = await containerComputerStatus(undefined, undefined, target);
+  }
+  return status;
 }
 
 async function existingPerBotLocalVmCount(runtime: Runtime) {


### PR DESCRIPTION
## The bug

`LocalVmIdleTimer` **removes** an unused Local VM rather than pausing it:

```ts
if (status.container === "running")
  await containerComputerAction("remove", undefined, undefined, target);
```

The next turn then fails with **"Create the Local VM (App Settings → Local VM)"** — which reads like a fault the person has to repair by hand, for a container the app itself deleted eight hours earlier. Step away overnight and your first message the next morning is an error.

I hit this on a live workspace. The container had run cleanly for `1d 20h`, peaked at 225 MB, and was removed by the idle timer overnight. Every bot with `computer: vm` then failed until someone opened Settings — including on a task that needed no desktop at all.

## Why this is inconsistent rather than just unfortunate

The cloud branch, ~80 lines below, already does the opposite:

```ts
if (!b && mountsCloudComputer && (wants === "cloud" || …)) {
  broadcast({ kind: "computer", botId: bot.id, state: "provisioning" });
  await box.provisionBox(cfg, bot.id, bot.name);   // absent box: made
}
if (b && !["idle","ready","running"].includes(b.state)) {
  broadcast({ kind: "computer", botId: bot.id, state: "waking" });
  b = await box.readyBox(cfg, bot.id);             // archived box: woken
}
```

Box provisions and wakes on first use. The Local VM did neither. One half of its lifecycle was automated — the removal — and the other half was left to the person.

This gives the Local VM the same treatment, behind the same `provisioning` broadcast.

## Deliberately narrow

`localVmRecreatableOnDemand` is true for exactly one state: the container is gone and a plain `run` brings it back. Everything else still surfaces as before, because it needs a decision rather than a retry:

- no container runtime installed
- daemon down
- image never prepared (a 1.4 GB download is not something to start unasked)
- `create_supported` false
- an existing container that is stale, unmanaged, or has unsafe network/security/persistence

**A stopped container is excluded on purpose.** `statusProblem` says *"This desktop image cannot safely resume; recreate the Local VM"* — so auto-`start` would contradict the file's own stated intent, and auto-recreating is destructive enough to stay a human call.

Per-bot mode keeps its instance cap; creating past it here would quietly do what the lifecycle route refuses with a 409.

The container is up before Cua Driver is, so the turn waits for readiness rather than failing on a desktop that is still booting — bounded at 90s, after which it reports the status it has rather than hanging.

## Where the predicate lives

In `container-computer.ts`, immediately above `statusProblem`, so the two stay in step: every branch the predicate declines maps to a message that function already returns. Being pure, it is covered by `container-computer.test.ts` with a fake runner and no container runtime.

## Verification — please read, it is partial

Run locally:

- `tsc -p tsconfig.server.json --noEmit` — clean
- `vitest run server/container-computer.test.ts server/local-vm-idle.test.ts server/local-vm-lease.test.ts` — **52 passed**, including 4 new
- `oxlint` on all three touched files — no new findings (one pre-existing `no-useless-spread` warning at `server/index.ts:1484`, present on `main` too; I verified by stashing)

**Not run locally:** the full `pnpm test` suite and the packaged/Electron smoke tests. CI is the first run of those. The recovery path itself needs a real podman/docker to exercise end to end, which is why the decision logic was extracted into a pure predicate that tests can reach.

The four new tests cover: idle-removed container → recreatable; stopped container → not; no runtime → not; image not prepared → not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local VM environments can now be recreated automatically when needed for a turn.
  * The system waits for the VM desktop to become ready before proceeding.
  * VM provisioning limits and unsupported states are handled safely.

* **Tests**
  * Added coverage for VM recreation eligibility, including missing, stopped, unavailable, and unprepared environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->