### PR TITLE
Add the preview OpenMaus-owned runtime

### DIFF
--- a/docs/custom-engines.md
+++ b/docs/custom-engines.md
@@ -67,7 +67,33 @@ entry:
   `model` as a custom option either way.
 - Honest limits: chat text + reasoning streams only — **no tool calls**, so
   bots on these instances answer and write, but don't operate computers or
-  connected apps.
+  connected apps. The one exception is the preview engine below, which runs
+  its own tool loop.
+
+## OpenMaus Runtime (preview): the loop runs inside OpenMausBot
+
+Every other engine hands the inner model/tool loop to an installed CLI or a
+one-shot chat endpoint. This one runs it in-process — model call, tool call,
+approval, steering, cancellation — against any OpenAI-compatible endpoint.
+It is off until you enable it in Settings → Experimental features, and no
+existing bot is moved onto it; you pick it per bot in the model menu.
+
+- **It does not use a Claude or Codex login.** Authentication is an API key
+  (the same `openaiCompat.key` the OpenAI-compatible engine uses) or a local
+  server that needs none. Usage is billed by that provider.
+- **No key is accepted only for a local endpoint** — loopback or a private
+  network address (`127.0.0.1`, `localhost`, `10.x`, `192.168.x`, `172.16–31.x`,
+  `[::1]`, `fd..`). A remote URL with no key shows as unavailable and says so;
+  every prompt would otherwise go to a host you never authenticated with.
+- **Tools:** your own `mcpServers` from `config.json` mount as tools, namespaced
+  by server. Every call asks for approval through the ordinary card, or your
+  auto-approve rules; an unanswered ask is a deny, never an allow.
+- **Context:** the engine row and model menu show `Context: OpenMaus managed`
+  alongside `API key · billed by the provider` — two labels on purpose. Who
+  owns the conversation's context and how the engine is paid for are separate
+  questions, and this is the engine where they differ.
+- Bounds: 32 model calls and 64 tool calls per turn, 180 s per tool, and a stop
+  after the same call is repeated five times.
 
 ## Notes
 

--- a/docs/superpowers/plans/2026-09-03-hybrid-context-runtime.md
+++ b/docs/superpowers/plans/2026-09-03-hybrid-context-runtime.md
@@ -557,6 +557,26 @@ asserted.
 - [ ] State explicitly that OpenMaus Runtime does not reuse Claude/Codex subscription login and may incur provider API charges.
 - [ ] Do not auto-migrate `openai-compat` bots. Switching to/from the preview is an explicit per-bot engine selection.
 - [ ] Verify keys never enter config responses, renderer state, diagnostics, analytics, or logs.
+
+  **Resolved 2026-09-04 (Task 10 shipped):**
+  - The credential is `openaiCompatApiKey`, one row in `WORKSPACE_CREDENTIALS`, one entry in
+    `main.mjs`'s `CREDENTIAL_PATCH`, one literal in the `setCredential` union. The server side
+    (`syncCredentialEnv`) already handled `openaiCompat.key`; only Electron and the renderer
+    were missing. The renderer sees `openaiCompat: { configured }` — a boolean, never the key.
+  - No-key endpoints are allowed only for loopback and private-network hosts
+    (`server/drivers/local-endpoint.ts`): `127.0.0.1`, `localhost`, `*.localhost`, `[::1]`,
+    RFC 1918, link-local, and IPv6 ULA/link-local. An unparseable URL is treated as remote — the
+    safe side. A remote URL with no key is unavailable with a reason that names the rule.
+  - `features.ownedRuntime` is a Settings → Experimental switch. Off means absent from the
+    fleet; a bot that chose it sees an unavailable engine and keeps every transcript. Nothing
+    migrates an existing bot.
+  - The disclosure lives once, in `src/lib/context-label.ts` (`OWNED_RUNTIME_DISCLOSURE`), and
+    the settings toggle, engine row, model menu, and setup card all render from it, so three
+    surfaces cannot drift into three promises. `contextLabel()` and `authLabel()` are kept
+    deliberately separate: who owns the context is not how it is paid for, and this engine is
+    the case where they differ.
+  - `registry.describe()` now projects `contextOwnership`, so the UI can label every engine,
+    not only this one.
 - [ ] Run targeted config, Electron credential, setup, engine/model-picker, and secret-redaction tests, then:
 
   ```sh

--- a/docs/superpowers/plans/2026-09-03-hybrid-context-runtime.md
+++ b/docs/superpowers/plans/2026-09-03-hybrid-context-runtime.md
@@ -493,6 +493,33 @@ asserted.
 - [ ] Implement steering before the next model call and test no-live-turn fallback.
 - [ ] Enforce 32 model calls, 64 tool calls, 180-second default tool timeout, advisory at three identical calls in a six-call window, and stop at five identical calls. The existing total-turn watchdog wins if earlier.
 - [ ] Advertise each MCP capability only after its integration test passes.
+
+  **Resolved 2026-09-04 (Task 9 shipped):** `customMcp` is advertised — the user's own
+  `config.json` servers mount as namespaced tools (`server__tool`) with a reverse routing map,
+  proven by `server/runtime/mcp-tools.test.ts` against a real stdio child in every failure mode
+  the fake supports. `agentsMcp`, `computerMcp`, `composioMcp`, `phoneMcp`, and `browserMcp`
+  stay unadvertised: each needs its own proof before a bot is told it has that tool.
+
+  Two findings worth more than the checklist:
+
+  - **Silence is a deny, and it broke the right tests.** Wiring the approval gate made every
+    one of Task 8's tool-call tests time out — they assumed a tool runs unprompted, and now
+    nothing runs without an answer. The tests were changed to play the harness's auto-approve;
+    the runtime was not. A future test that "just calls a tool" and hangs is hitting this
+    property, not a bug.
+  - **The MCP SDK silently drops a malformed `tools/list` reply.** A server that answers the
+    handshake and then speaks garbage does not error; the client simply waits. Only
+    `MCP_STARTUP_TIMEOUT_MS` (20 s) returns the turn, so that constant is load-bearing. Tests
+    shorten it through `mcpStartupTimeoutMs`; production must not.
+  - **The MCP SDK's stdio transport broke the packaged build, and only the packaged smoke
+    caught it.** `cross-spawn@7.0.6` (pulled in by `StdioClientTransport`) calls
+    `require("child_process")` at load time; esbuild's ESM output has no `require`, so
+    `dist-server/index.js` threw on boot while vitest and Electron dev — both unbundled — were
+    green. Fixed with a `createRequire` banner on both server builds in
+    `scripts/bundle-server.mjs`. `child_process` is a builtin, so the shim resolves it with no
+    `node_modules` in reach and the packaged server stays self-contained. Bundle after Task 9:
+    **3,599,073 bytes** (+425 KB over Task 8 for the MCP client; the require shim is 122 bytes). Keep running
+    `pnpm test:packaged-server` before every task commit; nothing else exercises the bundle.
 - [ ] Run:
 
   ```sh

--- a/docs/superpowers/plans/2026-09-03-hybrid-context-runtime.md
+++ b/docs/superpowers/plans/2026-09-03-hybrid-context-runtime.md
@@ -442,6 +442,15 @@ asserted.
   message, and run `pnpm build:server && pnpm test:packaged-server` before the task commit — not
   only in Task 11.
 
+  **Resolved 2026-09-04:** `@earendil-works/pi-agent-core@0.85.0`, `@earendil-works/pi-ai@0.85.0`,
+  `@modelcontextprotocol/sdk@1.30.0`, all MIT. `scripts/bundle-server.mjs` has no `external`
+  list, so esbuild inlines whatever is imported. Importing `@earendil-works/pi-ai/compat` took
+  `dist-server/index.js` from **2,199,143 to 6,442,198 bytes (+4.2 MB, 2.9x)** because `compat`
+  re-exports every provider pi ships. Importing the one provider this engine speaks —
+  `@earendil-works/pi-ai/api/openai-completions` — lands at **3,173,475 bytes (+0.97 MB, +44%)**.
+  Rule: import the provider subpath, never `/compat`; a future reviewer seeing `/compat` in
+  `pi-runtime.ts` should treat it as a 3 MB regression.
+
 - [ ] Define concrete internal `OwnedAgentRuntime` inputs/events; keep all Pi imports inside `pi-runtime.ts`.
 - [ ] Create a deterministic fake streaming model covering text, reasoning, one/multiple tool calls, cancellation, provider error, and usage.
 - [ ] Adapt `TurnContextPlan.messages` to Pi model messages. Keep native tool-call/result pairs only in live state and use portable observations after restart.

--- a/docs/superpowers/plans/2026-09-03-hybrid-context-runtime.md
+++ b/docs/superpowers/plans/2026-09-03-hybrid-context-runtime.md
@@ -636,6 +636,38 @@ asserted.
 - [ ] Manually verify ownership labels, preview disclosure, compaction divider, inspector row, engine switch/rollback, approval, interrupt, and steering in a rebuilt renderer. Keep this evidence separate from server-harness evidence.
 - [ ] Commit: `test: verify portable context and owned runtime`.
 
+  **Resolved 2026-09-04 (Task 11 shipped), and precise about what proved what:**
+
+  Driven through the shared control surface (`docs/verification/context-runtime.md`):
+  1. more than 40 turns — 151 items on a 200k window (Task 7 evidence);
+  3. rewind excluding the abandoned branch — `omb edit` (#760);
+  5. a small window creating a divider with history intact — `OMB_CONTEXT_WINDOW` + `edit`;
+  7. the owned runtime calling a tool, asking, and being interruptible — `OMB_VERIFY_OWNED=1`
+     with `set-model`: `request.opened` for `notes__read_notes`, an "Approval needed" card,
+     `needs-user`, then `interrupt` draining the ask as a system deny;
+  8. restart without native state — a second turn carried `sent=3/3` from the plan alone;
+  9. no key or tool output in diagnostics — canary `verify-key-canary-0000` absent from the
+     whole event log, no tool output in any `context.prepared` line.
+
+  Proven by tests, not the fixture — and the plan should say so rather than imply otherwise:
+  2. vendor-to-replay switch preserving tool observations — `prepare-turn.test.ts`,
+     `replay-once.test.ts`;
+  4. external/delegated updates entering the next plan — `prepare-turn.test.ts`;
+  6. one safe resume retry, never after acceptance — `codex/claude/pi/acp` driver tests;
+  10. `openai-compat` receiving history once — `replay-once.test.ts`;
+  11. room attribution across an engine switch — `rebuild.test.ts`.
+  Approval allow/deny/timeout and steering on the owned runtime — `pi-runtime.test.ts`,
+  `approval-gate.test.ts`. The control surface deliberately has no `approve` command, so
+  `needs-user` is the fixture's proof that a call asked and blocked.
+
+  Two gaps in the shared surface found on the way, left as they are:
+  - `registry.describe()` does not project `customMcp`, and `list_available_models` projects
+    only `snapshot.state`, so `omb models` shows neither `customMcp` nor `billing`. Both are
+    pre-existing projections; adding them is a small follow-up, not part of this release.
+  - `FAKE_OPENAI_TOOL` exists because a tool call to a name the loop has not mounted is
+    reported as unknown BEFORE the approval gate runs — which proves nothing. Point the fake
+    at the mounted, namespaced name or the scenario silently degrades.
+
 ---
 
 ## Release gates

--- a/docs/verification/context-runtime.md
+++ b/docs/verification/context-runtime.md
@@ -91,6 +91,77 @@ sqlite3 "$DATA_DIR/messages.db" "SELECT json FROM messages WHERE kind='compactio
 Observed on 2026-09-04: `tokensBefore 5358` against a 4,800-token budget on a
 12k window, one record, the display path still holding every message.
 
+## Driving the owned runtime (preview)
+
+`OMB_VERIFY_OWNED=1` makes `launch` also start a loopback fake OpenAI-compatible
+server it owns, enable `features.ownedRuntime`, add an `openmausRuntime`
+instance pointed at that server, and mount the fake MCP server as the bot's
+own tool. Nothing leaves 127.0.0.1 and everything dies with the launcher.
+
+```sh
+OMB_VERIFY_OWNED=1 FAKE_OPENAI_MODE=tool FAKE_OPENAI_TOOL=notes__read_notes \
+  node --experimental-strip-types scripts/control-omb.ts launch
+# the JSON now includes ownedRuntimeUrl
+omb() { node --experimental-strip-types scripts/control-omb.ts "$@"; }
+omb models --url $URL                      # openmausRuntime: available, contextOwnership omb-loop
+BOT=$(omb new-bot --name Owned --url $URL | python3 -c "import sys,json;print(json.load(sys.stdin)['bot']['id'])")
+omb set-model --bot $BOT --instance openmausRuntime --model fake-model --url $URL
+omb send --bot $BOT --text "read my notes" --url $URL
+omb wait --bot $BOT --timeout 30 --url $URL   # needs-user: the tool call asked, a card is up
+omb messages --bot $BOT --limit 6 --url $URL  # "Approval needed" with the call's arguments
+omb interrupt --bot $BOT --url $URL
+omb wait --bot $BOT --timeout 30 --url $URL   # settled: the pending ask drained as a system deny
+omb send --bot $BOT --text "what did I just ask?" --url $URL
+omb wait --bot $BOT --timeout 30 --url $URL   # settled: a second turn from canonical context alone
+```
+
+`FAKE_OPENAI_MODE=tool` makes the fake answer the FIRST model call with a tool
+call to `FAKE_OPENAI_TOOL` and every later call with text. The tool name must
+be the mounted, namespaced one — otherwise the loop reports an unknown tool
+and the approval gate is never reached, which proves nothing.
+
+## Expected
+
+Observed on 2026-09-04, `"$DATA_DIR"/events/*.ndjson`:
+
+```
+context.prepared: ownership=omb-loop  sent=1/1  window=128000
+request.opened:   permission tool=notes__read_notes
+request.resolved: deny source=system              ← the interrupt drained it
+turn.completed:   ok=false stop=interrupted
+context.prepared: ownership=omb-loop  mode=replay-required  sent=3/3
+turn.completed:   ok=true
+```
+
+`omb models` shows all three ownership modes side by side — `claude`
+`vendor-session`, `openaiCompat` `omb-replay`, `openmausRuntime` `omb-loop` —
+and the preview engine available on a keyless loopback URL. The server log
+has zero errors; the fixture's data dir is removed on interrupt.
+
+Leak check: the seeded key is `verify-key-canary-0000`. It must appear
+nowhere in the event log, and no tool output may appear in any
+`context.prepared` line:
+
+```sh
+grep -c verify-key-canary "$DATA_DIR"/events/*.ndjson     # 0
+grep context.prepared "$DATA_DIR"/events/*.ndjson | grep -c "echoed:"   # 0
+```
+
+## What this harness cannot prove about the owned runtime
+
+- **Answering an approval.** The control surface deliberately exposes no
+  `approve` command (the MCP surface test asserts `approve_request` is
+  absent). So `needs-user` IS the proof that a tool call asked and blocked;
+  allow, deny, timeout-deny, and steering are proven by
+  `server/runtime/pi-runtime.test.ts` and `approval-gate.test.ts`, not here.
+- **The card's tool name.** `messages` projects a bounded, redacted card and
+  does not carry `tool`; the `request.opened` event in the log does.
+- **`mode` on a first turn reads `resume-preferred`.** The plan computes it
+  from cursors, and a brand-new bot has none to invalidate. The owned runtime
+  ignores `mode` — it rebuilds from the plan on every call — so the label is
+  accurate to the plan and irrelevant to the engine. A later change could
+  force `replay-required` for `omb-loop` to make the log read plainly.
+
 ## Gotchas
 
 - Run on Node 24. On 22 the electron suite reports 10 cancelled subtests and

--- a/docs/verification/engines.md
+++ b/docs/verification/engines.md
@@ -24,4 +24,13 @@ engine is available. The isolated fixture should expose `claude`.
 
 - Doctor proves server/engine readiness, not authentication against a real
   provider.
+- The preview `openmausRuntime` instance appears in `models` only when
+  `features.ownedRuntime` is true in the fixture's config; by default it is
+  absent, not unavailable. Its `capabilities.contextOwnership` is `omb-loop`,
+  where every installed CLI reports `vendor-session` and the OpenAI-compatible
+  engines report `omb-replay`.
+- With no key, the preview engine is available only for a loopback or
+  private-network URL. Point it at a public host without a key and `models`
+  shows it unavailable with a reason naming the rule — that is the policy
+  working, not a broken fixture.
 - Model-picker rendering is Electron UI and remains outside this first map.

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -2070,6 +2070,7 @@ const CREDENTIAL_PATCH = {
   opencodeGoApiKey: (value) => ({ opencodeGo: { apiKey: value } }),
   ttsKey: (value) => ({ tts: { key: value } }),
   openaiImageApiKey: (value) => ({ imageGen: { key: value } }),
+  openaiCompatApiKey: (value) => ({ openaiCompat: { key: value } }),
 };
 
 ipcMain.handle("credential:set", localOnly("credential:set", async (_event, name, value) => {

--- a/electron/workspace-credentials.mjs
+++ b/electron/workspace-credentials.mjs
@@ -13,6 +13,8 @@ export const WORKSPACE_CREDENTIALS = [
   { section: "tts", field: "key", name: "ttsKey", env: "OMB_TTS_KEY" },
   { section: "imageGen", field: "key", name: "openaiImageApiKey", env: "OMB_OPENAI_IMAGE_KEY" },
   { section: "opencodeGo", field: "apiKey", name: "opencodeGoApiKey", env: "OPENCODE_API_KEY" },
+  // shared by the openai-compat engine and the preview OpenMaus Runtime
+  { section: "openaiCompat", field: "key", name: "openaiCompatApiKey", env: "OPENAI_COMPAT_API_KEY" },
 ];
 
 /** One boot-time sweep of config.json: move every plaintext workspace secret

--- a/electron/workspace-credentials.test.mjs
+++ b/electron/workspace-credentials.test.mjs
@@ -14,6 +14,7 @@ describe("workspace credential migration", () => {
       tts: { key: "tts-secret", voice: "narrator" },
       imageGen: { key: "image-secret" },
       opencodeGo: { apiKey: "ocg-secret" },
+      openaiCompat: { key: "compat-secret", url: "https://openrouter.ai/api/v1" },
       profile: { name: "Ada" },
     };
     const result = migrateWorkspaceCredentials(config, {});
@@ -25,6 +26,7 @@ describe("workspace credential migration", () => {
       ttsKey: "tts-secret",
       opencodeGoApiKey: "ocg-secret",
       openaiImageApiKey: "image-secret",
+      openaiCompatApiKey: "compat-secret",
     });
     // secrets are DELETED (not blanked) so "" stays meaningful as "cleared";
     // non-secret siblings (endpoint url, chosen voice) stay in the file
@@ -34,6 +36,8 @@ describe("workspace credential migration", () => {
       tts: { voice: "narrator" },
       imageGen: {},
       opencodeGo: {},
+      // the URL is configuration, not a credential: it stays in the file
+      openaiCompat: { url: "https://openrouter.ai/api/v1" },
       profile: { name: "Ada" },
     });
     // inputs are never mutated — main.mjs decides which files to rewrite

--- a/package.json
+++ b/package.json
@@ -79,6 +79,9 @@
     "control-plane:dry-run": "pnpm --filter @openmausbot/control-plane dry-run"
   },
   "dependencies": {
+    "@earendil-works/pi-agent-core": "0.85.0",
+    "@earendil-works/pi-ai": "0.85.0",
+    "@modelcontextprotocol/sdk": "1.30.0",
     "@trycua/cua-driver": "0.20.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.539.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@earendil-works/pi-agent-core':
+        specifier: 0.85.0
+        version: 0.85.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai':
+        specifier: 0.85.0
+        version: 0.85.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@modelcontextprotocol/sdk':
+        specifier: 1.30.0
+        version: 1.30.0(zod@4.4.3)
       '@trycua/cua-driver':
         specifier: 0.20.0
         version: 0.20.0
@@ -191,6 +200,112 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@anthropic-ai/sdk@0.123.0':
+    resolution: {integrity: sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.9':
+    resolution: {integrity: sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    resolution: {integrity: sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    resolution: {integrity: sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    resolution: {integrity: sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    resolution: {integrity: sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.82':
+    resolution: {integrity: sha512-znDkEOGXB8W3kG1LJUKP3foBZY/9qLM0eil/DxWXSp37XsdsRLQHE/d/OaCGGVgKpA6znR38h/+INk8do1FjiA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    resolution: {integrity: sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    resolution: {integrity: sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    resolution: {integrity: sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.34':
+    resolution: {integrity: sha512-cTeVzpu1xEAkryTZBYhGwnQ6gOGyp8ZYZvmn0Sg/nI/ABmy/CRHHxPDJDUi9PxwxUtGGaatvfRUB3FCgT/rSWw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.29':
+    resolution: {integrity: sha512-dlRzHCgyB8W6hLuDC5pcT5q+ziPt00n4QGgGBE17ucLVU4zMa6lsbuUdQ2Pm75Z5VA8GF+R/+SgrRcaTdIzSIQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.52':
+    resolution: {integrity: sha512-vsPPM+nMbKJlUCFU+eoGZbdxdxDIAX9LbpjSXaR5Ufpmqgp8TdYQnoExhLu4T3umW/JIIPny1ydbhWidZZYokQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.44':
+    resolution: {integrity: sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    resolution: {integrity: sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1048.0':
+    resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1116.0':
+    resolution: {integrity: sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.5':
+    resolution: {integrity: sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.10':
+    resolution: {integrity: sha512-ycwH6Zd2GhuSqdXX9ihbCjeGTB6xOJs+O3+Jb8/zDG9978XU80qs75dfkPJRMNKe5MvBZPuNeFpd4JZKPoUF4g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.40':
+    resolution: {integrity: sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -474,6 +589,23 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@earendil-works/chord@0.85.0':
+    resolution: {integrity: sha512-m/eFMaUg2gFUqEqzffgt/d3xPNKEvD++NZrYDBqpCEc2/dqMoS13Pdx/tofe8t5/DHgnzHxlRQFD5bLPUdPmvw==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-agent-core@0.85.0':
+    resolution: {integrity: sha512-uOvSDEG5B/P1mpxnuXCkvlvEKcFpyQ9qgCB2r+LY3YTko996iCCq6OEUWk/Af4xCPXx92Pj73ilNoYa40M7EQg==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-ai@0.85.0':
+    resolution: {integrity: sha512-CbeeZH3NHav7Rs182tYq0eoCAWfDd1MvOAXKzonIF4uN3uO99EB8iT1HfyGofJmPkAf8MeIwOBQtqqd0zgrPWA==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-telemetry@0.85.0':
+    resolution: {integrity: sha512-gs8Zq1lySn8liq7U7CCSgWHJcA8c6+ZWk+CBPp7w0K+SN5LcLcsbs3+bh7zipm4CqNkVhcpwGAEGJp7qZqsVnA==}
+    engines: {node: '>=22.19.0'}
 
   '@electron-internal/extract-zip@1.0.5':
     resolution: {integrity: sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==}
@@ -890,6 +1022,21 @@ packages:
   '@fumari/image-size@0.1.0':
     resolution: {integrity: sha512-x2o9u6P8uKUK15B8XgEoRhR3PgLoLSbQKK6FUCd14JzumEw+e8FXZPelij/dZ4VQVMp4r61VD3DcvSo3aEhLAA==}
 
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
+  '@hono/node-server@2.1.1':
+    resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -1247,6 +1394,16 @@ packages:
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
     engines: {node: ^22.20 || ^24.12 || >=25}
@@ -1479,6 +1636,33 @@ packages:
   '@posthog/types@1.402.3':
     resolution: {integrity: sha512-nnqKIGUqggeNbCZg6of/hYN+4shYZUoPFkILIIpYq0p9HDX8PgOrnrtBAUH8kr1MOmDh2nm+fY5Ceks7A5y6BQ==}
 
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -1659,8 +1843,51 @@ packages:
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
 
+  '@smithy/core@3.33.3':
+    resolution: {integrity: sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.5.2':
+    resolution: {integrity: sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.8.0':
+    resolution: {integrity: sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.12.1':
+    resolution: {integrity: sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.7.3':
+    resolution: {integrity: sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.18.0':
+    resolution: {integrity: sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
   '@speed-highlight/core@1.2.24':
     resolution: {integrity: sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1872,6 +2099,9 @@ packages:
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
@@ -2046,6 +2276,10 @@ packages:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2059,6 +2293,14 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
@@ -2198,15 +2440,25 @@ packages:
       zod:
         optional: true
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
@@ -2223,6 +2475,9 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -2233,6 +2488,10 @@ packages:
   builder-util@26.15.3:
     resolution: {integrity: sha512-q2hn7Mbo2nFNkVekPiHFx6Nfo3hURmES3tfBn+k5Pqxl2RkmP3QGqZUhH/q9Pch/4G05NRhPjDlVj1O8q4Txvw==}
     engines: {node: '>=14.0.0'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   bytestreamjs@2.0.1:
     resolution: {integrity: sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==}
@@ -2248,6 +2507,10 @@ packages:
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   caniuse-lite@1.0.30001809:
@@ -2357,8 +2620,28 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -2370,6 +2653,10 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
   cross-dirname@0.1.0:
     resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==}
 
@@ -2379,6 +2666,10 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -2415,6 +2706,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -2431,6 +2726,10 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
 
   dir-compare@4.2.0:
     resolution: {integrity: sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==}
@@ -2455,6 +2754,12 @@ packages:
 
   duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
@@ -2489,6 +2794,10 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -2557,6 +2866,9 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
@@ -2589,6 +2901,18 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
@@ -2596,11 +2920,24 @@ packages:
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
+  express-rate-limit@8.7.0:
+    resolution: {integrity: sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-uri@3.1.5:
     resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
@@ -2614,15 +2951,31 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   fflate@0.4.9:
     resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
 
   framer-motion@13.1.1:
     resolution: {integrity: sha512-B/xn2TPS4f61cEBLFjiYlQFnBZUW1YVj/LM+C+N4OP8Rs95VLEI2ot/RlfBg111la/EiyECFaJJi/A3FWA8MUA==}
@@ -2634,6 +2987,10 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -2766,6 +3123,14 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gaxios@7.3.1:
+    resolution: {integrity: sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -2804,6 +3169,14 @@ packages:
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
+
+  google-auth-library@10.9.1:
+    resolution: {integrity: sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -2862,6 +3235,10 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  hono@4.13.5:
+    resolution: {integrity: sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
@@ -2875,6 +3252,10 @@ packages:
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -2887,6 +3268,14 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -2896,6 +3285,14 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  ip-address@10.7.0:
+    resolution: {integrity: sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -2916,6 +3313,9 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -2963,11 +3363,21 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
@@ -2982,6 +3392,12 @@ packages:
 
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3081,6 +3497,9 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -3173,6 +3592,14 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -3283,9 +3710,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
@@ -3367,6 +3802,10 @@ packages:
     resolution: {integrity: sha512-B0UbxzK1s0CN8Xht6r+7iT5+xV8PTaRERR1nATeplRv1Rw5YLWfVAid0hkqY3EceqpG4RjTk8GAwIxQY39Rnwg==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
+  negotiator@1.1.0:
+    resolution: {integrity: sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==}
+    engines: {node: '>=18'}
+
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
     peerDependencies:
@@ -3401,6 +3840,15 @@ packages:
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   node-gyp@12.4.0:
     resolution: {integrity: sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -3426,6 +3874,14 @@ packages:
     resolution: {integrity: sha512-K1HmQeZT2HrjpsR6KgqbN2FAXL2NrJJmNUSD9ck7HGTVu1JKXox8n9SB+tjbU8m8JGLF4OscrroPepew/L7/Xw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
@@ -3433,6 +3889,10 @@ packages:
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -3442,6 +3902,17 @@ packages:
 
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
+  openai@6.40.0:
+    resolution: {integrity: sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==}
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   oxlint@1.80.0:
     resolution: {integrity: sha512-5nTiSps4qdbCWLbxzuO00alHkEO2exR9YMN/ig6QXWrLsYSG0KaObOAM+l6oU2LcKPWoSAGYbkZIGEu1ViiWKA==}
@@ -3464,11 +3935,22 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -3480,6 +3962,9 @@ packages:
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -3494,6 +3979,10 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkijs@3.4.0:
     resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
@@ -3548,6 +4037,14 @@ packages:
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
+  protobufjs@7.6.6:
+    resolution: {integrity: sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==}
+    engines: {node: '>=12.0.0'}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -3563,12 +4060,24 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
+    engines: {node: '>=0.6'}
+
   query-selector-shadow-dom@1.0.1:
     resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
@@ -3702,6 +4211,10 @@ packages:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   rimraf@2.6.3:
     resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
@@ -3719,8 +4232,15 @@ packages:
   rou3@0.9.2:
     resolution: {integrity: sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   sanitize-filename@1.6.4:
     resolution: {integrity: sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==}
@@ -3756,12 +4276,23 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
 
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@3.1.2:
     resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.35.2:
     resolution: {integrity: sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==}
@@ -3787,6 +4318,22 @@ packages:
   shiki@4.4.3:
     resolution: {integrity: sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==}
     engines: {node: '>=20'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -3822,9 +4369,16 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.1.1:
+    resolution: {integrity: sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==}
+
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
@@ -3928,6 +4482,10 @@ packages:
     resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -3937,12 +4495,19 @@ packages:
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typebox@1.3.7:
     resolution: {integrity: sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==}
@@ -4006,6 +4571,10 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   unzipper@0.12.5:
     resolution: {integrity: sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==}
 
@@ -4045,6 +4614,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -4138,6 +4711,10 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   web-vitals@5.3.0:
     resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
@@ -4268,6 +4845,11 @@ packages:
     resolution: {integrity: sha512-gm4zfO31n2ZdruTTRQoWVWO4Q2+zrDt2GlrvIc+5JulRQNAm4IanCxER82vQ7Ug96FYkGqWUJBXFe1kGAcDWaQ==}
     engines: {node: '>= 20.0.0'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -4277,6 +4859,227 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@anthropic-ai/sdk@0.123.0(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.1.1
+    optionalDependencies:
+      zod: 4.4.3
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.974.5
+      '@aws-sdk/util-locate-window': 3.965.10
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.974.5
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.82
+      '@aws-sdk/eventstream-handler-node': 3.972.34
+      '@aws-sdk/middleware-eventstream': 3.972.29
+      '@aws-sdk/middleware-websocket': 3.972.52
+      '@aws-sdk/token-providers': 3.1048.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.8.0
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.9':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@aws-sdk/xml-builder': 3.972.40
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.18.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.8.0
+      '@smithy/node-http-handler': 4.12.1
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-login': 3.972.77
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.82':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-ini': 3.973.15
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/token-providers': 3.1116.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/eventstream-handler-node@3.972.34':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.29':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.52':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.8.0
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.44':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.8.0
+      '@smithy/node-http-handler': 4.12.1
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1048.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1116.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.5':
+    dependencies:
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.10':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.40':
+    dependencies:
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -4536,6 +5339,49 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@earendil-works/chord@0.85.0':
+    dependencies:
+      esbuild: 0.28.1
+
+  '@earendil-works/pi-agent-core@0.85.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/chord': 0.85.0
+      '@earendil-works/pi-ai': 0.85.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-telemetry': 0.85.0
+      diff: 8.0.4
+      ignore: 7.0.5
+      typebox: 1.3.7
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.85.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.123.0(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@earendil-works/pi-telemetry': 0.85.0
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.40.0(ws@8.21.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.3.7
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-telemetry@0.85.0': {}
 
   '@electron-internal/extract-zip@1.0.5': {}
 
@@ -4849,6 +5695,23 @@ snapshots:
 
   '@fumari/image-size@0.1.0': {}
 
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))':
+    dependencies:
+      google-auth-library: 10.9.1
+      p-retry: 4.6.2
+      protobufjs: 7.6.6
+      ws: 8.21.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@hono/node-server@2.1.1(hono@4.13.5)':
+    dependencies:
+      hono: 4.13.5
+
   '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.35.2':
@@ -5136,6 +5999,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 2.1.1(hono@4.13.5)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.1
+      express: 5.2.1
+      express-rate-limit: 8.7.0(express@5.2.1)
+      hono: 4.13.5
+      jose: 6.2.10
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
 
@@ -5275,6 +6160,26 @@ snapshots:
 
   '@posthog/types@1.402.3': {}
 
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.62.4':
@@ -5396,7 +6301,62 @@ snapshots:
 
   '@sindresorhus/is@7.2.0': {}
 
+  '@smithy/core@3.33.3':
+    dependencies:
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.5.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.8.0':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.12.1':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.7.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/types@4.18.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
   '@speed-highlight/core@1.2.24': {}
+
+  '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -5601,6 +6561,8 @@ snapshots:
     dependencies:
       '@types/node': 26.2.0
 
+  '@types/retry@0.12.0': {}
+
   '@types/trusted-types@2.0.7':
     optional: true
 
@@ -5742,6 +6704,11 @@ snapshots:
 
   abbrev@4.0.0: {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.1.0
+
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
       acorn: 8.18.0
@@ -5749,6 +6716,10 @@ snapshots:
   acorn@8.18.0: {}
 
   agent-base@7.1.4: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
 
   ajv@8.20.0:
     dependencies:
@@ -5880,12 +6851,30 @@ snapshots:
     optionalDependencies:
       zod: 4.4.3
 
+  bignumber.js@9.3.1: {}
+
   blake3-wasm@2.1.5: {}
 
   bluebird@3.7.2: {}
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.1.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.16.0
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   boolean@3.2.0:
     optional: true
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.18:
     dependencies:
@@ -5907,6 +6896,8 @@ snapshots:
       electron-to-chromium: 1.5.404
       node-releases: 2.0.53
       update-browserslist-db: 1.3.1(browserslist@4.28.8)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -5936,6 +6927,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bytes@3.1.2: {}
+
   bytestreamjs@2.0.1: {}
 
   cacheable-lookup@5.0.4: {}
@@ -5954,6 +6947,11 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   caniuse-lite@1.0.30001809: {}
 
@@ -6036,13 +7034,28 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.1.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   cookie@1.1.1: {}
 
   core-js@3.50.0: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-dirname@0.1.0:
     optional: true
@@ -6054,6 +7067,8 @@ snapshots:
       which: 2.0.2
 
   csstype@3.2.3: {}
+
+  data-uri-to-buffer@4.0.1: {}
 
   debug@4.4.3:
     dependencies:
@@ -6087,6 +7102,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -6099,6 +7116,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  diff@8.0.4: {}
 
   dir-compare@4.2.0:
     dependencies:
@@ -6134,6 +7153,12 @@ snapshots:
   duplexer2@0.1.4:
     dependencies:
       readable-stream: 2.3.8
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  ee-first@1.1.1: {}
 
   ejs@3.1.10:
     dependencies:
@@ -6214,6 +7239,8 @@ snapshots:
       - supports-color
 
   emoji-regex@8.0.0: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -6328,6 +7355,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@4.0.0:
     optional: true
 
@@ -6370,13 +7399,64 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.1.1: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.1
+
   expect-type@1.4.0: {}
 
   exponential-backoff@3.1.3: {}
 
+  express-rate-limit@8.7.0(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.16.0
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-sha256@1.3.0: {}
 
   fast-uri@3.1.5: {}
 
@@ -6384,11 +7464,27 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   fflate@0.4.9: {}
 
   filelist@1.0.6:
     dependencies:
       minimatch: 5.1.9
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   form-data@4.0.6:
     dependencies:
@@ -6398,6 +7494,12 @@ snapshots:
       hasown: 2.0.4
       mime-types: 2.1.35
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
+  forwarded@0.2.0: {}
+
   framer-motion@13.1.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       motion-dom: 13.1.1
@@ -6406,6 +7508,8 @@ snapshots:
     optionalDependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
+
+  fresh@2.0.0: {}
 
   fs-extra@10.1.0:
     dependencies:
@@ -6518,6 +7622,22 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  gaxios@7.3.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.3.1
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
@@ -6572,6 +7692,19 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
     optional: true
+
+  google-auth-library@10.9.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.3.1
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
 
@@ -6716,6 +7849,8 @@ snapshots:
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
 
+  hono@4.13.5: {}
+
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
@@ -6725,6 +7860,14 @@ snapshots:
   html-void-elements@3.0.0: {}
 
   http-cache-semantics@4.2.0: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -6745,6 +7888,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  ignore@7.0.5: {}
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -6753,6 +7902,10 @@ snapshots:
   inherits@2.0.4: {}
 
   inline-style-parser@0.2.7: {}
+
+  ip-address@10.7.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -6768,6 +7921,8 @@ snapshots:
   is-hexadecimal@2.0.1: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-promise@4.0.0: {}
 
   isarray@1.0.0: {}
 
@@ -6799,9 +7954,20 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
+
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stringify-safe@5.0.1:
     optional: true
@@ -6817,6 +7983,17 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.1.2
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.1.2
 
   keyv@4.5.4:
     dependencies:
@@ -6882,6 +8059,8 @@ snapshots:
   lodash.isequal@4.5.0: {}
 
   lodash@4.18.1: {}
+
+  long@5.3.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -7084,6 +8263,10 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  media-typer@1.1.1: {}
+
+  merge-descriptors@2.0.0: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -7351,9 +8534,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@2.6.0: {}
 
@@ -7433,6 +8622,10 @@ snapshots:
 
   nanostores@1.5.2: {}
 
+  negotiator@1.1.0:
+    dependencies:
+      content-type: 2.1.0
+
   next-themes@0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       react: 19.2.8
@@ -7471,6 +8664,14 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
   node-gyp@12.4.0:
     dependencies:
       env-paths: 2.2.1
@@ -7496,10 +8697,18 @@ snapshots:
 
   npm-to-yarn@3.2.0: {}
 
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   object-keys@1.1.1:
     optional: true
 
   obug@2.1.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -7512,6 +8721,11 @@ snapshots:
       oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
+
+  openai@6.40.0(ws@8.21.0)(zod@4.4.3):
+    optionalDependencies:
+      ws: 8.21.0
+      zod: 4.4.3
 
   oxlint@1.80.0:
     optionalDependencies:
@@ -7541,6 +8755,11 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
   parse-entities@4.0.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -7555,11 +8774,17 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseurl@1.3.3: {}
+
+  partial-json@0.1.7: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
 
   path-to-regexp@6.3.0: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -7568,6 +8793,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkijs@3.4.0:
     dependencies:
@@ -7637,6 +8864,25 @@ snapshots:
 
   property-information@7.2.0: {}
 
+  protobufjs@7.6.6:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 26.2.0
+      long: 5.3.2
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -7652,9 +8898,23 @@ snapshots:
     dependencies:
       react: 19.2.8
 
+  qs@6.16.0:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   query-selector-shadow-dom@1.0.1: {}
 
   quick-lru@5.1.1: {}
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   react-dom@19.2.8(react@19.2.8):
     dependencies:
@@ -7849,6 +9109,8 @@ snapshots:
 
   retry@0.12.0: {}
 
+  retry@0.13.1: {}
+
   rimraf@2.6.3:
     dependencies:
       glob: 7.2.3
@@ -7897,7 +9159,19 @@ snapshots:
 
   rou3@0.9.2: {}
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   safe-buffer@5.1.2: {}
+
+  safer-buffer@2.1.2: {}
 
   sanitize-filename@1.6.4:
     dependencies:
@@ -7922,12 +9196,39 @@ snapshots:
 
   semver@7.8.5: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
     optional: true
 
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-cookie-parser@3.1.2: {}
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.35.2:
     dependencies:
@@ -8012,6 +9313,34 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.5
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
@@ -8038,7 +9367,14 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.1.1:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   stat-mode@1.0.0: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.2.0: {}
 
@@ -8143,6 +9479,8 @@ snapshots:
 
   tmp@0.2.7: {}
 
+  toidentifier@1.0.1: {}
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
@@ -8151,10 +9489,18 @@ snapshots:
     dependencies:
       utf8-byte-length: 1.0.5
 
+  ts-algebra@2.0.0: {}
+
   tslib@2.8.1: {}
 
   type-fest@0.13.1:
     optional: true
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.1.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
 
   typebox@1.3.7: {}
 
@@ -8220,6 +9566,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unpipe@1.0.0: {}
+
   unzipper@0.12.5:
     dependencies:
       bluebird: 3.7.2
@@ -8256,6 +9604,8 @@ snapshots:
   utf8-byte-length@1.0.5: {}
 
   util-deprecate@1.0.2: {}
+
+  vary@1.1.2: {}
 
   vfile-location@5.0.3:
     dependencies:
@@ -8316,6 +9666,8 @@ snapshots:
       - msw
 
   web-namespaces@2.0.1: {}
+
+  web-streams-polyfill@3.3.3: {}
 
   web-vitals@5.3.0: {}
 
@@ -8468,6 +9820,10 @@ snapshots:
       '@yuku-toolchain/types': 0.8.7
 
   zbsearch@4.0.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@4.4.3: {}
 

--- a/scripts/bundle-server.mjs
+++ b/scripts/bundle-server.mjs
@@ -61,12 +61,21 @@ const ENTRY_POINTS = [
   "drivers/browser-proxy.ts",
 ];
 
+// CommonJS dependencies (cross-spawn, via the MCP SDK's stdio transport) call
+// require() for Node builtins at load time. An ESM bundle has no require, so
+// give it one. createRequire resolves builtins without node_modules, which
+// keeps the packaged server self-contained — test:packaged-server proves it.
+const REQUIRE_SHIM = {
+  js: 'import { createRequire as __omb_createRequire } from "node:module"; const require = __omb_createRequire(import.meta.url);',
+};
+
 await build({
   entryPoints: ENTRY_POINTS.map((entry) => join(server, entry)),
   bundle: true,
   platform: "node",
   target: "node20",
   format: "esm",
+  banner: REQUIRE_SHIM,
   outbase: server,
   outdir: join(root, "dist-server"),
   // Written after tsc, replacing its output for these entry points.
@@ -85,6 +94,7 @@ await build({
   platform: "node",
   target: "node20",
   format: "esm",
+  banner: REQUIRE_SHIM,
   outfile: join(root, "dist-server", "mcp-server.js"),
   allowOverwrite: true,
   logLevel: "info",

--- a/scripts/control-omb.ts
+++ b/scripts/control-omb.ts
@@ -14,7 +14,9 @@ import { freePortBlock } from "../server/testing/ports.ts";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const FAKE_CLI = join(ROOT, "server", "testing", "fake-claude-cli.ts");
-const MUTATING = new Set(["new-bot", "new-channel", "send", "send-channel", "interrupt", "edit"]);
+const FAKE_OPENAI = join(ROOT, "server", "testing", "fake-openai-server.ts");
+const FAKE_MCP = join(ROOT, "server", "testing", "fake-mcp-server.ts");
+const MUTATING = new Set(["new-bot", "new-channel", "send", "send-channel", "interrupt", "edit", "set-model"]);
 
 export class ControlOmbError extends Error {
   readonly hint?: string;
@@ -54,9 +56,13 @@ mutating (an explicit --url or OPENMAUSBOT_URL/OMB_PORT is required):
   interrupt --bot ID [--dry-run] [--url URL]
   interrupt --channel ID [--dry-run] [--url URL]
   edit --bot ID --message ID --text TEXT [--url URL]
+  set-model --bot ID --instance ID --model ID [--url URL]
 
 isolated fixture:
   node --experimental-strip-types scripts/control-omb.ts launch
+  OMB_VERIFY_OWNED=1 … launch   also starts a loopback fake OpenAI-compatible
+                                server and enables the preview OpenMaus Runtime
+                                against it, with a fake MCP server mounted
 
 Output is JSON. launch owns a temporary fake-engine server until interrupted.`;
 
@@ -203,6 +209,22 @@ export async function runControlOmb(
     }, opts.url);
   }
 
+  if (command === "set-model") {
+    // Switching a bot's engine is the one mapped way to reach the
+    // engine-switch replay path, and the only way to move a bot onto the
+    // preview runtime in the fixture.
+    const opts = parse(command, args, {
+      bot: { type: "string" },
+      instance: { type: "string" },
+      model: { type: "string" },
+    });
+    return call("set_bot_model", {
+      bot_id: required(opts.bot, "--bot"),
+      instance_id: required(opts.instance, "--instance"),
+      model: required(opts.model, "--model"),
+    }, opts.url);
+  }
+
   if (command === "new-channel") {
     const values = parse(command, args, {
       name: { type: "string" },
@@ -288,6 +310,35 @@ export async function launchVerificationServer(
   const evidenceDir = join(tmpdir(), "openmausbot-verification-evidence");
   mkdirSync(evidenceDir, { recursive: true });
   const logPath = join(evidenceDir, `server-${Date.now()}-${process.pid}.log`);
+  // OMB_VERIFY_OWNED=1 adds the preview OpenMaus Runtime, pointed at a
+  // loopback fake OpenAI-compatible server this launcher owns, with the fake
+  // MCP server mounted as the bot's own tool. Everything stays on 127.0.0.1
+  // and dies with the launcher.
+  const verifyOwned = parentEnv.OMB_VERIFY_OWNED === "1";
+  let fakeOpenAI: ReturnType<typeof spawn> | null = null;
+  let fakeOpenAIUrl: string | null = null;
+  if (verifyOwned) {
+    fakeOpenAI = spawn(process.execPath, ["--experimental-strip-types", FAKE_OPENAI], {
+      env: {
+        ...process.env,
+        ...(parentEnv.FAKE_OPENAI_MODE ? { FAKE_OPENAI_MODE: parentEnv.FAKE_OPENAI_MODE } : {}),
+        ...(parentEnv.FAKE_OPENAI_TOOL ? { FAKE_OPENAI_TOOL: parentEnv.FAKE_OPENAI_TOOL } : {}),
+      },
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    fakeOpenAIUrl = await new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("fake OpenAI server did not report its URL")), 10_000);
+      let buffer = "";
+      fakeOpenAI!.stdout!.on("data", (chunk) => {
+        buffer += String(chunk);
+        const line = buffer.split("\n").find((l) => l.startsWith("{"));
+        if (!line) return;
+        clearTimeout(timer);
+        resolve((JSON.parse(line) as { url: string }).url);
+      });
+      fakeOpenAI!.once("exit", () => reject(new Error("fake OpenAI server exited before reporting its URL")));
+    });
+  }
   writeFileSync(join(dataDir, "config.json"), JSON.stringify({
     instances: {
       claude: {
@@ -295,7 +346,19 @@ export async function launchVerificationServer(
         displayName: "Verification fixture",
         config: { cli: FAKE_CLI },
       },
+      ...(fakeOpenAIUrl
+        ? { openmausRuntime: { driver: "openmaus-runtime", displayName: "Owned fixture", config: { url: fakeOpenAIUrl, model: "fake-model" } } }
+        : {}),
     },
+    ...(fakeOpenAIUrl
+      ? {
+          features: { ownedRuntime: true },
+          // a loopback endpoint needs no key; one is set anyway so the
+          // credential path is exercised and the canary can be grepped for
+          openaiCompat: { key: "verify-key-canary-0000" },
+          mcpServers: { notes: { command: process.execPath, args: ["--experimental-strip-types", FAKE_MCP] } },
+        }
+      : {}),
   }, null, 2));
 
   const log = openSync(logPath, "a", 0o600);
@@ -329,7 +392,7 @@ export async function launchVerificationServer(
   // without them whole features are unverifiable here: OMB_CONTEXT_WINDOW
   // shrinks every model's window so compaction can be watched on a short
   // thread, and FAKE_CLAUDE_MODE drives the CLI failure paths.
-  for (const key of ["OMB_CONTEXT_WINDOW", "FAKE_CLAUDE_MODE"]) {
+  for (const key of ["OMB_CONTEXT_WINDOW", "FAKE_CLAUDE_MODE", "FAKE_OPENAI_MODE"]) {
     const value = parentEnv[key];
     if (value) childEnv[key] = value;
   }
@@ -362,19 +425,22 @@ export async function launchVerificationServer(
     }
   } catch (error) {
     await waitForExit(child, { signal: "SIGTERM" });
+    if (fakeOpenAI) await waitForExit(fakeOpenAI, { signal: "SIGTERM" });
     await removeTempDir(dataDir);
     throw error;
   }
 
   let closed = false;
   return {
-    info: { url, pid: child.pid!, dataDir, logPath },
+    info: { url, pid: child.pid!, dataDir, logPath, ...(fakeOpenAIUrl ? { ownedRuntimeUrl: fakeOpenAIUrl } : {}) },
     fixtureDumpPath,
     child,
     async close() {
       if (closed) return;
       closed = true;
       await waitForExit(child, { signal: "SIGTERM" });
+      // the fake provider is this launcher's child too; it never outlives it
+      if (fakeOpenAI) await waitForExit(fakeOpenAI, { signal: "SIGTERM" });
       await removeTempDir(dataDir);
     },
   };

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -17,6 +17,7 @@ import { customMcpServers,
   showToolCallsEnabled,
   saveConfig,
   skillRecorderEnabled,
+  ownedRuntimeEnabled,
   builtInBrowserEnabled,
   browserProfilePartitionId,
   browserProfilePartitionTarget,
@@ -303,6 +304,36 @@ describe("configuration boundaries", () => {
     });
     expect(localVmMode({ localVm: { mode: "per-bot" } })).toBe("per-bot");
     expect(localVmMaxInstances({ localVm: { maxInstances: 3 } })).toBe(3);
+  });
+
+  it("keeps the preview OpenMaus Runtime off by default and out of the fleet", () => {
+    expect(ownedRuntimeEnabled({})).toBe(false);
+    expect(ownedRuntimeEnabled({ features: { browser: true } })).toBe(false);
+    expect(Object.hasOwn(instanceConfigs({}), "openmausRuntime")).toBe(false);
+  });
+
+  it("adds the preview engine to the fleet only on an explicit opt-in, reusing openai-compat's contract", () => {
+    expect(parseConfigPatch({ features: { ownedRuntime: true } })).toEqual({ features: { ownedRuntime: true } });
+    expect(ownedRuntimeEnabled({ features: { ownedRuntime: true } })).toBe(true);
+    const cfg = {
+      features: { ownedRuntime: true },
+      openaiCompat: { key: "sk-or-test", url: "https://openrouter.ai/api/v1", model: "some/model", provider: "groq" },
+    };
+    const map = instanceConfigs(cfg);
+    const entry = map.openmausRuntime;
+    expect(entry?.driver).toBe("openmaus-runtime");
+    // the same key and URL the openai-compat instance gets — switching a bot
+    // between the two engines moves nothing else
+    expect(entry?.environment).toMatchObject({ OPENAI_COMPAT_API_KEY: "sk-or-test", OPENAI_COMPAT_URL: "https://openrouter.ai/api/v1" });
+    expect(entry?.config).toMatchObject({ url: "https://openrouter.ai/api/v1", model: "some/model", provider: "groq" });
+    expect(map.openaiCompat?.environment).toMatchObject({ OPENAI_COMPAT_API_KEY: "sk-or-test" });
+  });
+
+  it("joins a persisted product fleet too, and never overrides a user-defined instance", () => {
+    const configured = { claude: { driver: "claudeAgent" }, openmausRuntime: { driver: "openmaus-runtime", displayName: "Mine", config: { url: "http://127.0.0.1:8080/v1" } } };
+    const map = instanceConfigs({ features: { ownedRuntime: true }, instances: configured });
+    expect(map.openmausRuntime?.displayName).toBe("Mine");
+    expect(map.openmausRuntime?.config).toMatchObject({ url: "http://127.0.0.1:8080/v1" });
   });
 
   it("keeps experimental features off by default and accepts an explicit opt-in", () => {

--- a/server/config.ts
+++ b/server/config.ts
@@ -220,6 +220,9 @@ const featureConfigSchema = z.object({
   /** Experimental built-in browser. Off until explicitly enabled; each bot
    * also has its own switch. */
   browser: z.boolean().optional(),
+  /** Preview: the OpenMaus-owned agent loop for API-key and local-model
+   * bots. Off until explicitly enabled; existing bots are never migrated. */
+  ownedRuntime: z.boolean().optional(),
 });
 const instanceConfigSchema = z.object({
   driver: z.string().min(1),
@@ -290,7 +293,7 @@ export interface AppConfig {
    * separate container, durable workspace, viewer and lease. */
   localVm?: { mode?: "shared" | "per-bot"; maxInstances?: number };
   /** Opt-in product experiments. Every flag defaults to disabled. */
-  features?: { skillRecorder?: boolean; showToolCalls?: boolean; browser?: boolean };
+  features?: { skillRecorder?: boolean; showToolCalls?: boolean; browser?: boolean; ownedRuntime?: boolean };
   /** Named browser sessions any bot can be pointed at. */
   browserProfiles?: BrowserProfile[];
   instances?: InstanceConfigMap;
@@ -428,6 +431,13 @@ export function showToolCallsEnabled(cfg: AppConfig): boolean {
  * switch sits under it, so either can withhold the browser. */
 export function builtInBrowserEnabled(cfg: AppConfig): boolean {
   return cfg.features?.browser === true;
+}
+
+/** Workspace-level gate for the preview OpenMaus Runtime engine. Off means
+ * the instance is simply absent from the fleet: a bot that selected it
+ * shows its engine as unavailable, and no transcript is touched. */
+export function ownedRuntimeEnabled(cfg: AppConfig): boolean {
+  return cfg.features?.ownedRuntime === true;
 }
 
 // OMB_DATA_DIR isolates test/soak rigs from the user's real fleet.
@@ -693,9 +703,12 @@ interface InstanceCliUpdate {
 function injectedEnvironment(cfg: AppConfig, driver: string): Map<string, string> {
   const environment = new Map<string, string>();
   if (driver === "grok" && cfg.xai?.key) environment.set("XAI_API_KEY", cfg.xai.key);
-  if (driver === "openai-compat" && cfg.openaiCompat?.key)
+  // the owned runtime reuses openai-compat's key and URL contract exactly,
+  // so switching a bot between the two moves nothing else
+  const compatDriver = driver === "openai-compat" || driver === "openmaus-runtime";
+  if (compatDriver && cfg.openaiCompat?.key)
     environment.set("OPENAI_COMPAT_API_KEY", cfg.openaiCompat.key);
-  if (driver === "openai-compat" && cfg.openaiCompat?.url)
+  if (compatDriver && cfg.openaiCompat?.url)
     environment.set("OPENAI_COMPAT_URL", cfg.openaiCompat.url);
   if (driver === "boxAgent" && cfg.box?.token) environment.set("BOX_TOKEN", cfg.box.token);
   if (driver === "opencodeGo" && cfg.opencodeGo?.apiKey) environment.set("OPENCODE_API_KEY", cfg.opencodeGo.apiKey);
@@ -761,6 +774,12 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
       if (!Object.hasOwn(map, id)) map[id] = { ...entry };
     }
   }
+  // The preview engine joins the fleet only while its flag is on. A user
+  // who turns it off keeps every transcript; the bots that chose it just
+  // see an unavailable engine until they pick another.
+  if (ownedRuntimeEnabled(cfg) && !Object.hasOwn(map, "openmausRuntime")) {
+    map.openmausRuntime = { driver: "openmaus-runtime" };
+  }
   for (const [id, sourceEntry] of Object.entries(map)) {
     // instanceConfigs() builds a transient runtime map. Never mutate the
     // caller's persisted entries while injecting workspace defaults: doing so
@@ -774,7 +793,7 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
     // intentionally not consulted by ProviderRegistry when it decodes a
     // driver's config, so carry the workspace default into the transient
     // instance map while preserving a per-instance override.
-    if (entry.driver === "openai-compat" && cfg.openaiCompat) {
+    if ((entry.driver === "openai-compat" || entry.driver === "openmaus-runtime") && cfg.openaiCompat) {
       const defaults: Record<string, string> = {};
       if (cfg.openaiCompat.url) defaults.url = cfg.openaiCompat.url;
       if (cfg.openaiCompat.model) defaults.model = cfg.openaiCompat.model;

--- a/server/context/ownership.test.ts
+++ b/server/context/ownership.test.ts
@@ -53,6 +53,12 @@ describe("context ownership is declared, not inferred", () => {
     }
   });
 
+  it("declares `omb-loop` for the owned runtime — the third mode, now real", async () => {
+    // The one engine where OpenMausBot runs the model/tool loop itself. It
+    // creates no process and reaches no network, so create() is safe here.
+    expect(await ownershipOf("openmaus-runtime")).toBe("omb-loop");
+  });
+
   it("never reports a value outside the union", async () => {
     for (const kind of CHAT_RUNTIME_KINDS) {
       expect(OWNERSHIP, kind).toContain(await ownershipOf(kind));

--- a/server/control-omb.test.ts
+++ b/server/control-omb.test.ts
@@ -114,6 +114,39 @@ describe("control-omb command mapping", () => {
     });
   });
 
+  it("maps an engine switch onto set_bot_model", async () => {
+    // the one mapped way to reach the engine-switch replay path, and to
+    // move a bot onto the preview runtime inside the fixture
+    const callTool = vi.fn(async (name: string, args: Record<string, unknown>) => ({ name, args }));
+    await expect(runControlOmb(
+      ["set-model", "--bot", "bot-1", "--instance", "openmausRuntime", "--model", "fake-model"],
+      { callTool: callTool as any, env: { OPENMAUSBOT_URL: "http://127.0.0.1:19999" } },
+    )).resolves.toEqual({
+      name: "set_bot_model",
+      args: { bot_id: "bot-1", instance_id: "openmausRuntime", model: "fake-model" },
+    });
+  });
+
+  it("treats set-model as mutating", async () => {
+    await expect(runControlOmb(["set-model", "--bot", "b", "--instance", "i", "--model", "m"], {
+      callTool: vi.fn() as any,
+      env: {},
+    })).rejects.toMatchObject({ message: "mutating commands require an explicit OpenMausBot instance" });
+  });
+
+  it("requires bot, instance, and model for set-model", async () => {
+    const callTool = vi.fn();
+    const env = { OPENMAUSBOT_URL: "http://127.0.0.1:19999" };
+    for (const args of [
+      ["set-model", "--instance", "i", "--model", "m"],
+      ["set-model", "--bot", "b", "--model", "m"],
+      ["set-model", "--bot", "b", "--instance", "i"],
+    ]) {
+      await expect(runControlOmb(args, { callTool: callTool as any, env })).rejects.toThrow(/is required/);
+    }
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
   it("requires every part of an edit before calling the shared tool", async () => {
     const callTool = vi.fn();
     const env = { OPENMAUSBOT_URL: "http://127.0.0.1:19999" };

--- a/server/drivers/builtIn.ts
+++ b/server/drivers/builtIn.ts
@@ -18,6 +18,7 @@ import { HermesAgentDriver } from "./acp/hermes.ts";
 import { OpenAICompatDriver } from "./openai-compat.ts";
 import { PiDriver } from "./pi.ts";
 import { MinimaxDriver } from "./minimax.ts";
+import { OpenMausRuntimeDriver } from "./openmaus-runtime.ts";
 
 export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   GrokDriver,
@@ -37,4 +38,6 @@ export const BUILT_IN_DRIVERS: readonly AnyProviderDriver[] = [
   AntigravityDriver,
   BoxAgentDriver,
   MinimaxDriver,
+  // preview; joins the fleet only when features.ownedRuntime is on
+  OpenMausRuntimeDriver,
 ];

--- a/server/drivers/local-endpoint.test.ts
+++ b/server/drivers/local-endpoint.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { isLocalEndpoint } from "./local-endpoint.ts";
+
+describe("isLocalEndpoint", () => {
+  it("accepts loopback and private-network hosts", () => {
+    for (const url of [
+      "http://127.0.0.1:8080/v1",
+      "http://localhost:1234/v1",
+      "http://[::1]:8080/v1",
+      "http://10.0.0.5:11434/v1",
+      "http://192.168.1.20:8000/v1",
+      "http://172.16.0.9/v1",
+      "http://mybox.localhost/v1",
+      "http://[fd12::1]:8080/v1",
+    ]) {
+      expect(isLocalEndpoint(url), url).toBe(true);
+    }
+  });
+
+  it("rejects public hosts, however local they sound", () => {
+    for (const url of [
+      "https://openrouter.ai/api/v1",
+      "https://api.groq.com/openai/v1",
+      "http://172.32.0.1/v1", // just outside 172.16/12
+      "http://localhost.evil.example/v1",
+      "http://8.8.8.8/v1",
+    ]) {
+      expect(isLocalEndpoint(url), url).toBe(false);
+    }
+  });
+
+  it("treats an unparseable URL as remote — the safe side", () => {
+    expect(isLocalEndpoint("not a url")).toBe(false);
+    expect(isLocalEndpoint("")).toBe(false);
+  });
+});

--- a/server/drivers/local-endpoint.ts
+++ b/server/drivers/local-endpoint.ts
@@ -1,0 +1,32 @@
+// Whether an endpoint is on this machine or this network — the only case
+// in which the owned runtime may run without an API key.
+//
+// A remote endpoint with no key would send every prompt to a host the user
+// never authenticated with. A local one is the user's own llama.cpp, vLLM,
+// LM Studio, or Ollama, which commonly need none. The distinction is made
+// on the URL's host, never on a header or a probe.
+const LOOPBACK = new Set(["localhost", "127.0.0.1", "::1", "[::1]", "0.0.0.0"]);
+
+function isPrivateV4(host: string): boolean {
+  const parts = host.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return false;
+  const [a, b] = parts as [number, number, number, number];
+  return a === 10 || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168) || (a === 169 && b === 254) || a === 127;
+}
+
+function isPrivateV6(host: string): boolean {
+  const h = host.replace(/^\[|\]$/g, "").toLowerCase();
+  return h === "::1" || h.startsWith("fc") || h.startsWith("fd") || h.startsWith("fe80:");
+}
+
+export function isLocalEndpoint(url: string): boolean {
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  if (LOOPBACK.has(host)) return true;
+  if (host.endsWith(".localhost")) return true;
+  return isPrivateV4(host) || isPrivateV6(host);
+}

--- a/server/drivers/openmaus-runtime.test.ts
+++ b/server/drivers/openmaus-runtime.test.ts
@@ -1,0 +1,208 @@
+// The driver over the owned loop: how OwnedRuntimeEvents become canonical
+// RuntimeEvents, and what the adapter refuses. The runtime itself is faked
+// here — pi-runtime.test.ts covers the loop; this covers the seam.
+import { describe, expect, it } from "vitest";
+
+import type { RuntimeEvent } from "../contracts.ts";
+import type { TurnContextPlan } from "../context/types.ts";
+import type { OwnedAgentRuntime, OwnedRuntimeEmit, OwnedRuntimeEvent, OwnedTurnInput } from "../runtime/contracts.ts";
+import { recordEvents } from "../testing/events.ts";
+import { OpenMausRuntimeDriver, createOpenMausRuntimeInstance } from "./openmaus-runtime.ts";
+
+const plan: TurnContextPlan = {
+  ownership: "omb-loop",
+  mode: "replay-required",
+  currentPrompt: "what now?",
+  replayPrompt: "what now?",
+  messages: [{ kind: "user-text", messageId: "m1", text: "hi" }],
+  budget: { contextWindow: 200_000, historyTokens: 80_000, limitsSource: "pattern" },
+  diagnostics: { sourceItems: 1, sentItems: 1, estimatedInputTokens: 5, compacted: false, clipped: false },
+};
+
+/** A runtime that replays a script of events for each run() and records
+ * what it was asked to do. */
+function fakeRuntime(script: OwnedRuntimeEvent[]) {
+  const runs: OwnedTurnInput[] = [];
+  const runtime: OwnedAgentRuntime & { runs: OwnedTurnInput[]; steered: string[]; interrupted: string[] } = {
+    runs,
+    steered: [],
+    interrupted: [],
+    async run(input, emit: OwnedRuntimeEmit) {
+      runs.push(input);
+      for (const event of script) emit(event);
+    },
+    steer(threadId, text) {
+      runtime.steered.push(`${threadId}:${text}`);
+      return true;
+    },
+    interrupt(threadId) {
+      runtime.interrupted.push(threadId);
+    },
+    hasTurn: () => false,
+    dispose: async () => {},
+  };
+  return runtime;
+}
+
+const instanceWith = (runtime: OwnedAgentRuntime, key = "sk-test") =>
+  createOpenMausRuntimeInstance(
+    {
+      instanceId: "owned-test",
+      displayName: "Owned",
+      environment: key ? { OPENAI_COMPAT_API_KEY: key } : {},
+      enabled: true,
+      config: OpenMausRuntimeDriver.decodeConfig({ url: "http://127.0.0.1:1/v1", model: "test-model" }),
+    },
+    { runtime },
+  );
+
+describe("OpenMausRuntimeDriver", () => {
+  it("declares ownership of the loop, queueing, and no MCP capability yet", () => {
+    const inst = instanceWith(fakeRuntime([]));
+    const caps = inst.adapter.capabilities;
+    expect(caps.contextOwnership).toBe("omb-loop");
+    expect(caps.queueing).toBe(true);
+    // advertised only after each integration test passes (Task 9)
+    for (const cap of ["agentsMcp", "computerMcp", "composioMcp", "phoneMcp", "browserMcp", "customMcp", "localComputerMcp"] as const) {
+      expect(caps[cap], cap).toBeFalsy();
+    }
+  });
+
+  it("is available and metered with a key, unavailable without one", async () => {
+    await expect(instanceWith(fakeRuntime([])).snapshot()).resolves.toMatchObject({ state: "available", billing: "metered" });
+    await expect(instanceWith(fakeRuntime([]), "").snapshot()).resolves.toMatchObject({ state: "unavailable" });
+  });
+
+  it("refuses a turn without a key, and never calls the runtime", async () => {
+    const runtime = fakeRuntime([]);
+    await expect(instanceWith(runtime, "").adapter.sendTurn({ threadId: "t", text: "hi", context: plan })).rejects.toThrow(/no API key/);
+    expect(runtime.runs).toHaveLength(0);
+  });
+
+  it("refuses a turn without a context plan — for this engine the plan is the only history", async () => {
+    const runtime = fakeRuntime([]);
+    await expect(instanceWith(runtime).adapter.sendTurn({ threadId: "t", text: "hi" })).rejects.toThrow(/requires SendTurnInput.context/);
+    expect(runtime.runs).toHaveLength(0);
+  });
+
+  it("hands the runtime the plan, the model target, and the loop limits", async () => {
+    const runtime = fakeRuntime([{ type: "completed", ok: true, stopReason: "end_turn" }]);
+    const inst = instanceWith(runtime);
+    const rec = recordEvents(inst.adapter);
+    await inst.adapter.sendTurn({ threadId: "t", text: "hi", system: "You are Wren.", model: "test-model", effort: "high", context: plan });
+    await rec.until((e) => e.type === "turn.completed");
+    const run = runtime.runs[0]!;
+    expect(run.plan).toBe(plan);
+    expect(run.system).toBe("You are Wren.");
+    expect(run.effort).toBe("high");
+    expect(run.model).toMatchObject({ id: "test-model", baseUrl: "http://127.0.0.1:1/v1", apiKey: "sk-test" });
+    expect(run.limits).toEqual({ maxModelCalls: 32, maxToolCalls: 64, toolTimeoutMs: 180_000 });
+    expect(run.tools).toEqual([]);
+    rec.stop();
+  });
+
+  it("maps every runtime event onto the canonical bus", async () => {
+    const runtime = fakeRuntime([
+      { type: "model.call", call: 1 },
+      { type: "delta", kind: "reasoning", text: "hm" },
+      { type: "delta", kind: "text", text: "Hel" },
+      { type: "delta", kind: "text", text: "lo" },
+      { type: "tool.started", callId: "c1", name: "echo", inputSummary: "{}" },
+      { type: "tool.completed", callId: "c1", name: "echo", ok: true, observation: { name: "echo", ok: true } },
+      { type: "assistant", text: "Hello" },
+      { type: "usage", input: 10, output: 2, cachedInput: 4 },
+      { type: "completed", ok: true, stopReason: "end_turn" },
+    ]);
+    const inst = instanceWith(runtime);
+    const rec = recordEvents(inst.adapter);
+    await inst.adapter.sendTurn({ threadId: "t", text: "hi", context: plan });
+    await rec.until((e) => e.type === "turn.completed");
+    const seen = rec.events.map((e: RuntimeEvent) => e.type);
+    expect(seen).toEqual([
+      "turn.started",
+      "session.started",
+      "content.delta",
+      "content.delta",
+      "content.delta",
+      "item.started",
+      "item.completed",
+      "item.completed",
+      "thread.token-usage.updated",
+      "turn.completed",
+    ]);
+    expect(rec.events[2]).toMatchObject({ type: "content.delta", streamKind: "reasoning_text", delta: "hm" });
+    expect(rec.events[5]).toMatchObject({ type: "item.started", itemType: "tool", title: "echo", itemId: "c1" });
+    expect(rec.events[6]).toMatchObject({ type: "item.completed", itemType: "tool", ok: true });
+    expect(rec.events[7]).toMatchObject({ type: "item.completed", itemType: "assistant_text", text: "Hello" });
+    expect(rec.events[8]).toMatchObject({ type: "thread.token-usage.updated", input: 10, output: 2, cachedInput: 4 });
+    expect(rec.events[9]).toMatchObject({ type: "turn.completed", ok: true, stopReason: null });
+    rec.stop();
+  });
+
+  it("surfaces a loop cap as the turn's stop reason", async () => {
+    const runtime = fakeRuntime([{ type: "completed", ok: true, stopReason: "max_tool_calls" }]);
+    const inst = instanceWith(runtime);
+    const rec = recordEvents(inst.adapter);
+    await inst.adapter.sendTurn({ threadId: "t", text: "hi", context: plan });
+    const done = await rec.until((e) => e.type === "turn.completed");
+    expect(done).toMatchObject({ ok: true, stopReason: "max_tool_calls" });
+    rec.stop();
+  });
+
+  it("reports a runtime error and settles the turn as failed", async () => {
+    const runtime = fakeRuntime([{ type: "error", message: "upstream 503" }, { type: "completed", ok: false, stopReason: "error" }]);
+    const inst = instanceWith(runtime);
+    const rec = recordEvents(inst.adapter);
+    await inst.adapter.sendTurn({ threadId: "t", text: "hi", context: plan });
+    await rec.until((e) => e.type === "turn.completed");
+    expect(rec.events.some((e) => e.type === "runtime.error" && e.message === "upstream 503")).toBe(true);
+    expect(rec.events.at(-1)).toMatchObject({ type: "turn.completed", ok: false, stopReason: "error" });
+    expect(inst.adapter.hasSession("t")).toBe(false);
+    rec.stop();
+  });
+
+  it("never leaves a thread busy when the adapter itself throws", async () => {
+    // run() is contracted not to reject; this is the belt for a bug in it
+    const runtime = fakeRuntime([]);
+    runtime.run = async () => {
+      throw new Error("adapter bug");
+    };
+    const inst = instanceWith(runtime);
+    const rec = recordEvents(inst.adapter);
+    await inst.adapter.sendTurn({ threadId: "t", text: "hi", context: plan });
+    const done = await rec.until((e) => e.type === "turn.completed");
+    expect(done).toMatchObject({ ok: false, stopReason: "error" });
+    expect(inst.adapter.hasSession("t")).toBe(false);
+    rec.stop();
+  });
+
+  it("allows one turn per thread at a time", async () => {
+    const runtime = fakeRuntime([]);
+    runtime.run = () => new Promise(() => {});
+    const inst = instanceWith(runtime);
+    await inst.adapter.sendTurn({ threadId: "t", text: "hi", context: plan });
+    await expect(inst.adapter.sendTurn({ threadId: "t", text: "again", context: plan })).rejects.toThrow(/already running/);
+  });
+
+  it("delegates steer and interrupt to the runtime", async () => {
+    const runtime = fakeRuntime([]);
+    runtime.run = () => new Promise(() => {});
+    const inst = instanceWith(runtime);
+    await inst.adapter.sendTurn({ threadId: "t", text: "hi", context: plan });
+    await expect(inst.adapter.steer!("t", "stop")).resolves.toBe(true);
+    expect(runtime.steered).toEqual(["t:stop"]);
+    await inst.adapter.interruptTurn("t");
+    expect(runtime.interrupted).toEqual(["t"]);
+  });
+
+  it("reuses openai-compat's config envelope so the two engines are interchangeable", () => {
+    const decoded = OpenMausRuntimeDriver.decodeConfig({ url: "https://openrouter.ai/api/v1/", apiKeyEnv: "MY_KEY", model: "m", provider: "groq" });
+    expect(decoded).toEqual({ url: "https://openrouter.ai/api/v1", apiKeyEnv: "MY_KEY", key: undefined, model: "m", provider: "groq" });
+  });
+
+  it("says plainly that it is not a subscription login", () => {
+    expect(OpenMausRuntimeDriver.metadata.access).toBe("custom");
+    expect(OpenMausRuntimeDriver.install?.signInCommand).toMatch(/not a Claude or Codex login/);
+    expect(OpenMausRuntimeDriver.install?.signInCommand).toMatch(/billed/);
+  });
+});

--- a/server/drivers/openmaus-runtime.test.ts
+++ b/server/drivers/openmaus-runtime.test.ts
@@ -53,16 +53,23 @@ function fakeRuntime(script: OwnedRuntimeEvent[]) {
   return runtime;
 }
 
-const instanceWith = (runtime: OwnedAgentRuntime, key = "sk-test", options: { mcpStartupTimeoutMs?: number } = {}) =>
+const REMOTE = "https://openrouter.ai/api/v1";
+const LOCAL = "http://127.0.0.1:1/v1";
+
+const instanceWith = (
+  runtime: OwnedAgentRuntime,
+  key = "sk-test",
+  options: { mcpStartupTimeoutMs?: number; url?: string } = {},
+) =>
   createOpenMausRuntimeInstance(
     {
       instanceId: "owned-test",
       displayName: "Owned",
       environment: key ? { OPENAI_COMPAT_API_KEY: key } : {},
       enabled: true,
-      config: OpenMausRuntimeDriver.decodeConfig({ url: "http://127.0.0.1:1/v1", model: "test-model" }),
+      config: OpenMausRuntimeDriver.decodeConfig({ url: options.url ?? LOCAL, model: "test-model" }),
     },
-    { runtime, ...options },
+    { runtime, mcpStartupTimeoutMs: options.mcpStartupTimeoutMs },
   );
 
 describe("OpenMausRuntimeDriver", () => {
@@ -78,14 +85,34 @@ describe("OpenMausRuntimeDriver", () => {
     }
   });
 
-  it("is available and metered with a key, unavailable without one", async () => {
-    await expect(instanceWith(fakeRuntime([])).snapshot()).resolves.toMatchObject({ state: "available", billing: "metered" });
-    await expect(instanceWith(fakeRuntime([]), "").snapshot()).resolves.toMatchObject({ state: "unavailable" });
+  it("is available and metered with a key; a REMOTE endpoint is unavailable without one", async () => {
+    await expect(instanceWith(fakeRuntime([]), "sk-test", { url: REMOTE }).snapshot()).resolves.toMatchObject({ state: "available", billing: "metered" });
+    await expect(instanceWith(fakeRuntime([]), "", { url: REMOTE }).snapshot()).resolves.toMatchObject({ state: "unavailable" });
   });
 
-  it("refuses a turn without a key, and never calls the runtime", async () => {
+  it("runs a LOCAL endpoint with no key — it is the user's own server", async () => {
+    const runtime = fakeRuntime([{ type: "completed", ok: true, stopReason: "end_turn" }]);
+    const inst = instanceWith(runtime, "", { url: "http://127.0.0.1:8080/v1" });
+    await expect(inst.snapshot()).resolves.toMatchObject({ state: "available", billing: "metered" });
+    const rec = recordEvents(inst.adapter);
+    await inst.adapter.sendTurn({ threadId: "t", text: "hi", context: plan });
+    await rec.until((e) => e.type === "turn.completed");
+    expect(runtime.runs[0]!.model.apiKey).toBeUndefined();
+    rec.stop();
+  });
+
+  it("refuses a REMOTE endpoint with no key, and says why", async () => {
+    // every prompt would go to a host the user never authenticated with
     const runtime = fakeRuntime([]);
-    await expect(instanceWith(runtime, "").adapter.sendTurn({ threadId: "t", text: "hi", context: plan })).rejects.toThrow(/no API key/);
+    const inst = instanceWith(runtime, "", { url: REMOTE });
+    await expect(inst.snapshot()).resolves.toMatchObject({ state: "unavailable", reason: expect.stringContaining("not a local endpoint") });
+    await expect(inst.adapter.sendTurn({ threadId: "t", text: "hi", context: plan })).rejects.toThrow(/not a local endpoint/);
+    expect(runtime.runs).toHaveLength(0);
+  });
+
+  it("refuses a keyless turn to a remote endpoint, and never calls the runtime", async () => {
+    const runtime = fakeRuntime([]);
+    await expect(instanceWith(runtime, "", { url: REMOTE }).adapter.sendTurn({ threadId: "t", text: "hi", context: plan })).rejects.toThrow(/needs an API key/);
     expect(runtime.runs).toHaveLength(0);
   });
 

--- a/server/drivers/openmaus-runtime.test.ts
+++ b/server/drivers/openmaus-runtime.test.ts
@@ -1,6 +1,8 @@
 // The driver over the owned loop: how OwnedRuntimeEvents become canonical
 // RuntimeEvents, and what the adapter refuses. The runtime itself is faked
 // here — pi-runtime.test.ts covers the loop; this covers the seam.
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import type { RuntimeEvent } from "../contracts.ts";
@@ -8,6 +10,8 @@ import type { TurnContextPlan } from "../context/types.ts";
 import type { OwnedAgentRuntime, OwnedRuntimeEmit, OwnedRuntimeEvent, OwnedTurnInput } from "../runtime/contracts.ts";
 import { recordEvents } from "../testing/events.ts";
 import { OpenMausRuntimeDriver, createOpenMausRuntimeInstance } from "./openmaus-runtime.ts";
+
+const FAKE_MCP = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-mcp-server.ts");
 
 const plan: TurnContextPlan = {
   ownership: "omb-loop",
@@ -23,10 +27,15 @@ const plan: TurnContextPlan = {
  * what it was asked to do. */
 function fakeRuntime(script: OwnedRuntimeEvent[]) {
   const runs: OwnedTurnInput[] = [];
-  const runtime: OwnedAgentRuntime & { runs: OwnedTurnInput[]; steered: string[]; interrupted: string[] } = {
+  const runtime: OwnedAgentRuntime & { runs: OwnedTurnInput[]; steered: string[]; interrupted: string[]; answered: string[] } = {
     runs,
     steered: [],
     interrupted: [],
+    answered: [],
+    answer(threadId, requestId, behavior) {
+      runtime.answered.push(`${threadId}:${requestId}:${behavior}`);
+      return "unavailable";
+    },
     async run(input, emit: OwnedRuntimeEmit) {
       runs.push(input);
       for (const event of script) emit(event);
@@ -44,7 +53,7 @@ function fakeRuntime(script: OwnedRuntimeEvent[]) {
   return runtime;
 }
 
-const instanceWith = (runtime: OwnedAgentRuntime, key = "sk-test") =>
+const instanceWith = (runtime: OwnedAgentRuntime, key = "sk-test", options: { mcpStartupTimeoutMs?: number } = {}) =>
   createOpenMausRuntimeInstance(
     {
       instanceId: "owned-test",
@@ -53,17 +62,18 @@ const instanceWith = (runtime: OwnedAgentRuntime, key = "sk-test") =>
       enabled: true,
       config: OpenMausRuntimeDriver.decodeConfig({ url: "http://127.0.0.1:1/v1", model: "test-model" }),
     },
-    { runtime },
+    { runtime, ...options },
   );
 
 describe("OpenMausRuntimeDriver", () => {
-  it("declares ownership of the loop, queueing, and no MCP capability yet", () => {
+  it("declares ownership of the loop and queueing, and only the MCP capability it has proven", () => {
     const inst = instanceWith(fakeRuntime([]));
     const caps = inst.adapter.capabilities;
     expect(caps.contextOwnership).toBe("omb-loop");
     expect(caps.queueing).toBe(true);
-    // advertised only after each integration test passes (Task 9)
-    for (const cap of ["agentsMcp", "computerMcp", "composioMcp", "phoneMcp", "browserMcp", "customMcp", "localComputerMcp"] as const) {
+    // each integration is advertised only after its own test passes; the
+    // user's own MCP servers are (mcp-tools.test.ts), the rest are not yet
+    for (const cap of ["agentsMcp", "computerMcp", "composioMcp", "phoneMcp", "browserMcp", "localComputerMcp"] as const) {
       expect(caps[cap], cap).toBeFalsy();
     }
   });
@@ -193,6 +203,95 @@ describe("OpenMausRuntimeDriver", () => {
     expect(runtime.steered).toEqual(["t:stop"]);
     await inst.adapter.interruptTurn("t");
     expect(runtime.interrupted).toEqual(["t"]);
+  });
+
+  it("turns a runtime ask into an approval request and its answer into a resolution", async () => {
+    const runtime = fakeRuntime([
+      { type: "ask.opened", requestId: "ask-1", kind: "permission", tool: "notes__read_notes", summary: '{"text":"a"}' },
+      { type: "ask.resolved", requestId: "ask-1", behavior: "allow", source: "user" },
+      { type: "ask.opened", requestId: "ask-2", kind: "question", tool: "ask_user", summary: "which?", choices: ["x", "y"] },
+      { type: "ask.resolved", requestId: "ask-2", behavior: "answer", source: "timeout" },
+      { type: "completed", ok: true, stopReason: "end_turn" },
+    ]);
+    const inst = instanceWith(runtime);
+    const rec = recordEvents(inst.adapter);
+    await inst.adapter.sendTurn({ threadId: "t", text: "hi", context: plan });
+    await rec.until((e) => e.type === "turn.completed");
+    const opened = rec.events.filter((e) => e.type === "request.opened");
+    expect(opened[0]).toMatchObject({ requestId: "ask-1", requestType: "permission", tool: "notes__read_notes", summary: '{"text":"a"}' });
+    expect(opened[1]).toMatchObject({ requestId: "ask-2", requestType: "question", choices: ["x", "y"] });
+    const resolved = rec.events.filter((e) => e.type === "request.resolved");
+    expect(resolved[0]).toMatchObject({ requestId: "ask-1", behavior: "allow", source: "user" });
+    expect(resolved[1]).toMatchObject({ requestId: "ask-2", behavior: "answer", source: "timeout" });
+    rec.stop();
+  });
+
+  it("routes the harness's answer to the runtime and returns what it said", async () => {
+    const runtime = fakeRuntime([]);
+    runtime.run = () => new Promise(() => {});
+    const inst = instanceWith(runtime);
+    await inst.adapter.sendTurn({ threadId: "t", text: "hi", context: plan });
+    // the fake always says unavailable — the point is the delegation, and
+    // that unavailable is passed through untouched rather than upgraded
+    await expect(inst.adapter.respondToRequest("t", "ask-9", { behavior: "allow" })).resolves.toBe("unavailable");
+    expect(runtime.answered).toEqual(["t:ask-9:allow"]);
+  });
+
+  it("advertises the user's own MCP servers, and nothing else, as mountable", () => {
+    const caps = instanceWith(fakeRuntime([])).adapter.capabilities;
+    expect(caps.customMcp).toBe(true);
+    for (const cap of ["agentsMcp", "computerMcp", "composioMcp", "phoneMcp", "browserMcp", "localComputerMcp"] as const) {
+      expect(caps[cap], cap).toBeFalsy();
+    }
+  });
+
+  it("mounts the turn's MCP servers as namespaced tools and hands them to the loop", async () => {
+    const runtime = fakeRuntime([{ type: "completed", ok: true, stopReason: "end_turn" }]);
+    const inst = instanceWith(runtime);
+    const rec = recordEvents(inst.adapter);
+    const custom = {
+      notes: { command: process.execPath, args: ["--experimental-strip-types", FAKE_MCP], env: { ...process.env as Record<string, string> } },
+    };
+    await inst.adapter.sendTurn({ threadId: "t", text: "hi", context: plan, integrations: { custom } });
+    await rec.until((e) => e.type === "turn.completed");
+    expect(runtime.runs[0]!.tools.map((t) => t.name)).toEqual(["notes__read_notes"]);
+    // no runtime.error: the server started cleanly
+    expect(rec.events.some((e) => e.type === "runtime.error")).toBe(false);
+    rec.stop();
+  });
+
+  it("reports a server that failed to start and still runs the turn", async () => {
+    const runtime = fakeRuntime([{ type: "completed", ok: true, stopReason: "end_turn" }]);
+    // a garbage tools/list reply is dropped silently by the SDK; only the
+    // startup timeout brings the turn back, so it is shortened here
+    const inst = instanceWith(runtime, "sk-test", { mcpStartupTimeoutMs: 1_000 });
+    const rec = recordEvents(inst.adapter);
+    const custom = {
+      broken: { command: process.execPath, args: ["--experimental-strip-types", FAKE_MCP], env: { ...process.env as Record<string, string>, FAKE_MCP_MODE: "malformed" } },
+    };
+    await inst.adapter.sendTurn({ threadId: "t", text: "hi", context: plan, integrations: { custom } });
+    await rec.until((e) => e.type === "turn.completed");
+    expect(rec.events.some((e) => e.type === "runtime.error" && e.message.includes('"broken"'))).toBe(true);
+    expect(runtime.runs[0]!.tools).toEqual([]);
+    expect(rec.events.at(-1)).toMatchObject({ type: "turn.completed", ok: true });
+    rec.stop();
+  });
+
+  it("mounts fresh for each turn — a second turn is not handed the first turn's children", async () => {
+    const runtime = fakeRuntime([{ type: "completed", ok: true, stopReason: "end_turn" }]);
+    const inst = instanceWith(runtime);
+    const rec = recordEvents(inst.adapter);
+    const custom = {
+      notes: { command: process.execPath, args: ["--experimental-strip-types", FAKE_MCP], env: { ...process.env as Record<string, string> } },
+    };
+    await inst.adapter.sendTurn({ threadId: "t", text: "one", context: plan, integrations: { custom } });
+    await rec.until((e) => e.type === "turn.completed");
+    await inst.adapter.sendTurn({ threadId: "t", text: "two", context: plan, integrations: { custom } });
+    await rec.until((e) => e.type === "turn.completed" && rec.events.filter((x) => x.type === "turn.completed").length === 2);
+    expect(runtime.runs).toHaveLength(2);
+    expect(runtime.runs[1]!.tools[0]).not.toBe(runtime.runs[0]!.tools[0]);
+    expect(runtime.runs[1]!.tools.map((t) => t.name)).toEqual(["notes__read_notes"]);
+    rec.stop();
   });
 
   it("reuses openai-compat's config envelope so the two engines are interchangeable", () => {

--- a/server/drivers/openmaus-runtime.ts
+++ b/server/drivers/openmaus-runtime.ts
@@ -29,6 +29,7 @@ import { newEventId, newId } from "../contracts.ts";
 import { contextLimitsFor } from "../context/budget.ts";
 import type { OwnedAgentRuntime, OwnedRuntimeEvent } from "../runtime/contracts.ts";
 import { mountMcpServers, type MountedMcp } from "../runtime/mcp-tools.ts";
+import { isLocalEndpoint } from "./local-endpoint.ts";
 import { createPiRuntime } from "../runtime/pi-runtime.ts";
 import { appendNative } from "./native.ts";
 
@@ -73,6 +74,8 @@ function decodeConfig(raw: unknown): OpenMausRuntimeConfig {
 }
 
 const NO_KEY = (env: string) => `no API key — set ${env} or add it to the instance config`;
+const REMOTE_NEEDS_KEY = (env: string, url: string) =>
+  `${url} is not a local endpoint, so it needs an API key — set ${env} or add it to the instance config. Only loopback and private-network hosts may run without one.`;
 
 export interface CreateOpenMausRuntimeOptions {
   /** injected by tests; production uses the Pi-backed runtime. */
@@ -105,6 +108,12 @@ export function createOpenMausRuntimeInstance(
       }
     : DEFAULT_MODELS;
 
+  // A local endpoint (loopback / private network) may run with no key: it
+  // is the user's own server. A remote one never may — every prompt would
+  // go to a host the user never authenticated with.
+  const local = isLocalEndpoint(config.url);
+  const usable = Boolean(apiKey) || local;
+  const unavailableReason = local ? NO_KEY(config.apiKeyEnv) : REMOTE_NEEDS_KEY(config.apiKeyEnv, config.url);
   const runtime = options.runtime ?? createPiRuntime();
   const listeners = new Set<RuntimeEventListener>();
   const active = new Map<string, AbortController>();
@@ -181,7 +190,7 @@ export function createOpenMausRuntimeInstance(
   };
 
   const sendTurn = async (turn: SendTurnInput) => {
-    if (!apiKey) throw new Error(NO_KEY(config.apiKeyEnv));
+    if (!usable) throw new Error(unavailableReason);
     if (active.has(turn.threadId)) throw new Error("a turn is already running on this thread");
     // For an omb-loop engine the plan is not a compatibility projection, it
     // is the only history there is. Refusing a planless turn is how a
@@ -262,9 +271,9 @@ export function createOpenMausRuntimeInstance(
     displayName: input.displayName,
     enabled: input.enabled,
     models: catalog,
-    snapshot: async () => apiKey
+    snapshot: async () => usable
       ? { state: "available", authenticated: true, version: null, billing: "metered" }
-      : { state: "unavailable", reason: NO_KEY(config.apiKeyEnv) },
+      : { state: "unavailable", reason: unavailableReason },
     adapter: {
       provider: OPENMAUS_RUNTIME_KIND,
       capabilities: {

--- a/server/drivers/openmaus-runtime.ts
+++ b/server/drivers/openmaus-runtime.ts
@@ -12,9 +12,10 @@
 // another CLI's auth files. Authentication here is an API key or a local
 // endpoint that needs none, and usage is billed by that provider.
 //
-// Preview: disabled unless config.features.ownedRuntime is true. No MCP
-// integrations are mounted yet — those capabilities are advertised only
-// after each one is proven.
+// Preview: disabled unless config.features.ownedRuntime is true. The user's
+// own MCP servers (config.json mcpServers) mount as tools; every call asks
+// for approval through the ordinary card / auto-approve flow and fails
+// closed. Other integrations are advertised only as each one is proven.
 import type {
   DriverCreateInput,
   ModelCatalog,
@@ -27,6 +28,7 @@ import type {
 import { newEventId, newId } from "../contracts.ts";
 import { contextLimitsFor } from "../context/budget.ts";
 import type { OwnedAgentRuntime, OwnedRuntimeEvent } from "../runtime/contracts.ts";
+import { mountMcpServers, type MountedMcp } from "../runtime/mcp-tools.ts";
 import { createPiRuntime } from "../runtime/pi-runtime.ts";
 import { appendNative } from "./native.ts";
 
@@ -75,6 +77,11 @@ const NO_KEY = (env: string) => `no API key — set ${env} or add it to the inst
 export interface CreateOpenMausRuntimeOptions {
   /** injected by tests; production uses the Pi-backed runtime. */
   runtime?: OwnedAgentRuntime;
+  /** how long a mounted MCP server may take to answer its handshake. Tests
+   * shorten it; production keeps MCP_STARTUP_TIMEOUT_MS. That timeout is
+   * load-bearing: a server that replies to tools/list with garbage is
+   * silently dropped by the SDK, and only the timeout returns the turn. */
+  mcpStartupTimeoutMs?: number;
 }
 
 export function createOpenMausRuntimeInstance(
@@ -101,8 +108,15 @@ export function createOpenMausRuntimeInstance(
   const runtime = options.runtime ?? createPiRuntime();
   const listeners = new Set<RuntimeEventListener>();
   const active = new Map<string, AbortController>();
+  /** MCP children live exactly as long as the turn that mounted them. */
+  const mounted = new Map<string, MountedMcp>();
+  const unmount = async (threadId: string) => {
+    const servers = mounted.get(threadId);
+    mounted.delete(threadId);
+    await servers?.close();
+  };
   const emit = (event: RuntimeEvent) => {
-    for (const listener of [...listeners]) listener(event);
+    for (const listener of listeners) listener(event);
   };
   const base = (threadId: string, turnId: string) => ({
     eventId: newEventId(),
@@ -117,6 +131,20 @@ export function createOpenMausRuntimeInstance(
     const b = base(threadId, turnId);
     switch (event.type) {
       case "model.call":
+        return;
+      case "ask.opened":
+        emit({
+          ...b,
+          requestId: event.requestId,
+          type: "request.opened",
+          requestType: event.kind,
+          tool: event.tool,
+          summary: event.summary,
+          ...(event.choices ? { choices: event.choices } : {}),
+        });
+        return;
+      case "ask.resolved":
+        emit({ ...b, requestId: event.requestId, type: "request.resolved", behavior: event.behavior, source: event.source });
         return;
       case "delta":
         emit({ ...b, type: "content.delta", streamKind: event.kind === "text" ? "assistant_text" : "reasoning_text", delta: event.text });
@@ -138,6 +166,9 @@ export function createOpenMausRuntimeInstance(
         return;
       case "completed":
         active.delete(threadId);
+        // children stop on settle, not on dispose: a turn's servers must not
+        // outlive it and keep a socket or a process around
+        void unmount(threadId);
         emit({
           ...b,
           type: "turn.completed",
@@ -157,6 +188,8 @@ export function createOpenMausRuntimeInstance(
     // future caller learns that, instead of the model silently starting
     // from nothing.
     if (!turn.context) throw new Error("openmaus-runtime requires SendTurnInput.context");
+    // captured here: the async body below cannot see the guard's narrowing
+    const plan = turn.context;
 
     const turnId = newId();
     const abort = new AbortController();
@@ -166,16 +199,32 @@ export function createOpenMausRuntimeInstance(
     appendNative(turn.threadId, {
       dir: "out",
       source: "openmaus-runtime.turn",
-      msg: { model, items: turn.context.messages.length, ownership: turn.context.ownership },
+      msg: { model, items: plan.messages.length, ownership: plan.ownership },
     });
     emit({ ...base(turn.threadId, turnId), type: "turn.started" });
     emit({ ...base(turn.threadId, turnId), type: "session.started", sessionId: null, model });
 
-    void runtime.run(
+    // Mount inside the async body: a server that takes seconds to start
+    // must not block the HTTP request that started the turn. A server that
+    // fails is recorded and the turn proceeds without it.
+    void (async () => {
+      const servers = await mountMcpServers(turn.integrations?.custom ?? {}, {
+        toolTimeoutMs: OWNED_LOOP_LIMITS.toolTimeoutMs,
+        ...(options.mcpStartupTimeoutMs === undefined ? {} : { startupTimeoutMs: options.mcpStartupTimeoutMs }),
+      });
+      mounted.set(turn.threadId, servers);
+      for (const [name, reason] of servers.failures) {
+        emit({ ...base(turn.threadId, turnId), type: "runtime.error", message: `MCP server "${name}" did not start: ${reason}` });
+      }
+      if (abort.signal.aborted) {
+        await unmount(turn.threadId);
+        return;
+      }
+      await runtime.run(
       {
         threadId: turn.threadId,
         turnId,
-        plan: turn.context,
+        plan,
         system: turn.system,
         model: {
           id: model,
@@ -189,16 +238,18 @@ export function createOpenMausRuntimeInstance(
           ...(config.provider ? { openRouterProvider: config.provider } : {}),
         },
         effort: turn.effort,
-        tools: [],
+        tools: servers.tools,
         signal: abort.signal,
         limits: OWNED_LOOP_LIMITS,
       },
       forward(turn.threadId, turnId),
-    ).catch((error: unknown) => {
+      );
+    })().catch(async (error: unknown) => {
       // run() is contracted never to reject for model/tool failures; this is
       // the belt for a bug in the adapter itself, so the thread is not left
       // busy forever
       active.delete(turn.threadId);
+      await unmount(turn.threadId);
       emit({ ...base(turn.threadId, turnId), type: "runtime.error", message: error instanceof Error ? error.message : String(error) });
       emit({ ...base(turn.threadId, turnId), type: "turn.completed", ok: false, stopReason: "error", cost: null });
     });
@@ -223,19 +274,26 @@ export function createOpenMausRuntimeInstance(
         queueing: true,
         images: false,
         effortLevels: ["none", "low", "medium", "high", "xhigh", "max"],
-        // no MCP capability is advertised until its integration test passes
+        // the user's own MCP servers, proven by mcp-tools.test.ts; every
+        // other integration is advertised only once its own test passes
+        customMcp: true,
       },
       sendTurn,
       interruptTurn: async (threadId) => {
         active.get(threadId)?.abort();
         runtime.interrupt(threadId);
+        await unmount(threadId);
       },
-      respondToRequest: async () => "unavailable" as const,
+      // the harness's answer to an approval card; `unavailable` when nothing
+      // is pending, which the harness treats as a deny
+      respondToRequest: async (threadId, requestId, decision) =>
+        runtime.answer(threadId, requestId, decision.behavior, decision.message),
       steer: async (threadId, text) => runtime.steer(threadId, text),
       hasSession: (threadId) => active.has(threadId),
       stopAll: async () => {
         for (const abort of active.values()) abort.abort();
         await runtime.dispose();
+        await Promise.all([...mounted.keys()].map(unmount));
       },
       onEvent: (listener) => {
         listeners.add(listener);
@@ -245,6 +303,7 @@ export function createOpenMausRuntimeInstance(
     dispose: async () => {
       for (const abort of active.values()) abort.abort();
       await runtime.dispose();
+      await Promise.all([...mounted.keys()].map(unmount));
       listeners.clear();
     },
   };

--- a/server/drivers/openmaus-runtime.ts
+++ b/server/drivers/openmaus-runtime.ts
@@ -1,0 +1,277 @@
+// OpenMaus Runtime: the harness owns the whole loop.
+//
+// Every other engine hands the inner model/tool loop to an installed CLI or a
+// one-shot chat endpoint. This one runs it in-process — model call, tool
+// call, approval, steering, cancellation — against any OpenAI-compatible
+// endpoint the user supplies a key for (OpenRouter, Groq, llama.cpp, a local
+// server). It reuses openai-compat's configuration and key contract exactly,
+// so switching a bot between the two is a per-bot engine choice and nothing
+// else moves.
+//
+// It does NOT reuse a Claude or Codex subscription login. It never reads
+// another CLI's auth files. Authentication here is an API key or a local
+// endpoint that needs none, and usage is billed by that provider.
+//
+// Preview: disabled unless config.features.ownedRuntime is true. No MCP
+// integrations are mounted yet — those capabilities are advertised only
+// after each one is proven.
+import type {
+  DriverCreateInput,
+  ModelCatalog,
+  ProviderDriver,
+  ProviderInstance,
+  RuntimeEvent,
+  RuntimeEventListener,
+  SendTurnInput,
+} from "../contracts.ts";
+import { newEventId, newId } from "../contracts.ts";
+import { contextLimitsFor } from "../context/budget.ts";
+import type { OwnedAgentRuntime, OwnedRuntimeEvent } from "../runtime/contracts.ts";
+import { createPiRuntime } from "../runtime/pi-runtime.ts";
+import { appendNative } from "./native.ts";
+
+export const OPENMAUS_RUNTIME_KIND = "openmaus-runtime";
+
+/** The plan's Task 9 bounds, plumbed from day one so the loop has never
+ * run unbounded. Repeat detection and the advisory land with Task 9. */
+export const OWNED_LOOP_LIMITS = { maxModelCalls: 32, maxToolCalls: 64, toolTimeoutMs: 180_000 } as const;
+
+const DEFAULT_MODELS: ModelCatalog = {
+  default: "meta-llama/llama-3.3-70b-instruct",
+  options: [
+    { id: "meta-llama/llama-3.3-70b-instruct", label: "Llama 3.3 70B (OpenRouter)", custom: true },
+    { id: "llama-3.3-70b-versatile", label: "Llama 3.3 70B (Groq)", custom: true },
+  ],
+};
+
+export interface OpenMausRuntimeConfig {
+  url: string;
+  apiKeyEnv: string;
+  key?: string;
+  model?: string;
+  provider?: string;
+}
+
+/** Same envelope as openai-compat, on purpose: the two engines are
+ * interchangeable per bot, and a config that works for one works for the
+ * other. */
+function decodeConfig(raw: unknown): OpenMausRuntimeConfig {
+  const config = (raw ?? {}) as Record<string, unknown>;
+  const envUrl = process.env.OPENAI_COMPAT_URL;
+  return {
+    url: (typeof config.url === "string" && config.url ? config.url : envUrl || "https://openrouter.ai/api/v1")
+      .replace(/\/+$/, ""),
+    apiKeyEnv: typeof config.apiKeyEnv === "string" && config.apiKeyEnv ? config.apiKeyEnv : "OPENAI_COMPAT_API_KEY",
+    key: typeof config.key === "string" && config.key ? config.key : undefined,
+    model: typeof config.model === "string" && config.model ? config.model : process.env.OPENAI_COMPAT_MODEL || undefined,
+    provider: typeof config.provider === "string" && config.provider
+      ? config.provider
+      : process.env.OPENAI_COMPAT_PROVIDER || undefined,
+  };
+}
+
+const NO_KEY = (env: string) => `no API key — set ${env} or add it to the instance config`;
+
+export interface CreateOpenMausRuntimeOptions {
+  /** injected by tests; production uses the Pi-backed runtime. */
+  runtime?: OwnedAgentRuntime;
+}
+
+export function createOpenMausRuntimeInstance(
+  input: DriverCreateInput<OpenMausRuntimeConfig>,
+  options: CreateOpenMausRuntimeOptions = {},
+): ProviderInstance {
+  const { config } = input;
+  const apiKey =
+    config.key ??
+    input.environment[config.apiKeyEnv] ??
+    input.environment.OPENAI_COMPAT_API_KEY ??
+    process.env[config.apiKeyEnv] ??
+    process.env.OPENAI_COMPAT_API_KEY ??
+    "";
+  const catalog: ModelCatalog = config.model
+    ? {
+        default: config.model,
+        options: DEFAULT_MODELS.options.some((model) => model.id === config.model)
+          ? DEFAULT_MODELS.options
+          : [{ id: config.model, label: config.model, custom: true }, ...DEFAULT_MODELS.options],
+      }
+    : DEFAULT_MODELS;
+
+  const runtime = options.runtime ?? createPiRuntime();
+  const listeners = new Set<RuntimeEventListener>();
+  const active = new Map<string, AbortController>();
+  const emit = (event: RuntimeEvent) => {
+    for (const listener of [...listeners]) listener(event);
+  };
+  const base = (threadId: string, turnId: string) => ({
+    eventId: newEventId(),
+    provider: OPENMAUS_RUNTIME_KIND,
+    threadId,
+    turnId,
+    createdAt: new Date().toISOString(),
+  });
+
+  /** The whole OwnedRuntimeEvent → RuntimeEvent mapping, in one place. */
+  const forward = (threadId: string, turnId: string) => (event: OwnedRuntimeEvent) => {
+    const b = base(threadId, turnId);
+    switch (event.type) {
+      case "model.call":
+        return;
+      case "delta":
+        emit({ ...b, type: "content.delta", streamKind: event.kind === "text" ? "assistant_text" : "reasoning_text", delta: event.text });
+        return;
+      case "tool.started":
+        emit({ ...b, itemId: event.callId, type: "item.started", itemType: "tool", title: event.name });
+        return;
+      case "tool.completed":
+        emit({ ...b, itemId: event.callId, type: "item.completed", itemType: "tool", ok: event.ok });
+        return;
+      case "assistant":
+        emit({ ...b, type: "item.completed", itemType: "assistant_text", text: event.text });
+        return;
+      case "usage":
+        emit({ ...b, type: "thread.token-usage.updated", input: event.input, output: event.output, ...(event.cachedInput ? { cachedInput: event.cachedInput } : {}) });
+        return;
+      case "error":
+        emit({ ...b, type: "runtime.error", message: event.message });
+        return;
+      case "completed":
+        active.delete(threadId);
+        emit({
+          ...b,
+          type: "turn.completed",
+          ok: event.ok,
+          stopReason: event.ok ? (event.stopReason === "end_turn" ? null : event.stopReason) : event.stopReason,
+          cost: null,
+        });
+        return;
+    }
+  };
+
+  const sendTurn = async (turn: SendTurnInput) => {
+    if (!apiKey) throw new Error(NO_KEY(config.apiKeyEnv));
+    if (active.has(turn.threadId)) throw new Error("a turn is already running on this thread");
+    // For an omb-loop engine the plan is not a compatibility projection, it
+    // is the only history there is. Refusing a planless turn is how a
+    // future caller learns that, instead of the model silently starting
+    // from nothing.
+    if (!turn.context) throw new Error("openmaus-runtime requires SendTurnInput.context");
+
+    const turnId = newId();
+    const abort = new AbortController();
+    const model = turn.model || catalog.default;
+    const limits = contextLimitsFor(model, catalog);
+    active.set(turn.threadId, abort);
+    appendNative(turn.threadId, {
+      dir: "out",
+      source: "openmaus-runtime.turn",
+      msg: { model, items: turn.context.messages.length, ownership: turn.context.ownership },
+    });
+    emit({ ...base(turn.threadId, turnId), type: "turn.started" });
+    emit({ ...base(turn.threadId, turnId), type: "session.started", sessionId: null, model });
+
+    void runtime.run(
+      {
+        threadId: turn.threadId,
+        turnId,
+        plan: turn.context,
+        system: turn.system,
+        model: {
+          id: model,
+          baseUrl: config.url,
+          ...(apiKey ? { apiKey } : {}),
+          contextWindow: limits.contextWindow,
+          // pi needs a ceiling; the projector's share-of-window budget has
+          // already left room for the answer
+          maxOutputTokens: 4_096,
+          reasoning: true,
+          ...(config.provider ? { openRouterProvider: config.provider } : {}),
+        },
+        effort: turn.effort,
+        tools: [],
+        signal: abort.signal,
+        limits: OWNED_LOOP_LIMITS,
+      },
+      forward(turn.threadId, turnId),
+    ).catch((error: unknown) => {
+      // run() is contracted never to reject for model/tool failures; this is
+      // the belt for a bug in the adapter itself, so the thread is not left
+      // busy forever
+      active.delete(turn.threadId);
+      emit({ ...base(turn.threadId, turnId), type: "runtime.error", message: error instanceof Error ? error.message : String(error) });
+      emit({ ...base(turn.threadId, turnId), type: "turn.completed", ok: false, stopReason: "error", cost: null });
+    });
+    return { turnId };
+  };
+
+  return {
+    instanceId: input.instanceId,
+    driverKind: OPENMAUS_RUNTIME_KIND,
+    displayName: input.displayName,
+    enabled: input.enabled,
+    models: catalog,
+    snapshot: async () => apiKey
+      ? { state: "available", authenticated: true, version: null, billing: "metered" }
+      : { state: "unavailable", reason: NO_KEY(config.apiKeyEnv) },
+    adapter: {
+      provider: OPENMAUS_RUNTIME_KIND,
+      capabilities: {
+        sessionModelSwitch: "in-session",
+        contextOwnership: "omb-loop",
+        // the loop takes a user message before its next model call
+        queueing: true,
+        images: false,
+        effortLevels: ["none", "low", "medium", "high", "xhigh", "max"],
+        // no MCP capability is advertised until its integration test passes
+      },
+      sendTurn,
+      interruptTurn: async (threadId) => {
+        active.get(threadId)?.abort();
+        runtime.interrupt(threadId);
+      },
+      respondToRequest: async () => "unavailable" as const,
+      steer: async (threadId, text) => runtime.steer(threadId, text),
+      hasSession: (threadId) => active.has(threadId),
+      stopAll: async () => {
+        for (const abort of active.values()) abort.abort();
+        await runtime.dispose();
+      },
+      onEvent: (listener) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    },
+    dispose: async () => {
+      for (const abort of active.values()) abort.abort();
+      await runtime.dispose();
+      listeners.clear();
+    },
+  };
+}
+
+export const OpenMausRuntimeDriver: ProviderDriver<OpenMausRuntimeConfig> = {
+  driverKind: OPENMAUS_RUNTIME_KIND,
+  metadata: {
+    displayName: "OpenMaus Runtime (preview)",
+    supportsMultipleInstances: true,
+    access: "custom",
+  },
+  models: DEFAULT_MODELS,
+  install: {
+    docsUrl: "https://openrouter.ai/keys",
+    signInCommand:
+      "add {\"openaiCompat\":{\"key\":\"sk-or-v1-…\"}} to ~/.openmausbot/config.json (or set OPENAI_COMPAT_API_KEY). "
+      + "This engine uses an API key, not a Claude or Codex login, and usage is billed by that provider.",
+    command: {
+      darwin: "Get a key at https://openrouter.ai/keys (or run a local OpenAI-compatible server) and add it under openaiCompat.key in ~/.openmausbot/config.json",
+      linux: "Get a key at https://openrouter.ai/keys (or run a local OpenAI-compatible server) and add it under openaiCompat.key in ~/.openmausbot/config.json",
+      win32: "Get a key at https://openrouter.ai/keys (or run a local OpenAI-compatible server) and add it under openaiCompat.key in %USERPROFILE%\\.openmausbot\\config.json",
+    },
+  },
+  decodeConfig,
+  defaultConfig: () => decodeConfig({}),
+  async create(input) {
+    return createOpenMausRuntimeInstance(input);
+  },
+};

--- a/server/harness/registry.ts
+++ b/server/harness/registry.ts
@@ -190,6 +190,8 @@ export class ProviderRegistry {
             queueing: inst.adapter.capabilities.queueing === true,
             localComputerMcp: inst.adapter.capabilities.localComputerMcp === true,
             approvalReview: inst.reviewPermission !== undefined,
+            // who owns the model-facing context — the UI labels engines by it
+            contextOwnership: inst.adapter.capabilities.contextOwnership,
           },
           access: driver?.metadata.access ?? "subscription",
           install: driver?.install,

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -3333,20 +3333,20 @@ describe("harness HTTP API", () => {
   it("keeps Teach a skill off by default and persists an explicit opt-in", async () => {
     const before = await api("GET", "/api/config");
     expect(before.status).toBe(200);
-    expect(before.body.features).toEqual({ browser: false, skillRecorder: false, showToolCalls: false });
+    expect(before.body.features).toEqual({ browser: false, skillRecorder: false, showToolCalls: false, ownedRuntime: false });
 
     const saved = await api("PATCH", "/api/config", {
       features: { skillRecorder: true },
     });
     expect(saved.status).toBe(200);
-    expect(saved.body.features).toEqual({ browser: false, skillRecorder: true, showToolCalls: false });
+    expect(saved.body.features).toEqual({ browser: false, skillRecorder: true, showToolCalls: false, ownedRuntime: false });
 
     const disk = JSON.parse(readFileSync(join(home, ".openmausbot", "config.json"), "utf8"));
     expect(disk.features).toEqual({ skillRecorder: true });
 
     const tools = await api("PATCH", "/api/config", { features: { showToolCalls: true } });
     expect(tools.status).toBe(200);
-    expect(tools.body.features).toEqual({ browser: false, skillRecorder: true, showToolCalls: true });
+    expect(tools.body.features).toEqual({ browser: false, skillRecorder: true, showToolCalls: true, ownedRuntime: false });
 
     await api("PATCH", "/api/config", { features: { skillRecorder: false, showToolCalls: false } });
   });

--- a/server/index.ts
+++ b/server/index.ts
@@ -89,6 +89,7 @@ import {
   showToolCallsEnabled,
   skillRecorderEnabled,
   builtInBrowserEnabled,
+  ownedRuntimeEnabled,
   browserProfileReplacementConflict,
   browserProfilePartitionTarget,
   syncCredentialEnv,
@@ -5796,6 +5797,9 @@ function configStatus() {
     box: { configured: Boolean(cfg.box?.token) },
     vps: { configured: Boolean(vpsSshAlias(cfg)), sshAlias: vpsSshAlias(cfg) ?? "" },
     opencodeGo: { configured: Boolean(cfg.opencodeGo?.apiKey) },
+    // shared by openai-compat and the preview OpenMaus Runtime; a boolean,
+    // so the key itself never reaches the renderer
+    openaiCompat: { configured: Boolean(cfg.openaiCompat?.key) },
     // the chosen voice is a setting, not a secret; the key is reported the
     // same configured-or-not way as every other credential
     tts: tts.describeVoice(cfg),
@@ -5813,6 +5817,7 @@ function configStatus() {
       skillRecorder: skillRecorderEnabled(cfg),
       showToolCalls: showToolCallsEnabled(cfg),
       browser: builtInBrowserEnabled(cfg),
+      ownedRuntime: ownedRuntimeEnabled(cfg),
     },
     // partitionId is non-secret routing metadata. The renderer needs it to
     // show the same durable session as an agent, but config PATCH validation

--- a/server/runtime/approval-gate.test.ts
+++ b/server/runtime/approval-gate.test.ts
@@ -1,0 +1,130 @@
+// Every way an answer can fail to arrive is a deny.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ASK_TIMEOUT_MS,
+  DENY_TIMEOUT_NOTE,
+  DUPLICATE_ASK_ID_NOTE,
+  QUESTION_TIMEOUT_NOTE,
+  createApprovalGate,
+  type Ask,
+  type AskResolution,
+} from "./approval-gate.ts";
+
+function gateWith(timeoutMs?: number) {
+  const opened: Ask[] = [];
+  const resolved: Array<{ ask: Ask; resolution: AskResolution }> = [];
+  const gate = createApprovalGate({
+    onOpen: (ask) => opened.push(ask),
+    onResolve: (ask, resolution) => resolved.push({ ask, resolution }),
+    ...(timeoutMs === undefined ? {} : { timeoutMs }),
+  });
+  return { gate, opened, resolved };
+}
+
+describe("createApprovalGate", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("opens an ask and resolves it with the user's allow", async () => {
+    const { gate, opened, resolved } = gateWith();
+    const pending = gate.ask({ kind: "permission", tool: "notes__read", summary: "{}" });
+    expect(opened).toHaveLength(1);
+    expect(gate.pending()).toBe(1);
+    expect(gate.answer(opened[0]!.id, "allow")).toBe("allowed-once");
+    await expect(pending).resolves.toEqual({ behavior: "allow", message: undefined, source: "user" });
+    expect(resolved[0]!.resolution.source).toBe("user");
+    expect(gate.pending()).toBe(0);
+  });
+
+  it("resolves a deny, with the reason", async () => {
+    const { gate, opened } = gateWith();
+    const pending = gate.ask({ kind: "permission", tool: "t", summary: "s" });
+    expect(gate.answer(opened[0]!.id, "deny", "not today")).toBe("rejected");
+    await expect(pending).resolves.toMatchObject({ behavior: "deny", message: "not today", source: "user" });
+  });
+
+  it("answers a question", async () => {
+    const { gate, opened } = gateWith();
+    const pending = gate.ask({ kind: "question", tool: "ask_user", summary: "which one?", choices: ["a", "b"] });
+    expect(opened[0]!.choices).toEqual(["a", "b"]);
+    expect(gate.answer(opened[0]!.id, "answer", "b")).toBe("answered");
+    await expect(pending).resolves.toMatchObject({ behavior: "answer", message: "b" });
+  });
+
+  it("treats an allow on a question as an answer — a question has no allow", async () => {
+    const { gate, opened } = gateWith();
+    const pending = gate.ask({ kind: "question", tool: "ask_user", summary: "?" });
+    expect(gate.answer(opened[0]!.id, "allow", "yes")).toBe("answered");
+    await expect(pending).resolves.toMatchObject({ behavior: "answer", message: "yes" });
+  });
+
+  it("is unavailable for an id nothing is waiting on — never an allow", () => {
+    const { gate } = gateWith();
+    expect(gate.answer("never-opened", "allow")).toBe("unavailable");
+  });
+
+  it("is unavailable for an id that was already answered", async () => {
+    const { gate, opened } = gateWith();
+    const pending = gate.ask({ kind: "permission", tool: "t", summary: "s" });
+    gate.answer(opened[0]!.id, "allow");
+    await pending;
+    expect(gate.answer(opened[0]!.id, "allow")).toBe("unavailable");
+  });
+
+  it("denies a permission nobody answers in time, and says so", async () => {
+    const { gate, resolved } = gateWith(1_000);
+    const pending = gate.ask({ kind: "permission", tool: "t", summary: "s" });
+    vi.advanceTimersByTime(1_000);
+    await expect(pending).resolves.toEqual({ behavior: "deny", message: DENY_TIMEOUT_NOTE, source: "timeout" });
+    expect(resolved[0]!.resolution.source).toBe("timeout");
+  });
+
+  it("answers a question nobody answers in time with the best-judgment note", async () => {
+    const { gate } = gateWith(1_000);
+    const pending = gate.ask({ kind: "question", tool: "ask_user", summary: "?" });
+    vi.advanceTimersByTime(1_000);
+    await expect(pending).resolves.toEqual({ behavior: "answer", message: QUESTION_TIMEOUT_NOTE, source: "timeout" });
+  });
+
+  it("defaults to the CLI broker's fifteen minutes", async () => {
+    const { gate } = gateWith();
+    const pending = gate.ask({ kind: "permission", tool: "t", summary: "s" });
+    vi.advanceTimersByTime(ASK_TIMEOUT_MS - 1);
+    expect(gate.pending()).toBe(1);
+    vi.advanceTimersByTime(1);
+    await expect(pending).resolves.toMatchObject({ source: "timeout" });
+  });
+
+  it("drains everything still open with the system reply when the turn ends", async () => {
+    const { gate, resolved } = gateWith();
+    const permission = gate.ask({ kind: "permission", tool: "t", summary: "s" });
+    const question = gate.ask({ kind: "question", tool: "q", summary: "?" });
+    gate.drain();
+    await expect(permission).resolves.toMatchObject({ behavior: "deny", source: "system" });
+    await expect(question).resolves.toMatchObject({ behavior: "answer", source: "system" });
+    expect(resolved).toHaveLength(2);
+    expect(gate.pending()).toBe(0);
+  });
+
+  it("denies a duplicate id outright rather than merging two asks", async () => {
+    const { gate, opened, resolved } = gateWith();
+    const first = gate.ask({ id: "same", kind: "permission", tool: "t", summary: "s" });
+    const second = gate.ask({ id: "same", kind: "permission", tool: "t2", summary: "s2" });
+    await expect(second).resolves.toEqual({ behavior: "deny", message: DUPLICATE_ASK_ID_NOTE, source: "system" });
+    // the first is untouched and still answerable
+    expect(opened).toHaveLength(1);
+    expect(gate.answer("same", "allow")).toBe("allowed-once");
+    await expect(first).resolves.toMatchObject({ behavior: "allow" });
+    expect(resolved.filter((r) => r.resolution.source === "user")).toHaveLength(1);
+  });
+
+  it("resolves each ask exactly once even if answered and timed out", async () => {
+    const { gate, opened, resolved } = gateWith(1_000);
+    const pending = gate.ask({ kind: "permission", tool: "t", summary: "s" });
+    gate.answer(opened[0]!.id, "allow");
+    vi.advanceTimersByTime(5_000);
+    await expect(pending).resolves.toMatchObject({ behavior: "allow", source: "user" });
+    expect(resolved).toHaveLength(1);
+  });
+});

--- a/server/runtime/approval-gate.ts
+++ b/server/runtime/approval-gate.ts
@@ -1,0 +1,121 @@
+// Approvals for the owned loop, failing closed.
+//
+// This is the in-process counterpart of the CLI drivers' permission broker
+// (claude.ts createPermissionBroker), with the same rules and the same
+// wording, minus the socket: a tool call asks, the harness answers through
+// the ordinary card / auto-approve flow, and the answer arrives via
+// respondToRequest. Every way an answer can fail to arrive resolves to a
+// DENY — the answerer went away, the turn ended, the request was never
+// pending, time ran out. An unanswered ask never becomes an allow.
+import { newId } from "../contracts.ts";
+import type { RequestOutcome } from "../contracts.ts";
+
+export type AskKind = "permission" | "question";
+export type AskBehavior = "allow" | "deny" | "answer";
+export type AskSource = "user" | "timeout" | "system" | "unavailable";
+
+export const DENY_TIMEOUT_NOTE =
+  "OpenMausBot: nobody answered this permission request in time. Skip this action and finish what you can without it.";
+export const QUESTION_TIMEOUT_NOTE = "OpenMausBot: nobody answered in time. Use your best judgment and continue.";
+export const DUPLICATE_ASK_ID_NOTE = "OpenMausBot: duplicate ask id — skipping this request.";
+/** Same default as the CLI broker: a person may be away from the keyboard
+ * for a while, and a denied ask cannot be un-denied. */
+export const ASK_TIMEOUT_MS = 15 * 60_000;
+
+export interface Ask {
+  id: string;
+  kind: AskKind;
+  tool: string;
+  summary: string;
+  choices?: string[];
+}
+
+export interface AskResolution {
+  behavior: AskBehavior;
+  message?: string;
+  source: AskSource;
+}
+
+/** The system-source reply for an ask that outlives the turn. */
+export function systemEndedReply(kind: AskKind): { behavior: AskBehavior; message: string } {
+  return kind === "question"
+    ? { behavior: "answer", message: "OpenMausBot: the turn is ending — wrap up." }
+    : { behavior: "deny", message: "OpenMausBot: the turn ended" };
+}
+
+export interface ApprovalGateOptions {
+  /** the ask is now open — the driver turns this into request.opened. */
+  onOpen: (ask: Ask) => void;
+  /** the ask is settled, however it settled — request.resolved. */
+  onResolve: (ask: Ask, resolution: AskResolution) => void;
+  timeoutMs?: number;
+}
+
+export interface ApprovalGate {
+  /** Open an ask and wait for its answer. Never rejects: every failure to
+   * answer is a deny. */
+  ask(input: Omit<Ask, "id"> & { id?: string }): Promise<AskResolution>;
+  /** The harness's answer. `unavailable` when nothing by that id is
+   * pending — the caller treats it as a deny, never retries as an allow. */
+  answer(requestId: string, behavior: AskBehavior, message?: string): RequestOutcome;
+  /** Settle everything still open with the system reply. Turn end, cancel,
+   * and dispose all come here. */
+  drain(): void;
+  pending(): number;
+}
+
+export function createApprovalGate(options: ApprovalGateOptions): ApprovalGate {
+  const timeoutMs = options.timeoutMs ?? ASK_TIMEOUT_MS;
+  const pending = new Map<string, { ask: Ask; finish: (r: AskResolution) => void }>();
+
+  return {
+    ask(input) {
+      const ask: Ask = { ...input, id: input.id ?? newId() };
+      return new Promise<AskResolution>((resolve) => {
+        if (pending.has(ask.id)) {
+          // a second ask with a live id is denied outright, never merged:
+          // merging would let one answer settle two different actions
+          const resolution: AskResolution = { behavior: "deny", message: DUPLICATE_ASK_ID_NOTE, source: "system" };
+          options.onResolve(ask, resolution);
+          resolve(resolution);
+          return;
+        }
+        let settled = false;
+        const finish = (resolution: AskResolution) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          pending.delete(ask.id);
+          options.onResolve(ask, resolution);
+          resolve(resolution);
+        };
+        const timer = setTimeout(
+          () =>
+            ask.kind === "question"
+              ? finish({ behavior: "answer", message: QUESTION_TIMEOUT_NOTE, source: "timeout" })
+              : finish({ behavior: "deny", message: DENY_TIMEOUT_NOTE, source: "timeout" }),
+          timeoutMs,
+        );
+        timer.unref?.();
+        pending.set(ask.id, { ask, finish });
+        options.onOpen(ask);
+      });
+    },
+    answer(requestId, behavior, message) {
+      const entry = pending.get(requestId);
+      if (!entry) return "unavailable";
+      // a question can only be answered; an allow/deny on it is not a
+      // decision about the question, so it is treated as an answer text
+      const applied: AskBehavior = entry.ask.kind === "question" ? "answer" : behavior;
+      entry.finish({ behavior: applied, message, source: "user" });
+      return applied === "allow" ? "allowed-once" : applied === "answer" ? "answered" : "rejected";
+    },
+    drain() {
+      // finish() deletes the current entry; a Map tolerates that mid-iteration
+      for (const { ask, finish } of pending.values()) {
+        finish({ ...systemEndedReply(ask.kind), source: "system" });
+      }
+    },
+    pending: () => pending.size,
+  };
+}

--- a/server/runtime/contracts.ts
+++ b/server/runtime/contracts.ts
@@ -81,6 +81,10 @@ export interface OwnedLoopLimits {
 export type OwnedRuntimeEvent =
   | { type: "model.call"; call: number }
   | { type: "delta"; kind: "text" | "reasoning"; text: string }
+  /** a tool call is waiting on the harness. The driver turns this into
+   * request.opened; the answer comes back through answer(). */
+  | { type: "ask.opened"; requestId: string; kind: "permission" | "question"; tool: string; summary: string; choices?: string[] }
+  | { type: "ask.resolved"; requestId: string; behavior: "allow" | "deny" | "answer"; source: "user" | "timeout" | "system" | "unavailable" }
   | { type: "tool.started"; callId: string; name: string; inputSummary: string }
   | { type: "tool.completed"; callId: string; name: string; ok: boolean; observation: ToolContextSnapshot }
   | { type: "assistant"; text: string }
@@ -101,6 +105,9 @@ export interface OwnedAgentRuntime {
   steer(threadId: string, text: string): boolean;
   /** Abort the running turn on this thread, if any. */
   interrupt(threadId: string): void;
+  /** The harness's answer to an open ask. `unavailable` when nothing by
+   * that id is pending on that thread — never treated as an allow. */
+  answer(threadId: string, requestId: string, behavior: "allow" | "deny" | "answer", message?: string): "allowed-once" | "rejected" | "answered" | "unavailable";
   hasTurn(threadId: string): boolean;
   dispose(): Promise<void>;
 }

--- a/server/runtime/contracts.ts
+++ b/server/runtime/contracts.ts
@@ -1,0 +1,106 @@
+// The internal seam between OpenMausBot and whatever agent core runs the
+// owned loop.
+//
+// Everything Pi-specific lives behind this file's types in pi-runtime.ts.
+// Dispatch, the driver, and the tests speak only these shapes, so the core
+// can be swapped, faked, or upgraded without the rest of the harness
+// noticing. Nothing here names a Pi type.
+import type { EffortLevel } from "../contracts.ts";
+import type { ToolContextSnapshot, TurnContextPlan } from "../context/types.ts";
+
+/** Where the model lives and how to reach it. The key is passed explicitly
+ * per call and never read from the process environment or any credential
+ * store the core might know about. */
+export interface OwnedModelTarget {
+  /** the model id as the endpoint knows it. */
+  id: string;
+  /** an OpenAI-compatible chat-completions base URL, no trailing slash. */
+  baseUrl: string;
+  /** absent for a loopback/local endpoint that needs none. */
+  apiKey?: string;
+  contextWindow: number;
+  maxOutputTokens: number;
+  /** the endpoint can return reasoning content. */
+  reasoning: boolean;
+  /** OpenRouter provider routing (`provider.order`), when the URL is
+   * OpenRouter and the user pinned one. */
+  openRouterProvider?: string;
+}
+
+/** A JSON-Schema object for tool parameters. The model produces JSON against
+ * it; the runtime validates before execute() sees anything. */
+export interface OwnedToolSchema {
+  type: "object";
+  properties: Record<string, Record<string, unknown>>;
+  required?: string[];
+  additionalProperties?: boolean;
+}
+
+export interface OwnedToolResult {
+  /** what the model is told. Bounded by the runtime before it reaches the
+   * context. */
+  text: string;
+  ok: boolean;
+  /** the durable, portable record — already sanitized. */
+  observation: ToolContextSnapshot;
+}
+
+export interface OwnedTool {
+  name: string;
+  description: string;
+  parameters: OwnedToolSchema;
+  execute(callId: string, args: Record<string, unknown>, signal: AbortSignal): Promise<OwnedToolResult>;
+}
+
+export interface OwnedTurnInput {
+  threadId: string;
+  turnId: string;
+  /** the canonical context. The runtime rebuilds the model's view from
+   * this before EVERY model call; it never keeps a private history. */
+  plan: TurnContextPlan;
+  system?: string;
+  model: OwnedModelTarget;
+  effort?: EffortLevel;
+  tools: OwnedTool[];
+  /** abort ends the current model call and any running tool. */
+  signal: AbortSignal;
+  /** the hard bounds the loop must respect. */
+  limits: OwnedLoopLimits;
+}
+
+export interface OwnedLoopLimits {
+  maxModelCalls: number;
+  maxToolCalls: number;
+  toolTimeoutMs: number;
+}
+
+/** Everything the loop reports, in the order it happens. Maps one-to-one
+ * onto the canonical RuntimeEvent bus in the driver; this union exists so
+ * the mapping is a table rather than something scattered through the
+ * core adapter. */
+export type OwnedRuntimeEvent =
+  | { type: "model.call"; call: number }
+  | { type: "delta"; kind: "text" | "reasoning"; text: string }
+  | { type: "tool.started"; callId: string; name: string; inputSummary: string }
+  | { type: "tool.completed"; callId: string; name: string; ok: boolean; observation: ToolContextSnapshot }
+  | { type: "assistant"; text: string }
+  | { type: "usage"; input: number; output: number; cachedInput?: number; costUsd?: number }
+  | { type: "completed"; ok: true; stopReason: "end_turn" | "max_model_calls" | "max_tool_calls" }
+  | { type: "completed"; ok: false; stopReason: "interrupted" | "error" }
+  | { type: "error"; message: string };
+
+export type OwnedRuntimeEmit = (event: OwnedRuntimeEvent) => void;
+
+export interface OwnedAgentRuntime {
+  /** Run one turn to completion. Resolves after the terminal `completed`
+   * event has been emitted; never rejects for a model or tool failure —
+   * those become `error` + `completed{ok:false}`. */
+  run(input: OwnedTurnInput, emit: OwnedRuntimeEmit): Promise<void>;
+  /** Deliver a user message into the running turn, ahead of the next model
+   * call. False when nothing is running on this thread. */
+  steer(threadId: string, text: string): boolean;
+  /** Abort the running turn on this thread, if any. */
+  interrupt(threadId: string): void;
+  hasTurn(threadId: string): boolean;
+  dispose(): Promise<void>;
+}

--- a/server/runtime/fake-model.ts
+++ b/server/runtime/fake-model.ts
@@ -1,0 +1,139 @@
+// A deterministic model for exercising the owned loop without a provider.
+//
+// This is a test fixture that must produce exactly what the Pi agent core
+// consumes, so it is the one file besides pi-runtime.ts that imports Pi.
+// It scripts responses in order; each call to the stream function consumes
+// the next one and records the context it was shown, so a test can assert
+// both what the loop did and what the model saw.
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
+import type { Api, AssistantMessage, Context, Model, SimpleStreamOptions, Usage } from "@earendil-works/pi-ai";
+
+export interface FakeToolCall {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+export interface FakeResponse {
+  text?: string;
+  reasoning?: string;
+  toolCalls?: FakeToolCall[];
+  /** fail this call instead of answering. */
+  error?: string;
+  usage?: { input: number; output: number };
+  /** hold the stream open until the signal aborts — for cancellation tests. */
+  hang?: boolean;
+}
+
+export interface FakeModel {
+  streamFn: (model: Model<Api>, context: Context, options?: SimpleStreamOptions) => ReturnType<typeof createAssistantMessageEventStream>;
+  /** every context the model was shown, in order. */
+  calls: Context[];
+  /** the api key each call was given, so a test can prove it arrived
+   * explicitly and only there. */
+  keys: Array<string | undefined>;
+}
+
+const zeroUsage = (): Usage => ({
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+});
+
+/** Split text into two deltas so streaming order is actually exercised. */
+const halves = (text: string): string[] => {
+  if (text.length < 2) return [text];
+  const mid = Math.ceil(text.length / 2);
+  return [text.slice(0, mid), text.slice(mid)];
+};
+
+export function makeFakeModel(script: FakeResponse[]): FakeModel {
+  const queue = [...script];
+  const fake: FakeModel = { calls: [], keys: [], streamFn: undefined as never };
+
+  fake.streamFn = (model, context, options) => {
+    const stream = createAssistantMessageEventStream();
+    // Snapshot, never the reference: the agent core appends its own reply
+    // to context.messages after the call, and a test asserting what the
+    // model was SHOWN must not see what it went on to say.
+    fake.calls.push({ ...context, messages: [...context.messages] });
+    fake.keys.push(options?.apiKey);
+    const response = queue.shift() ?? { text: "(script exhausted)" };
+    const signal = options?.signal;
+
+    const base = (): AssistantMessage => ({
+      role: "assistant",
+      content: [],
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: zeroUsage(),
+      stopReason: "stop",
+      timestamp: Date.now(),
+    });
+
+    const fail = (reason: "aborted" | "error", message: string) => {
+      const error = base();
+      error.stopReason = reason;
+      error.errorMessage = message;
+      stream.push({ type: "error", reason, error });
+      stream.end(error);
+    };
+
+    queueMicrotask(() => {
+      if (signal?.aborted) return fail("aborted", "aborted before start");
+      if (response.hang) {
+        signal?.addEventListener("abort", () => fail("aborted", "aborted while streaming"), { once: true });
+        return;
+      }
+      if (response.error) return fail("error", response.error);
+
+      const message = base();
+      stream.push({ type: "start", partial: message });
+
+      if (response.reasoning) {
+        stream.push({ type: "thinking_start", contentIndex: 0, partial: message });
+        for (const delta of halves(response.reasoning)) {
+          stream.push({ type: "thinking_delta", contentIndex: 0, delta, partial: message });
+        }
+        message.content.push({ type: "thinking", thinking: response.reasoning });
+        stream.push({ type: "thinking_end", contentIndex: 0, content: response.reasoning, partial: message });
+      }
+      if (response.text) {
+        const index = message.content.length;
+        stream.push({ type: "text_start", contentIndex: index, partial: message });
+        for (const delta of halves(response.text)) {
+          stream.push({ type: "text_delta", contentIndex: index, delta, partial: message });
+        }
+        message.content.push({ type: "text", text: response.text });
+        stream.push({ type: "text_end", contentIndex: index, content: response.text, partial: message });
+      }
+      for (const [i, call] of (response.toolCalls ?? []).entries()) {
+        const index = message.content.length;
+        const id = `call-${fake.calls.length}-${i}`;
+        stream.push({ type: "toolcall_start", contentIndex: index, partial: message });
+        message.content.push({ type: "toolCall", id, name: call.name, arguments: call.args });
+        stream.push({
+          type: "toolcall_end",
+          contentIndex: index,
+          toolCall: { type: "toolCall", id, name: call.name, arguments: call.args },
+          partial: message,
+        });
+      }
+      if (response.usage) {
+        message.usage.input = response.usage.input;
+        message.usage.output = response.usage.output;
+        message.usage.totalTokens = response.usage.input + response.usage.output;
+      }
+      message.stopReason = response.toolCalls?.length ? "toolUse" : "stop";
+      stream.push({ type: "done", reason: message.stopReason, message });
+      stream.end(message);
+    });
+
+    return stream;
+  };
+
+  return fake;
+}

--- a/server/runtime/fake-openai-server.test.ts
+++ b/server/runtime/fake-openai-server.test.ts
@@ -1,0 +1,72 @@
+// The fake OpenAI-compatible server, parsed by pi-ai's REAL provider — the
+// only way to prove the wire shape is right rather than merely plausible.
+import { afterEach, describe, expect, it } from "vitest";
+
+import { streamSimple } from "@earendil-works/pi-ai/api/openai-completions";
+
+import { startFakeOpenAI, type FakeOpenAIOptions, type FakeOpenAIServer } from "../testing/fake-openai-server.ts";
+import { toPiModel } from "./pi-runtime.ts";
+
+let live: FakeOpenAIServer[] = [];
+const start = async (mode: FakeOpenAIOptions["mode"]) => {
+  const s = await startFakeOpenAI({ mode, delayMs: 2_000 });
+  live.push(s);
+  return s;
+};
+afterEach(async () => {
+  await Promise.all(live.map((s) => s.close()));
+  live = [];
+});
+
+const modelFor = (url: string) =>
+  toPiModel({ id: "fake-model", baseUrl: url, apiKey: "k", contextWindow: 8_000, maxOutputTokens: 512, reasoning: true });
+
+async function collect(stream: ReturnType<typeof streamSimple>) {
+  const events: string[] = [];
+  for await (const e of stream) events.push(e.type);
+  return { events, message: await stream.result() };
+}
+
+describe("fake OpenAI-compatible server × pi-ai openai-completions", () => {
+  it("streams text the provider assembles into one assistant message", async () => {
+    const s = await start("echo");
+    const { events, message } = await collect(streamSimple(modelFor(s.url), { messages: [{ role: "user", content: "hello", timestamp: 1 }] }, { apiKey: "k", env: {} }));
+    expect(events).toContain("text_delta");
+    expect(events.at(-1)).toBe("done");
+    expect(message.stopReason).toBe("stop");
+    expect(message.content).toEqual([{ type: "text", text: "fake says: hello" }]);
+    // the provider reports input NET of cache reads: 12 prompt tokens with
+    // 4 served from cache is 8 billed-as-input plus 4 cacheRead
+    expect(message.usage.input).toBe(8);
+    expect(message.usage.cacheRead).toBe(4);
+    expect(message.usage.output).toBe(5);
+  });
+
+  it("streams reasoning as thinking content, separate from text", async () => {
+    const s = await start("reasoning");
+    const { message } = await collect(streamSimple(modelFor(s.url), { messages: [{ role: "user", content: "why", timestamp: 1 }] }, { apiKey: "k", env: {} }));
+    expect(message.content[0]).toMatchObject({ type: "thinking", thinking: "thinking about the answer" });
+    expect(message.content[1]).toMatchObject({ type: "text", text: "fake says: why" });
+  });
+
+  it("reassembles a tool call split across chunks, ending in toolUse", async () => {
+    const s = await start("tool");
+    const { message } = await collect(streamSimple(modelFor(s.url), { messages: [{ role: "user", content: "do it", timestamp: 1 }] }, { apiKey: "k", env: {} }));
+    expect(message.stopReason).toBe("toolUse");
+    expect(message.content).toEqual([{ type: "toolCall", id: "call_fake_1", name: "echo", arguments: { text: "from the fake" } }]);
+  });
+
+  it("surfaces an upstream error as an error event, not a hang", async () => {
+    const s = await start("error");
+    const stream = streamSimple(modelFor(s.url), { messages: [{ role: "user", content: "x", timestamp: 1 }] }, { apiKey: "k", env: {}, maxRetries: 0 });
+    const events: string[] = [];
+    for await (const e of stream) events.push(e.type);
+    expect(events.at(-1)).toBe("error");
+  });
+
+  it("sends the key it was given and only that", async () => {
+    const s = await start("echo");
+    await collect(streamSimple(modelFor(s.url), { messages: [{ role: "user", content: "x", timestamp: 1 }] }, { apiKey: "sk-explicit", env: {} }));
+    expect(s.requests).toHaveLength(1);
+  });
+});

--- a/server/runtime/loop-guard.test.ts
+++ b/server/runtime/loop-guard.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { REPEAT_ADVISORY_AT, REPEAT_STOP_AT, REPEAT_WINDOW, createLoopGuard } from "./loop-guard.ts";
+
+describe("createLoopGuard", () => {
+  it("lets distinct calls through", () => {
+    const guard = createLoopGuard();
+    expect(guard.observe("read", { path: "a" })).toBe("ok");
+    expect(guard.observe("read", { path: "b" })).toBe("ok");
+    expect(guard.observe("write", { path: "a" })).toBe("ok");
+  });
+
+  it("advises at the third identical call inside the window", () => {
+    const guard = createLoopGuard();
+    const verdicts = Array.from({ length: REPEAT_ADVISORY_AT }, () => guard.observe("read", { path: "a" }));
+    expect(verdicts).toEqual(["ok", "ok", "advisory"]);
+  });
+
+  it("stops at the fifth identical call overall", () => {
+    const guard = createLoopGuard();
+    const verdicts = Array.from({ length: REPEAT_STOP_AT }, () => guard.observe("read", { path: "a" }));
+    expect(verdicts.at(-1)).toBe("stop");
+    expect(guard.repeatsOfLast()).toBe(REPEAT_STOP_AT);
+  });
+
+  it("only counts repeats inside the rolling window for the advisory", () => {
+    // two identical calls, then enough different ones to roll them out
+    const guard = createLoopGuard();
+    guard.observe("read", { path: "a" });
+    guard.observe("read", { path: "a" });
+    for (let i = 0; i < REPEAT_WINDOW; i += 1) guard.observe("other", { i });
+    expect(guard.observe("read", { path: "a" })).toBe("ok");
+  });
+
+  it("treats argument objects that differ only in key order as identical", () => {
+    const guard = createLoopGuard();
+    guard.observe("read", { path: "a", line: 1 });
+    guard.observe("read", { line: 1, path: "a" });
+    expect(guard.observe("read", { path: "a", line: 1 })).toBe("advisory");
+  });
+
+  it("does not confuse the same arguments to a different tool", () => {
+    const guard = createLoopGuard();
+    guard.observe("read", { path: "a" });
+    guard.observe("write", { path: "a" });
+    expect(guard.observe("read", { path: "a" })).toBe("ok");
+  });
+
+  it("handles nested and array arguments deterministically", () => {
+    const guard = createLoopGuard();
+    guard.observe("t", { list: [1, { z: 1, a: 2 }] });
+    guard.observe("t", { list: [1, { a: 2, z: 1 }] });
+    expect(guard.observe("t", { list: [1, { z: 1, a: 2 }] })).toBe("advisory");
+    // order inside an array is meaningful
+    expect(guard.observe("t", { list: [{ a: 2, z: 1 }, 1] })).toBe("ok");
+  });
+});

--- a/server/runtime/loop-guard.ts
+++ b/server/runtime/loop-guard.ts
@@ -1,0 +1,57 @@
+// Noticing when the loop is going in circles.
+//
+// A model that calls the same tool with the same arguments over and over
+// is not making progress, and every repeat costs a model call, a tool
+// call, and the user's money. The hard caps (32 model calls, 64 tool
+// calls) catch it eventually; this catches it early. Three identical calls
+// inside a window of six is an advisory the model is told about — most
+// models take the hint. Five identical is a stop.
+//
+// "Identical" is name plus arguments, serialized with sorted keys so two
+// argument objects that differ only in key order compare equal.
+export const REPEAT_WINDOW = 6;
+export const REPEAT_ADVISORY_AT = 3;
+export const REPEAT_STOP_AT = 5;
+
+export type RepeatVerdict = "ok" | "advisory" | "stop";
+
+export const REPEAT_ADVISORY_NOTE =
+  "OpenMausBot: you have made this exact call several times. Its result will not change; use what you already have or try something different.";
+export const REPEAT_STOP_NOTE = "OpenMausBot: stopping — the same call was repeated too many times without progress.";
+
+function canonical(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${canonical(record[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+export interface LoopGuard {
+  /** Record one tool call and say whether the loop should carry on. */
+  observe(name: string, args: unknown): RepeatVerdict;
+  /** How many times the most recent call has been seen in total. */
+  repeatsOfLast(): number;
+}
+
+export function createLoopGuard(): LoopGuard {
+  const recent: string[] = [];
+  const totals = new Map<string, number>();
+  let last = "";
+
+  return {
+    observe(name, args) {
+      const key = `${name}:${canonical(args)}`;
+      last = key;
+      recent.push(key);
+      if (recent.length > REPEAT_WINDOW) recent.shift();
+      const total = (totals.get(key) ?? 0) + 1;
+      totals.set(key, total);
+      if (total >= REPEAT_STOP_AT) return "stop";
+      const inWindow = recent.filter((k) => k === key).length;
+      return inWindow >= REPEAT_ADVISORY_AT ? "advisory" : "ok";
+    },
+    repeatsOfLast: () => totals.get(last) ?? 0,
+  };
+}

--- a/server/runtime/mcp-tools.test.ts
+++ b/server/runtime/mcp-tools.test.ts
@@ -1,0 +1,113 @@
+// The MCP mount against a real stdio child: the fake server under
+// server/testing, spawned per case. Every failure mode is a mode the fake
+// supports, so nothing here depends on timing luck.
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { MODEL_VISIBLE_RESULT_LIMIT, mountMcpServers, type McpServerSpec, type MountedMcp } from "./mcp-tools.ts";
+
+const FAKE = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-mcp-server.ts");
+
+const server = (env: Record<string, string> = {}): McpServerSpec => ({
+  command: process.execPath,
+  args: ["--experimental-strip-types", FAKE],
+  env: { ...process.env as Record<string, string>, ...env },
+});
+
+let live: MountedMcp[] = [];
+const mount = async (servers: Record<string, McpServerSpec>, options: Parameters<typeof mountMcpServers>[1] = { toolTimeoutMs: 5_000 }) => {
+  const mounted = await mountMcpServers(servers, options);
+  live.push(mounted);
+  return mounted;
+};
+
+afterEach(async () => {
+  await Promise.all(live.map((m) => m.close()));
+  live = [];
+});
+
+describe("mountMcpServers", () => {
+  it("starts a server, discovers its tools, and namespaces them by server", async () => {
+    const mounted = await mount({ notes: server() });
+    expect(mounted.failures.size).toBe(0);
+    expect(mounted.tools.map((t) => t.name)).toEqual(["notes__read_notes"]);
+    expect(mounted.routes.get("notes__read_notes")).toEqual({ server: "notes", tool: "read_notes" });
+    expect(mounted.tools[0]!.parameters).toMatchObject({ type: "object", properties: { text: { type: "string" } } });
+  });
+
+  it("keeps two servers exposing the same tool name apart", async () => {
+    const mounted = await mount({ a: server({ FAKE_MCP_TOOL_NAME: "search" }), b: server({ FAKE_MCP_TOOL_NAME: "search" }) });
+    expect(mounted.tools.map((t) => t.name).sort()).toEqual(["a__search", "b__search"]);
+    expect(mounted.routes.get("a__search")).toEqual({ server: "a", tool: "search" });
+    expect(mounted.routes.get("b__search")).toEqual({ server: "b", tool: "search" });
+  });
+
+  it("calls a tool and returns its text", async () => {
+    const mounted = await mount({ notes: server() });
+    const result = await mounted.tools[0]!.execute("c1", { text: "hello" }, new AbortController().signal);
+    expect(result).toMatchObject({ ok: true, text: "echoed: hello", observation: { name: "notes__read_notes", ok: true } });
+  });
+
+  it("reports a tool's own error as ok:false, not as a thrown failure", async () => {
+    const mounted = await mount({ notes: server({ FAKE_MCP_MODE: "error" }) });
+    const result = await mounted.tools[0]!.execute("c1", { text: "x" }, new AbortController().signal);
+    expect(result.ok).toBe(false);
+    expect(result.text).toContain("simulated tool failure");
+  });
+
+  it("records a server that speaks garbage and mounts its healthy sibling anyway", async () => {
+    const mounted = await mount({ bad: server({ FAKE_MCP_MODE: "malformed" }), good: server() }, { toolTimeoutMs: 5_000, startupTimeoutMs: 3_000 });
+    expect(mounted.failures.has("bad")).toBe(true);
+    expect(mounted.tools.map((t) => t.name)).toEqual(["good__read_notes"]);
+  });
+
+  it("gives up on a server that never answers the handshake, on the startup timeout", async () => {
+    const started = Date.now();
+    const mounted = await mount({ mute: server({ FAKE_MCP_MODE: "silent" }) }, { toolTimeoutMs: 5_000, startupTimeoutMs: 500 });
+    expect(mounted.failures.has("mute")).toBe(true);
+    expect(mounted.tools).toHaveLength(0);
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+
+  it("does not hang on a server that exits right after the handshake", async () => {
+    const mounted = await mount({ flaky: server({ FAKE_MCP_MODE: "exit-after-init" }) }, { toolTimeoutMs: 5_000, startupTimeoutMs: 2_000 });
+    // either it listed before dying or it was recorded as failed — never a hang
+    expect(mounted.failures.has("flaky") || mounted.tools.length === 1).toBe(true);
+  });
+
+  it("times out a tool call that takes too long", async () => {
+    const mounted = await mount({ slow: server({ FAKE_MCP_MODE: "slow", FAKE_MCP_DELAY_MS: "3000" }) }, { toolTimeoutMs: 300 });
+    await expect(mounted.tools[0]!.execute("c1", { text: "x" }, new AbortController().signal)).rejects.toThrow();
+  });
+
+  it("cancels a tool call when the signal aborts", async () => {
+    const mounted = await mount({ slow: server({ FAKE_MCP_MODE: "slow", FAKE_MCP_DELAY_MS: "3000" }) }, { toolTimeoutMs: 10_000 });
+    const abort = new AbortController();
+    const call = mounted.tools[0]!.execute("c1", { text: "x" }, abort.signal);
+    abort.abort();
+    await expect(call).rejects.toThrow();
+  });
+
+  it("bounds what the model sees from a huge result", async () => {
+    const mounted = await mount({ notes: server() });
+    const text = "y".repeat(MODEL_VISIBLE_RESULT_LIMIT * 2);
+    const result = await mounted.tools[0]!.execute("c1", { text }, new AbortController().signal);
+    expect(result.text.length).toBeLessThanOrEqual(MODEL_VISIBLE_RESULT_LIMIT + 20);
+    expect(result.text.endsWith("[truncated]")).toBe(true);
+  });
+
+  it("mounts several servers concurrently", async () => {
+    const started = Date.now();
+    const mounted = await mount({ a: server(), b: server(), c: server() });
+    expect(mounted.tools).toHaveLength(3);
+    // three sequential 20s startup budgets would be 60s; concurrent is one
+    expect(Date.now() - started).toBeLessThan(10_000);
+  });
+
+  it("closes idempotently", async () => {
+    const mounted = await mount({ notes: server() });
+    await mounted.close();
+    await expect(mounted.close()).resolves.toBeUndefined();
+  });
+});

--- a/server/runtime/mcp-tools.ts
+++ b/server/runtime/mcp-tools.ts
@@ -1,0 +1,134 @@
+// The MCP servers a bot may use, mounted as tools the owned loop can call.
+//
+// One client per integration server, over the official stdio transport.
+// Tools are namespaced by the server that owns them (`notes__read_notes`)
+// so two servers exposing the same name cannot collide or shadow each
+// other, and a reverse map routes each namespaced call back to exactly the
+// server and tool it came from.
+//
+// What the MODEL sees from a call is bounded here; what the TRANSCRIPT
+// keeps is the far smaller ToolContextSnapshot, sanitized once at the
+// runtime seam. Those are deliberately different limits.
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+import type { OwnedTool, OwnedToolSchema } from "./contracts.ts";
+
+export interface McpServerSpec {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+/** The model may read this much of a tool result. Larger than the durable
+ * snapshot's cap on purpose: a file listing is useful to reason over in
+ * full once, and useless to keep forever. */
+export const MODEL_VISIBLE_RESULT_LIMIT = 24_000;
+/** A server that has not finished its handshake in this long is treated as
+ * broken, not slow: the turn must not hang on a child that never speaks. */
+export const MCP_STARTUP_TIMEOUT_MS = 20_000;
+
+export interface MountedMcp {
+  tools: OwnedTool[];
+  /** namespaced tool name → { server, tool }. */
+  routes: ReadonlyMap<string, { server: string; tool: string }>;
+  /** servers that failed to start, with why. Never a thrown error: one
+   * broken server must not take the others — or the turn — down. */
+  failures: ReadonlyMap<string, string>;
+  /** stop every child. Idempotent; safe on turn settle, cancel, and dispose. */
+  close(): Promise<void>;
+}
+
+const namespaced = (server: string, tool: string) => `${server}__${tool}`;
+
+/** A JSON-Schema object the model can be constrained by. MCP servers may
+ * omit properties or send something odd; an empty object schema is the
+ * honest fallback rather than a guess. */
+function toolSchema(raw: unknown): OwnedToolSchema {
+  const schema = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+  const properties = schema.properties && typeof schema.properties === "object"
+    ? (schema.properties as Record<string, Record<string, unknown>>)
+    : {};
+  const required = Array.isArray(schema.required) ? schema.required.filter((r): r is string => typeof r === "string") : undefined;
+  return { type: "object", properties, ...(required?.length ? { required } : {}), additionalProperties: false };
+}
+
+function textOf(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => (part && typeof part === "object" && (part as { type?: unknown }).type === "text" ? String((part as { text?: unknown }).text ?? "") : ""))
+    .filter(Boolean)
+    .join("\n");
+}
+
+/** Start every server, discover its tools, and hand back one flat tool list.
+ * Servers start concurrently; a failure in one is recorded and the rest
+ * proceed. */
+export async function mountMcpServers(
+  servers: Record<string, McpServerSpec>,
+  options: { toolTimeoutMs: number; startupTimeoutMs?: number } ,
+): Promise<MountedMcp> {
+  const clients = new Map<string, Client>();
+  const transports = new Map<string, StdioClientTransport>();
+  const routes = new Map<string, { server: string; tool: string }>();
+  const failures = new Map<string, string>();
+  const tools: OwnedTool[] = [];
+  const startupTimeoutMs = options.startupTimeoutMs ?? MCP_STARTUP_TIMEOUT_MS;
+
+  await Promise.all(
+    Object.entries(servers).map(async ([name, spec]) => {
+      const transport = new StdioClientTransport({ command: spec.command, args: spec.args, env: spec.env, stderr: "ignore" });
+      const client = new Client({ name: "openmausbot", version: "1" });
+      try {
+        await client.connect(transport, { timeout: startupTimeoutMs });
+        const listed = await client.listTools(undefined, { timeout: startupTimeoutMs });
+        clients.set(name, client);
+        transports.set(name, transport);
+        for (const tool of listed.tools) {
+          const fullName = namespaced(name, tool.name);
+          routes.set(fullName, { server: name, tool: tool.name });
+          tools.push({
+            name: fullName,
+            description: tool.description ?? `${tool.name} from ${name}`,
+            parameters: toolSchema(tool.inputSchema),
+            async execute(_callId, args, signal) {
+              const result = await client.callTool(
+                { name: tool.name, arguments: args },
+                undefined,
+                { signal, timeout: options.toolTimeoutMs },
+              );
+              const text = textOf(result.content);
+              const ok = result.isError !== true;
+              const visible = text.length > MODEL_VISIBLE_RESULT_LIMIT
+                ? `${text.slice(0, MODEL_VISIBLE_RESULT_LIMIT)}\n[truncated]`
+                : text;
+              // the runtime sanitizes and bounds the durable observation;
+              // this only reports the raw facts of the call
+              return {
+                text: visible || (ok ? "(no output)" : "(tool reported an error with no message)"),
+                ok,
+                observation: { name: fullName, ok },
+              };
+            },
+          });
+        }
+      } catch (error) {
+        failures.set(name, error instanceof Error ? error.message : String(error));
+        await transport.close().catch(() => {});
+      }
+    }),
+  );
+
+  let closed = false;
+  return {
+    tools,
+    routes,
+    failures,
+    async close() {
+      if (closed) return;
+      closed = true;
+      await Promise.all([...clients.values()].map((client) => client.close().catch(() => {})));
+      await Promise.all([...transports.values()].map((transport) => transport.close().catch(() => {})));
+    },
+  };
+}

--- a/server/runtime/pi-runtime.test.ts
+++ b/server/runtime/pi-runtime.test.ts
@@ -53,7 +53,12 @@ async function turn(script: FakeResponse[], over: Partial<OwnedTurnInput> = {}) 
     limits: { maxModelCalls: 32, maxToolCalls: 64, toolTimeoutMs: 5_000 },
     ...over,
   };
-  await runtime.run(input, (e) => events.push(e));
+  await runtime.run(input, (e) => {
+    events.push(e);
+    // every tool call asks; these tests are about the loop, not approval,
+    // so they play the harness's auto-approve and allow each one
+    if (e.type === "ask.opened") runtime.answer(input.threadId, e.requestId, "allow");
+  });
   return { events, fake, runtime, abort };
 }
 
@@ -189,7 +194,10 @@ describe("createPiRuntime", () => {
       threadId: "t1", turnId: "turn-1", plan: plan(), system: "", tools: [steerOnce], signal: new AbortController().signal,
       model: { id: "m", baseUrl: "http://127.0.0.1:1/v1", apiKey: "k", contextWindow: 8_000, maxOutputTokens: 1_000, reasoning: false },
       limits: { maxModelCalls: 32, maxToolCalls: 64, toolTimeoutMs: 5_000 },
-    }, (e) => events.push(e));
+    }, (e) => {
+      events.push(e);
+      if (e.type === "ask.opened") runtime.answer("t1", e.requestId, "allow");
+    });
     const second = fake.calls[1]!;
     expect(second.messages.some((m) => m.role === "user" && m.content === "actually, stop after this")).toBe(true);
   });
@@ -209,11 +217,107 @@ describe("createPiRuntime", () => {
       model: { id: "m", baseUrl: "http://127.0.0.1:1/v1", apiKey: "k", contextWindow: 8_000, maxOutputTokens: 1_000, reasoning: false },
       limits: { maxModelCalls: 32, maxToolCalls: 64, toolTimeoutMs: 5_000 },
     };
-    await runtime.run({ ...base, turnId: "turn-1", plan: plan() }, () => {});
-    await runtime.run({ ...base, turnId: "turn-2", plan: plan() }, () => {});
+    const allow = (e: OwnedRuntimeEvent) => {
+      if (e.type === "ask.opened") runtime.answer("t1", e.requestId, "allow");
+    };
+    await runtime.run({ ...base, turnId: "turn-1", plan: plan() }, allow);
+    await runtime.run({ ...base, turnId: "turn-2", plan: plan() }, allow);
     const third = fake.calls[2]!;
     expect(third.messages.some((m) => m.role === "toolResult")).toBe(false);
     expect(third.messages).toHaveLength(3);
+  });
+});
+
+describe("createPiRuntime — approvals and the loop guard", () => {
+  const TOOL_TURN = [{ toolCalls: [{ name: "echo", args: { text: "a" } }] }, { text: "done" }];
+
+  /** Run a tool turn while answering asks with `decide`. */
+  async function approvalTurn(
+    decide: (ask: Extract<OwnedRuntimeEvent, { type: "ask.opened" }>, answer: (b: "allow" | "deny" | "answer", m?: string) => string) => void,
+    script = TOOL_TURN,
+    opts: { askTimeoutMs?: number } = {},
+  ) {
+    const calls: Array<Record<string, unknown>> = [];
+    const fake = makeFakeModel(script);
+    const runtime = createPiRuntime({ streamFn: fake.streamFn, ...opts });
+    const events: OwnedRuntimeEvent[] = [];
+    const run = runtime.run({
+      threadId: "t1", turnId: "turn-1", plan: plan(), system: "", tools: [echoTool(calls)], signal: new AbortController().signal,
+      model: { id: "m", baseUrl: "http://127.0.0.1:1/v1", apiKey: "k", contextWindow: 8_000, maxOutputTokens: 1_000, reasoning: false },
+      limits: { maxModelCalls: 32, maxToolCalls: 64, toolTimeoutMs: 5_000 },
+    }, (e) => {
+      events.push(e);
+      if (e.type === "ask.opened") decide(e, (b, m) => runtime.answer("t1", e.requestId, b, m));
+    });
+    await run;
+    return { events, calls, fake, runtime };
+  }
+
+  it("asks before every tool call and runs it on allow", async () => {
+    const { events, calls } = await approvalTurn((ask, answer) => {
+      expect(ask.kind).toBe("permission");
+      expect(ask.tool).toBe("echo");
+      expect(ask.summary).toContain("a");
+      expect(answer("allow")).toBe("allowed-once");
+    });
+    expect(calls).toEqual([{ text: "a" }]);
+    expect(events.find((e) => e.type === "ask.resolved")).toMatchObject({ behavior: "allow", source: "user" });
+    expect(events.at(-1)).toEqual({ type: "completed", ok: true, stopReason: "end_turn" });
+  });
+
+  it("never runs a denied tool, and tells the model why", async () => {
+    const { calls, fake } = await approvalTurn((_ask, answer) => {
+      expect(answer("deny", "not on this machine")).toBe("rejected");
+    });
+    expect(calls).toEqual([]);
+    // the second model call saw the refusal as the tool's result
+    const toolResult = fake.calls[1]!.messages.find((m) => m.role === "toolResult");
+    expect(JSON.stringify(toolResult)).toContain("not on this machine");
+  });
+
+  it("denies when nobody answers in time — silence is never an allow", async () => {
+    const { calls, events } = await approvalTurn(() => {}, TOOL_TURN, { askTimeoutMs: 50 });
+    expect(calls).toEqual([]);
+    expect(events.find((e) => e.type === "ask.resolved")).toMatchObject({ behavior: "deny", source: "timeout" });
+  });
+
+  it("answers a stale request id with unavailable", async () => {
+    const { runtime } = await approvalTurn((_a, answer) => answer("allow"));
+    expect(runtime.answer("t1", "no-such-ask", "allow")).toBe("unavailable");
+    expect(runtime.answer("other-thread", "x", "allow")).toBe("unavailable");
+  });
+
+  it("settles a pending ask with the system reply when the turn is interrupted", async () => {
+    const fake = makeFakeModel(TOOL_TURN);
+    const runtime = createPiRuntime({ streamFn: fake.streamFn });
+    const events: OwnedRuntimeEvent[] = [];
+    const run = runtime.run({
+      threadId: "t1", turnId: "turn-1", plan: plan(), system: "", tools: [echoTool()], signal: new AbortController().signal,
+      model: { id: "m", baseUrl: "http://127.0.0.1:1/v1", apiKey: "k", contextWindow: 8_000, maxOutputTokens: 1_000, reasoning: false },
+      limits: { maxModelCalls: 32, maxToolCalls: 64, toolTimeoutMs: 5_000 },
+    }, (e) => {
+      events.push(e);
+      if (e.type === "ask.opened") runtime.interrupt("t1");
+    });
+    await run;
+    expect(events.find((e) => e.type === "ask.resolved")).toMatchObject({ behavior: "deny", source: "system" });
+    expect(events.at(-1)).toMatchObject({ type: "completed", ok: false, stopReason: "interrupted" });
+  });
+
+  it("warns the model on the third identical call, in the result it reads next", async () => {
+    const repeat = { toolCalls: [{ name: "echo", args: { text: "same" } }] };
+    const { fake } = await approvalTurn((_a, answer) => answer("allow"), [repeat, repeat, repeat, { text: "ok" }]);
+    const afterThird = fake.calls[3]!.messages.filter((m) => m.role === "toolResult").at(-1);
+    expect(JSON.stringify(afterThird)).toContain("made this exact call several times");
+    const afterFirst = fake.calls[1]!.messages.filter((m) => m.role === "toolResult").at(-1);
+    expect(JSON.stringify(afterFirst)).not.toContain("made this exact call");
+  });
+
+  it("stops the loop on the fifth identical call", async () => {
+    const repeat = { toolCalls: [{ name: "echo", args: { text: "same" } }] };
+    const { events, calls } = await approvalTurn((_a, answer) => answer("allow"), Array.from({ length: 10 }, () => repeat));
+    expect(calls.length).toBe(4);
+    expect(events.at(-1)).toEqual({ type: "completed", ok: true, stopReason: "max_tool_calls" });
   });
 });
 

--- a/server/runtime/pi-runtime.test.ts
+++ b/server/runtime/pi-runtime.test.ts
@@ -1,0 +1,246 @@
+// The owned loop against a scripted model: what it does, and what the model
+// is shown. Every case runs through the real Pi agent core; only the
+// provider call is faked.
+import { describe, expect, it } from "vitest";
+
+import type { TurnContextPlan } from "../context/types.ts";
+import type { OwnedRuntimeEvent, OwnedTool, OwnedTurnInput } from "./contracts.ts";
+import { makeFakeModel, type FakeResponse } from "./fake-model.ts";
+import { createPiRuntime, toPiMessages, toPiModel } from "./pi-runtime.ts";
+
+const plan = (over: Partial<TurnContextPlan> = {}): TurnContextPlan => ({
+  ownership: "omb-loop",
+  mode: "replay-required",
+  currentPrompt: "what now?",
+  replayPrompt: "what now?",
+  messages: [
+    { kind: "user-text", messageId: "m1", text: "my dog is Biscuit" },
+    { kind: "assistant-text", messageId: "m2", text: "Noted — Biscuit." },
+  ],
+  budget: { contextWindow: 200_000, historyTokens: 80_000, limitsSource: "pattern" },
+  diagnostics: { sourceItems: 2, sentItems: 2, estimatedInputTokens: 20, compacted: false, clipped: false },
+  ...over,
+});
+
+const echoTool = (calls: Array<Record<string, unknown>> = []): OwnedTool => ({
+  name: "echo",
+  description: "Echo the input back",
+  parameters: { type: "object", properties: { text: { type: "string" } }, required: ["text"], additionalProperties: false },
+  async execute(callId, args) {
+    calls.push(args);
+    return {
+      text: `echoed: ${String(args.text)}`,
+      ok: true,
+      observation: { callId, name: "echo", inputSummary: String(args.text), outputSummary: `echoed: ${String(args.text)}`, ok: true },
+    };
+  },
+});
+
+/** Run one turn and collect everything it reported. */
+async function turn(script: FakeResponse[], over: Partial<OwnedTurnInput> = {}) {
+  const fake = makeFakeModel(script);
+  const runtime = createPiRuntime({ streamFn: fake.streamFn });
+  const events: OwnedRuntimeEvent[] = [];
+  const abort = new AbortController();
+  const input: OwnedTurnInput = {
+    threadId: "t1",
+    turnId: "turn-1",
+    plan: plan(),
+    system: "You are Wren.",
+    model: { id: "test-model", baseUrl: "http://127.0.0.1:1/v1", apiKey: "sk-test-key", contextWindow: 200_000, maxOutputTokens: 4_096, reasoning: true },
+    tools: [],
+    signal: abort.signal,
+    limits: { maxModelCalls: 32, maxToolCalls: 64, toolTimeoutMs: 5_000 },
+    ...over,
+  };
+  await runtime.run(input, (e) => events.push(e));
+  return { events, fake, runtime, abort };
+}
+
+const types = (events: OwnedRuntimeEvent[]) => events.map((e) => e.type);
+
+describe("createPiRuntime", () => {
+  it("streams text and reports the final answer, then completes", async () => {
+    const { events } = await turn([{ text: "Hello there", usage: { input: 12, output: 3 } }]);
+    expect(events.filter((e) => e.type === "delta" && e.kind === "text").map((e) => (e as { text: string }).text).join(""))
+      .toBe("Hello there");
+    expect(events).toContainEqual({ type: "assistant", text: "Hello there" });
+    expect(events).toContainEqual({ type: "usage", input: 12, output: 3 });
+    expect(events.at(-1)).toEqual({ type: "completed", ok: true, stopReason: "end_turn" });
+  });
+
+  it("streams reasoning separately from text", async () => {
+    const { events } = await turn([{ reasoning: "thinking hard", text: "answer" }]);
+    const reasoning = events.filter((e) => e.type === "delta" && e.kind === "reasoning").map((e) => (e as { text: string }).text).join("");
+    expect(reasoning).toBe("thinking hard");
+    expect(events).toContainEqual({ type: "assistant", text: "answer" });
+  });
+
+  it("rebuilds the model's view from the plan — the plan is the only history", async () => {
+    const { fake } = await turn([{ text: "ok" }]);
+    const shown = fake.calls[0]!;
+    expect(shown.systemPrompt).toBe("You are Wren.");
+    // user content is a string OR a content array (Pi's prompt(string)
+    // stores the array form); read both the same way
+    const textOf = (content: string | Array<{ type: string; text?: string }>) =>
+      typeof content === "string" ? content : content.map((c) => c.text ?? "").join("");
+    const texts = shown.messages.map((m) => (m.role === "toolResult" ? "" : textOf(m.content)));
+    expect(texts).toEqual(["my dog is Biscuit", "Noted — Biscuit.", "what now?"]);
+  });
+
+  it("passes the API key explicitly on every call and gives Pi an empty env", async () => {
+    // the key must ride on the request and only there; an empty env means
+    // Pi has nowhere else to look for one
+    const { fake } = await turn([{ toolCalls: [{ name: "echo", args: { text: "a" } }] }, { text: "done" }], { tools: [echoTool()] });
+    expect(fake.keys).toEqual(["sk-test-key", "sk-test-key"]);
+  });
+
+  it("runs one tool call and feeds the result back into a second model call", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const { events, fake } = await turn(
+      [{ toolCalls: [{ name: "echo", args: { text: "ping" } }] }, { text: "it said pong" }],
+      { tools: [echoTool(calls)] },
+    );
+    expect(calls).toEqual([{ text: "ping" }]);
+    expect(types(events)).toContain("tool.started");
+    const done = events.find((e) => e.type === "tool.completed") as Extract<OwnedRuntimeEvent, { type: "tool.completed" }>;
+    expect(done.ok).toBe(true);
+    expect(done.observation).toMatchObject({ name: "echo", inputSummary: expect.stringContaining("ping") });
+    // the second call saw the tool result
+    expect(fake.calls).toHaveLength(2);
+    expect(fake.calls[1]!.messages.some((m) => m.role === "toolResult")).toBe(true);
+    expect(events.at(-1)).toEqual({ type: "completed", ok: true, stopReason: "end_turn" });
+  });
+
+  it("runs several tool calls from one model turn", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const { events } = await turn(
+      [{ toolCalls: [{ name: "echo", args: { text: "one" } }, { name: "echo", args: { text: "two" } }] }, { text: "both done" }],
+      { tools: [echoTool(calls)] },
+    );
+    expect(calls).toEqual([{ text: "one" }, { text: "two" }]);
+    expect(events.filter((e) => e.type === "tool.completed")).toHaveLength(2);
+  });
+
+  it("stores a bounded, redacted observation — never the raw result", async () => {
+    const leaky: OwnedTool = {
+      ...echoTool(),
+      async execute(callId) {
+        const output = `token=sk-ant-abcdefghijklmnop0123456789 ${"x".repeat(20_000)}`;
+        return { text: output, ok: true, observation: { callId, name: "echo", ok: true } };
+      },
+    };
+    const { events } = await turn([{ toolCalls: [{ name: "echo", args: { text: "a" } }] }, { text: "ok" }], { tools: [leaky] });
+    const done = events.find((e) => e.type === "tool.completed") as Extract<OwnedRuntimeEvent, { type: "tool.completed" }>;
+    expect(done.observation.outputSummary).not.toContain("sk-ant-abcdefghijklmnop");
+    expect(done.observation.outputSummary!.length).toBeLessThanOrEqual(6_000);
+    expect(done.observation.clipped).toBe(true);
+  });
+
+  it("reports a provider error and completes as failed, without throwing", async () => {
+    const { events } = await turn([{ error: "upstream 503" }]);
+    expect(events).toContainEqual({ type: "error", message: "upstream 503" });
+    expect(events.at(-1)).toEqual({ type: "completed", ok: false, stopReason: "error" });
+  });
+
+  it("interrupts a hanging model call and completes as interrupted", async () => {
+    const fake = makeFakeModel([{ hang: true }]);
+    const runtime = createPiRuntime({ streamFn: fake.streamFn });
+    const events: OwnedRuntimeEvent[] = [];
+    const abort = new AbortController();
+    const running = runtime.run({
+      threadId: "t1", turnId: "turn-1", plan: plan(), system: "", tools: [], signal: abort.signal,
+      model: { id: "m", baseUrl: "http://127.0.0.1:1/v1", apiKey: "k", contextWindow: 8_000, maxOutputTokens: 1_000, reasoning: false },
+      limits: { maxModelCalls: 32, maxToolCalls: 64, toolTimeoutMs: 5_000 },
+    }, (e) => events.push(e));
+    expect(runtime.hasTurn("t1")).toBe(true);
+    runtime.interrupt("t1");
+    await running;
+    expect(events.at(-1)).toEqual({ type: "completed", ok: false, stopReason: "interrupted" });
+    expect(runtime.hasTurn("t1")).toBe(false);
+  });
+
+  it("stops at the model-call limit", async () => {
+    // a model that always asks for another tool would loop forever
+    const endless = Array.from({ length: 10 }, () => ({ toolCalls: [{ name: "echo", args: { text: "again" } }] }));
+    const { events } = await turn(endless, { tools: [echoTool()], limits: { maxModelCalls: 3, maxToolCalls: 64, toolTimeoutMs: 5_000 } });
+    expect(events.filter((e) => e.type === "model.call")).toHaveLength(3);
+    expect(events.at(-1)).toEqual({ type: "completed", ok: true, stopReason: "max_model_calls" });
+  });
+
+  it("stops at the tool-call limit", async () => {
+    const endless = Array.from({ length: 10 }, () => ({ toolCalls: [{ name: "echo", args: { text: "again" } }] }));
+    const { events } = await turn(endless, { tools: [echoTool()], limits: { maxModelCalls: 32, maxToolCalls: 2, toolTimeoutMs: 5_000 } });
+    expect(events.at(-1)).toEqual({ type: "completed", ok: true, stopReason: "max_tool_calls" });
+  });
+
+  it("delivers a steered message before the next model call", async () => {
+    const fake = makeFakeModel([{ toolCalls: [{ name: "echo", args: { text: "a" } }] }, { text: "done" }]);
+    const runtime = createPiRuntime({ streamFn: fake.streamFn });
+    const events: OwnedRuntimeEvent[] = [];
+    const steerOnce: OwnedTool = {
+      ...echoTool(),
+      async execute(callId) {
+        runtime.steer("t1", "actually, stop after this");
+        return { text: "ok", ok: true, observation: { callId, name: "echo", ok: true } };
+      },
+    };
+    await runtime.run({
+      threadId: "t1", turnId: "turn-1", plan: plan(), system: "", tools: [steerOnce], signal: new AbortController().signal,
+      model: { id: "m", baseUrl: "http://127.0.0.1:1/v1", apiKey: "k", contextWindow: 8_000, maxOutputTokens: 1_000, reasoning: false },
+      limits: { maxModelCalls: 32, maxToolCalls: 64, toolTimeoutMs: 5_000 },
+    }, (e) => events.push(e));
+    const second = fake.calls[1]!;
+    expect(second.messages.some((m) => m.role === "user" && m.content === "actually, stop after this")).toBe(true);
+  });
+
+  it("steer returns false when nothing is running", () => {
+    const runtime = createPiRuntime({ streamFn: makeFakeModel([]).streamFn });
+    expect(runtime.steer("nope", "hi")).toBe(false);
+  });
+
+  it("starts every turn from the plan alone — nothing survives a previous turn", async () => {
+    // the second turn must see exactly its own plan, not the first turn's
+    // tool results
+    const fake = makeFakeModel([{ toolCalls: [{ name: "echo", args: { text: "a" } }] }, { text: "one" }, { text: "two" }]);
+    const runtime = createPiRuntime({ streamFn: fake.streamFn });
+    const base = {
+      threadId: "t1", system: "", tools: [echoTool()], signal: new AbortController().signal,
+      model: { id: "m", baseUrl: "http://127.0.0.1:1/v1", apiKey: "k", contextWindow: 8_000, maxOutputTokens: 1_000, reasoning: false },
+      limits: { maxModelCalls: 32, maxToolCalls: 64, toolTimeoutMs: 5_000 },
+    };
+    await runtime.run({ ...base, turnId: "turn-1", plan: plan() }, () => {});
+    await runtime.run({ ...base, turnId: "turn-2", plan: plan() }, () => {});
+    const third = fake.calls[2]!;
+    expect(third.messages.some((m) => m.role === "toolResult")).toBe(false);
+    expect(third.messages).toHaveLength(3);
+  });
+});
+
+describe("toPiMessages", () => {
+  it("renders portable tool observations as descriptive text, never fabricated tool calls", () => {
+    const messages = toPiMessages([{ kind: "tool-observation", messageId: "m1", observation: { name: "Edit", ok: true } }]);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.role).toBe("assistant");
+    expect(messages.some((m) => m.role === "toolResult")).toBe(false);
+  });
+
+  it("keeps room speakers attributed", () => {
+    const [m] = toPiMessages([{ kind: "assistant-text", messageId: "m1", text: "on it", speaker: "Fig" }]);
+    expect(m!.role === "assistant" && m!.content[0]!.type === "text" ? m!.content[0]!.text : "").toBe("Fig: on it");
+  });
+});
+
+describe("toPiModel", () => {
+  it("routes an OpenRouter target through the pinned provider without fallbacks", () => {
+    const model = toPiModel({ id: "x", baseUrl: "https://openrouter.ai/api/v1", contextWindow: 1, maxOutputTokens: 1, reasoning: false, openRouterProvider: "groq" });
+    expect(model.provider).toBe("openrouter");
+    expect(model.compat).toEqual({ openRouterRouting: { order: ["groq"], allow_fallbacks: false } });
+  });
+
+  it("ignores a provider pin for a non-OpenRouter endpoint", () => {
+    const model = toPiModel({ id: "x", baseUrl: "http://127.0.0.1:8080/v1", contextWindow: 1, maxOutputTokens: 1, reasoning: false, openRouterProvider: "groq" });
+    expect(model.provider).toBe("openmaus");
+    expect(model.compat).toBeUndefined();
+  });
+});

--- a/server/runtime/pi-runtime.ts
+++ b/server/runtime/pi-runtime.ts
@@ -28,7 +28,9 @@ import type { EffortLevel } from "../contracts.ts";
 import { sanitizeToolObservation } from "../context/sanitize.ts";
 import type { ModelContextItem } from "../context/types.ts";
 import { renderToolChip } from "../context/project.ts";
+import { createApprovalGate, type ApprovalGate } from "./approval-gate.ts";
 import type { OwnedAgentRuntime, OwnedModelTarget, OwnedTool } from "./contracts.ts";
+import { REPEAT_ADVISORY_NOTE, REPEAT_STOP_NOTE, createLoopGuard } from "./loop-guard.ts";
 
 /** What a Pi model call is made with. Exported so the driver can pass a
  * fake in tests and so nothing else needs to spell Pi's signature. */
@@ -137,9 +139,10 @@ function toPiTool(tool: OwnedTool, timeoutMs: number): AgentTool {
 interface LiveTurn {
   agent: Agent;
   abort: AbortController;
+  gate: ApprovalGate;
 }
 
-export function createPiRuntime(options: { streamFn?: PiStreamFn } = {}): OwnedAgentRuntime {
+export function createPiRuntime(options: { streamFn?: PiStreamFn; askTimeoutMs?: number } = {}): OwnedAgentRuntime {
   const live = new Map<string, LiveTurn>();
   // streamSimple maps the thinking level onto provider-specific fields and
   // takes the same options shape the Agent hands us
@@ -159,6 +162,16 @@ export function createPiRuntime(options: { streamFn?: PiStreamFn } = {}): OwnedA
     const model = toPiModel(input.model);
     let modelCalls = 0;
     let toolCalls = 0;
+    // Every tool call asks. Auto-approval is the harness's decision, made
+    // on the request.opened event; from here it is just an answer that
+    // arrived. Nothing runs on silence.
+    const gate = createApprovalGate({
+      onOpen: (ask) => emit({ type: "ask.opened", requestId: ask.id, kind: ask.kind, tool: ask.tool, summary: ask.summary, ...(ask.choices ? { choices: ask.choices } : {}) }),
+      onResolve: (ask, r) => emit({ type: "ask.resolved", requestId: ask.id, behavior: r.behavior, source: r.source }),
+      ...(options.askTimeoutMs === undefined ? {} : { timeoutMs: options.askTimeoutMs }),
+    });
+    const guard = createLoopGuard();
+    const advisories = new Set<string>();
     let stopReason: "end_turn" | "max_model_calls" | "max_tool_calls" = "end_turn";
     let failed: string | null = null;
     let finalText = "";
@@ -181,13 +194,31 @@ export function createPiRuntime(options: { streamFn?: PiStreamFn } = {}): OwnedA
         return streamFn(m, context, { ...opts, apiKey: input.model.apiKey, env: {}, signal: abort.signal });
       },
       convertToLlm: (messages) => messages as Message[],
-      beforeToolCall: async () => {
+      beforeToolCall: async (context) => {
         toolCalls += 1;
         if (toolCalls > input.limits.maxToolCalls) {
           stopReason = "max_tool_calls";
           return { block: true, reason: `tool call limit of ${input.limits.maxToolCalls} reached`, terminate: true };
         }
+        const verdict = guard.observe(context.toolCall.name, context.args);
+        if (verdict === "stop") {
+          stopReason = "max_tool_calls";
+          return { block: true, reason: REPEAT_STOP_NOTE, terminate: true };
+        }
+        if (verdict === "advisory") advisories.add(context.toolCall.id);
+        const summary = JSON.stringify(context.args ?? {}).slice(0, 300);
+        const answer = await gate.ask({ kind: "permission", tool: context.toolCall.name, summary });
+        if (answer.behavior !== "allow") {
+          return { block: true, reason: answer.message ?? "OpenMausBot: this action was not approved." };
+        }
         return undefined;
+      },
+      afterToolCall: async (context) => {
+        if (!advisories.delete(context.toolCall.id)) return undefined;
+        // the model is told, in the result it is about to read, that it is
+        // repeating itself — most models take the hint before the stop
+        const content = Array.isArray(context.result?.content) ? context.result.content : [];
+        return { content: [...content, { type: "text", text: REPEAT_ADVISORY_NOTE }] };
       },
       shouldStopAfterTurn: () => {
         if (modelCalls >= input.limits.maxModelCalls) {
@@ -257,7 +288,7 @@ export function createPiRuntime(options: { streamFn?: PiStreamFn } = {}): OwnedA
       }
     });
 
-    live.set(input.threadId, { agent, abort });
+    live.set(input.threadId, { agent, abort, gate });
     try {
       await agent.prompt(input.plan.currentPrompt);
       if (!failed && agent.state.errorMessage && !abort.signal.aborted) failed = agent.state.errorMessage;
@@ -278,6 +309,9 @@ export function createPiRuntime(options: { streamFn?: PiStreamFn } = {}): OwnedA
         emit({ type: "completed", ok: false, stopReason: "error" });
       }
     } finally {
+      // an ask that outlives the turn is answered by the system, never left
+      // hanging for a tool that will never run
+      gate.drain();
       unsubscribe();
       input.signal.removeEventListener("abort", onOuterAbort);
       live.delete(input.threadId);
@@ -295,12 +329,21 @@ export function createPiRuntime(options: { streamFn?: PiStreamFn } = {}): OwnedA
     interrupt: (threadId) => {
       const turn = live.get(threadId);
       if (!turn) return;
+      turn.gate.drain();
       turn.abort.abort();
       turn.agent.abort();
+    },
+    answer: (threadId, requestId, behavior, message) => {
+      const turn = live.get(threadId);
+      // no live turn means no pending ask: unavailable, which the harness
+      // treats as a deny and never as an allow
+      if (!turn) return "unavailable";
+      return turn.gate.answer(requestId, behavior, message);
     },
     hasTurn: (threadId) => live.has(threadId),
     dispose: async () => {
       for (const turn of live.values()) {
+        turn.gate.drain();
         turn.abort.abort();
         turn.agent.abort();
       }

--- a/server/runtime/pi-runtime.ts
+++ b/server/runtime/pi-runtime.ts
@@ -1,0 +1,310 @@
+// The Pi-backed implementation of OwnedAgentRuntime.
+//
+// This is the ONLY production file that imports @earendil-works/pi-*. It
+// owns three things: turning a TurnContextPlan into the messages Pi will
+// send, running Pi's agent loop under OpenMausBot's bounds, and translating
+// Pi's events into the runtime's own union. Everything else — dispatch, the
+// driver, the event bus — sees only server/runtime/contracts.ts.
+//
+// Two rules are load-bearing here:
+//
+// - The model's view is rebuilt from the canonical plan before every model
+//   call. Pi keeps a live transcript inside the Agent, but that transcript is
+//   seeded from the plan at turn start and only THIS turn's tool-call/result
+//   pairs are appended to it. Nothing survives the turn; the next turn's
+//   plan is the only history.
+// - The API key is passed explicitly on every call and Pi is given an empty
+//   provider env, so it can never fall back to reading a key from the
+//   process environment or a credential store it happens to know about.
+import { Agent, type AgentEvent, type AgentTool, type AgentToolResult, type ThinkingLevel } from "@earendil-works/pi-agent-core";
+import { Type, type Api, type Context, type Message, type Model, type SimpleStreamOptions } from "@earendil-works/pi-ai";
+// The provider subpath, not /compat: compat re-exports every provider pi
+// ships (Anthropic, Bedrock, Google, Mistral, Azure, …) and esbuild inlines
+// all of it into the packaged server. This engine speaks exactly one wire
+// protocol, so it imports exactly one.
+import { streamSimple } from "@earendil-works/pi-ai/api/openai-completions";
+
+import type { EffortLevel } from "../contracts.ts";
+import { sanitizeToolObservation } from "../context/sanitize.ts";
+import type { ModelContextItem } from "../context/types.ts";
+import { renderToolChip } from "../context/project.ts";
+import type { OwnedAgentRuntime, OwnedModelTarget, OwnedTool } from "./contracts.ts";
+
+/** What a Pi model call is made with. Exported so the driver can pass a
+ * fake in tests and so nothing else needs to spell Pi's signature. */
+export type PiStreamFn = (model: Model<Api>, context: Context, options?: SimpleStreamOptions) => ReturnType<typeof streamSimple> | Promise<ReturnType<typeof streamSimple>>;
+
+/** Text summaries a model is handed for a tool result are bounded here,
+ * separately from the smaller durable ToolContextSnapshot: the model can
+ * usefully read more than the transcript should keep forever. */
+const MODEL_VISIBLE_RESULT_LIMIT = 24_000;
+
+const OPENROUTER_HOSTS = new Set(["openrouter.ai"]);
+
+function isOpenRouter(baseUrl: string): boolean {
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase();
+    return OPENROUTER_HOSTS.has(host) || host.endsWith(".openrouter.ai");
+  } catch {
+    return false;
+  }
+}
+
+/** The plan's provider-neutral items, as Pi messages. Portable tool
+ * observations become descriptive assistant text — never fabricated Pi
+ * tool-call/result pairs with invented ids, which a provider could reject or
+ * misattribute. */
+export function toPiMessages(items: readonly ModelContextItem[]): Message[] {
+  const at = Date.now();
+  const messages: Message[] = [];
+  for (const item of items) {
+    switch (item.kind) {
+      case "user-text":
+        messages.push({ role: "user", content: item.text, timestamp: at });
+        break;
+      case "assistant-text":
+      case "summary":
+      case "tool-observation": {
+        const text = item.kind === "assistant-text"
+          ? item.speaker ? `${item.speaker}: ${item.text}` : item.text
+          : item.kind === "summary"
+            ? `[Summary of the earlier conversation]\n${item.text}`
+            : renderToolChip(item.observation);
+        messages.push({
+          role: "assistant",
+          content: [{ type: "text", text }],
+          api: "openai-completions",
+          provider: "openmaus",
+          model: "history",
+          usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+          stopReason: "stop",
+          timestamp: at,
+        });
+        break;
+      }
+    }
+  }
+  return messages;
+}
+
+export function toPiModel(target: OwnedModelTarget): Model<"openai-completions"> {
+  const openRouter = isOpenRouter(target.baseUrl);
+  return {
+    id: target.id,
+    name: target.id,
+    api: "openai-completions",
+    provider: openRouter ? "openrouter" : "openmaus",
+    baseUrl: target.baseUrl,
+    reasoning: target.reasoning,
+    input: ["text"],
+    // metered cost is reported by the provider in usage; nothing is
+    // estimated here
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: target.contextWindow,
+    maxTokens: target.maxOutputTokens,
+    ...(openRouter && target.openRouterProvider
+      ? { compat: { openRouterRouting: { order: [target.openRouterProvider], allow_fallbacks: false } } }
+      : {}),
+  };
+}
+
+function thinkingLevel(effort: EffortLevel | undefined, reasoning: boolean): ThinkingLevel | undefined {
+  if (!reasoning || !effort) return undefined;
+  return effort === "none" ? "off" : effort;
+}
+
+function toPiTool(tool: OwnedTool, timeoutMs: number): AgentTool {
+  return {
+    name: tool.name,
+    label: tool.name,
+    description: tool.description,
+    parameters: Type.Unsafe(tool.parameters),
+    async execute(toolCallId, params, signal): Promise<AgentToolResult<{ ok: boolean }>> {
+      // A tool that never returns must not hold the turn forever; the
+      // turn-level watchdog upstream wins if it fires first.
+      const timeout = AbortSignal.timeout(timeoutMs);
+      const combined = AbortSignal.any([timeout, ...(signal ? [signal] : [])]);
+      const args = (params ?? {}) as Record<string, unknown>;
+      const result = await tool.execute(toolCallId, args, combined);
+      const text = result.text.length > MODEL_VISIBLE_RESULT_LIMIT
+        ? `${result.text.slice(0, MODEL_VISIBLE_RESULT_LIMIT)}\n[truncated]`
+        : result.text;
+      return { content: [{ type: "text", text }], details: { ok: result.ok } };
+    },
+  };
+}
+
+interface LiveTurn {
+  agent: Agent;
+  abort: AbortController;
+}
+
+export function createPiRuntime(options: { streamFn?: PiStreamFn } = {}): OwnedAgentRuntime {
+  const live = new Map<string, LiveTurn>();
+  // streamSimple maps the thinking level onto provider-specific fields and
+  // takes the same options shape the Agent hands us
+  const streamFn: PiStreamFn = options.streamFn ?? ((model, context, opts) => {
+    // the Agent's contract is Model<Api>; this runtime only ever builds one
+    // api, so the narrowing is a fact about toPiModel, not a hope
+    if (model.api !== "openai-completions") throw new Error(`openmaus-runtime speaks openai-completions, not ${model.api}`);
+    return streamSimple(model as Model<"openai-completions">, context, opts);
+  });
+
+  const run: OwnedAgentRuntime["run"] = async (input, emit) => {
+    if (live.has(input.threadId)) throw new Error("a turn is already running on this thread");
+    const abort = new AbortController();
+    const onOuterAbort = () => abort.abort();
+    input.signal.addEventListener("abort", onOuterAbort, { once: true });
+
+    const model = toPiModel(input.model);
+    let modelCalls = 0;
+    let toolCalls = 0;
+    let stopReason: "end_turn" | "max_model_calls" | "max_tool_calls" = "end_turn";
+    let failed: string | null = null;
+    let finalText = "";
+    const observations = new Map<string, { name: string; inputSummary: string }>();
+
+    const agent = new Agent({
+      initialState: {
+        systemPrompt: input.system ?? "",
+        model,
+        thinkingLevel: thinkingLevel(input.effort, input.model.reasoning) ?? "off",
+        // the canonical plan IS the history; nothing else is carried in
+        messages: toPiMessages(input.plan.messages),
+        tools: input.tools.map((tool) => toPiTool(tool, input.limits.toolTimeoutMs)),
+      },
+      // the key rides on every request explicitly; an empty env means Pi has
+      // nowhere else to look
+      streamFn: (m, context, opts) => {
+        modelCalls += 1;
+        emit({ type: "model.call", call: modelCalls });
+        return streamFn(m, context, { ...opts, apiKey: input.model.apiKey, env: {}, signal: abort.signal });
+      },
+      convertToLlm: (messages) => messages as Message[],
+      beforeToolCall: async () => {
+        toolCalls += 1;
+        if (toolCalls > input.limits.maxToolCalls) {
+          stopReason = "max_tool_calls";
+          return { block: true, reason: `tool call limit of ${input.limits.maxToolCalls} reached`, terminate: true };
+        }
+        return undefined;
+      },
+      shouldStopAfterTurn: () => {
+        if (modelCalls >= input.limits.maxModelCalls) {
+          stopReason = "max_model_calls";
+          return true;
+        }
+        return false;
+      },
+    });
+
+    const unsubscribe = agent.subscribe((event: AgentEvent) => {
+      switch (event.type) {
+        case "message_update": {
+          const e = event.assistantMessageEvent;
+          if (e.type === "text_delta") emit({ type: "delta", kind: "text", text: e.delta });
+          else if (e.type === "thinking_delta") emit({ type: "delta", kind: "reasoning", text: e.delta });
+          else if (e.type === "error") failed = e.error.errorMessage ?? "model error";
+          return;
+        }
+        case "message_end": {
+          const message = event.message;
+          if (message.role !== "assistant") return;
+          const text = message.content
+            .filter((c): c is { type: "text"; text: string } => c.type === "text")
+            .map((c) => c.text)
+            .join("");
+          if (message.stopReason === "error") failed = message.errorMessage ?? "model error";
+          if (text.trim()) finalText = text;
+          if (message.usage.totalTokens > 0) {
+            emit({
+              type: "usage",
+              input: message.usage.input,
+              output: message.usage.output,
+              ...(message.usage.cacheRead ? { cachedInput: message.usage.cacheRead } : {}),
+              ...(message.usage.cost.total ? { costUsd: message.usage.cost.total } : {}),
+            });
+          }
+          return;
+        }
+        case "tool_execution_start": {
+          const inputSummary = JSON.stringify(event.args ?? {});
+          observations.set(event.toolCallId, { name: event.toolName, inputSummary });
+          emit({ type: "tool.started", callId: event.toolCallId, name: event.toolName, inputSummary });
+          return;
+        }
+        case "tool_execution_end": {
+          const started = observations.get(event.toolCallId);
+          const output = typeof event.result === "string"
+            ? event.result
+            : Array.isArray(event.result?.content)
+              ? event.result.content.map((c: { text?: string }) => c.text ?? "").join("")
+              : "";
+          // the durable record is bounded and redacted here, once, so no
+          // caller can persist a raw result by accident
+          const observation = sanitizeToolObservation({
+            callId: event.toolCallId,
+            name: event.toolName,
+            input: started?.inputSummary,
+            output,
+            ok: !event.isError,
+          });
+          emit({ type: "tool.completed", callId: event.toolCallId, name: event.toolName, ok: !event.isError, observation });
+          return;
+        }
+        default:
+          return;
+      }
+    });
+
+    live.set(input.threadId, { agent, abort });
+    try {
+      await agent.prompt(input.plan.currentPrompt);
+      if (!failed && agent.state.errorMessage && !abort.signal.aborted) failed = agent.state.errorMessage;
+      if (failed) {
+        emit({ type: "error", message: failed });
+        emit({ type: "completed", ok: false, stopReason: "error" });
+      } else if (abort.signal.aborted) {
+        emit({ type: "completed", ok: false, stopReason: "interrupted" });
+      } else {
+        if (finalText.trim()) emit({ type: "assistant", text: finalText });
+        emit({ type: "completed", ok: true, stopReason });
+      }
+    } catch (error) {
+      if (abort.signal.aborted) {
+        emit({ type: "completed", ok: false, stopReason: "interrupted" });
+      } else {
+        emit({ type: "error", message: error instanceof Error ? error.message : String(error) });
+        emit({ type: "completed", ok: false, stopReason: "error" });
+      }
+    } finally {
+      unsubscribe();
+      input.signal.removeEventListener("abort", onOuterAbort);
+      live.delete(input.threadId);
+    }
+  };
+
+  return {
+    run,
+    steer: (threadId, text) => {
+      const turn = live.get(threadId);
+      if (!turn) return false;
+      turn.agent.steer({ role: "user", content: text, timestamp: Date.now() });
+      return true;
+    },
+    interrupt: (threadId) => {
+      const turn = live.get(threadId);
+      if (!turn) return;
+      turn.abort.abort();
+      turn.agent.abort();
+    },
+    hasTurn: (threadId) => live.has(threadId),
+    dispose: async () => {
+      for (const turn of live.values()) {
+        turn.abort.abort();
+        turn.agent.abort();
+      }
+      live.clear();
+    },
+  };
+}

--- a/server/testing/fake-mcp-server.ts
+++ b/server/testing/fake-mcp-server.ts
@@ -1,31 +1,65 @@
+// A stdio MCP server for tests. Speaks just enough of the protocol to be
+// mounted: initialize, tools/list, tools/call. Modes, via env:
+//   FAKE_MCP_MODE      healthy (default) | silent | malformed | slow |
+//                      exit-after-init | error
+//   FAKE_MCP_TOOL_NAME the one tool it exposes (default read_notes) — set the
+//                      same name on two servers to test collisions
+//   FAKE_MCP_DELAY_MS  how long `slow` holds a tools/call (default 2000)
+//   FAKE_MCP_DESCRIPTION  the tool's description
 import { createInterface } from "node:readline";
 
 const mode = process.env.FAKE_MCP_MODE ?? "healthy";
+const toolName = process.env.FAKE_MCP_TOOL_NAME ?? "read_notes";
+const delayMs = Number(process.env.FAKE_MCP_DELAY_MS ?? "2000");
+
+const reply = (frame: unknown) => process.stdout.write(`${JSON.stringify(frame)}\n`);
+
 if (mode === "silent") setInterval(() => {}, 60_000);
 else {
   const lines = createInterface({ input: process.stdin });
   lines.on("line", (line) => {
-    const frame = JSON.parse(line) as { id?: number; method?: string };
+    const frame = JSON.parse(line) as { id?: number; method?: string; params?: { name?: string; arguments?: Record<string, unknown> } };
     if (frame.method === "initialize") {
-      process.stdout.write(`${JSON.stringify({
+      reply({
+        jsonrpc: "2.0",
+        id: frame.id,
+        result: { protocolVersion: "2025-06-18", capabilities: { tools: {} }, serverInfo: { name: "fake-mcp", version: "1" } },
+      });
+      // a server that dies right after the handshake: the mount must record
+      // the failure, not hang the turn
+      if (mode === "exit-after-init") setTimeout(() => process.exit(0), 20);
+      return;
+    }
+    if (frame.method === "tools/list") {
+      // a frame the client cannot parse; the SDK must surface an error
+      // rather than wedge on it
+      if (mode === "malformed") {
+        process.stdout.write("this is not json\n");
+        return;
+      }
+      reply({
         jsonrpc: "2.0",
         id: frame.id,
         result: {
-          protocolVersion: "2025-06-18",
-          capabilities: { tools: {} },
-          serverInfo: { name: "fake-mcp", version: "1" },
+          tools: [{
+            name: toolName,
+            description: process.env.FAKE_MCP_DESCRIPTION ?? "Read saved notes",
+            inputSchema: { type: "object", properties: { text: { type: "string" } } },
+          }],
         },
-      })}\n`);
+      });
+      return;
     }
-    if (frame.method === "tools/list") {
-      process.stdout.write(`${JSON.stringify({
-        jsonrpc: "2.0",
-        id: frame.id,
-        result: { tools: [{
-          name: "read_notes",
-          description: process.env.FAKE_MCP_DESCRIPTION ?? "Read saved notes",
-        }] },
-      })}\n`);
+    if (frame.method === "tools/call") {
+      const text = String(frame.params?.arguments?.text ?? "");
+      const send = () =>
+        reply(
+          mode === "error"
+            ? { jsonrpc: "2.0", id: frame.id, result: { content: [{ type: "text", text: "simulated tool failure" }], isError: true } }
+            : { jsonrpc: "2.0", id: frame.id, result: { content: [{ type: "text", text: `echoed: ${text}` }] } },
+        );
+      if (mode === "slow") setTimeout(send, delayMs);
+      else send();
     }
   });
 }

--- a/server/testing/fake-openai-server.ts
+++ b/server/testing/fake-openai-server.ts
@@ -1,0 +1,137 @@
+// A loopback OpenAI-compatible chat-completions server for verification.
+//
+// Speaks exactly the SSE shape pi-ai's openai-completions provider parses:
+// `data: {json}` chunks with choices[0].delta.{content,reasoning_content,
+// tool_calls}, a final chunk carrying finish_reason (the provider throws if
+// a stream ends without one) and usage, then `data: [DONE]`.
+//
+// Modes, via env or the exported factory options:
+//   FAKE_OPENAI_MODE   echo (default) | tool | reasoning | error | slow
+//   FAKE_OPENAI_PORT   0 (default) = pick a free port; the chosen port is
+//                      printed as JSON on stdout when run as a script.
+//   FAKE_OPENAI_TOOL   the tool name `tool` mode calls (default echo). Set
+//                      it to a mounted, namespaced tool so the call reaches
+//                      the approval gate instead of failing as unknown.
+// `tool` answers the FIRST call with a tool call to `echo` and any later
+// call in the same process with text, so a two-step agent turn completes.
+// Never listens beyond 127.0.0.1.
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+
+export interface FakeOpenAIOptions {
+  mode?: "echo" | "tool" | "reasoning" | "error" | "slow";
+  port?: number;
+  /** delay before the first chunk in `slow` mode. */
+  delayMs?: number;
+  /** the tool `tool` mode calls. */
+  toolName?: string;
+}
+
+export interface FakeOpenAIServer {
+  port: number;
+  url: string;
+  /** every request body received, in order. */
+  requests: Array<{ model: string; messages: unknown[]; stream: boolean; tools?: unknown[] }>;
+  close(): Promise<void>;
+}
+
+const sse = (res: ServerResponse, payload: unknown) => res.write(`data: ${JSON.stringify(payload)}\n\n`);
+
+export function startFakeOpenAI(options: FakeOpenAIOptions = {}): Promise<FakeOpenAIServer> {
+  const mode = options.mode ?? (process.env.FAKE_OPENAI_MODE as FakeOpenAIOptions["mode"]) ?? "echo";
+  const delayMs = options.delayMs ?? Number(process.env.FAKE_OPENAI_DELAY_MS ?? "3000");
+  const toolName = options.toolName ?? process.env.FAKE_OPENAI_TOOL ?? "echo";
+  const requests: FakeOpenAIServer["requests"] = [];
+  let calls = 0;
+
+  const readBody = (req: IncomingMessage) =>
+    new Promise<string>((resolve) => {
+      let body = "";
+      req.on("data", (chunk) => (body += chunk));
+      req.on("end", () => resolve(body));
+    });
+
+  const server: Server = createServer(async (req, res) => {
+    if (req.method === "GET" && req.url?.endsWith("/models")) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ data: [{ id: "fake-model", name: "Fake model" }] }));
+      return;
+    }
+    if (req.method !== "POST" || !req.url?.endsWith("/chat/completions")) {
+      res.writeHead(404).end();
+      return;
+    }
+    const body = JSON.parse(await readBody(req)) as FakeOpenAIServer["requests"][number];
+    requests.push(body);
+    calls += 1;
+    const lastUser = [...(body.messages as Array<{ role: string; content: unknown }>)].reverse().find((m) => m.role === "user");
+    // pi-ai sends user content in array form; echo the text, not the JSON
+    const content = lastUser?.content;
+    const echoed = typeof content === "string"
+      ? content
+      : Array.isArray(content)
+        ? (content as Array<{ text?: string }>).map((part) => part.text ?? "").join("")
+        : "";
+
+    if (mode === "error") {
+      res.writeHead(503, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: { message: "simulated upstream failure" } }));
+      return;
+    }
+    res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+    const id = `chatcmpl-${calls}`;
+    const chunk = (delta: Record<string, unknown>, extra: Record<string, unknown> = {}) =>
+      sse(res, { id, object: "chat.completion.chunk", model: body.model, choices: [{ index: 0, delta, finish_reason: null, ...extra }] });
+    const finish = (finish_reason: "stop" | "tool_calls") =>
+      sse(res, {
+        id,
+        object: "chat.completion.chunk",
+        model: body.model,
+        choices: [{ index: 0, delta: {}, finish_reason }],
+        usage: { prompt_tokens: 12, completion_tokens: 5, prompt_tokens_details: { cached_tokens: 4 } },
+      });
+
+    const send = () => {
+      if (mode === "tool" && calls === 1) {
+        // one tool call, split the way real providers split it: id + name
+        // first, arguments as deltas after
+        chunk({ role: "assistant", tool_calls: [{ index: 0, id: "call_fake_1", type: "function", function: { name: toolName, arguments: "" } }] });
+        chunk({ tool_calls: [{ index: 0, function: { arguments: '{"text":' } }] });
+        chunk({ tool_calls: [{ index: 0, function: { arguments: '"from the fake"}' } }] });
+        finish("tool_calls");
+      } else {
+        if (mode === "reasoning") {
+          chunk({ role: "assistant", reasoning_content: "thinking about " });
+          chunk({ reasoning_content: "the answer" });
+        }
+        const text = `fake says: ${echoed}`;
+        chunk({ role: "assistant", content: text.slice(0, Math.ceil(text.length / 2)) });
+        chunk({ content: text.slice(Math.ceil(text.length / 2)) });
+        finish("stop");
+      }
+      res.write("data: [DONE]\n\n");
+      res.end();
+    };
+    if (mode === "slow") setTimeout(send, delayMs);
+    else send();
+  });
+
+  return new Promise((resolve) => {
+    server.listen(options.port ?? Number(process.env.FAKE_OPENAI_PORT ?? "0"), "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      resolve({
+        port,
+        url: `http://127.0.0.1:${port}/v1`,
+        requests,
+        close: () => new Promise((done) => server.close(() => done())),
+      });
+    });
+  });
+}
+
+// Run as a script: print the URL so a fixture launcher can pass it on.
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].split("/").pop() ?? "")) {
+  void startFakeOpenAI().then((s) => {
+    process.stdout.write(`${JSON.stringify({ ok: true, url: s.url, port: s.port })}\n`);
+  });
+}

--- a/src/components/ApiKeys.tsx
+++ b/src/components/ApiKeys.tsx
@@ -6,7 +6,7 @@ import { Check, CircleHelp, ExternalLink, Loader2, TriangleAlert } from "lucide-
 import { api, useStore, type ConfigStatus } from "@/state/store";
 import { cn } from "@/lib/cn";
 
-export type ConfigSection = "composio" | "box" | "opencodeGo";
+export type ConfigSection = "composio" | "box" | "opencodeGo" | "openaiCompat";
 
 const SECTIONS: Record<
   ConfigSection,
@@ -18,12 +18,14 @@ const SECTIONS: Record<
   },
   box: { body: (v) => ({ box: { token: v } }), flag: (c) => c.box.configured },
   opencodeGo: { body: (v) => ({ opencodeGo: { apiKey: v } }), flag: (c) => c.opencodeGo?.configured ?? false },
+  openaiCompat: { body: (v) => ({ openaiCompat: { key: v } }), flag: (c) => c.openaiCompat?.configured ?? false },
 };
 
-const ELECTRON_CREDENTIAL: Record<ConfigSection, "composioApiKey" | "boxToken" | "opencodeGoApiKey"> = {
+const ELECTRON_CREDENTIAL: Record<ConfigSection, "composioApiKey" | "boxToken" | "opencodeGoApiKey" | "openaiCompatApiKey"> = {
   composio: "composioApiKey",
   box: "boxToken",
   opencodeGo: "opencodeGoApiKey",
+  openaiCompat: "openaiCompatApiKey",
 };
 
 const CREDENTIALS: Record<
@@ -62,6 +64,15 @@ const CREDENTIALS: Record<
     href: "https://opencode.ai/docs/providers/",
     linkLabel: "Open the OpenCode provider guide",
     optional: true,
+  },
+  openaiCompat: {
+    label: "OpenAI-compatible API key",
+    placeholder: "sk-or-v1-… (OpenRouter), gsk_… (Groq), or leave empty for a local server",
+    description: "Used by the OpenAI-compatible engine and the preview OpenMaus Runtime. A local llama.cpp, vLLM, or LM Studio endpoint needs no key.",
+    href: "https://openrouter.ai/keys",
+    linkLabel: "Get an OpenRouter key",
+    optional: true,
+    warning: "This is a metered API key, not a Claude or Codex login. The provider bills for usage.",
   },
 };
 

--- a/src/components/EngineSetup.tsx
+++ b/src/components/EngineSetup.tsx
@@ -2,6 +2,7 @@
 // errors. The command has one inline copy action and one primary next step;
 // unusable model lists stay out of the way until the engine is ready.
 import { useState } from "react";
+import { authLabel, contextLabel } from "@/lib/context-label";
 import { Check, Copy, Download, ExternalLink, LogIn, TerminalSquare } from "lucide-react";
 import type { EngineInstall, InstanceInfo } from "@/state/store";
 import { cn } from "@/lib/cn";
@@ -160,6 +161,13 @@ export function EngineSetup({
         </p>
       )}
 
+      {instance.access === "custom" && (
+        <p className="mt-2 text-[11px] leading-relaxed text-ink-secondary/80">
+          {authLabel(instance)}
+          {contextLabel(instance.capabilities?.contextOwnership) ? ` · Context: ${contextLabel(instance.capabilities?.contextOwnership)}` : ""}
+          . This engine does not use a Claude or Codex login.
+        </p>
+      )}
       {!signInOnly && install.needsNode && (
         <p className="mt-2 text-[11px] leading-relaxed text-ink-secondary/70">
           Requires Node.js and <code className="font-mono">npm</code>.

--- a/src/components/EnginesSettings.tsx
+++ b/src/components/EnginesSettings.tsx
@@ -5,6 +5,7 @@
 // asks before registering — the classic miss is a path the terminal sees
 // but this GUI app can't.
 import { useEffect, useRef, useState } from "react";
+import { authLabel, contextLabel } from "@/lib/context-label";
 import { Check, ChevronDown, Loader2, RefreshCw, TriangleAlert } from "lucide-react";
 
 import { api, useStore, type InstanceInfo } from "@/state/store";
@@ -270,6 +271,14 @@ function EngineRow({ instance }: { instance: InstanceInfo }) {
             {instance.snapshot.version}
           </span>
         )}
+        {contextLabel(instance.capabilities?.contextOwnership) && (
+          <span className="shrink-0 text-[11px] text-ink-secondary" title="Who owns the model-facing context">
+            {contextLabel(instance.capabilities?.contextOwnership)}
+          </span>
+        )}
+        <span className="shrink-0 text-[11px] text-ink-secondary/80" title="How this engine authenticates and bills">
+          {authLabel(instance)}
+        </span>
         <span className="flex-1" />
         {instance.driverKind === "claudeAgent" && (
           <button

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -2,6 +2,7 @@
 // show a short suggested list with search and an explicit all-models view;
 // engines that need setup show one focused action instead of a disabled wall.
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { authLabel, contextLabel } from "@/lib/context-label";
 import { Check, ChevronDown, ChevronLeft, ChevronRight, Loader2, RefreshCw, Search } from "lucide-react";
 import { useStore, type Bot, type InstanceInfo, type ModelSelection } from "@/state/store";
 import { filterCustomModels, partitionCustomModels, suggestedModels } from "@/lib/custom-models";
@@ -26,7 +27,10 @@ function modelProvider(instance: InstanceInfo | undefined, model: string): strin
 function engineStatus(instance: InstanceInfo): string {
   if (needsCli(instance)) return "Not installed";
   if (needsSignIn(instance)) return "Sign-in required";
-  return instance.snapshot.version ?? "Ready";
+  // the two labels stay separate: who owns the context is not how it is
+  // paid for, and the preview engine is the case where they differ
+  const context = contextLabel(instance.capabilities?.contextOwnership);
+  return [instance.snapshot.version ?? "Ready", context && `Context: ${context}`, authLabel(instance)].filter(Boolean).join(" · ");
 }
 
 function ModelRow({

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -9,6 +9,7 @@ import { analyticsEnabled, setAnalyticsEnabled } from "@/lib/analytics";
 import { builtInBrowserEnabled, showToolCallsEnabled, skillRecorderEnabled } from "@/lib/feature-flags";
 import { localeChoices } from "@/locales";
 import { ApiKeyRow, VpsConnection } from "./ApiKeys";
+import { OWNED_RUNTIME_DISCLOSURE } from "@/lib/context-label";
 import { useUpdaterState } from "@/lib/updater";
 import { EnginesSettings } from "./EnginesSettings";
 import { LocalComputerSection } from "./LocalComputerSection";
@@ -244,10 +245,10 @@ function ExperimentalFeaturesRow() {
   const browser = builtInBrowserEnabled(state.config);
   const desktopBrowser = Boolean(window.ogb?.browser);
   const browserBlockedOnWindows = window.ogb?.platform === "win32" && !desktopBrowser;
-  const [saving, setSaving] = useState<"skillRecorder" | "browser" | null>(null);
+  const [saving, setSaving] = useState<"skillRecorder" | "browser" | "ownedRuntime" | null>(null);
   const [error, setError] = useState("");
 
-  const toggle = async (feature: "skillRecorder" | "browser", next: boolean) => {
+  const toggle = async (feature: "skillRecorder" | "browser" | "ownedRuntime", next: boolean) => {
     if (saving) return;
     setSaving(feature);
     setError("");
@@ -302,6 +303,22 @@ function ExperimentalFeaturesRow() {
           aria-label="Enable the built-in browser"
           disabled={saving !== null || (!browser && !desktopBrowser)}
           onClick={() => void toggle("browser", !browser)}
+          className="disabled:cursor-wait disabled:opacity-50"
+        />
+      </div>
+      <div className="mt-4 flex items-center justify-between gap-4 border-t border-hairline/30 pt-4">
+        <div className="min-w-0">
+          <div className="text-[14px] font-medium text-ink">OpenMaus Runtime (preview)</div>
+          <div className="mt-0.5 text-[12px] leading-relaxed text-ink-secondary">{OWNED_RUNTIME_DISCLOSURE}</div>
+          <div className="mt-1 text-[11px] text-ink-secondary/80">
+            Context: OpenMaus managed · Auth: API key, billed by the provider. Existing bots are never moved; pick it per bot in the model menu.
+          </div>
+        </div>
+        <Switch
+          checked={Boolean(state.config?.features?.ownedRuntime)}
+          aria-label="Enable OpenMaus Runtime preview"
+          disabled={saving !== null}
+          onClick={() => void toggle("ownedRuntime", !state.config?.features?.ownedRuntime)}
           className="disabled:cursor-wait disabled:opacity-50"
         />
       </div>
@@ -681,6 +698,7 @@ export function SettingsModal() {
                   <ApiKeyRow section="box" />
                   <VpsConnection />
                   <ApiKeyRow section="opencodeGo" />
+                  <ApiKeyRow section="openaiCompat" />
                   <details className="rounded-lg border border-hairline/40 bg-inset px-3 py-2">
                     <summary className="cursor-pointer text-[13px] text-ink-secondary">Self-host connected apps</summary>
                     <div className="mt-3">

--- a/src/lib/context-label.test.ts
+++ b/src/lib/context-label.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { OWNED_RUNTIME_DISCLOSURE, authLabel, contextLabel } from "./context-label";
+
+describe("contextLabel", () => {
+  it("names each ownership mode in words a person can read", () => {
+    expect(contextLabel("vendor-session")).toBe("Vendor session");
+    expect(contextLabel("omb-replay")).toBe("OpenMaus replay");
+    expect(contextLabel("omb-loop")).toBe("OpenMaus managed");
+  });
+
+  it("says nothing for an engine that has not declared one", () => {
+    expect(contextLabel(undefined)).toBeUndefined();
+  });
+});
+
+describe("authLabel", () => {
+  it("labels a metered or custom engine as key-based and provider-billed", () => {
+    expect(authLabel({ access: "custom", snapshot: { state: "available", billing: "metered" } })).toBe("API key · billed by the provider");
+    expect(authLabel({ access: "custom", snapshot: { state: "unavailable" } })).toBe("API key · billed by the provider");
+  });
+
+  it("labels a subscription engine as a sign-in", () => {
+    expect(authLabel({ access: "subscription", snapshot: { state: "available", billing: "subscription" } })).toBe("Subscription sign-in");
+  });
+
+  it("keeps ownership and billing as separate questions", () => {
+    expect(contextLabel("omb-loop")).not.toMatch(/subscription|claude|codex/i);
+    expect(authLabel({ access: "custom", snapshot: { state: "available", billing: "metered" } })).not.toMatch(/subscription/i);
+  });
+});
+
+describe("OWNED_RUNTIME_DISCLOSURE", () => {
+  it("states the two things a user must know before enabling it", () => {
+    expect(OWNED_RUNTIME_DISCLOSURE).toMatch(/does not use a Claude or Codex login/);
+    expect(OWNED_RUNTIME_DISCLOSURE).toMatch(/billed by that provider/);
+  });
+});

--- a/src/lib/context-label.ts
+++ b/src/lib/context-label.ts
@@ -1,0 +1,37 @@
+// Two labels every engine surface shows side by side, on purpose kept
+// separate: WHO OWNS THE CONTEXT is not the same question as HOW IT IS PAID
+// FOR, and conflating them is how a user comes to believe the preview
+// engine reuses their Claude subscription. It does not.
+import type { InstanceInfo } from "@/state/store";
+
+export type ContextOwnership = NonNullable<NonNullable<InstanceInfo["capabilities"]>["contextOwnership"]>;
+
+/** "Vendor session" — the installed CLI keeps the live session; "OpenMaus
+ * replay" — OpenMausBot sends bounded history each turn; "OpenMaus managed"
+ * — OpenMausBot runs the whole loop. */
+export function contextLabel(ownership: ContextOwnership | undefined): string | undefined {
+  switch (ownership) {
+    case "vendor-session":
+      return "Vendor session";
+    case "omb-replay":
+      return "OpenMaus replay";
+    case "omb-loop":
+      return "OpenMaus managed";
+    default:
+      return undefined;
+  }
+}
+
+/** Authentication and billing in one short phrase. A subscription engine
+ * signs in through its own CLI; a metered one uses an API key and the
+ * provider bills for usage. */
+export function authLabel(instance: Pick<InstanceInfo, "access" | "snapshot">): string {
+  if (instance.snapshot.billing === "metered" || instance.access === "custom") return "API key · billed by the provider";
+  return "Subscription sign-in";
+}
+
+/** The sentence the preview engine must always carry. Written once, here,
+ * so the settings toggle, the engine row, and the setup card cannot drift
+ * into three different promises. */
+export const OWNED_RUNTIME_DISCLOSURE =
+  "Runs the model and tool loop inside OpenMausBot against an OpenAI-compatible endpoint using your own API key, or a local server that needs none. It does not use a Claude or Codex login, and usage is billed by that provider.";

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -370,6 +370,9 @@ export interface ConfigStatus {
   rooms: { turnTimeoutMinutes: number };
   localVm: { mode: "shared" | "per-bot"; maxInstances: number };
   opencodeGo?: { configured: boolean };
+  /** One key shared by the openai-compat engine and the preview OpenMaus
+   * Runtime; `configured` only — the key never reaches the renderer. */
+  openaiCompat?: { configured: boolean };
   /** Voice (ElevenLabs). `configured` = a key is saved; `ready` = a key AND
    * a voice, which is what it takes to actually speak. The key itself is
    * never echoed back. */
@@ -381,7 +384,7 @@ export interface ConfigStatus {
   /** UI language override; "" (or absent) follows the system language. */
   language?: string;
   /** Opt-in flags. Absent means off. */
-  features?: { skillRecorder: boolean; showToolCalls?: boolean; browser?: boolean };
+  features?: { skillRecorder: boolean; showToolCalls?: boolean; browser?: boolean; ownedRuntime?: boolean };
   /** Named browser sessions any bot can be pointed at. */
   browserProfiles?: BrowserProfile[];
 }
@@ -396,7 +399,7 @@ export interface BrowserProfile {
 
 export type ConfigStatusFrame = Pick<
   ConfigStatus,
-  "xai" | "composio" | "box" | "vps" | "rooms" | "localVm" | "opencodeGo" | "tts" | "imageGen" | "profile" | "language" | "features" | "browserProfiles"
+  "xai" | "composio" | "box" | "vps" | "rooms" | "localVm" | "opencodeGo" | "openaiCompat" | "tts" | "imageGen" | "profile" | "language" | "features" | "browserProfiles"
 >;
 
 export function configStatusFromFrame(frame: ConfigStatusFrame): ConfigStatus {
@@ -408,6 +411,7 @@ export function configStatusFromFrame(frame: ConfigStatusFrame): ConfigStatus {
     rooms: frame.rooms,
     localVm: frame.localVm,
     opencodeGo: frame.opencodeGo,
+    openaiCompat: frame.openaiCompat,
     tts: frame.tts,
     imageGen: frame.imageGen,
     profile: frame.profile,
@@ -454,6 +458,8 @@ export interface InstanceInfo {
     /** This engine can answer a bounded review prompt without changing the
      * bot's active conversation. */
     approvalReview?: boolean;
+    /** who owns the model-facing context; see src/lib/context-label.ts */
+    contextOwnership?: "vendor-session" | "omb-replay" | "omb-loop";
   };
   /** `custom` agents sit below the rail divider — no subscription catalog. */
   access?: "subscription" | "custom";

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -270,7 +270,7 @@ type SkillRecordingPayload = {
       saveFile?(filePath: string): Promise<string | null>;
       /** Save a provider credential through Electron's OS-backed store. */
       setCredential?(
-        name: "composioApiKey" | "xaiApiKey" | "boxToken" | "opencodeGoApiKey" | "ttsKey" | "openaiImageApiKey",
+        name: "composioApiKey" | "xaiApiKey" | "boxToken" | "opencodeGoApiKey" | "ttsKey" | "openaiImageApiKey" | "openaiCompatApiKey",
         value: string,
       ): Promise<ConfigStatus>;
       /** In-app auto-update (packaged app only; dormant in dev). onState


### PR DESCRIPTION
**Stacked on #760, which is stacked on #759.** Merge those first; the base retargets automatically.

Tasks 8–11 of [the hybrid context runtime plan](docs/superpowers/plans/2026-09-03-hybrid-context-runtime.md): an engine where OpenMausBot runs the whole model/tool loop in-process against any OpenAI-compatible endpoint. The third context-ownership mode, `omb-loop`, is now real.

**Off by default.** `features.ownedRuntime` under Settings → Experimental. Off means absent from the fleet; a bot that chose it sees an unavailable engine and keeps every transcript. Nothing migrates an existing bot.

**Not a subscription login.** Authentication is an API key — the same `openaiCompat.key` the OpenAI-compatible engine uses — or a local server that needs none. Usage is billed by that provider. The disclosure is written once (`OWNED_RUNTIME_DISCLOSURE`) and rendered by the settings toggle, engine row, model menu, and setup card, so the surfaces cannot drift into different promises.

## What's in it

| | |
|---|---|
| `server/runtime/contracts.ts` | The internal seam. Nothing here names a Pi type. |
| `server/runtime/pi-runtime.ts` | The **only** production file importing `pi-*`. Rebuilds the model's view from the canonical `TurnContextPlan` at every turn; nothing survives a turn. The API key rides explicitly on every request with an empty provider env. |
| `server/runtime/mcp-tools.ts` | The user's `config.json` MCP servers, mounted over the official stdio transport, namespaced `server__tool`. |
| `server/runtime/approval-gate.ts` | Every tool call asks. Every way an answer can fail to arrive is a **deny** — silence is never an allow. |
| `server/runtime/loop-guard.ts` | Advisory at 3 identical calls in 6; stop at 5. Plus 32 model calls / 64 tool calls / 180 s per tool. |
| `server/drivers/openmaus-runtime.ts` | Reuses openai-compat's config and key contract byte for byte. Advertises `customMcp` only — every other integration waits for its own proof. |
| `server/drivers/local-endpoint.ts` | No key allowed only for loopback/private-network hosts. A remote URL with no key is unavailable and says why. |

## Dependencies and bundle

`@earendil-works/pi-agent-core@0.85.0`, `@earendil-works/pi-ai@0.85.0`, `@modelcontextprotocol/sdk@1.30.0` — all MIT, pinned exact.

`scripts/bundle-server.mjs` inlines everything, so this is real installer weight: **2,199,143 → 3,600,771 bytes (+1.40 MB, +64%)**. Importing `pi-ai/compat` — the obvious entry point — measured **6,442,198** because it re-exports every provider; the runtime imports the one provider subpath it speaks. A future `/compat` import in `pi-runtime.ts` is a 3 MB regression.

## Three things the packaged smoke caught that nothing else would have

- **`cross-spawn` broke the packaged boot.** The MCP SDK's stdio transport pulls in `cross-spawn`, which calls `require("child_process")` at load time; esbuild's ESM output has no `require`. Vitest and Electron dev — both unbundled — were green. Fixed with a `createRequire` banner on both server builds; `child_process` is a builtin, so the packaged server stays self-contained.
- **The SDK silently drops a malformed `tools/list` reply.** Only the 20 s startup timeout returns the turn, so that constant is load-bearing.
- **Silence-is-deny broke exactly the right tests.** Wiring the gate made every Task 8 tool-call test time out — they assumed a tool runs unprompted. The tests changed; the runtime did not.

## Verification

`vitest 3375 · broker 7 · electron 90/90 · packaged-server smoke · 0 lint errors` on Node 24.14.1.

Driven through the control surface (`docs/verification/context-runtime.md`): `OMB_VERIFY_OWNED=1` launches a loopback fake provider it owns; `set-model` moves a bot onto the preview; its tool call reaches the gate → `request.opened` → an **Approval needed** card → `needs-user`; `interrupt` drains the ask as a system deny; a second turn carries history from the plan with no live state. The seeded canary key appears nowhere in the event log. The doc is precise about which scenarios the fixture proves and which the tests do — the control surface deliberately has no `approve` command, so `needs-user` is the fixture's proof that a call asked and blocked.

## Deliberately not done

`agentsMcp`, `computerMcp`, `composioMcp`, `phoneMcp`, `browserMcp` stay unadvertised until each has its own proof. `registry.describe()` still does not project `customMcp` or `billing` to `omb models` — pre-existing projections, small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)