### PR TITLE
fix(desktop): release single-instance lock on update-driven quit

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, WebContentsView, clipboard, desktopCapturer, dialog, ipcMain, Menu, nativeImage, powerSaveBlocker, safeStorage, screen, session, shell, systemPreferences, utilityProcess } from "electron";
+import { app, autoUpdater as nativeAutoUpdater, BrowserWindow, WebContentsView, clipboard, desktopCapturer, dialog, ipcMain, Menu, nativeImage, powerSaveBlocker, safeStorage, screen, session, shell, systemPreferences, utilityProcess } from "electron";
 import { createRequire } from "node:module";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
@@ -25,7 +25,7 @@ import {
   readSafeLogTail,
 } from "./diagnostics.mjs";
 import { migrateWorkspaceCredentials, workspaceCredentialEnv } from "./workspace-credentials.mjs";
-import { activateExistingWindow } from "./single-instance.mjs";
+import { activateExistingWindow, releaseSingleInstanceLock } from "./single-instance.mjs";
 import { pollServerIdentity } from "./server-boot-probe.mjs";
 import { packageUrlFromCommandLine, packageUrlFromDeepLink } from "./package-link.mjs";
 import { windowChromeOptions } from "./window-chrome.mjs";
@@ -205,6 +205,17 @@ if (!app.requestSingleInstanceLock()) {
   console.log("[desktop] OpenMausBot is already running — focusing that window");
   process.exit(0);
 }
+
+// An update install can start the new build while this process is still
+// inside the deferred before-quit cleanup further down, still holding the
+// lock; the relaunched copy then loses the check above and exits, leaving a
+// dead Starting window with no server. Electron's native autoUpdater emits
+// before-quit-for-update only when an update drives the quit (the vendored
+// electron-updater re-emits it on the same object before app.quit()), so the
+// lock is released on that event — never in before-quit, where a normal quit
+// would allow a concurrent second instance.
+nativeAutoUpdater.on("before-quit-for-update", () => releaseSingleInstanceLock(app));
+
 function deliverPackageInstall(win) {
   if (!pendingPackageInstallUrl || !win || win.isDestroyed()) return;
   if (win.webContents.isLoadingMainFrame()) return;

--- a/electron/single-instance.mjs
+++ b/electron/single-instance.mjs
@@ -14,3 +14,15 @@ export function activateExistingWindow(windows) {
   target.focus();
   return true;
 }
+
+// Drop this process's single-instance lock. The update-relaunch path needs
+// it: Squirrel.Mac can start the new build while the old process is still
+// inside its deferred before-quit cleanup, and the new copy exits at the
+// lock check unless the old one lets go first. The guard keeps the release
+// idempotent because both Electron and electron-updater can emit
+// before-quit-for-update for the same install.
+export function releaseSingleInstanceLock(app) {
+  if (!app.hasSingleInstanceLock()) return false;
+  app.releaseSingleInstanceLock();
+  return true;
+}

--- a/electron/single-instance.node-test.mjs
+++ b/electron/single-instance.node-test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { activateExistingWindow } from "./single-instance.mjs";
+import { activateExistingWindow, releaseSingleInstanceLock } from "./single-instance.mjs";
 
 function fakeWindow({ destroyed = false, minimized = false, focused = false } = {}) {
   const calls = [];
@@ -49,4 +49,36 @@ test("reports failure when no window can be activated", () => {
   assert.equal(activateExistingWindow([]), false);
   assert.equal(activateExistingWindow([dead]), false);
   assert.deepEqual(dead.calls, []);
+});
+
+function fakeApp({ holdsLock = true } = {}) {
+  const calls = [];
+  let held = holdsLock;
+  return {
+    calls,
+    hasSingleInstanceLock: () => held,
+    releaseSingleInstanceLock: () => {
+      held = false;
+      calls.push("releaseSingleInstanceLock");
+    },
+  };
+}
+
+test("releases a held single-instance lock for an update relaunch", () => {
+  const app = fakeApp();
+  assert.equal(releaseSingleInstanceLock(app), true);
+  assert.deepEqual(app.calls, ["releaseSingleInstanceLock"]);
+});
+
+test("stays a no-op when the lock is not held", () => {
+  const app = fakeApp({ holdsLock: false });
+  assert.equal(releaseSingleInstanceLock(app), false);
+  assert.deepEqual(app.calls, []);
+});
+
+test("releases the lock only once when the update signal fires twice", () => {
+  const app = fakeApp();
+  assert.equal(releaseSingleInstanceLock(app), true);
+  assert.equal(releaseSingleInstanceLock(app), false);
+  assert.deepEqual(app.calls, ["releaseSingleInstanceLock"]);
 });


### PR DESCRIPTION
## What changed

- `electron/single-instance.mjs`: added `releaseSingleInstanceLock(app)`, an Electron-free helper (same pattern as `activateExistingWindow`) that releases the single-instance lock only while this process still holds it.
- `electron/main.mjs`: listens for `before-quit-for-update` on Electron's **native `autoUpdater`** and releases the lock there.
- `electron/single-instance.node-test.mjs`: covers held → released, not-held → no-op, and double-fire → released exactly once.

Fixes #618

## Why

On macOS, `updater.quitAndInstall(true, true)` in `electron/updater-coordinator.mjs` relaunches the new build while the old process is still inside its deferred `before-quit` cleanup (`e.preventDefault()` + awaited child shutdown). The old process still holds the single-instance lock, so the new copy fails `app.requestSingleInstanceLock()` and exits before it can start a server; the old copy then finishes cleanup and dies. The user is left on the Starting spinner with no running instance until they quit and reopen.

`before-quit-for-update` is the safe release point because it is emitted only when an update drives the quit. On macOS the native Squirrel.Mac `autoUpdater.quitAndInstall()` emits it, and the vendored electron-updater additionally re-emits it on the same `require("electron").autoUpdater` object immediately before `app.quit()`. The lock is deliberately **not** released in `before-quit` — that handler runs on every quit, and releasing there would let a normal user quit spawn a concurrent second instance during the deferred cleanup.

One correction to the sketch in #618: the event is emitted on `autoUpdater`, not `app` — `app.on("before-quit-for-update")` would never fire. Listening on the native `autoUpdater` also covers the `autoInstallOnAppQuit` install path on macOS, where the update is applied during a user-initiated quit.

## How it was verified

- `node --test electron/single-instance.node-test.mjs` → 8/8 pass (Node 24).
- `pnpm check:electron` → "Syntax-checked 101 Electron modules."
- `pnpm typecheck` → clean.
- `pnpm test` → 3509 passed; 2 failures are environmental and reproduce identically on unmodified `upstream/main`: `server/control-omb.test.ts` (needs the fake-engine/`claude` fixture) and `scripts/linux-after-install.test.mjs` (temp-dir boundary). This diff touches only `electron/*.mjs`.
- The real Squirrel.Mac relaunch timing can't be exercised on a Linux dev box, so the release point is verified at the unit level and against the event source in `electron/vendor/electron-updater.cjs` (`autoUpdater.emit("before-quit-for-update")` right before `app.quit()`).

## Screenshots (UI changes)

n/a — no UI change.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally (see "How it was verified" for the 2 pre-existing env failures)
- [x] Server behavior changes come with tests — n/a, Electron shell only; the new helper is covered by `electron/single-instance.node-test.mjs`
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building — the listener is inert unless an update-driven quit emits the event
- [x] No secrets in logs, responses, events, or argv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved application updates and relaunches to prevent startup failures caused by a stale running-instance state.
  - Update-driven quits now correctly prepare the app for the next launch, helping ensure the main window opens normally after updating.
- **Reliability**
  - Improved handling of application instance state during update transitions, including repeated release attempts, for more consistent update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->