### PR TITLE
Notify where the message is

### DIFF
--- a/server/comms-visibility.test.ts
+++ b/server/comms-visibility.test.ts
@@ -3,9 +3,15 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { DATA_DIR } from "./config.ts";
 import type { ModelSelection } from "./contracts.ts";
-import { getOrCreateChannel } from "./comms-visibility.ts";
+import {
+  getOrCreateChannel,
+  mirrorActivity,
+  mirrorExchange,
+  mirrorReply,
+  type CommsBus,
+} from "./comms-visibility.ts";
 import { closeMessageDb } from "./message-db.ts";
-import { Store } from "./store.ts";
+import { Store, type StoreChange } from "./store.ts";
 
 const selection = (): ModelSelection => ({ instanceId: "claude", model: "fake-model" });
 
@@ -79,5 +85,72 @@ describe("bot-to-bot channel context", () => {
 
     expect(channel.id).toBe(dm.id);
     expect(channel.dm).toBe(true);
+  });
+});
+
+describe("bot⇄bot mirrors and the badge", () => {
+  /** A pair plus their auto-created channel, watching every store change
+   * from the moment the channel exists — the mirrors' own writes only. */
+  const pair = (dm = true) => {
+    const store = new Store(selection);
+    const from = store.createBot({ name: "Forge", section: "Agents" });
+    const target = store.createBot({ name: "Quarry", section: "Agents" });
+    const room = dm ? undefined : store.createGroup("Planning", [from.id, target.id], false, "Agents");
+    const channel = getOrCreateChannel(store, from, target, room);
+    const changes: StoreChange[] = [];
+    store.onChange((change) => changes.push(change));
+    const bus: CommsBus = { store, broadcast: () => {} };
+    return { store, from, target, channel, bus, changes };
+  };
+  const groupFrames = (changes: StoreChange[], groupId: string) =>
+    changes.filter((change) => change.type === "group" && change.groupId === groupId).length;
+
+  it("keeps the whole record of a pair exchange while raising no badge", () => {
+    const { store, from, target, channel, bus, changes } = pair();
+    mirrorExchange(bus, from, target, "can you take the deploy?", channel);
+
+    // the record, unabridged: the channel has the message and both 1:1
+    // threads have their clickable chip
+    expect(store.messagesFor(channel.threadId).some((m) => m.text === "can you take the deploy?")).toBe(true);
+    expect(
+      store.messagesFor(from.threadId).some((m) => m.tool?.name === "Messaged @Quarry" && m.comm?.groupId === channel.id),
+    ).toBe(true);
+    expect(
+      store.messagesFor(target.threadId).some((m) => m.tool?.name === "Message from @Forge" && m.comm?.groupId === channel.id),
+    ).toBe(true);
+    // ...and no badge, but still a group frame, so the channel keeps its
+    // place in the sidebar and the user can open it and read everything
+    expect(store.group(channel.id)?.unread).toBe(false);
+    expect(groupFrames(changes, channel.id)).toBe(1);
+  });
+
+  it("keeps a peer reply and a terminal chip silent in the same way", () => {
+    const { store, target, channel, bus, changes } = pair();
+    mirrorReply(bus, target, "on it", channel);
+    mirrorActivity(bus, target, channel, "Delegated turn completed", true);
+
+    expect(store.messagesFor(channel.threadId).some((m) => m.text === "on it")).toBe(true);
+    expect(store.messagesFor(channel.threadId).some((m) => m.tool?.name === "Delegated turn completed")).toBe(true);
+    expect(store.group(channel.id)?.unread).toBe(false);
+    expect(groupFrames(changes, channel.id)).toBe(2);
+  });
+
+  it("still badges a shared room — people are reading that one", () => {
+    const { store, from, target, channel, bus } = pair(false);
+    expect(channel.dm).toBeFalsy();
+    mirrorExchange(bus, from, target, "@Quarry can you take the deploy?", channel);
+    expect(store.group(channel.id)?.unread).toBe(true);
+  });
+
+  it("lets a caller ask for the badge on a pair channel anyway", () => {
+    const { store, from, target, channel, bus } = pair();
+    mirrorExchange(bus, from, target, "heads up", channel, from.threadId, true);
+    expect(store.group(channel.id)?.unread).toBe(true);
+    store.patchGroup(channel.id, { unread: false });
+    mirrorReply(bus, target, "noted", channel, true);
+    expect(store.group(channel.id)?.unread).toBe(true);
+    store.patchGroup(channel.id, { unread: false });
+    mirrorActivity(bus, target, channel, "Delegated turn completed", true, true);
+    expect(store.group(channel.id)?.unread).toBe(true);
   });
 });

--- a/server/comms-visibility.ts
+++ b/server/comms-visibility.ts
@@ -42,11 +42,29 @@ export function getOrCreateChannel(
   return store.createGroup(`${from.name} ⇄ ${target.name}`, [from.id, target.id], true, from.section);
 }
 
-/** Mirror `from`'s outgoing message into the channel, drop chips into
- * both 1:1 threads linking to the channel, and bump the channel's unread
- * count. The chips are what make bot-to-bot turns observable — those
- * turns cost the user tokens, and a hidden exchange is exactly the kind
- * of mistake peer coordination is supposed to avoid. */
+/** Whether this mirror is worth a badge, and the group frame either way.
+ *
+ * A pair channel is the bots' own coordination: the person asked ONE bot,
+ * and the hops behind its answer are that bot's work, not mail addressed to
+ * them. Badging every hop turned the sidebar, the dock and the phone into a
+ * running commentary on chatter nobody asked to watch. What is NOT withheld
+ * is the record — the messages and chips above are already written, and the
+ * frame still goes out so the channel keeps its place in every client's
+ * list. Hidden bot-to-bot talk is where a prompt injection would propagate
+ * unobserved; silence the alert, never the record. A shared room is the
+ * other case: people are reading it, so it badges as it always has. */
+function markMirrored(bus: CommsBus, channel: GroupRecord, notify: boolean | undefined): void {
+  const patch: Partial<Pick<GroupRecord, "unread">> = {};
+  if (notify ?? !channel.dm) patch.unread = true;
+  bus.store.patchGroup(channel.id, patch);
+}
+
+/** Mirror `from`'s outgoing message into the channel and drop chips into
+ * both 1:1 threads linking to the channel. The chips are what make
+ * bot-to-bot turns observable — those turns cost the user tokens, and a
+ * hidden exchange is exactly the kind of mistake peer coordination is
+ * supposed to avoid. `notify` decides only whether the channel also raises
+ * a badge; it defaults to off for a bot⇄bot pair channel. */
 export function mirrorExchange(
   bus: CommsBus,
   from: BotRecord,
@@ -54,6 +72,7 @@ export function mirrorExchange(
   message: string,
   channel: GroupRecord | undefined,
   sourceThreadId = from.threadId,
+  notify?: boolean,
 ): void {
   const note = (threadId: string, m: Omit<Message, "id" | "at">) => {
     bus.store.appendMessage(threadId, m);
@@ -83,9 +102,7 @@ export function mirrorExchange(
       ? { groupId: channel.id, withBotId: from.id, withName: from.name, withColor: from.color }
       : undefined,
   });
-  if (channel) {
-    bus.store.patchGroup(channel.id, { unread: true });
-  }
+  if (channel) markMirrored(bus, channel, notify);
 }
 
 /** Mirror `target`'s reply into the channel so the channel stays the
@@ -96,6 +113,7 @@ export function mirrorReply(
   target: BotRecord,
   reply: string,
   channel: GroupRecord | undefined,
+  notify?: boolean,
 ): void {
   if (!channel || !reply.trim()) return;
   bus.store.appendMessage(channel.threadId, {
@@ -104,7 +122,7 @@ export function mirrorReply(
     text: reply,
     from: { botId: target.id, name: target.name, color: target.color },
   });
-  bus.store.patchGroup(channel.id, { unread: true });
+  markMirrored(bus, channel, notify);
 }
 
 /** Mirror a terminal activity note into the channel — for async handoffs
@@ -118,6 +136,7 @@ export function mirrorActivity(
   channel: GroupRecord | undefined,
   name: string,
   ok: boolean,
+  notify?: boolean,
 ): void {
   if (!channel) return;
   bus.store.appendMessage(channel.threadId, {
@@ -126,5 +145,5 @@ export function mirrorActivity(
     tool: { name, ok },
     from: { botId: from.id, name: from.name, color: from.color },
   });
-  bus.store.patchGroup(channel.id, { unread: true });
+  markMirrored(bus, channel, notify);
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -2356,8 +2356,10 @@ bus.subscribe((event: RuntimeEvent) => {
       turnUsage.set(event.threadId, { input: event.input, output: event.output, cachedInput: event.cachedInput });
       break;
     case "turn.completed": {
-      // Read the classification before releasing it for whatever runs on this
-      // thread next: a peer-started turn settles as coordination, not as news.
+      // A peer-started turn settles as coordination, not as news. What keeps
+      // that classification from outliving its turn is the rewrite at
+      // dispatch, not this line — releasing it here too is hygiene, so a
+      // thread nobody types in again (a deleted bot's) is not held forever.
       const internal = isInternalTurn(event.threadId);
       clearInternalTurn(event.threadId);
       const generatedKey = generatedImageTurnKey(event.threadId, event.turnId);

--- a/server/index.ts
+++ b/server/index.ts
@@ -107,7 +107,7 @@ import { ComputerControl } from "./computer-control.ts";
 import { MAX_REMOTE_COMMAND_LENGTH } from "./remote-computer.ts";
 import { augmentedPath, findCliCandidates, resetPathCache } from "./env-path.ts";
 import { describeSpawnFailure, execCli } from "./procs.ts";
-import { buildNotification, type Notification } from "./notify.ts";
+import { blockedTarget, buildNotification, type Notification } from "./notify.ts";
 import {
   isEffortLevel,
   type ModelSelection,
@@ -1838,6 +1838,29 @@ function isUnattended(botId?: string | null): boolean {
   unattendedBots.set(botId, Date.now());
   return true;
 }
+
+// Threads whose turn in flight was started by another BOT — an ask_bot hop,
+// a drained delegation. The person asked ONE bot; the fan-out behind that
+// answer is that bot's work, not mail addressed to them, so its completion
+// raises no badge and no banner. Anything that genuinely needs a human still
+// breaks through from its own path: a card that reached a person, a takeover,
+// a peer-approval — none of which run through the completion fold.
+//
+// Keyed by THREAD because turn.completed carries nothing else, and derived
+// from commsDepth, which every peer path already threads through. Every
+// dispatch rewrites the flag, so a peer turn that dies before it starts can
+// never silence the person's own next turn on that thread.
+const internalTurnThreads = new Set<string>();
+
+function markInternalTurn(threadId: string) {
+  internalTurnThreads.add(threadId);
+}
+function clearInternalTurn(threadId: string) {
+  internalTurnThreads.delete(threadId);
+}
+function isInternalTurn(threadId: string): boolean {
+  return internalTurnThreads.has(threadId);
+}
 let routines: RoutineManager | null = null;
 let calendarCalls: CalendarCallManager | null = null;
 const localVmOwnerBusy = (botId: string) => store.bot(botId)?.busy === true;
@@ -2333,6 +2356,10 @@ bus.subscribe((event: RuntimeEvent) => {
       turnUsage.set(event.threadId, { input: event.input, output: event.output, cachedInput: event.cachedInput });
       break;
     case "turn.completed": {
+      // Read the classification before releasing it for whatever runs on this
+      // thread next: a peer-started turn settles as coordination, not as news.
+      const internal = isInternalTurn(event.threadId);
+      clearInternalTurn(event.threadId);
       const generatedKey = generatedImageTurnKey(event.threadId, event.turnId);
       const generated = generatedImagesByTurn.get(generatedKey) ?? [];
       generatedImagesByTurn.delete(generatedKey);
@@ -2389,8 +2416,14 @@ bus.subscribe((event: RuntimeEvent) => {
         const routineReportGroup = routineReportThread ? store.groupByThread(routineReportThread) : undefined;
         // Group-origin routines belong to that channel's unread state. Their
         // hidden execution task should not light up the bot's 1:1 sidebar too.
-        if (!routineReportGroup) store.patchBot(bot.id, { unread: true });
-        if (routineRun?.status !== "failed") {
+        // Neither should a peer's hop: the exchange is already recorded in the
+        // pair channel and chipped into both threads, which is the whole of
+        // what the person needs to be able to find it.
+        if (!routineReportGroup && !internal) store.patchBot(bot.id, { unread: true });
+        // A failed peer turn stays a chip too. The bot that delegated is woken
+        // with the failure and answers the person in its own thread — buzzing
+        // here as well would ring twice for one piece of news.
+        if (routineRun?.status !== "failed" && !internal) {
           // the frame carries the bot's avatar so every desktop client can
           // show the notification under that bot's own face
           const completionDetail = routineRun
@@ -2430,7 +2463,6 @@ bus.subscribe((event: RuntimeEvent) => {
         const speakingBot = store.bot(speaker.botId);
         if (speakingBot?.busy) {
           store.setActivity(speakingBot.id, "idle");
-          store.patchBot(speakingBot.id, { unread: true });
           retryDelegationsWaitingOn(speakingBot.id);
         }
       }
@@ -3042,6 +3074,10 @@ async function startTurn(
   const providerText = usesNativeImageInput ? resolvedImages.text : text;
   const turnImages = usesNativeImageInput ? resolvedImages.images : [];
   const commsDepth = opts?.commsDepth ?? 0;
+  // Classify the turn where the peer paths' depth actually arrives: by the
+  // time it settles, the fold has only a thread id to go on.
+  if (commsDepth > 0) markInternalTurn(threadId);
+  else clearInternalTurn(threadId);
   // a task takes its name from the first thing you asked it to do
   if (resolvedImages.text.trim() && !opts?.cardContinuation) {
     store.titleTaskFromFirstMessage(bot.id, resolvedImages.text, threadId);
@@ -6677,9 +6713,16 @@ const server = createServer(async (req, res) => {
           const body = await readBody(req);
           const { snapshot, requestId } = computerControl.requestHelpLease(botId, body.reason);
           // worth a buzz: the bot is blocked on the person's hands, which
-          // is exactly the "blocked on you" rule notify.ts encodes
+          // is exactly the "blocked on you" rule notify.ts encodes.
+          // A bot stuck mid-room is not in its 1:1 thread — the turn and the
+          // screen it needs hands on are in the room — so send the person
+          // where the work is, and say which room it was.
+          const roomTurn = activeGroupTurnForBot(bot.id);
+          const target = blockedTarget(bot, roomTurn && { ...roomTurn.group, threadId: roomTurn.threadId });
           notify(
-            buildNotification("takeover", bot, bot.threadId, snapshot.helpReason ?? "asked you to take over"),
+            buildNotification("takeover", bot, target.threadId, snapshot.helpReason ?? "asked you to take over", {
+              group: target.group,
+            }),
           );
           return json(res, 200, { held: snapshot.held, helpOpen: snapshot.helpReason !== null, requestId });
         }

--- a/server/notification-routing.e2e.test.ts
+++ b/server/notification-routing.e2e.test.ts
@@ -23,6 +23,11 @@ import { openSse } from "./testing/sse.ts";
 // human, and a bot asking for hands — which now deep-links to the room it is
 // stuck in. The unit halves of these rules live in notify.test.ts and
 // comms-visibility.test.ts; this file pins the wiring around them.
+//
+// Every silence asserted below is only worth something beside the noise, so
+// the ordinary turn — the one a person asked for, which must still badge and
+// still buzz — is pinned first. A gate that suppressed everything would pass
+// the quiet cases perfectly.
 
 const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(SERVER_DIR, "..");
@@ -183,6 +188,34 @@ afterAll(async () => {
   if (home) await removeTempDir(home);
 });
 
+describe("an ordinary turn still announces itself", () => {
+  it("badges the bot and banners the person when a person asked", async () => {
+    const bot = await createBot("Herald", "quick");
+    const stream = await openSse(`${base}/api/events`);
+    try {
+      expect((await api("POST", `/api/bots/${bot.id}/messages`, { text: "how did it go?" })).status).toBe(202);
+
+      // the plain case the whole feature is carved out of: nobody delegated
+      // this, so the answer is news, and news gets a badge and a banner
+      const frame = await stream.until(
+        (candidate) =>
+          candidate.kind === "notify" &&
+          candidate.notification?.kind === "done" &&
+          candidate.notification?.botId === bot.id,
+        20_000,
+      );
+      expect(frame.notification).toMatchObject({ threadId: bot.threadId, title: "Herald finished" });
+      expect(frame.notification.body).toContain("hello from fake claude");
+      // no room in the picture, so nothing to group it under
+      expect(frame.notification.groupId).toBeUndefined();
+      await expect.poll(async () => (await botState(bot.id))?.unread, { timeout: 20_000 }).toBe(true);
+    } finally {
+      stream.close();
+      await cleanup([], [bot.id]);
+    }
+  }, 40_000);
+});
+
 describe("a room turn belongs to the room", () => {
   it("leaves the speaking bot's own thread unread-free while the room lights up", async () => {
     const bot = await createBot("Roomie", "quick");
@@ -323,6 +356,92 @@ describe("bot-to-bot coordination is recorded, not announced", () => {
         (candidate) => candidate.kind === "bot" && candidate.bot?.id === asker.id && candidate.bot?.name === "Pen observed",
       );
       expect(stream.frames.filter((candidate) => candidate.kind === "notify")).toEqual([]);
+    } finally {
+      stream.close();
+      await cleanup([channelId], [asker.id, peer.id]);
+    }
+  }, 45_000);
+
+  // A hop runs on the PEER'S OWN 1:1 thread (askBotAndWait dispatches to
+  // target.threadId) — the very thread the person types into. So the
+  // classification must not outlive the turn that earned it: leak it once,
+  // in either of the two ways a hop can end, and that bot's DM is mute from
+  // then on, with nothing anywhere to say why.
+  const pairChannelId = async (a: string, b: string) =>
+    (await state(0)).groups.find(
+      (group: { dm?: boolean; memberIds: string[] }) =>
+        group.dm === true && group.memberIds.includes(a) && group.memberIds.includes(b),
+    )?.id;
+
+  it("still announces the person's own next message after a hop that finished", async () => {
+    const asker = await createBot("Nib", "quick");
+    const peer = await createBot("Vellum", "quick");
+    let channelId: string | undefined;
+    const stream = await openSse(`${base}/api/events`);
+    try {
+      const asked = await api(
+        "POST",
+        "/api/internal/ask-bot",
+        { fromBotId: asker.id, toBotId: peer.id, message: "Vellum, is the branch green?" },
+        { authorization: `Bearer ${commsToken}` },
+      );
+      expect(asked.status).toBe(200);
+      expect((await botState(peer.id))?.unread).toBeFalsy();
+
+      // same bot, same thread, but a person is asking this time
+      expect((await api("POST", `/api/bots/${peer.id}/messages`, { text: "and for me?" })).status).toBe(202);
+      const frame = await stream.until(
+        (candidate) =>
+          candidate.kind === "notify" &&
+          candidate.notification?.kind === "done" &&
+          candidate.notification?.botId === peer.id,
+        20_000,
+      );
+      expect(frame.notification.threadId).toBe(peer.threadId);
+      await expect.poll(async () => (await botState(peer.id))?.unread, { timeout: 20_000 }).toBe(true);
+      channelId = await pairChannelId(asker.id, peer.id);
+    } finally {
+      stream.close();
+      await cleanup([channelId], [asker.id, peer.id]);
+    }
+  }, 45_000);
+
+  it("still announces the person's own next message after a hop that never started", async () => {
+    const asker = await createBot("Quire", "quick");
+    const peer = await createBot("Folio", "quick");
+    let channelId: string | undefined;
+    const stream = await openSse(`${base}/api/events`);
+    try {
+      // Park the peer on an engine that is not there. startTurn classifies the
+      // turn and THEN refuses to run it, so this hop marks the thread and dies
+      // without ever reaching the completion fold — the one release the fold
+      // cannot perform for it.
+      expect((await api("PATCH", `/api/bots/${peer.id}`, {
+        modelSelection: { instanceId: "ghost", model: "ghost-1" },
+      })).status).toBe(200);
+      const asked = await api(
+        "POST",
+        "/api/internal/ask-bot",
+        { fromBotId: asker.id, toBotId: peer.id, message: "Folio, still there?" },
+        { authorization: `Bearer ${commsToken}` },
+      );
+      expect(asked.status).toBe(200);
+      expect(asked.body.text).toContain("couldn't start");
+
+      expect((await api("PATCH", `/api/bots/${peer.id}`, {
+        modelSelection: { instanceId: "quick", model: "claude-sonnet-5" },
+      })).status).toBe(200);
+      expect((await api("POST", `/api/bots/${peer.id}/messages`, { text: "back? tell me when" })).status).toBe(202);
+      const frame = await stream.until(
+        (candidate) =>
+          candidate.kind === "notify" &&
+          candidate.notification?.kind === "done" &&
+          candidate.notification?.botId === peer.id,
+        20_000,
+      );
+      expect(frame.notification.threadId).toBe(peer.threadId);
+      await expect.poll(async () => (await botState(peer.id))?.unread, { timeout: 20_000 }).toBe(true);
+      channelId = await pairChannelId(asker.id, peer.id);
     } finally {
       stream.close();
       await cleanup([channelId], [asker.id, peer.id]);

--- a/server/notification-routing.e2e.test.ts
+++ b/server/notification-routing.e2e.test.ts
@@ -1,0 +1,377 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { removeTempDir, waitForExit } from "./testing/cleanup.ts";
+import { freePortBlock } from "./testing/ports.ts";
+import { openSse } from "./testing/sse.ts";
+
+// Where a signal lands, end to end. Two bugs live here, and both are about a
+// notification pointing at a conversation that did not change:
+//
+//   • a room reply also lit the speaking bot's own 1:1 badge — the sidebar
+//     dot, the section count, the dock badge and the phone's Updates row all
+//     opened a transcript where nothing had happened;
+//   • bot-to-bot coordination raised badges and OS banners for the hop
+//     behind one answer, because the peer's turn settles on its own thread.
+//
+// What must still break through is the other half: a card that reached a
+// human, and a bot asking for hands — which now deep-links to the room it is
+// stuck in. The unit halves of these rules live in notify.test.ts and
+// comms-visibility.test.ts; this file pins the wiring around them.
+
+const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(SERVER_DIR, "..");
+const FAKE_CLAUDE = join(SERVER_DIR, "testing", "fake-claude-cli.ts");
+const FAKE_ACP = join(SERVER_DIR, "testing", "fake-acp-cli.ts");
+
+let child: ChildProcess;
+let home = "";
+let base = "";
+let stderr = "";
+let dumpFile = "";
+let commsToken = "";
+
+const api = async (
+  method: string,
+  path: string,
+  body?: unknown,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; body: any }> => {
+  const response = await fetch(`${base}${path}`, {
+    method,
+    headers: { ...(body ? { "content-type": "application/json" } : {}), ...headers },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return { status: response.status, body: response.status === 204 ? null : await response.json() };
+};
+
+/** expect.poll only works inside a test; the boot below needs the same
+ * wait-don't-sleep discipline in beforeAll. */
+const waitUntil = async (ready: () => boolean | Promise<boolean>, timeoutMs: number, what: string) => {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await ready()) return;
+    if (Date.now() > deadline) throw new Error(`${what}. stderr: ${stderr.slice(-2000)}`);
+    await new Promise((resolve) => setTimeout(resolve, 150));
+  }
+};
+
+const state = async (messages = 40) => (await api("GET", `/api/bots?messages=${messages}`)).body;
+const botState = async (botId: string) =>
+  (await state(40)).bots.find((candidate: { id: string }) => candidate.id === botId);
+const groupState = async (groupId: string) =>
+  (await state(40)).groups.find((candidate: { id: string }) => candidate.id === groupId);
+
+const createBot = async (name: string, instanceId: string, model = "claude-sonnet-5") => {
+  const created = (await api("POST", "/api/bots", {})).body.bot;
+  // notifications on, explicitly: a silent bot would pass the "no banner"
+  // assertions for the wrong reason
+  const patched = await api("PATCH", `/api/bots/${created.id}`, {
+    name,
+    notifications: true,
+    modelSelection: { instanceId, model },
+  });
+  expect(patched.status).toBe(200);
+  return patched.body.bot;
+};
+
+const cleanup = async (groupIds: Array<string | undefined>, botIds: string[]) => {
+  for (const groupId of groupIds) {
+    if (groupId) await api("POST", `/api/groups/${groupId}/interrupt`, {}).catch(() => undefined);
+  }
+  for (const botId of botIds) await api("POST", `/api/bots/${botId}/interrupt`, {}).catch(() => undefined);
+  for (const groupId of groupIds) {
+    if (groupId) await api("DELETE", `/api/groups/${groupId}`).catch(() => undefined);
+  }
+  for (const botId of botIds) await api("DELETE", `/api/bots/${botId}`).catch(() => undefined);
+};
+
+beforeAll(async () => {
+  chmodSync(FAKE_CLAUDE, 0o755);
+  chmodSync(FAKE_ACP, 0o755);
+  home = mkdtempSync(join(tmpdir(), "omb-notification-routing-"));
+  const data = join(home, ".openmausbot");
+  mkdirSync(data, { recursive: true });
+  dumpFile = join(home, "quick-dump.json");
+  writeFileSync(join(data, "config.json"), JSON.stringify({
+    instances: {
+      // the everyday fixture: answers at once. Its dump is also the only
+      // place a test can read the per-boot comms token from, and the
+      // internal endpoints these tests drive are sealed behind it.
+      quick: {
+        driver: "claudeAgent",
+        displayName: "Quick fixture",
+        environment: { FAKE_CLAUDE_MODE: "happy", FAKE_CLAUDE_DUMP: dumpFile },
+        config: { cli: FAKE_CLAUDE },
+      },
+      // never finishes: how a bot is held mid-room long enough to ask for
+      // hands while the room still owns it
+      stuck: {
+        driver: "claudeAgent",
+        displayName: "Stuck fixture",
+        environment: { FAKE_CLAUDE_MODE: "hang" },
+        config: { cli: FAKE_CLAUDE },
+      },
+      // stops mid-turn to ask the person a question no rule may answer —
+      // the card that has to reach a human even from a peer's turn
+      curious: {
+        driver: "grokAgent",
+        displayName: "Curious fixture",
+        environment: { FAKE_ACP_MODE: "question" },
+        config: { cli: FAKE_ACP, fullAuto: true },
+      },
+    },
+  }));
+  const port = await freePortBlock([0, 1]);
+  base = `http://127.0.0.1:${port}`;
+  child = spawn(process.execPath, [join(SERVER_DIR, "index.ts")], {
+    cwd: ROOT,
+    env: {
+      ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
+      ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
+      HOME: home,
+      USERPROFILE: home,
+      OMB_PORT: String(port),
+      OMB_WEBHOOK_PORT: String(port + 1),
+      // the question-card test leaves its peer turn open on purpose; keep the
+      // synchronous ask from parking for the production four minutes
+      OMB_ASK_BOT_TIMEOUT_MS: "6000",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stderr!.on("data", (chunk) => (stderr += chunk));
+
+  const deadline = Date.now() + 20_000;
+  for (;;) {
+    if (child.exitCode !== null) throw new Error(`server exited ${child.exitCode}: ${stderr}`);
+    try {
+      if ((await fetch(`${base}/api/health`)).status === 200) break;
+    } catch {
+      // still starting
+    }
+    if (Date.now() >= deadline) throw new Error(`server never became healthy: ${stderr}`);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  // one ordinary turn hands the fake CLI its MCP config, which carries the
+  // boot token the internal endpoints below are sealed behind
+  const scribe = await createBot("Scribe", "quick");
+  expect((await api("POST", `/api/bots/${scribe.id}/messages`, { text: "warm up" })).status).toBe(202);
+  const readToken = (): string | undefined => {
+    try {
+      const dump = JSON.parse(readFileSync(dumpFile, "utf8"));
+      const value: unknown = dump?.mcpConfig?.mcpServers?.agents?.env?.OMB_COMMS_TOKEN;
+      return typeof value === "string" && value ? value : undefined;
+    } catch {
+      // not written yet, or mid-write
+      return undefined;
+    }
+  };
+  await waitUntil(() => Boolean(readToken()), 15_000, "the fake CLI never dumped its MCP config");
+  commsToken = readToken() ?? "";
+  await waitUntil(async () => (await botState(scribe.id))?.busy === false, 15_000, "the warm-up turn never settled");
+  await cleanup([], [scribe.id]);
+}, 45_000);
+
+afterAll(async () => {
+  if (child) await waitForExit(child, { signal: "SIGTERM" });
+  if (home) await removeTempDir(home);
+});
+
+describe("a room turn belongs to the room", () => {
+  it("leaves the speaking bot's own thread unread-free while the room lights up", async () => {
+    const bot = await createBot("Roomie", "quick");
+    let roomId: string | undefined;
+    try {
+      const room = (await api("POST", "/api/groups", {
+        name: "Standup",
+        memberIds: [bot.id],
+        setup: { bulletin: "", defaultResponder: { kind: "everyone" } },
+      })).body.group;
+      roomId = room.id;
+      expect((await api("POST", `/api/groups/${room.id}/messages`, { text: "status?" })).status).toBe(202);
+
+      await expect.poll(async () => {
+        const current = await groupState(room.id);
+        const replied = (current?.messages ?? []).some(
+          (message: { kind: string; role?: string }) => message.kind === "text" && message.role === "bot",
+        );
+        return { working: current?.working, replied };
+      }, { timeout: 20_000 }).toEqual({ working: false, replied: true });
+
+      // the room is where the reply is, so the room is what is unread. The
+      // bot's 1:1 transcript never changed and must not claim otherwise.
+      expect((await groupState(room.id))?.unread).toBe(true);
+      expect((await botState(bot.id))?.unread).toBeFalsy();
+    } finally {
+      await cleanup([roomId], [bot.id]);
+    }
+  }, 40_000);
+
+  it("sends a takeover raised mid-room to the room, not to the bot's DM", async () => {
+    const bot = await createBot("Handsy", "stuck");
+    let roomId: string | undefined;
+    let requestId: string | undefined;
+    try {
+      const room = (await api("POST", "/api/groups", {
+        name: "War Room",
+        memberIds: [bot.id],
+        setup: { bulletin: "", defaultResponder: { kind: "everyone" } },
+      })).body.group;
+      roomId = room.id;
+      expect((await api("POST", `/api/groups/${room.id}/messages`, { text: "take the wheel" })).status).toBe(202);
+      // the room must actually own the bot before it asks for hands
+      await expect.poll(async () => (await groupState(room.id))?.busyBotId, { timeout: 20_000 }).toBe(bot.id);
+
+      const stream = await openSse(`${base}/api/events`);
+      try {
+        const asked = await api(
+          "POST",
+          `/api/internal/computer-control?botId=${bot.id}`,
+          { reason: "the login page wants a code" },
+          { authorization: `Bearer ${commsToken}` },
+        );
+        expect(asked.status).toBe(200);
+        requestId = asked.body.requestId;
+
+        const frame = await stream.until(
+          (candidate) => candidate.kind === "notify" && candidate.notification?.kind === "takeover",
+          15_000,
+        );
+        expect(frame.notification).toMatchObject({
+          botId: bot.id,
+          threadId: room.threadId,
+          groupId: room.id,
+          title: "Handsy in War Room needs your hands",
+          body: "the login page wants a code",
+        });
+        // the DM is exactly where the person must NOT be sent: the screen
+        // that needs hands is attached to the room's turn
+        expect(frame.notification.threadId).not.toBe(bot.threadId);
+      } finally {
+        stream.close();
+      }
+    } finally {
+      if (requestId) {
+        await api(
+          "DELETE",
+          `/api/internal/computer-control?botId=${bot.id}`,
+          { requestId },
+          { authorization: `Bearer ${commsToken}` },
+        ).catch(() => undefined);
+      }
+      await cleanup([roomId], [bot.id]);
+    }
+  }, 45_000);
+});
+
+describe("bot-to-bot coordination is recorded, not announced", () => {
+  it("runs an ask_bot round trip with no badge and no banner anywhere", async () => {
+    const asker = await createBot("Pen", "quick");
+    const peer = await createBot("Ink", "quick");
+    let channelId: string | undefined;
+    const stream = await openSse(`${base}/api/events`);
+    try {
+      const asked = await api(
+        "POST",
+        "/api/internal/ask-bot",
+        { fromBotId: asker.id, toBotId: peer.id, message: "Ink, can you take the deploy?" },
+        { authorization: `Bearer ${commsToken}` },
+      );
+      expect(asked.status).toBe(200);
+      expect(asked.body.botName).toBe("Ink");
+      expect(asked.body.text).toContain("hello from fake claude");
+
+      const current = await state(40);
+      const channel = current.groups.find(
+        (group: { dm?: boolean; memberIds: string[] }) =>
+          group.dm === true && group.memberIds.includes(asker.id) && group.memberIds.includes(peer.id),
+      );
+      channelId = channel?.id;
+      expect(channel).toBeTruthy();
+
+      // the record is whole: the channel holds both sides of the exchange...
+      expect(channel.messages.some((message: { text?: string }) => message.text === "Ink, can you take the deploy?")).toBe(true);
+      expect(channel.messages.some(
+        (message: { from?: { botId?: string }; text?: string }) =>
+          message.from?.botId === peer.id && (message.text ?? "").includes("hello from fake claude"),
+      )).toBe(true);
+      // ...and both 1:1 threads keep their clickable chip into it
+      const chip = (botId: string, name: string) =>
+        (current.bots.find((candidate: { id: string }) => candidate.id === botId)?.messages ?? []).some(
+          (message: { kind: string; tool?: { name?: string }; comm?: { groupId?: string } }) =>
+            message.kind === "activity" && message.tool?.name === name && message.comm?.groupId === channel.id,
+        );
+      expect(chip(asker.id, "Messaged @Ink")).toBe(true);
+      expect(chip(peer.id, "Message from @Pen")).toBe(true);
+
+      // nothing about it is worth interrupting anyone: no channel badge, no
+      // sidebar dot on the peer whose 1:1 thread only carries a chip
+      expect(channel.unread).toBeFalsy();
+      expect(current.bots.find((candidate: { id: string }) => candidate.id === peer.id)?.unread).toBeFalsy();
+
+      // A unique bot patch is an SSE ordering barrier: by the time it is
+      // observed, every notification this exchange raised is already in
+      // `frames` — including one the fold should never have sent.
+      expect((await api("PATCH", `/api/bots/${asker.id}`, { name: "Pen observed" })).status).toBe(200);
+      await stream.until(
+        (candidate) => candidate.kind === "bot" && candidate.bot?.id === asker.id && candidate.bot?.name === "Pen observed",
+      );
+      expect(stream.frames.filter((candidate) => candidate.kind === "notify")).toEqual([]);
+    } finally {
+      stream.close();
+      await cleanup([channelId], [asker.id, peer.id]);
+    }
+  }, 45_000);
+
+  it("still buzzes when a peer's turn stops to ask the person a question", async () => {
+    const asker = await createBot("Quill", "quick");
+    const peer = await createBot("Sage", "curious", "fake-model");
+    let channelId: string | undefined;
+    const stream = await openSse(`${base}/api/events`);
+    // the peer's turn parks on its card, so the ask cannot be awaited yet
+    const asking = api(
+      "POST",
+      "/api/internal/ask-bot",
+      { fromBotId: asker.id, toBotId: peer.id, message: "Sage, which colour?" },
+      { authorization: `Bearer ${commsToken}` },
+    );
+    try {
+      const frame = await stream.until(
+        (candidate) => candidate.kind === "notify" && candidate.notification?.botId === peer.id,
+        20_000,
+      );
+      // silencing the peer's completion must never silence the peer asking a
+      // person for something only a person can give
+      expect(frame.notification).toMatchObject({
+        kind: "question",
+        botId: peer.id,
+        threadId: peer.threadId,
+        title: "Sage has a question",
+      });
+      // the card is really open in the peer's thread — the banner is not
+      // announcing something the person cannot act on (a new bot's onboarding
+      // card sits above it, so take the turn's own)
+      const card = (await botState(peer.id))?.messages.findLast(
+        (message: { kind: string; card?: { title?: string } }) => message.kind === "options" && Boolean(message.card),
+      );
+      expect(card?.card).toMatchObject({ title: "Your bot has a question", subtitle: "Which color?" });
+
+      const current = await state(0);
+      channelId = current.groups.find(
+        (group: { dm?: boolean; memberIds: string[] }) =>
+          group.dm === true && group.memberIds.includes(asker.id) && group.memberIds.includes(peer.id),
+      )?.id;
+    } finally {
+      stream.close();
+      await api("POST", `/api/bots/${peer.id}/interrupt`, {}).catch(() => undefined);
+      await asking.catch(() => undefined);
+      await cleanup([channelId], [asker.id, peer.id]);
+    }
+  }, 45_000);
+});

--- a/server/notify.test.ts
+++ b/server/notify.test.ts
@@ -2,7 +2,7 @@
 // tests are mostly about the cases where the answer is "stay quiet".
 import { describe, expect, it } from "vitest";
 
-import { buildNotification, summarize } from "./notify.ts";
+import { blockedTarget, buildNotification, summarize } from "./notify.ts";
 
 const bot = { id: "bot-1", name: "Scout", threadId: "thread-1" };
 
@@ -53,6 +53,42 @@ describe("buildNotification", () => {
 
     // no profile image → the frame stays exactly as before
     expect(buildNotification("done", bot, "thread-1", "pushed")?.avatarUrl).toBeUndefined();
+  });
+});
+
+describe("blockedTarget", () => {
+  const room = { id: "room-1", name: "Launch", threadId: "room-thread", busyBotId: "bot-1" };
+
+  it("opens the room a bot is speaking in, not the bot's own thread", () => {
+    // the turn, the screen and the card are all in the room; the 1:1 thread
+    // the notification used to open has nothing on it
+    expect(blockedTarget(bot, room)).toEqual({
+      threadId: "room-thread",
+      group: { id: "room-1", name: "Launch" },
+    });
+  });
+
+  it("stays on the bot's own thread for a room it is not holding", () => {
+    expect(blockedTarget(bot, { ...room, busyBotId: "someone-else" })).toEqual({ threadId: "thread-1" });
+    expect(blockedTarget(bot, { ...room, busyBotId: null })).toEqual({ threadId: "thread-1" });
+    expect(blockedTarget(bot, null)).toEqual({ threadId: "thread-1" });
+    expect(blockedTarget(bot)).toEqual({ threadId: "thread-1" });
+  });
+
+  it("names the room in the title and carries its id for grouping", () => {
+    const target = blockedTarget(bot, room);
+    expect(buildNotification("takeover", bot, target.threadId, "the login page wants a code", {
+      group: target.group,
+    })).toMatchObject({
+      kind: "takeover",
+      threadId: "room-thread",
+      groupId: "room-1",
+      title: "Scout in Launch needs your hands",
+    });
+    // a 1:1 takeover is untouched — no room to name, nothing to group under
+    const direct = buildNotification("takeover", bot, bot.threadId, "the login page wants a code");
+    expect(direct?.title).toBe("Scout needs your hands");
+    expect(direct?.groupId).toBeUndefined();
   });
 });
 

--- a/server/notify.ts
+++ b/server/notify.ts
@@ -27,6 +27,10 @@ export interface Notification {
   /** The bot's stored profile image, when it has one; clients show it as
    * the OS notification's icon so every banner carries its bot's face. */
   avatarUrl?: string;
+  /** The room this came out of, when the bot was speaking in one. Routing
+   * already works off `threadId` alone; this is what lets a client say which
+   * room, and stack a room's banners together instead of under the bot. */
+  groupId?: string;
 }
 
 /** One line, short enough for a lock screen, with the newlines and code
@@ -43,6 +47,27 @@ export interface NotifyBot {
   notifications?: boolean;
 }
 
+/** The room a bot is holding while it works, as this module needs it. */
+export interface NotifyRoom {
+  id: string;
+  name: string;
+  threadId: string;
+  busyBotId?: string | null;
+}
+
+/** Where a "blocked on you" notification has to open. A bot speaking in a
+ * room is not reachable in its own 1:1 thread — the turn, its screen and the
+ * card all live in the room — so the room wins while it owns that bot. A
+ * room it merely belongs to, or one another member is speaking in, is not
+ * where this bot is: those fall back to its own thread. */
+export function blockedTarget(
+  bot: NotifyBot,
+  room?: NotifyRoom | null,
+): { threadId: string; group?: { id: string; name: string } } {
+  if (!room || room.busyBotId !== bot.id) return { threadId: bot.threadId };
+  return { threadId: room.threadId, group: { id: room.id, name: room.name } };
+}
+
 /** Build the frame for one event, or null when it should stay quiet.
  *
  * Kept pure and separate from the event fold so the policy — which is the
@@ -52,7 +77,7 @@ export function buildNotification(
   bot: NotifyBot,
   threadId: string,
   detail: string,
-  extra?: { avatarUrl?: string },
+  extra?: { avatarUrl?: string; group?: { id: string; name: string } },
 ): Notification | null {
   // The toggle means what it says: off is off, including for approvals.
   // A bot whose notifications you turned off can still block waiting for
@@ -60,22 +85,29 @@ export function buildNotification(
   if (bot.notifications === false) return null;
 
   const body = summarize(detail);
+  // A bot working in a room is not "Scout" to whoever reads the banner — it
+  // is Scout, in that room. Name the room or the notification reads as if it
+  // came from the 1:1 thread it will not open.
+  const who = extra?.group ? `${bot.name} in ${extra.group.name}` : bot.name;
   const title =
     kind === "approval"
-      ? `${bot.name} needs approval`
+      ? `${who} needs approval`
       : kind === "question"
-        ? `${bot.name} has a question`
+        ? `${who} has a question`
         : kind === "takeover"
-          ? `${bot.name} needs your hands`
+          ? `${who} needs your hands`
           : kind === "routine-failed"
-            ? `${bot.name}'s routine failed`
+            ? `${who}'s routine failed`
             : kind === "turn-failed"
-              ? `${bot.name} couldn't start`
-              : `${bot.name} finished`;
+              ? `${who} couldn't start`
+              : `${who} finished`;
 
   // A "finished" with nothing to say is not worth a notification — the
   // badge in the sidebar already carries that much.
   if (kind === "done" && !body) return null;
 
-  return { kind, botId: bot.id, botName: bot.name, threadId, title, body, ...extra };
+  const notification: Notification = { kind, botId: bot.id, botName: bot.name, threadId, title, body };
+  if (extra?.avatarUrl) notification.avatarUrl = extra.avatarUrl;
+  if (extra?.group) notification.groupId = extra.group.id;
+  return notification;
 }


### PR DESCRIPTION
## In plain terms

Two reported problems, both about a notification pointing at the wrong conversation.

**A channel reply lit up the bot's private chat.** When a bot finished a turn in a room, the code marked the room unread, correctly, and then also marked the bot unread. That flag carries no thread, so the sidebar dot, the dock badge and the iPhone's row all pointed at a one-to-one transcript that had not changed, and the same event was counted twice. Four sibling room-release paths already patch the group alone.

**Bot-to-bot coordination buzzed the user.** Every mirror into the automatic pair channel marked it unread, and because a peer's turn runs on its own thread, the ordinary completion path also fired: an unread badge plus a full notification carrying the peer's reply text, so internal coordination produced a desktop banner and a phone push.

## What changed

- The stray bot-unread call in the room fold is gone, and the takeover notification now targets the room when the bot is that room's current speaker instead of hardcoding its direct-message thread.
- Peer-initiated turns are classified as internal, derived from the comms depth that already threads through every peer path and tracked per thread beside the existing unattended set. The badge and the completion notification are gated on it.
- The three mirror calls take a notify flag that defaults to off for pair channels.

**The record is untouched; only the alert goes away.** The messages, the clickable chips and the live group frame all still update, so the user can open the pair channel and read the whole exchange. This is deliberate: hidden bot-to-bot chatter is where prompt injection propagates unobserved, so the design silences the interrupt and never the transcript. Cards that reach a human, takeover requests and peer-approval cards still break through, and a failed peer turn still surfaces through the delegating bot's resumed turn rather than buzzing twice.

## Test plan

- [x] New end-to-end coverage: a room turn leaves the speaking bot's own thread unread-free; a takeover raised mid-room deep-links to the room and is titled "<Bot> in <Room>"; an ask round trip produces both chips, no badge and zero notification frames; a peer's question card still notifies; and a control that a person's own message still badges and banners.
- [x] Unit coverage for the notification target rule and for all four mirror cases.
- [x] Mutation-checked, including two over-application checks: gating the human-facing notify path breaks the "still buzzes when a peer stops to ask" test, and forcing every turn internal breaks the control. One redundant line is reported honestly in the commit: it kills no test and is kept only to stop the internal-thread set retaining ids of deleted bots.
- [x] `pnpm typecheck`, `pnpm check:electron`, oxlint clean on all six touched files, full suite 3225 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved unread-badge behavior for bot-to-bot conversations while preserving alerts for shared rooms.
  - Prevented duplicate unread indicators and completion notifications for delegated bot activity.
  - Improved takeover notifications to open the relevant room and include its room context.
  - Room-scoped notifications now display the room name and group correctly.
  - Improved peer authorization and roster consistency.
  - Added support for forwarding images in direct and room conversations, with inline previews for attachments.
  - Improved recovery and validation for local virtual machine operations.

- **Tests**
  - Added coverage for notification routing, unread states, bot coordination, takeover requests, failures, and human questions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->