### PR TITLE
fix(claude): keep bot tools and approvals attached to live turns

### DIFF
--- a/docs/verification/claude-tool-lifecycle.md
+++ b/docs/verification/claude-tool-lifecycle.md
@@ -1,0 +1,43 @@
+# Claude coordination and turn-scoped tools
+
+“OpenMausBot: the turn ended” is an approval-broker denial, not evidence of
+an internet outage. Browser capabilities also expire when their owning turn
+ends; “unauthorized” after that boundary must not be repaired by giving a
+worker permanent browser credentials.
+
+The Claude driver keeps native background tasks disabled. Native subagents
+can still work within the active turn; asynchronous work across bots uses
+OpenMausBot's `delegate_bot` path, which owns each recipient's turn, approvals,
+and completion receipt. Long-running native Bash commands can no longer
+auto-background past the owning turn. This does not change approval modes or
+disable sandbox protections.
+
+Claude can emit a synthetic result with `origin.kind = "task-notification"`.
+That result must not settle a submitted user turn or consume its permissions.
+The regression fixture emits this result, then asks for WebFetch permission,
+and only finishes the parent after the test releases a file gate.
+
+The small `agents` and `ogb` MCP servers use `alwaysLoad: true` so the first
+prompt includes coordination and approval tools. Other MCP servers retain
+normal deferred loading. This prevents the deferred-lookup dependency; it
+does not magically reconnect a crashed server or override a user's denied
+tool policy.
+
+Sources:
+
+- [Claude MCP server loading](https://code.claude.com/docs/en/mcp#exempt-a-server-from-deferral)
+- [Claude background-task setting](https://code.claude.com/docs/en/env-vars)
+- [SDK result and background-task messages](https://code.claude.com/docs/en/agent-sdk/typescript)
+
+Regression checks:
+
+```sh
+pnpm exec vitest run server/drivers/claude.test.ts server/drivers/agents-proxy.test.ts server/browser-connection.test.ts
+```
+
+For end-to-end verification, launch the isolated fixture described in
+[README.md](README.md), then follow [Chat turns](chat-turns.md). Never use the
+customer's running app to create test bots, approve requests, or rotate tools.
+These fixture checks do not prove that a customer's real provider account or
+network is healthy. Ask for their app version, Claude CLI version, and a
+redacted diagnostic export if failures remain; do not request credentials.

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -507,6 +507,7 @@ describe("ClaudeDriver turns (fake CLI)", () => {
 
     const seen = JSON.parse(readFileSync(dump, "utf8"));
     expect(seen.mcpConfig.mcpServers.agents).toMatchObject({
+      alwaysLoad: true,
       args: ["/fake/agents-proxy.js"],
       env: { OMB_BOT_ID: "b1", OMB_COMMS_TOKEN: "tok" },
     });
@@ -515,6 +516,42 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     expect(JSON.stringify(seen.argv)).not.toContain("tok");
     const allowed = seen.argv[seen.argv.indexOf("--allowedTools") + 1];
     expect(allowed).toContain("mcp__agents");
+    expect(seen.mcpConfig.mcpServers.ogb.alwaysLoad).toBe(true);
+  });
+
+  it("keeps native background workers inside the harness-owned turn", async () => {
+    const dump = join(scratch, "background-policy.json");
+    await create(undefined, { FAKE_CLAUDE_DUMP: dump, CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "0" });
+    await instance.adapter.sendTurn({ threadId: "t-background-policy", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed");
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS).toBe("1");
+    expect(seen.argv[seen.argv.indexOf("--permission-mode") + 1]).toBe("acceptEdits");
+    expect(seen.argv).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("does not end the current turn or its approvals on a background-task result", async () => {
+    const gate = join(scratch, "finish-parent");
+    await create("background-result", { FAKE_CLAUDE_FINISH_GATE: gate });
+    const { turnId } = await instance.adapter.sendTurn({ threadId: "t-background-result", text: "hi" });
+    await recorder.until((e) => e.type === "content.delta" && e.delta === "parent still working");
+    expect(recorder.events.filter((e) => e.type === "turn.completed")).toHaveLength(0);
+    expect(instance.adapter.hasSession("t-background-result")).toBe(true);
+    const conn = await connectSocket(permissionSocketPath("t-background-result"));
+    try {
+      const answer = answerQueue(conn)();
+      conn.write(JSON.stringify({ t: "ask", id: "network-after-background", tool: "WebFetch", input: { url: "https://example.com" } }) + "\n");
+      await recorder.until((e) => e.type === "request.opened" && e.requestId === "network-after-background");
+      await expect(instance.adapter.respondToRequest("t-background-result", "network-after-background", { behavior: "allow" })).resolves.toBe("allowed-once");
+      await expect(answer).resolves.toMatchObject({ behavior: "allow" });
+      writeFileSync(gate, "finish");
+      await recorder.until((e) => e.type === "turn.completed");
+      expect(recorder.events.filter((e) => e.type === "turn.completed")).toEqual([
+        expect.objectContaining({ turnId, ok: true, cost: 0.01 }),
+      ]);
+    } finally {
+      conn.destroy();
+    }
   });
 
   it("mounts custom MCP servers without pre-allowing their tools", async () => {

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -767,7 +767,9 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       // agentsIntegration(); pre-allowing matters doubly here, or the CLI's
       // own ListAgents look-alike shadows it and "@Bot" asks go nowhere
       if (turn.integrations?.agents) {
-        mcpServers.agents = { ...turn.integrations.agents };
+        // Coordination is foundational, not an optional deferred lookup.
+        // Claude waits for always-loaded tools before building the prompt.
+        mcpServers.agents = { ...turn.integrations.agents, alwaysLoad: true };
         allowed.push("mcp__agents");
       }
       if (turn.integrations?.phone) {
@@ -808,7 +810,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       if (config.permissionMode !== "bypassPermissions") {
         socketPath = permissionSocketPath(threadId);
         args.push("--permission-prompt-tool", "mcp__ogb__approve");
-        mcpServers.ogb = { command: process.execPath, args: [PERM_PROXY_PATH, socketPath], env: { ...NODE_ENV_FLAG } };
+        mcpServers.ogb = { command: process.execPath, args: [PERM_PROXY_PATH, socketPath], env: { ...NODE_ENV_FLAG }, alwaysLoad: true };
         allowed.push("mcp__ogb");
       }
       // The MCP config carries credentials — a Composio consumer key in a
@@ -825,6 +827,10 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       }
 
       const env = claudeEnvironment(turnModel, turnEnvironment);
+      // Our approvals and browser credentials expire at the user-turn
+      // boundary. Native background workers cannot outlive that boundary;
+      // parallel bot work must use the harness's durable delegate_bot path.
+      env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS = "1";
       const cwd = turn.cwd ?? homedir();
       // Everything that shapes the process, minus session/turn-specific temp
       // paths. Their contents are represented directly in the key instead.
@@ -944,7 +950,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
           // the base path: the nonce is not part of the spawn contract, and a
           // retained session keeps its own broker object anyway.
           if (broker.socketPath !== socketPath && mcpConfigPath) {
-            mcpServers.ogb = { command: process.execPath, args: [PERM_PROXY_PATH, broker.socketPath], env: { ...NODE_ENV_FLAG } };
+            mcpServers.ogb = { command: process.execPath, args: [PERM_PROXY_PATH, broker.socketPath], env: { ...NODE_ENV_FLAG }, alwaysLoad: true };
           }
         }
 
@@ -1089,6 +1095,10 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
             }
             break;
           case "result":
+            // A synthetic background completion is not the result of the
+            // submitted user turn. Settling it would revoke browser access
+            // and deny approvals while that user turn is still running.
+            if (o.origin?.kind === "task-notification") break;
             // result.usage is this invocation's total — one process per turn,
             // so it is the turn's figure. cache reads count as input: they
             // are billed (at the cache rate) and they fill the window — but

--- a/server/testing/fake-claude-cli.ts
+++ b/server/testing/fake-claude-cli.ts
@@ -258,6 +258,18 @@ const playTurn = (prompt: JsonValue) => {
     turnRunning = false;
     finishIfDone();
   };
+  if (mode === "background-result") {
+    // Claude can emit a synthetic result when a background task finishes.
+    // It does not complete the user turn currently waiting on permission.
+    out({ type: "result", origin: { kind: "task-notification" }, is_error: false, total_cost_usd: 99 });
+    out({ type: "stream_event", event: { type: "content_block_delta", delta: { type: "text_delta", text: "parent still working" } } });
+    const poll = setInterval(() => {
+      if (!process.env.FAKE_CLAUDE_FINISH_GATE || !existsSync(process.env.FAKE_CLAUDE_FINISH_GATE)) return;
+      clearInterval(poll);
+      finish();
+    }, 10);
+    return;
+  }
   if (mode === "slow") {
     // a gap a test can steer into; the closing reply carries anything that
     // was folded in, the way the real CLI includes a mid-turn message in


### PR DESCRIPTION
## Summary
- Always-load the small agents and approval MCP servers using Claude’s supported per-server option. Other servers retain deferred loading; custom tools are not pre-approved.
- Keep native Claude background tasks inside the harness-owned turn. OpenMausBot delegate_bot still runs peers asynchronously with their own approvals and receipts.
- Ignore synthetic result messages whose origin is task-notification. They must not finish the active user turn, revoke its browser capability, or drain pending permissions.

## Customer report
Customers saw No matching deferred tools found for coordination tools, OpenMausBot: the turn ended for permission-requiring tools, and unauthorized from browser tools. The exact turn-ended string is generated by our permission broker, not a network firewall. These reports alone do not establish a network egress outage. Twitter is explicitly out of scope and untouched.

## Verification
- Three new assertions reproduced failures before the fix: missing eager tool loading, native background workers allowed beyond turn lifetime, and synthetic result prematurely settling the parent.
- 106 focused tests passed (1 platform-specific skip), including real subprocess Claude protocol fixtures, agents MCP tools, browser capability registration/revocation, and permission fail-closed behavior; TypeScript passed.
- An isolated control-omb server created Product test and Engineering test as ordinary non-Chief bots. The real agents proxy completed its handshake, listed all four reported tools, called list_bots and list_routines, and ask_bot returned Engineering’s fake-engine reply through the real harness.
- No live app/account data used. No real Claude inference or customer network test claimed. Full server integration tests are still running.

## Tradeoff
Native Bash/subagent backgrounding is disabled because its lifetime was not owned by the app; foreground native work still works and durable cross-bot delegation remains available. No permission-mode changes, auth bypass, sandbox removal, or permanent browser tokens.

Design sources and regression recipe: docs/verification/claude-tool-lifecycle.md. The customer should provide app version, Claude version and redacted diagnostics if issues remain; these fixes do not prove their exact session was reproduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented background task notifications from prematurely ending active conversations or approval flows.
  * Improved handling of turn-scoped browser capabilities and approval denials.
  * Ensured required agent tools are available consistently, including when fallback connections are used.
  * Preserved standard edit permissions without enabling unrestricted access.

* **Documentation**
  * Added guidance on tool lifecycle, background task behavior, approval handling, and verification procedures.

* **Tests**
  * Added coverage for background task isolation, permission settings, and eager tool availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->