### PR TITLE
Wait for the nested scroll instead of sleeping 50ms

### DIFF
--- a/electron/fixtures/browser-closed-shadow.cjs
+++ b/electron/fixtures/browser-closed-shadow.cjs
@@ -34,6 +34,25 @@ async function waitForFixedViewport(browserView, label, timeoutMs = 2_000) {
   throw new Error(`${label} viewport was not fixed: ${JSON.stringify(viewport)}`);
 }
 
+// Only Linux moves a nested scroller synchronously from the isolated world;
+// everywhere else browser_scroll dispatches a real mouseWheel, which CDP
+// acknowledges as soon as it is routed and the compositor applies a frame or
+// more later. A fixed settle therefore races a loaded runner — macOS CI has
+// read the pre-scroll 0px twice — so poll for the offset the way the viewport
+// above is polled for. Only the assertions that expect movement can wait like
+// this: a scroll that must NOT happen still needs a fixed settle.
+async function waitForScrollTop(browserView, selector, expected, label, timeoutMs = 2_000) {
+  const read = `document.querySelector(${JSON.stringify(selector)}).scrollTop`;
+  const deadline = Date.now() + timeoutMs;
+  let scrollTop = null;
+  do {
+    scrollTop = await browserView.webContents.executeJavaScript(read);
+    if (scrollTop === expected) return scrollTop;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  } while (Date.now() < deadline);
+  throw new Error(`${label} moved ${scrollTop}px instead of ${expected}px`);
+}
+
 async function closeFixture(manager, browserView, owner) {
   const viewContents = browserView?.webContents;
   const viewDestroyed = viewContents && !viewContents.isDestroyed()
@@ -294,9 +313,7 @@ async function run() {
     process.stdout.write("compact-known-coordinate-click\n");
 
     await manager.scroll("fixture-bot", "down", 600, "");
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    const compactScrollTop = await browserView.webContents.executeJavaScript(`document.getElementById("scroller").scrollTop`);
-    if (compactScrollTop !== 600) throw new Error(`compact nested scroll moved ${compactScrollTop}px instead of 600px`);
+    await waitForScrollTop(browserView, "#scroller", 600, "compact nested scroll");
     await browserView.webContents.executeJavaScript(`document.getElementById("scroller").scrollTop = 0`);
     process.stdout.write("compact-known-coordinate-scroll\n");
 
@@ -327,9 +344,7 @@ async function run() {
     process.stdout.write("real-double-click-sequence\n");
 
     await manager.scroll("fixture-bot", "down", 300, "");
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    const expandedScrollTop = await browserView.webContents.executeJavaScript(`document.getElementById("scroller").scrollTop`);
-    if (expandedScrollTop !== 300) throw new Error(`expanded nested scroll moved ${expandedScrollTop}px instead of 300px`);
+    await waitForScrollTop(browserView, "#scroller", 300, "expanded nested scroll");
     process.stdout.write("expanded-known-coordinate-scroll\n");
 
     const expandedShot = await manager.screenshot("fixture-bot", "");


### PR DESCRIPTION
## In plain terms

The macOS leg of CI fails intermittently on an Electron test that has nothing to do with the change being tested. It has been failing on `main` too. This makes it deterministic.

## The race

`electron/browser-surface.cjs` moves a scroller synchronously only on Linux, using an isolated-world scroll function that works around X11 dropping acknowledged wheel packets. macOS and Windows fall through to a CDP `Input.dispatchMouseEvent` wheel, which the protocol acknowledges on routing while the compositor applies it a frame or more later. The fixture waited a fixed 50 ms and then read `scrollTop`, so it read `0px` when the wheel had simply not landed yet. Ubuntu passes because it is on the synchronous path. Windows is on the same asynchronous path and has only been lucky.

Observed on `main` at `0f6800fe` (run 33753269864, macos-latest) before the pull request that surfaced it existed, with the same message: `compact nested scroll moved 0px instead of 600px`.

## Change

One file, `electron/fixtures/browser-closed-shadow.cjs`: a `waitForScrollTop()` deadline poll mirroring the existing `waitForFixedViewport` helper, replacing the two fixed sleeps. Error wording is preserved verbatim. The root-scroll-lock assertion still uses a fixed settle on purpose, because it asserts that `scrollTop` stays at zero and polling for that would be vacuous.

## Verification

The race would not reproduce on this hardware (72 concurrent fixture runs, zero failures), so it was pinned deterministically instead:

- Delayed scroll plus the old 50 ms wait reproduces the exact CI text. Delayed scroll plus the new poll passes.
- Mutation: expecting `601` goes red with `moved 600px instead of 601px`. Mutation: scrolling up instead of down goes red with `moved 0px instead of 600px`. Both restored byte-identically.
- `pnpm check:electron` clean, oxlint clean on the fixture, full `pnpm exec vitest run` green on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved validation of scrolling behavior in compact and expanded layouts.
  - Scroll position checks now wait for the expected offset before confirming results, reducing timing-related test failures and improving confidence in scrolling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->