### PR TITLE
fix(companion): add Windows Tailscale CLI paths and use path.delimiter in searchPath

### DIFF
--- a/companion/src/listener.ts
+++ b/companion/src/listener.ts
@@ -11,7 +11,7 @@
 // nobody runs is a thing that rots. index.ts owns the listeners now.
 import { execFile } from "node:child_process";
 import { homedir, networkInterfaces } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 
 /** Interfaces that exist to tunnel, bridge or mesh traffic — utun (Tailscale
  * and every other VPN), vmnet/bridge (VMs, containers, internet sharing),
@@ -100,6 +100,8 @@ export function tailscaleCandidates(home = homedir()): string[] {
     "/usr/local/bin/tailscale",
     "/usr/bin/tailscale",
     "/run/current-system/sw/bin/tailscale",
+    "C:\\Program Files\\Tailscale\\tailscale.exe",
+    "C:\\Program Files (x86)\\Tailscale\\tailscale.exe",
     "tailscale",
   ];
 }
@@ -109,10 +111,10 @@ const TAILSCALE_BUDGET_MS = 5000;
 
 /** PATH with the usual package-manager locations added back, for the bare
  * `tailscale` attempt. Costs nothing when PATH was already complete. */
-const searchPath = (): string =>
+export const searchPath = (): string =>
   [process.env.PATH ?? "", "/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"]
     .filter(Boolean)
-    .join(":");
+    .join(delimiter);
 
 /** Ask the Tailscale CLI where it thinks we are.
  *

--- a/companion/test/listener.test.ts
+++ b/companion/test/listener.test.ts
@@ -1,4 +1,4 @@
-import { delimiter } from "node:path";
+import { delimiter, join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { searchPath, tailscaleCandidates } from "../src/listener.ts";
@@ -10,14 +10,19 @@ describe("tailscaleCandidates", () => {
     expect(candidates).toContain("C:\\Program Files (x86)\\Tailscale\\tailscale.exe");
   });
 
-  it("keeps the macOS, Linux and bare-PATH lookups in order", () => {
-    const candidates = tailscaleCandidates("/home/test");
-    expect(candidates).toContain("/Applications/Tailscale.app/Contents/MacOS/Tailscale");
-    expect(candidates).toContain("/opt/homebrew/bin/tailscale");
-    expect(candidates).toContain("/usr/local/bin/tailscale");
-    expect(candidates).toContain("/usr/bin/tailscale");
-    expect(candidates).toContain("/run/current-system/sw/bin/tailscale");
-    expect(candidates[candidates.length - 1]).toBe("tailscale");
+  it("keeps the absolute candidates in documented lookup order with bare PATH last", () => {
+    const home = "/home/test";
+    expect(tailscaleCandidates(home)).toEqual([
+      "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+      join(home, "Applications", "Tailscale.app", "Contents", "MacOS", "Tailscale"),
+      "/opt/homebrew/bin/tailscale",
+      "/usr/local/bin/tailscale",
+      "/usr/bin/tailscale",
+      "/run/current-system/sw/bin/tailscale",
+      "C:\\Program Files\\Tailscale\\tailscale.exe",
+      "C:\\Program Files (x86)\\Tailscale\\tailscale.exe",
+      "tailscale",
+    ]);
   });
 });
 
@@ -33,7 +38,11 @@ describe("searchPath", () => {
       // The join character is the real check: ':' on POSIX, ';' on Windows.
       expect(result).toContain(delimiter);
     } finally {
-      process.env.PATH = before;
+      if (before === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = before;
+      }
     }
   });
 });

--- a/companion/test/listener.test.ts
+++ b/companion/test/listener.test.ts
@@ -1,0 +1,39 @@
+import { delimiter } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { searchPath, tailscaleCandidates } from "../src/listener.ts";
+
+describe("tailscaleCandidates", () => {
+  it("includes the standard Windows install locations", () => {
+    const candidates = tailscaleCandidates("/home/test");
+    expect(candidates).toContain("C:\\Program Files\\Tailscale\\tailscale.exe");
+    expect(candidates).toContain("C:\\Program Files (x86)\\Tailscale\\tailscale.exe");
+  });
+
+  it("keeps the macOS, Linux and bare-PATH lookups in order", () => {
+    const candidates = tailscaleCandidates("/home/test");
+    expect(candidates).toContain("/Applications/Tailscale.app/Contents/MacOS/Tailscale");
+    expect(candidates).toContain("/opt/homebrew/bin/tailscale");
+    expect(candidates).toContain("/usr/local/bin/tailscale");
+    expect(candidates).toContain("/usr/bin/tailscale");
+    expect(candidates).toContain("/run/current-system/sw/bin/tailscale");
+    expect(candidates[candidates.length - 1]).toBe("tailscale");
+  });
+});
+
+describe("searchPath", () => {
+  it("joins PATH with fallback directories using the platform delimiter", () => {
+    const before = process.env.PATH;
+    process.env.PATH = "/my/bin";
+    try {
+      const result = searchPath();
+      expect(result).toBe(
+        ["/my/bin", "/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"].join(delimiter),
+      );
+      // The join character is the real check: ':' on POSIX, ';' on Windows.
+      expect(result).toContain(delimiter);
+    } finally {
+      process.env.PATH = before;
+    }
+  });
+});


### PR DESCRIPTION
<!--
Please read CONTRIBUTING.md first — it's short. One concern per PR;
big changes should have an issue agreeing on the approach before code.
-->

## What changed

- `companion/src/listener.ts` now imports `delimiter` from `node:path` and uses it in `searchPath()` instead of the literal `":"`.
- `tailscaleCandidates()` now lists the two standard Windows install locations before the bare `tailscale` PATH lookup:
  - `C:\Program Files\Tailscale\tailscale.exe`
  - `C:\Program Files (x86)\Tailscale\tailscale.exe`
- Added a focused regression test in `companion/test/listener.test.ts` that proves the Windows candidates are present and that `searchPath()` joins with the platform path delimiter.

## Why

Fixes #755.

On Windows, `PATH` is semicolon-delimited. Joining with a literal colon welded the user's final `PATH` entry to the fallback `/opt/homebrew/bin`, producing a non-existent path and making the bare `tailscale` lookup fail. At the same time, no Windows absolute candidate existed, so there was no other path to try. The result is that Tailscale pairing silently fails on Windows depending on where `tailscale` appears in `PATH`.

## How it was verified

- `pnpm typecheck` passes (no output = clean).
- `pnpm exec vitest run companion/test/listener.test.ts` passes on Node v24.19.0.
- `pnpm exec vitest run companion/test/mdns.test.ts` still passes, confirming the existing listener imports are unaffected.
- `pnpm lint` reports 37 pre-existing warnings and 0 errors; none are in the changed files.

`companion/test/listener.test.ts` results:

```
 RUN  v4.1.10 /mnt/data/open-source/repos/OpenMausBot

 ✓ companion/test/listener.test.ts (3 tests) 10ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Duration  7.05s
```

## Screenshots (UI changes)

None — this is a companion-side CLI discovery change with no renderer surface.

## Checklist

- [x] `pnpm typecheck` and the focused `vitest run` test suite pass locally
- [x] Server/companion behavior change comes with tests (`companion/test/listener.test.ts`)
- [x] No `dist-server/` edits
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Tailscale command discovery on Windows.
  - Corrected PATH handling across platforms, including Windows, macOS, and Linux.
  - Preserved the expected order when searching for Tailscale installations.
  - Improved reliability when locating Tailscale through common installation paths.

- **Tests**
  - Added coverage for platform-specific command discovery and PATH behavior.
  - Verified candidate search order and handling when PATH is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->