### PR TITLE
fix(antigravity): recover after upgrading from agy

### DIFF
--- a/apps/docs/content/docs/providers/antigravity.mdx
+++ b/apps/docs/content/docs/providers/antigravity.mdx
@@ -15,6 +15,14 @@ OpenMausBot connects to Google Antigravity through Google's official Agent Clien
 
 The runtime download is large because Google ships the ACP server and its local computer harness together. OpenMausBot stores it in its own data directory; it does not modify a system installation.
 
+## After upgrading from the older agy integration
+
+Version 0.1.51 switched from the community `agy` CLI to Google's official ACP runtime. An existing Antigravity app or `agy` login does not sign this separate runtime in. Complete **Install official Antigravity** and **Sign in with Google** in the model picker, then refresh and choose a model available to that account.
+
+Saved legacy `agy` paths, including Windows `.cmd` shims, now resolve to the official runtime. Genuine custom ACP executable paths are still respected. The migration does not copy credentials from another app, remove the old CLI, or change which Google account you authorize.
+
+The Google sign-in belongs to the engine instance, not the runtime version, so ordinary app updates do not require signing in again. Cold starts can be slow, particularly on Windows; setup and model discovery allow up to 90 seconds. If Google expires or revokes the saved session, sign in again when prompted.
+
 ## Multiple Google accounts
 
 Create another Antigravity engine instance for another account. Each instance has a separate private `GEMINI_HOME`, token, settings file, and model catalog. Signing one instance in never replaces another instance's account.

--- a/server/drivers/antigravity-acp.ts
+++ b/server/drivers/antigravity-acp.ts
@@ -13,6 +13,9 @@ import type { AntigravityRuntime } from "./antigravity-runtime.ts";
 
 export const ANTIGRAVITY_AUTH_STDOUT_PREFIX = "Open the following link to authenticate the ACP server: ";
 const AUTH_TIMEOUT_MS = 5 * 60_000;
+// Google's packaged server can take tens of seconds to cold-start, especially
+// on Windows. Match T3 Code's bounded setup allowance, not a fast CLI probe.
+const STARTUP_TIMEOUT_MS = 90_000;
 const MAX_PROTOCOL_LINE_BYTES = 16 * 1024 * 1024;
 
 export interface AntigravityProfile {
@@ -213,7 +216,7 @@ export class AntigravityAcpClient {
     });
   }
 
-  async initialize(timeoutMs = 30_000): Promise<any> {
+  async initialize(timeoutMs = STARTUP_TIMEOUT_MS): Promise<any> {
     return this.request("initialize", {
       protocolVersion: 1,
       clientInfo: { name: "openmausbot", version: "0.0.0" },
@@ -343,7 +346,7 @@ export async function probeAntigravityModels(input: {
   fallbackDefault: string;
   timeoutMs?: number;
 }): Promise<ModelCatalog> {
-  const deadline = Date.now() + (input.timeoutMs ?? 5_000);
+  const deadline = Date.now() + (input.timeoutMs ?? STARTUP_TIMEOUT_MS);
   const remaining = () => {
     const milliseconds = deadline - Date.now();
     if (milliseconds <= 0) throw new Error("Antigravity model discovery timed out.");
@@ -430,7 +433,7 @@ export class AntigravityAuthController {
       const authenticated = client.request("authenticate", { methodId: "oauth-personal" }, AUTH_TIMEOUT_MS);
       let startupTimer: ReturnType<typeof setTimeout> | undefined;
       const startupTimeout = new Promise<never>((_resolve, reject) => {
-        startupTimer = setTimeout(() => reject(new Error("Google sign-in did not start in time.")), 30_000);
+        startupTimer = setTimeout(() => reject(new Error("Google sign-in did not start in time.")), STARTUP_TIMEOUT_MS);
         startupTimer.unref?.();
       });
       const outcome = await Promise.race([

--- a/server/drivers/antigravity-acp.ts
+++ b/server/drivers/antigravity-acp.ts
@@ -450,7 +450,7 @@ export class AntigravityAuthController {
       const flow: AuthFlow = {
         id: randomUUID(),
         client,
-        completed: authenticated.then(() => undefined),
+        completed: authenticated,
         pending: { redirectUri: outcome.request.redirectUri, state: outcome.request.state },
         expiresAt: Date.now() + AUTH_TIMEOUT_MS,
       };

--- a/server/drivers/antigravity-runtime.ts
+++ b/server/drivers/antigravity-runtime.ts
@@ -125,22 +125,29 @@ async function externalRuntime(candidate: string, source: "override" | "path"): 
 }
 
 /** Resolve an explicit official ACP binary, the pinned managed release, or an
- * official binary already on PATH. The old community `agy` default is treated
- * as "managed" so existing OpenMausBot configs migrate without edits. */
+ * official binary already on PATH. Legacy `agy` commands (including saved
+ * absolute paths and Windows shims) migrate without editing user config. */
 export async function resolveAntigravityRuntime(
   binaryPath?: string,
   env: NodeJS.ProcessEnv = process.env,
   baseDir = DATA_DIR,
 ): Promise<AntigravityRuntime> {
   const override = binaryPath?.trim();
+  const legacyCli = override !== undefined && /(?:^|[\\/])agy(?:\.(?:cmd|bat|exe|ps1))?$/iu.test(override);
   if (override && override !== "agy") {
     for (const candidate of pathCandidates(override, env)) {
       const found = await externalRuntime(candidate, "override");
       if (found) return found;
     }
-    throw new AntigravitySetupError(
-      "The custom Antigravity ACP executable or its localharness_external sibling is missing.",
-    );
+    // Older versions saved the detected agy path in engine settings. It is
+    // not an official ACP override: installing the new runtime must not leave
+    // discovery permanently stuck on that legacy command. A valid explicit
+    // ACP executable still wins above, regardless of its filename.
+    if (!legacyCli) {
+      throw new AntigravitySetupError(
+        "The custom Antigravity ACP executable or its localharness_external sibling is missing.",
+      );
+    }
   }
 
   const asset = resolveAntigravityReleaseAsset();
@@ -158,7 +165,9 @@ export async function resolveAntigravityRuntime(
       `Google does not publish an Antigravity runtime for ${process.platform}-${process.arch}. Set a custom executable path.`,
     );
   }
-  throw new AntigravitySetupError("Antigravity is not installed. Install the official Google runtime to continue.");
+  throw new AntigravitySetupError(legacyCli
+    ? "Antigravity now uses Google's official runtime. Choose Install official Antigravity, then Sign in with Google. Your previous agy login is not copied."
+    : "Antigravity is not installed. Install the official Google runtime to continue.");
 }
 
 interface PinnedZipEntry {

--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -10,6 +10,7 @@ import { recordEvents, type EventRecorder } from "../testing/events.ts";
 import { removeTempDir } from "../testing/cleanup.ts";
 import {
   ANTIGRAVITY_AUTH_STDOUT_PREFIX,
+  AntigravityAuthController,
   antigravityProfileDirectory,
   antigravityProfileAuthenticated,
   catalogFromAntigravityConfigOptions,
@@ -96,6 +97,37 @@ describe("official Antigravity catalog", () => {
         { id: "account-low", label: "Account Low" },
       ],
     });
+  });
+});
+
+describe("Antigravity sign-in lifecycle", () => {
+  it.each(["cancel", "provider failure"])("contains %s after handing the browser a sign-in URL", async (ending) => {
+    const fake = fakeRuntime();
+    const url = "https://accounts.google.com/o/oauth2/v2/auth?response_type=code&state=fixture&redirect_uri=http%3A%2F%2F127.0.0.1%3A54321%2F";
+    writeFileSync(fake.executable, `#!/usr/bin/env node
+import { createInterface } from 'node:readline';
+createInterface({ input: process.stdin }).on('line', line => {
+  const message = JSON.parse(line);
+  if (message.method === 'authenticate') {
+    console.log(${JSON.stringify(ANTIGRAVITY_AUTH_STDOUT_PREFIX + url)});
+    ${ending === "provider failure" ? `setTimeout(() => console.log(JSON.stringify({ jsonrpc: '2.0', id: message.id, error: { code: -1, message: 'Sign-in expired' } })), 100);` : ""}
+  } else console.log(JSON.stringify({ jsonrpc: '2.0', id: message.id, result: {} }));
+});
+`);
+    const runtime = await resolveAntigravityRuntime(fake.executable);
+    const profile = await prepareAntigravityProfile({ instanceId: "auth-lifecycle", runtime, baseDir: fake.directory });
+    const controller = new AntigravityAuthController();
+    try {
+      const flow = await controller.start(runtime, profile);
+      expect(flow.phase).toBe("waiting");
+      if (ending === "cancel") controller.cancel();
+      // Let rejected pending RPCs settle: Vitest must see no unhandled rejection.
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      await expect(controller.complete(flow.flowId!, "http://127.0.0.1:54321/?code=test&state=fixture"))
+        .rejects.toThrow(/no longer active/u);
+    } finally {
+      controller.cancel();
+    }
   });
 });
 

--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -1,7 +1,7 @@
 import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { ensureDirs } from "../config.ts";
@@ -11,6 +11,7 @@ import { removeTempDir } from "../testing/cleanup.ts";
 import {
   ANTIGRAVITY_AUTH_STDOUT_PREFIX,
   antigravityProfileDirectory,
+  antigravityProfileAuthenticated,
   catalogFromAntigravityConfigOptions,
   parseAntigravityAuthorizationUrl,
   prepareAntigravityProfile,
@@ -33,12 +34,15 @@ import {
 const FAKE_ACP = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-acp-cli.ts");
 const scratch: string[] = [];
 
-function fakeRuntime(): { directory: string; executable: string; harness: string } {
+function fakeRuntime(startupDelayMs = 0): { directory: string; executable: string; harness: string } {
   const directory = mkdtempSync(join(tmpdir(), "omb-antigravity-acp-"));
   scratch.push(directory);
   const executable = join(directory, "fake-antigravity.ts");
   const harness = join(directory, process.platform === "win32" ? "localharness_external.exe" : "localharness_external");
   copyFileSync(FAKE_ACP, executable);
+  if (startupDelayMs) {
+    writeFileSync(executable, `#!/usr/bin/env node\nsetTimeout(() => import(${JSON.stringify(pathToFileURL(FAKE_ACP).href)}), ${startupDelayMs});\n`);
+  }
   copyFileSync(FAKE_ACP, harness);
   if (process.platform !== "win32") {
     chmodSync(executable, 0o755);
@@ -120,6 +124,45 @@ describe("official Antigravity runtime", () => {
     });
   });
 
+  it.each([
+    "agy.cmd",
+    "C:\\Users\\Someone\\AppData\\Roaming\\npm\\agy.cmd",
+    "C:\\Tools\\agy.exe",
+    "C:\\Tools\\agy.bat",
+    "C:\\Tools\\agy.ps1",
+    "/opt/homebrew/bin/agy",
+    "/Users/someone/.local/bin/agy",
+  ])("migrates the saved legacy CLI path %s to the official runtime", async (legacyPath) => {
+    const fake = fakeRuntime();
+    const officialExecutable = join(fake.directory, process.platform === "win32" ? "agy_acp_server.exe" : "agy_acp_server.par");
+    copyFileSync(fake.executable, officialExecutable);
+    if (process.platform !== "win32") chmodSync(officialExecutable, 0o755);
+    const runtime = await resolveAntigravityRuntime(legacyPath, { PATH: fake.directory }, fake.directory);
+    expect(runtime).toMatchObject({ executablePath: officialExecutable, source: "path" });
+  });
+
+  it("explains the official setup when a legacy CLI has no replacement installed", async () => {
+    if (!resolveAntigravityReleaseAsset()) return;
+    const fake = fakeRuntime();
+    await expect(resolveAntigravityRuntime("/old/bin/agy", { PATH: "" }, fake.directory))
+      .rejects.toThrow(/Install official Antigravity, then Sign in with Google/);
+  });
+
+  it("preserves a valid explicitly selected official runtime even if named agy", async () => {
+    const fake = fakeRuntime();
+    const custom = join(fake.directory, "agy");
+    copyFileSync(fake.executable, custom);
+    if (process.platform !== "win32") chmodSync(custom, 0o755);
+    await expect(resolveAntigravityRuntime(custom, { PATH: "" }, fake.directory))
+      .resolves.toMatchObject({ executablePath: custom, source: "override" });
+  });
+
+  it("does not silently replace an unrecognized custom executable", async () => {
+    const fake = fakeRuntime();
+    await expect(resolveAntigravityRuntime(join(fake.directory, "custom-acp"), { PATH: "" }, fake.directory))
+      .rejects.toThrow(/custom Antigravity ACP executable/);
+  });
+
   it("atomically prepares one complete profile for concurrent callers", async () => {
     const fake = fakeRuntime();
     const runtime = await resolveAntigravityRuntime(fake.executable);
@@ -136,6 +179,29 @@ describe("official Antigravity runtime", () => {
     });
     expect(readdirSync(acpDirectory).filter((name) => name.endsWith(".tmp"))).toEqual([]);
   });
+
+  it("keeps the existing Google sign-in when the runtime version changes", async () => {
+    const fake = fakeRuntime();
+    const runtime = await resolveAntigravityRuntime(fake.executable);
+    const input = { instanceId: "persistent", runtime, baseEnv: {}, baseDir: fake.directory };
+    const before = await prepareAntigravityProfile(input);
+    writeFileSync(before.tokenPath, '{"fixture":"existing-login"}', { mode: 0o600 });
+    const after = await prepareAntigravityProfile({ ...input, runtime: { ...runtime, version: "new-version" } });
+    expect(after.tokenPath).toBe(before.tokenPath);
+    expect(readFileSync(after.tokenPath, "utf8")).toBe('{"fixture":"existing-login"}');
+    expect(await antigravityProfileAuthenticated(after)).toBe(true);
+  });
+
+  it("discovers account models when the packaged runtime takes over five seconds to start", async () => {
+    const fake = fakeRuntime(5_500);
+    const runtime = await resolveAntigravityRuntime(fake.executable);
+    const profile = await prepareAntigravityProfile({
+      instanceId: "slow-start", runtime, baseDir: fake.directory,
+      baseEnv: { PATH: process.env.PATH, FAKE_ACP_AUTH_METHOD: "oauth-personal", FAKE_ACP_MODELS: "account-model" },
+    });
+    await expect(probeAntigravityModels({ runtime, profile, fallbackDefault: "account-model" }))
+      .resolves.toMatchObject({ options: [{ id: "account-model" }] });
+  }, 20_000);
 
   it("rejects a download redirected to insecure HTTP", async () => {
     const baseDir = mkdtempSync(join(tmpdir(), "omb-antigravity-insecure-"));

--- a/src/components/EngineSetup.tsx
+++ b/src/components/EngineSetup.tsx
@@ -257,8 +257,9 @@ function ManagedEngineSetup({ instance, signInOnly }: { instance: InstanceInfo; 
         className="flex w-full items-center justify-center gap-2 rounded-lg bg-accent px-3 py-2 text-[12.5px] font-semibold text-white hover:brightness-110 disabled:cursor-wait disabled:opacity-70"
       >
         {busy === "signin" ? <Loader2 size={14} className="animate-spin" /> : <LogIn size={14} />}
-        {flow ? "Open Google sign-in again" : "Sign in with Google"}
+        {busy === "signin" ? "Starting Google sign-in…" : flow ? "Open Google sign-in again" : "Sign in with Google"}
       </button>
+      {busy === "signin" && <p role="status" className="text-[11.5px] text-ink-secondary">Starting Antigravity can take up to 90 seconds. Your browser will open when it’s ready.</p>}
       {flow && (
         <>
           <button type="button" onClick={() => void check()} className="w-full rounded-lg bg-control px-3 py-2 text-[12px] font-semibold text-ink hover:bg-raised-hover">


### PR DESCRIPTION
## Why
The 0.1.51 upgrade replaced the old agy CLI integration with the official Google ACP runtime. Two upgrade problems remain:
- Previously saved absolute agy paths and Windows shims keep taking precedence, even after the official runtime is installed.
- Model discovery has a five-second total deadline, too short for the packaged Google server on slower machines.

## Changes
- Recognize legacy agy paths and Windows cmd/bat/exe/ps1 shims; fall through to the verified managed runtime or official ACP on PATH.
- Preserve valid explicit official executables and fail closed for unrecognized custom paths.
- Give setup/model discovery a bounded 90-second cold-start allowance, matching the T3 Code approach. Keep caller-provided shorter test deadlines.
- Document the one-time migration sign-in and verify runtime version changes preserve the existing profile token.

## Evidence
- Seven legacy-path cases reproduced the old resolution failure (six initial cases were observed red before the fix).
- A 5.5-second startup fixture reproduced initialize timed out before the timeout fix.
- All 27 Antigravity tests pass, including account isolation, permission-mode enforcement, interactive questions, and real subprocess ACP turns against the fake engine.
- pnpm typecheck and git diff --check pass.
- Launched the isolated verification server and passed doctor. This is not proof of a real Google sign-in; no live user account, token, or app data was used.

T3 comparison: https://github.com/pingdotgg/t3code/blob/main/docs/user/providers-antigravity.md
T3 also requires separate Google sign-in for the official ACP provider. No account import, API-key fallback, or auth bypass is introduced.

The reporter has not supplied an error screenshot or OS yet, so these are confirmed code-level upgrade defects, not a claim that their exact incident has been reproduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved migration from the legacy Antigravity CLI to Google’s official runtime, including saved paths and Windows command shims.
  - Preserved existing Google sign-ins when the runtime updates.
  - Increased startup allowances for slower first-time setup and model discovery, especially on Windows.
  - Added clearer guidance when installation or sign-in is required.

- **Documentation**
  - Added upgrade guidance covering migration, sign-in behavior, startup delays, and expired or revoked sessions.

- **User Experience**
  - Added progress messaging while Google sign-in is starting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->