### PR TITLE
Give the busy-member waits headroom on a slow runner

### DIFF
--- a/server/room-chat-wait.e2e.test.ts
+++ b/server/room-chat-wait.e2e.test.ts
@@ -178,7 +178,14 @@ const cleanup = async (roomId: string | undefined, botIds: string[]) => {
   for (const botId of botIds) await api("DELETE", `/api/bots/${botId}`).catch(() => undefined);
 };
 
-describe("chat rooms wait for a member busy elsewhere", () => {
+/** These cases are deliberately slow: each one holds a real turn open on one
+ * bot and waits for a second bot to take its turn only once the first settles,
+ * through a real server and the fake CLI. The inner polls already allow 15s,
+ * which leaves nothing inside vitest's 20s default for process start-up — so on
+ * the slowest runner they time out for lack of headroom rather than because
+ * anything regressed. The wait itself is what is under test; the clock is not.
+ */
+describe("chat rooms wait for a member busy elsewhere", { timeout: 45_000 }, () => {
   it("parks on a responder busy in a 1:1, then lets them reply once that turn settles, in order", async () => {
     const busy = await createBot("Busy", "patient");
     const quick = await createBot("Quick", "quick");


### PR DESCRIPTION
## Why

Three cases in `server/room-chat-wait.e2e.test.ts` timed out on the Windows leg of #773 while a newly added end-to-end file ran alongside them. They passed on a rerun of the same commit, and passed on macOS and Linux in the same run. The failures were `Test timed out in 20000ms`, never an assertion.

The file is structurally marginal rather than unlucky: its inner polls already allow 15 seconds, inside vitest's 20 second default, which leaves under five seconds for a real server and the fake engine to start on the slowest runner. Any pull request that adds a concurrently running end-to-end file can tip it over, and the next person to hit it will start by suspecting their own change.

## Change

One file: the describe block gets a 45 second timeout and a comment saying why. Every assertion is unchanged. These cases hold a real turn open on one bot and wait for a second bot to take its turn only after the first settles, so slowness is the subject, not a defect.

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `server/room-chat-wait.e2e.test.ts` passes, 3 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the timeout for room chat wait end-to-end tests to accommodate intentionally longer-running scenarios.
  * Added clarification about the timing behavior of these tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->