### PR TITLE
feat(codex): guide users to GPT-6 Astra

### DIFF
--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -304,6 +304,13 @@ export interface ProviderSnapshot {
   reason?: string;
   authenticated?: boolean;
   version?: string | null;
+  /** A non-blocking provider update that unlocks newer capabilities. The
+   * engine remains usable; renderer surfaces the exact terminal command. */
+  update?: {
+    title: string;
+    message: string;
+    command: string;
+  };
   /** How this instance is paid for, when the driver can tell: a reported
    * cost on a subscription is notional and the UI labels it as such. */
   billing?: "metered" | "subscription";

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -14,7 +14,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ProviderInstance } from "../contracts.ts";
 import { NATIVE_DIR } from "../config.ts";
 import { recordEvents, type EventRecorder } from "../testing/events.ts";
-import { CodexDriver } from "./codex.ts";
+import { CodexDriver, codexPredatesAstra, codexUpdateCommand } from "./codex.ts";
 import { removeTempDir } from "../testing/cleanup.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-codex-app-server.ts");
@@ -60,6 +60,8 @@ describe("CodexDriver turns (fake app-server)", () => {
     delete process.env.FAKE_CODEX_PARTIAL_FAILS;
     delete process.env.FAKE_CODEX_STATE;
     delete process.env.FAKE_CODEX_RETRY_SCALE;
+    delete process.env.FAKE_CODEX_VERSION;
+    delete process.env.FAKE_CODEX_ASTRA;
     delete process.env.OPENAI_API_KEY;
     delete process.env.BOX_TOKEN;
     delete process.env.OMB_TTS_KEY;
@@ -548,6 +550,62 @@ describe("CodexDriver turns (fake app-server)", () => {
       state: "available",
       authenticated: true,
     });
+  });
+
+  it("offers the exact Astra update command without blocking older Codex models", async () => {
+    process.env.FAKE_CODEX_VERSION = "codex-cli 0.152.1";
+    await create();
+
+    await expect(instance.snapshot()).resolves.toMatchObject({
+      state: "available",
+      update: {
+        title: "Update Codex for GPT-6 Astra",
+        command: codexUpdateCommand(FAKE_CLI),
+      },
+    });
+  });
+
+  it("does not show an Astra update prompt for a supported Codex version", async () => {
+    process.env.FAKE_CODEX_VERSION = "codex-cli 0.153.1";
+    await create();
+
+    expect((await instance.snapshot()).update).toBeUndefined();
+  });
+
+  it("trusts a live Astra catalog even when the bundled CLI version predates the documented release", async () => {
+    process.env.FAKE_CODEX_VERSION = "codex-cli 0.153.0";
+    process.env.FAKE_CODEX_ASTRA = "1";
+    await create();
+
+    expect(instance.models.options.map((model) => model.id)).toContain("gpt-6-astra");
+    expect((await instance.snapshot()).update).toBeUndefined();
+  });
+
+  it("compares Codex versions conservatively", () => {
+    expect(codexPredatesAstra("codex-cli 0.152.1")).toBe(true);
+    expect(codexPredatesAstra("codex-cli 0.153.0")).toBe(true);
+    expect(codexPredatesAstra("codex-cli 0.153.1")).toBe(false);
+    expect(codexPredatesAstra("codex-cli 1.0.0-beta.1")).toBe(false);
+    expect(codexPredatesAstra("wrapper 0.1.0 using codex-cli 0.153.3")).toBe(false);
+    expect(codexPredatesAstra("wrapper 1.0.0 using codex-cli 0.151.0")).toBe(true);
+    expect(codexPredatesAstra("codex-cli 0.152.1.4")).toBe(false);
+    expect(codexPredatesAstra("custom nightly")).toBe(false);
+  });
+
+  it("updates the selected Codex executable instead of installing a second copy", () => {
+    expect(codexUpdateCommand("codex", "darwin")).toBe("codex update");
+    expect(codexUpdateCommand("'/Applications/My Codex/codex'", "darwin")).toBe(
+      "'/Applications/My Codex/codex' update",
+    );
+    expect(codexUpdateCommand("'C:\\Program Files\\Codex\\codex.exe'", "win32")).toBe(
+      "& 'C:\\Program Files\\Codex\\codex.exe' update",
+    );
+    expect(codexUpdateCommand("/usr/local/bin/ag codex", "darwin")).toBe(
+      "'/usr/local/bin/ag' 'codex' update",
+    );
+    expect(codexUpdateCommand("'C:\\Program Files\\ag.exe' codex", "win32")).toBe(
+      "& 'C:\\Program Files\\ag.exe' 'codex' update",
+    );
   });
 
   it("marks a Codex 401 as setup so the UI offers sign-in instead of Retry", async () => {

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -9,6 +9,7 @@
 //
 // resumeCursor is the codex thread id; a later turn tries thread/resume
 // and falls back to a fresh thread/start.
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 
 import { stripWorkspaceCredentialEnv } from "../config.ts";
@@ -28,13 +29,67 @@ import type {
 import { newEventId, newId } from "../contracts.ts";
 import { decodeCodexSelection, readCodexModelCatalog, STATIC_CODEX_MODELS } from "./codex-catalog.ts";
 import { codexLocalProviderArgs } from "./local-inject.ts";
-import { augmentedPath } from "../env-path.ts";
+import { augmentedPath, splitCliString } from "../env-path.ts";
 import { classifyError, computeBackoff, RETRY_MAX_ATTEMPTS } from "./retry.ts";
 import { appendNative } from "./native.ts";
 
 export { decodeCodexSelection, readCodexModelCatalog, STATIC_CODEX_MODELS } from "./codex-catalog.ts";
 
 const DRIVER_KIND = "codex";
+const ASTRA_MODEL_ID = "gpt-6-astra";
+const ASTRA_MIN_CODEX_VERSION = [0, 153, 1] as const;
+
+/** Whether an installed Codex predates the release that exposes GPT-6 Astra
+ * through app-server. Unknown version formats stay quiet: a bad guess should
+ * never nag someone whose custom build may already support the model. */
+export function codexPredatesAstra(version: string): boolean {
+  const value = version.trim();
+  const match = /\bcodex-cli\s+v?(\d+)\.(\d+)\.(\d+)(?:[-+][0-9a-z.-]+)?(?![\d.])\b/i.exec(value)
+    ?? /^v?(\d+)\.(\d+)\.(\d+)(?:[-+][0-9a-z.-]+)?$/i.exec(value);
+  if (!match) return false;
+  const installed = match.slice(1, 4).map(Number);
+  for (let i = 0; i < ASTRA_MIN_CODEX_VERSION.length; i += 1) {
+    if (installed[i] !== ASTRA_MIN_CODEX_VERSION[i]) {
+      return installed[i] < ASTRA_MIN_CODEX_VERSION[i];
+    }
+  }
+  return false;
+}
+
+/** Ask the configured executable to update itself. This matters when the user
+ * selected a non-PATH Codex: installing a second global copy would leave
+ * OpenMausBot pointing at the old binary. */
+export function codexUpdateCommand(cli: string, platform: NodeJS.Platform = process.platform): string {
+  if (cli === "codex") return "codex update";
+  const trimmed = cli.trim();
+  // Match resolveCliSpawn's one tokenizer pass, including its exception for
+  // real unquoted paths containing spaces. A wrapper's fixed arguments must
+  // precede `update`, just as they precede `app-server` and `--version`.
+  const tokens = trimmed.includes(" ") && existsSync(trimmed)
+    ? [trimmed]
+    : splitCliString(trimmed);
+  const quote = platform === "win32"
+    ? (token: string) => `'${token.replaceAll("'", "''")}'`
+    : (token: string) => `'${token.replaceAll("'", `'\\''`)}'`;
+  const command = (tokens.length > 0 ? tokens : [trimmed]).map(quote).join(" ");
+  return platform === "win32" ? `& ${command} update` : `${command} update`;
+}
+
+function codexAstraUpdate(
+  version: string,
+  models: typeof STATIC_CODEX_MODELS,
+  cli: string,
+): ProviderSnapshot["update"] | undefined {
+  if (models.options.some((model) => model.id === ASTRA_MODEL_ID) || !codexPredatesAstra(version)) {
+    return undefined;
+  }
+  return {
+    title: "Update Codex for GPT-6 Astra",
+    message:
+      "This Codex version predates Astra support. Update it, then refresh models. Astra must also be available to your signed-in ChatGPT account.",
+    command: codexUpdateCommand(cli),
+  };
+}
 
 export interface CodexConfig {
   cli: string;
@@ -684,7 +739,13 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       );
     });
     // childEnv drops OPENAI_API_KEY on purpose — turns run on the ChatGPT login
-    return { state: "available", version, authenticated, billing: "subscription" };
+    return {
+      state: "available",
+      version,
+      authenticated,
+      update: codexAstraUpdate(version, models, config.cli),
+      billing: "subscription",
+    };
   };
 
   return {

--- a/server/testing/fake-codex-app-server.ts
+++ b/server/testing/fake-codex-app-server.ts
@@ -14,7 +14,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 const mode = process.env.FAKE_CODEX_MODE ?? "happy";
 
 if (process.argv[2] === "--version") {
-  process.stdout.write("codex-cli 0.147.0\n");
+  process.stdout.write(`${process.env.FAKE_CODEX_VERSION ?? "codex-cli 0.147.0"}\n`);
   process.exit(0);
 }
 if (process.argv[2] === "login" && process.argv[3] === "status") {
@@ -111,12 +111,16 @@ process.stdin.on("data", (chunk) => {
             },
           });
         } else {
+          const hasAstra = process.env.FAKE_CODEX_ASTRA === "1";
           out({
             jsonrpc: "2.0",
             id: msg.id,
             result: {
               data: [
-                { id: "gpt-fake-default", displayName: "GPT Fake Default", hidden: false, isDefault: true },
+                ...(hasAstra
+                  ? [{ id: "gpt-6-astra", displayName: "GPT-6 Astra", hidden: false, isDefault: true }]
+                  : []),
+                { id: "gpt-fake-default", displayName: "GPT Fake Default", hidden: false, isDefault: !hasAstra },
               ],
               nextCursor: "page-2",
             },

--- a/src/components/EngineSetup.tsx
+++ b/src/components/EngineSetup.tsx
@@ -2,7 +2,7 @@
 // errors. The command has one inline copy action and one primary next step;
 // unusable model lists stay out of the way until the engine is ready.
 import { useEffect, useState } from "react";
-import { Check, Copy, Download, ExternalLink, Loader2, LogIn, TerminalSquare } from "lucide-react";
+import { AlertTriangle, Check, Copy, Download, ExternalLink, Loader2, LogIn, TerminalSquare } from "lucide-react";
 import { api, type EngineInstall, type InstanceInfo, useStore } from "@/state/store";
 import { cn } from "@/lib/cn";
 
@@ -34,9 +34,17 @@ export function needsCli(instance: InstanceInfo | undefined): boolean {
   return instance?.snapshot.state !== "available";
 }
 
-function CommandRow({ command, actionLabel }: { command: string; actionLabel: string }) {
+export function CommandRow({
+  command,
+  actionLabel,
+  compact = false,
+}: {
+  command: string;
+  actionLabel: string;
+  compact?: boolean;
+}) {
   const [status, setStatus] = useState<"copied" | "opened" | null>(null);
-  const canOpen = Boolean(window.ogb?.openInstallTerminal);
+  const canOpen = typeof window !== "undefined" && Boolean(window.ogb?.openInstallTerminal);
 
   const settle = (next: "copied" | "opened") => {
     setStatus(next);
@@ -56,6 +64,41 @@ function CommandRow({ command, actionLabel }: { command: string; actionLabel: st
     const opened = await window.ogb!.openInstallTerminal!(command);
     settle(opened ? "opened" : "copied");
   };
+
+  if (compact) {
+    return (
+      <div className="mt-2 flex min-w-0 items-center gap-1.5 rounded-lg border border-hairline/50 bg-app px-2 py-1.5">
+        <code className="min-w-0 flex-1 truncate font-mono text-[11px] text-ink-secondary" title={command}>
+          {command}
+        </code>
+        <button
+          type="button"
+          onClick={() => void copy()}
+          aria-label="Copy command"
+          title="Copy command"
+          className="flex shrink-0 items-center gap-1 rounded-md px-1.5 py-1 text-[11px] font-medium text-ink-secondary hover:bg-control hover:text-ink"
+        >
+          {status === "copied" ? <Check size={12} className="text-success" /> : <Copy size={12} />}
+          {status === "copied" ? "Copied" : "Copy"}
+        </button>
+        {canOpen && (
+          <button
+            type="button"
+            onClick={() => void openTerminal()}
+            aria-label={actionLabel}
+            title={actionLabel}
+            className="flex shrink-0 items-center gap-1 rounded-md bg-accent px-2 py-1 text-[11px] font-semibold text-white hover:brightness-110"
+          >
+            {status === "opened" ? <Check size={12} /> : <TerminalSquare size={12} />}
+            {status === "opened" ? "Opened" : "Terminal"}
+          </button>
+        )}
+        <span aria-live="polite" className="sr-only">
+          {status === "opened" ? "Terminal opened. Paste the command and press Enter." : ""}
+        </span>
+      </div>
+    );
+  }
 
   return (
     <div className="mt-3">
@@ -101,6 +144,30 @@ function CommandRow({ command, actionLabel }: { command: string; actionLabel: st
           {status === "copied" ? "Command copied" : "Copy command"}
         </button>
       )}
+    </div>
+  );
+}
+
+export function EngineUpdateNotice({
+  update,
+  className,
+}: {
+  update: NonNullable<InstanceInfo["snapshot"]["update"]>;
+  className?: string;
+}) {
+  return (
+    <div
+      data-engine-update-notice
+      className={cn("rounded-xl border border-warning/25 bg-warning/5 p-2.5", className)}
+    >
+      <div className="flex items-start gap-2">
+        <AlertTriangle size={14} className="mt-0.5 shrink-0 text-warning" aria-hidden="true" />
+        <div className="min-w-0">
+          <div className="text-[12.5px] font-semibold text-ink">{update.title}</div>
+          <p className="mt-0.5 text-[11.5px] leading-relaxed text-ink-secondary">{update.message}</p>
+        </div>
+      </div>
+      <CommandRow command={update.command} actionLabel="Open update in Terminal" compact />
     </div>
   );
 }

--- a/src/components/EngineUpdateNotice.test.ts
+++ b/src/components/EngineUpdateNotice.test.ts
@@ -1,0 +1,33 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { EngineUpdateNotice } from "./EngineSetup";
+
+const update = {
+  title: "Update Codex for GPT-6 Astra",
+  message: "This Codex version predates Astra support. Update it, then refresh models.",
+  command: "codex update",
+};
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("EngineUpdateNotice", () => {
+  it("keeps the terminal command visible and copyable without blocking the model list", () => {
+    const markup = renderToStaticMarkup(createElement(EngineUpdateNotice, { update }));
+
+    expect(markup).toContain("data-engine-update-notice");
+    expect(markup).toContain("Update Codex for GPT-6 Astra");
+    expect(markup).toContain("codex update");
+    expect(markup).toContain('aria-label="Copy command"');
+  });
+
+  it("offers the native Terminal action when the desktop bridge supports it", () => {
+    vi.stubGlobal("window", { ogb: { openInstallTerminal: vi.fn() } });
+
+    const markup = renderToStaticMarkup(createElement(EngineUpdateNotice, { update }));
+
+    expect(markup).toContain('aria-label="Open update in Terminal"');
+    expect(markup).toContain("Terminal");
+  });
+});

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -7,7 +7,7 @@ import { useStore, type Bot, type InstanceInfo, type ModelSelection } from "@/st
 import { filterCustomModels, partitionCustomModels, suggestedModels } from "@/lib/custom-models";
 import { isCustomOnly, splitEngineRail } from "@/lib/engine-rail";
 import { ProviderMark } from "./ProviderIcons";
-import { EngineSetup, needsCli, needsSignIn } from "./EngineSetup";
+import { EngineSetup, EngineUpdateNotice, needsCli, needsSignIn } from "./EngineSetup";
 import { EngineGroupLabel } from "./EngineGroupLabel";
 import { cn } from "@/lib/cn";
 import { COMPACT_SQUARE } from "@/lib/compact-chip";
@@ -323,7 +323,7 @@ export function ModelPicker({
               const { subscription, custom: local } = splitEngineRail(state.instances);
               const railButton = (instance: InstanceInfo) => {
                 const selected = instance.instanceId === railInstance?.instanceId;
-                const attention = needsCli(instance) || needsSignIn(instance);
+                const attention = needsCli(instance) || needsSignIn(instance) || Boolean(instance.snapshot.update);
                 return (
                   <button
                     type="button"
@@ -445,6 +445,9 @@ export function ModelPicker({
                     <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-2">
                       {pane === "main" ? (
                         <>
+                          {railInstance.snapshot.update && (
+                            <EngineUpdateNotice update={railInstance.snapshot.update} className="mx-1 mb-2" />
+                          )}
                           <EngineGroupLabel className="px-2 pb-1 pt-0.5">
                             {query ? `${filteredOfficial.length} results` : showAll ? `All models · ${official.length}` : "Suggested"}
                           </EngineGroupLabel>

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -402,6 +402,13 @@ export interface InstanceInfo {
     reason?: string;
     authenticated?: boolean;
     version?: string | null;
+    /** A newer provider version unlocks capabilities, but this installed
+     * version and its current models remain usable. */
+    update?: {
+      title: string;
+      message: string;
+      command: string;
+    };
     /** a reported cost on a subscription is notional; the UI says so */
     billing?: "metered" | "subscription";
   };


### PR DESCRIPTION
## What changed

- keep Codex models dynamic through app-server model/list, including GPT-6 Astra when the signed-in account exposes it
- detect Codex versions that predate Astra support and show a non-blocking update card in the model picker
- copy/open the selected Codex executable's own update command, while keeping existing models selectable
- suppress the warning when Astra is already present and avoid guessing for unknown version formats

## Verification

- 52 focused Codex/catalog/update-UI tests
- TypeScript typecheck and production build
- Oxlint and diff check
- isolated control:omb doctor + models fixture
- full Vitest: 3444 passed, 20 skipped, 1 unrelated goal orchestration timeout; the timed-out test passed alone immediately
- broker, Electron, and packaged-server suites passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Detects when a provider requires an update to access newer capabilities, including GPT-6 Astra.
  - Displays a non-blocking update notice with guidance and the exact platform-specific update command.
  - Provides one-click actions to copy the command or open it in a terminal.
  - Highlights instances with available updates in the model picker.
  - Continues allowing engine use while an update is pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->