### PR TITLE
fix(antigravity): read the Google sign-in link from stderr

### DIFF
--- a/server/drivers/antigravity-acp.ts
+++ b/server/drivers/antigravity-acp.ts
@@ -11,12 +11,16 @@ import type { ModelCatalog } from "../contracts.ts";
 import type { ChildProcess } from "node:child_process";
 import type { AntigravityRuntime } from "./antigravity-runtime.ts";
 
-export const ANTIGRAVITY_AUTH_STDOUT_PREFIX = "Open the following link to authenticate the ACP server: ";
+// Printed on stderr by Google's server, not stdout.
+export const ANTIGRAVITY_AUTH_PREFIX = "Open the following link to authenticate the ACP server: ";
 const AUTH_TIMEOUT_MS = 5 * 60_000;
 // Google's packaged server can take tens of seconds to cold-start, especially
 // on Windows. Match T3 Code's bounded setup allowance, not a fast CLI probe.
 const STARTUP_TIMEOUT_MS = 90_000;
 const MAX_PROTOCOL_LINE_BYTES = 16 * 1024 * 1024;
+// Past the 16 KiB ceiling parseAntigravityAuthorizationUrl accepts, so a
+// partial stderr line is never dropped while it could still become a link.
+const MAX_DIAGNOSTIC_LINE_CHARS = 64 * 1024;
 
 export interface AntigravityProfile {
   directory: string;
@@ -52,6 +56,29 @@ const browserHelperSource =
 
 function quoteBrowserArgument(value: string): string {
   return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+/** Complete lines in a stream buffer, plus the unterminated tail to keep. */
+function takeLines(buffer: string): { lines: string[]; rest: string } {
+  const parts = buffer.split("\n");
+  const rest = parts.pop() ?? "";
+  return { lines: parts.map((line) => line.replace(/\r$/u, "")), rest };
+}
+
+/** The sign-in link in a server output line, or null for anything else.
+ * Google announces it two ways and both land on stderr: it hands the link to
+ * $BROWSER — our helper re-emits it JSON-encoded behind a private marker — and
+ * it also prints the link in plain text for terminal users. Either is enough;
+ * the marker form is preferred because JSON delimits the URL exactly. */
+export function authorizationUrlFromLine(line: string): string | null {
+  if (line.startsWith(ANTIGRAVITY_AUTH_PREFIX)) return line.slice(ANTIGRAVITY_AUTH_PREFIX.length).trim();
+  if (!line.startsWith(BROWSER_MARKER)) return null;
+  try {
+    const url = JSON.parse(line.slice(BROWSER_MARKER.length));
+    return typeof url === "string" ? url : null;
+  } catch {
+    return null;
+  }
 }
 
 export function antigravityProfileDirectory(instanceId: string, baseDir = DATA_DIR): string {
@@ -129,6 +156,7 @@ export class AntigravityAcpClient {
   private nextId = 1;
   private pending = new Map<number, PendingRpc>();
   private buffer = "";
+  private diagnosticBuffer = "";
   private closed = false;
   private readonly onAuthorizationUrl?: (url: string) => void;
 
@@ -146,9 +174,11 @@ export class AntigravityAcpClient {
     );
     this.child.stdout!.setEncoding("utf8");
     this.child.stdout!.on("data", (chunk: string) => this.consume(chunk));
-    // OAuth URLs and authorization codes can appear on stderr. Never retain
-    // or expose it; the generic error is enough for setup UI.
-    this.child.stderr!.on("data", () => {});
+    // Google announces the sign-in link on stderr, not stdout. Scan for that
+    // one line and drop every other byte: stderr also carries authorization
+    // codes, so nothing else is retained or surfaced.
+    this.child.stderr!.setEncoding("utf8");
+    this.child.stderr!.on("data", (chunk: string) => this.consumeDiagnostics(chunk));
     this.child.once("error", (error) => this.failAll(error));
     this.child.once("close", (code) => {
       if (!this.closed) this.failAll(new Error(`Antigravity ACP exited ${code ?? "unexpectedly"}.`));
@@ -162,19 +192,10 @@ export class AntigravityAcpClient {
       this.close();
       return;
     }
-    for (;;) {
-      const newline = this.buffer.indexOf("\n");
-      if (newline < 0) break;
-      const line = this.buffer.slice(0, newline).replace(/\r$/u, "");
-      this.buffer = this.buffer.slice(newline + 1);
-      if (line.startsWith(ANTIGRAVITY_AUTH_STDOUT_PREFIX)) {
-        try {
-          this.onAuthorizationUrl?.(parseAntigravityAuthorizationUrl(line.slice(ANTIGRAVITY_AUTH_STDOUT_PREFIX.length)).authorizationUrl);
-        } catch (error) {
-          this.failAll(error instanceof Error ? error : new Error(String(error)));
-        }
-        continue;
-      }
+    const { lines, rest } = takeLines(this.buffer);
+    this.buffer = rest;
+    for (const line of lines) {
+      if (this.announceAuthorizationUrl(line)) continue;
       let message: any;
       try {
         message = JSON.parse(line);
@@ -192,6 +213,29 @@ export class AntigravityAcpClient {
         pending.reject(error);
       } else pending.resolve(message.result);
     }
+  }
+
+  /** Report a sign-in link if this line carries one. Returns whether the line
+   * was an announcement, so callers can skip protocol parsing for it. */
+  private announceAuthorizationUrl(line: string): boolean {
+    const raw = authorizationUrlFromLine(line);
+    if (raw === null) return false;
+    try {
+      this.onAuthorizationUrl?.(parseAntigravityAuthorizationUrl(raw).authorizationUrl);
+    } catch (error) {
+      this.failAll(error instanceof Error ? error : new Error(String(error)));
+    }
+    return true;
+  }
+
+  /** Read stderr only far enough to spot the sign-in link. Lines are matched
+   * and released immediately and the tail is capped, so no authorization code
+   * is ever held. Draining also keeps the pipe from stalling the server. */
+  private consumeDiagnostics(chunk: string) {
+    const { lines, rest } = takeLines(this.diagnosticBuffer + chunk);
+    // A partial line already longer than any legal link cannot become one.
+    this.diagnosticBuffer = rest.length > MAX_DIAGNOSTIC_LINE_CHARS ? "" : rest;
+    for (const line of lines) this.announceAuthorizationUrl(line);
   }
 
   private failAll(error: Error) {

--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -9,7 +9,8 @@ import type { ProviderInstance } from "../contracts.ts";
 import { recordEvents, type EventRecorder } from "../testing/events.ts";
 import { removeTempDir } from "../testing/cleanup.ts";
 import {
-  ANTIGRAVITY_AUTH_STDOUT_PREFIX,
+  ANTIGRAVITY_AUTH_PREFIX,
+  authorizationUrlFromLine,
   AntigravityAuthController,
   antigravityProfileDirectory,
   antigravityProfileAuthenticated,
@@ -102,6 +103,8 @@ describe("official Antigravity catalog", () => {
 });
 
 describe("Antigravity sign-in lifecycle", () => {
+  // Google's server announces the link on stderr, never stdout — a fake that
+  // prints to stdout passes against code that cannot sign in at all.
   it.each(["cancel", "provider failure"])("contains %s after handing the browser a sign-in URL", async (ending) => {
     const fake = fakeRuntime();
     const url = "https://accounts.google.com/o/oauth2/v2/auth?response_type=code&state=fixture&redirect_uri=http%3A%2F%2F127.0.0.1%3A54321%2F";
@@ -110,7 +113,7 @@ import { createInterface } from 'node:readline';
 createInterface({ input: process.stdin }).on('line', line => {
   const message = JSON.parse(line);
   if (message.method === 'authenticate') {
-    console.log(${JSON.stringify(ANTIGRAVITY_AUTH_STDOUT_PREFIX + url)});
+    console.error(${JSON.stringify(ANTIGRAVITY_AUTH_PREFIX + url)});
     ${ending === "provider failure" ? `setTimeout(() => console.log(JSON.stringify({ jsonrpc: '2.0', id: message.id, error: { code: -1, message: 'Sign-in expired' } })), 100);` : ""}
   } else console.log(JSON.stringify({ jsonrpc: '2.0', id: message.id, result: {} }));
 });
@@ -437,10 +440,25 @@ describe("Antigravity OAuth validation", () => {
   const authorizationUrl = `https://accounts.google.com/o/oauth2/v2/auth?response_type=code&state=${state}&redirect_uri=${encodeURIComponent(redirectUri)}`;
 
   it("accepts only Google's exact loopback authorization request", () => {
-    expect(ANTIGRAVITY_AUTH_STDOUT_PREFIX).toContain("authenticate the ACP server");
+    expect(ANTIGRAVITY_AUTH_PREFIX).toContain("authenticate the ACP server");
     expect(parseAntigravityAuthorizationUrl(authorizationUrl)).toEqual({ authorizationUrl, redirectUri, state });
     expect(() => parseAntigravityAuthorizationUrl(authorizationUrl.replace("accounts.google.com", "example.com"))).toThrow(/invalid/u);
     expect(() => parseAntigravityAuthorizationUrl(authorizationUrl.replace("127.0.0.1", "localhost"))).toThrow(/invalid/u);
+  });
+
+  it("reads the sign-in link from either announcement Google makes", () => {
+    // The $BROWSER helper re-emits the link JSON-encoded behind this marker;
+    // the plain notice is what a terminal user would have read.
+    expect(authorizationUrlFromLine(`__OPENMAUS_ANTIGRAVITY_AUTH_URL__${JSON.stringify(authorizationUrl)}`))
+      .toBe(authorizationUrl);
+    expect(authorizationUrlFromLine(`${ANTIGRAVITY_AUTH_PREFIX}${authorizationUrl}`)).toBe(authorizationUrl);
+  });
+
+  it("ignores ordinary server logs, including ones quoting a link", () => {
+    expect(authorizationUrlFromLine("I0905 11:02:06.473720 8283299200 main.py:80] Starting AGY ACP Server...")).toBeNull();
+    expect(authorizationUrlFromLine(`I0905 credential_manager.py:553] ${ANTIGRAVITY_AUTH_PREFIX}${authorizationUrl}`)).toBeNull();
+    expect(authorizationUrlFromLine("__OPENMAUS_ANTIGRAVITY_AUTH_URL__not-json")).toBeNull();
+    expect(authorizationUrlFromLine("")).toBeNull();
   });
 
   it("ties a pasted remote callback to the active state and loopback port", () => {


### PR DESCRIPTION
## Problem

Antigravity sign-in fails for everyone who migrated to the official ACP runtime. Clicking **Sign in with Google** spins for 90 seconds and then errors:

> Google sign-in did not start in time.

Google's ACP server prints the sign-in link on **stderr**, but `AntigravityAcpClient` only parsed stdout and threw stderr away:

```js
this.child.stderr!.on("data", () => {});
```

The link never reached `onAuthorizationUrl`, so `urlPromise` never resolved and the `STARTUP_TIMEOUT_MS` race won every time.

Tracing the real `agy_acp_server_1.1.1` confirms both announcements land on stderr, ~12s in:

```
[12.1s] STDERR: __OPENMAUS_ANTIGRAVITY_AUTH_URL__"https://accounts.google.com/o/oauth2/v2/auth?…"
[12.1s] STDERR: Open the following link to authenticate the ACP server: https://accounts.google.com/…
[130.0s] giving up
```

Two things hid this:

- `BROWSER_MARKER` and the `$BROWSER` helper that emits it were already written, but **nothing ever read the marker** — grep found only the two lines defining it. The intended path was dead code.
- The lifecycle test's fake server announced on **stdout** (`console.log`), so the suite passed against code that could not sign in at all. The constant was even named `ANTIGRAVITY_AUTH_STDOUT_PREFIX`, encoding the wrong assumption.

Regression from #729 / #744.

## Fix

Scan stderr for the link and drop every other byte.

- `authorizationUrlFromLine()` recognizes both announcement forms. The marker form is preferred because JSON delimits the URL exactly.
- `consumeDiagnostics()` line-buffers stderr, matches and releases each line immediately, and caps the partial tail. Draining also keeps the pipe from stalling the server.
- Renamed `ANTIGRAVITY_AUTH_STDOUT_PREFIX` → `ANTIGRAVITY_AUTH_PREFIX`.
- Extracted `takeLines()`, shared with the existing stdout reader.

**The security intent is preserved.** stderr also carries authorization codes, so nothing beyond a matched link is retained or surfaced, the tail is bounded, and `parseAntigravityAuthorizationUrl` still gates every URL to an `accounts.google.com` loopback request.

## Verification

Against the installed Google runtime, `auth.start()` returns a link in **1.4s** instead of timing out at 90s. After sign-in, the account catalog loads — 11 models, including ones absent from the static fallback, so it is reading the live account:

```
authenticated: true
default: gemini-3.8-flash-high
models: gemini-3.8-flash-high, …, gemini-3.7-flash-high, …, gemini-pro-agent, gemini-3.1-pro-low
```

The lifecycle test now announces on stderr like the real binary. Confirmed it is a genuine regression test by restoring only the discarded-stderr line — both cases fail, the cancel case hanging 20s:

```
× contains cancel after handing the browser a sign-in URL           20009ms
× contains provider failure after handing the browser a sign-in URL   343ms
```

With the fix: **39 passed**. `pnpm typecheck` and `oxlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Antigravity sign-in handling by recognizing Google authentication links from additional process output formats.
  * Authentication links are now surfaced more reliably when provided through browser-helper messages or plain-text announcements.
  * Improved handling of diagnostic output, including protection against excessively long lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->