### PR TITLE
fix: preserve existing bots and conversations during team import

### DIFF
--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -38,6 +38,7 @@ Use only mapped, tested commands:
 - [Chat turns](chat-turns.md)
 - [Channels](channels.md)
 - [Engines and Doctor](engines.md)
+- [Team backups](team-backups.md)
 
 Renderer-only behavior—Settings, sidebar drag-and-drop, the VM modal, the
 built-in browser panel, and updater UI—is not proven by this first harness.

--- a/docs/verification/team-backups.md
+++ b/docs/verification/team-backups.md
@@ -1,0 +1,55 @@
+# Team backups
+
+## User path
+
+Sidebar menu → **Export backup** → a dated `.mausbackup.json` file.
+Teams → Import → choose the file → review → **Import backup**.
+Import always adds independent copies; existing bots, Chiefs, rooms and chats
+are never archived, overwritten or merged. Repeated imports number copies.
+
+The private portable backup includes active and archived bot profiles,
+instructions, sections, room membership, Chiefs, playbooks, paused routine
+definitions, and conversation text from every task and branch. Action cards
+become inert text. It does not include files, screenshots, custom avatars,
+workspace memory, account connections, model settings or permissions. This
+is not a whole-computer backup. Store the file privately: chat text can
+contain sensitive information. The size limit is 50 MB; export fails clearly
+instead of producing a truncated or unimportable file.
+
+Rooms referencing previously deleted bots retain their conversation and
+remaining members; orphaned direct messages become ordinary rooms. Routines
+whose bot/room/coordinator was deleted are omitted. These cases produce
+explicit notes in the backup, download confirmation and import preview.
+
+Existing `.mausteam.json` and BotMRR Markdown templates remain importable;
+they contain setup only, not conversation history. Old clients attempting
+`mode=replace` receive a clear error and change nothing.
+
+## Drive and evidence
+
+```sh
+node --experimental-strip-types scripts/verify-team-backup.ts
+```
+
+This mapped regression command uses `launchVerificationServer` and the shared
+MCP/control request core. It accepts no live URL, owns a temporary fake-engine
+server, prints its URL/PID/data directory/log path, and closes that exact
+fixture in `finally`. Its steps are covered by
+`server/team-backup-workflow.test.ts`.
+
+The output records doctor, new-bot, send, wait and messages; the export/import
+counts; exact original-record and transcript comparisons; rejection of old
+replace mode and malformed files; and a settled new turn on the imported bot.
+Keep that JSON output and the printed persistent server log as evidence.
+
+`server/team-backup.test.ts` additionally covers all-task/branch restoration,
+multi-section Chiefs, room-goal routines, repeat imports, restart persistence,
+malformed reference graphs, permission injection and rollback on failure.
+The scripted fixture does not by itself prove the native file picker or
+download UI; verify those separately in a renderer connected to a fixture.
+
+## Recovering bots hidden by older imports
+
+Open **Archived bots** in the sidebar menu and restore the original bots.
+Their existing conversations remain attached. No automatic unarchive is
+performed: intentionally archived bots must stay archived.

--- a/scripts/verify-team-backup.ts
+++ b/scripts/verify-team-backup.ts
@@ -1,0 +1,67 @@
+// One owned fake-engine fixture. This command accepts no live server URL.
+import assert from "node:assert/strict";
+import { pathToFileURL } from "node:url";
+import { launchVerificationServer, runControlOmb } from "./control-omb.ts";
+import { request } from "./mcp-server.ts";
+import { parseTeamBackup } from "../shared/team-backup.ts";
+
+export async function verifyTeamBackup(report: (event: unknown) => void = () => {}) {
+  const fixture = await launchVerificationServer();
+  report({ fixture: fixture.info });
+  const url = fixture.info.url;
+  const command = async (...args: string[]) => {
+    const result = await runControlOmb([...args, "--url", url]);
+    report({ command: [...args, "--url", url], result });
+    return result;
+  };
+  const post = (path: string, body: unknown) => request(path, { method: "POST", body: JSON.stringify(body) }, url);
+  try {
+    const doctor = await command("doctor") as { ok: boolean };
+    assert.equal(doctor.ok, true);
+    const { bot } = await command("new-bot", "--name", "Backup probe", "--section", "Original team") as { bot: { id: string } };
+    await command("send", "--bot", bot.id, "--text", "Remember the backup verification conversation. Reply once.");
+    const wait = await command("wait", "--bot", bot.id, "--timeout", "30") as { status: string };
+    assert.equal(wait.status, "settled");
+    const transcript = await command("messages", "--bot", bot.id, "--limit", "10");
+    const before = await request("/api/bots", {}, url);
+    const backup = parseTeamBackup(await post("/api/teams/export", { format: "backup", name: "Fixture backup" }));
+    report({ command: "export backup", bots: backup.bots.length, conversations: backup.bots.reduce((n, bot) => n + bot.tasks.length, 0) });
+    const imported = await post("/api/teams/import?mode=add", JSON.parse(JSON.stringify(backup)));
+    assert.equal(imported.bots.length, before.bots.length);
+    const added = imported.bots.find((candidate: { name: string }) => candidate.name === "Backup probe 2");
+    assert.ok(added);
+    assert.equal(added.section, "Original team 2");
+    const after = await request("/api/bots", {}, url);
+    for (const existing of before.bots) assert.deepEqual(after.bots.find((candidate: { id: string }) => candidate.id === existing.id), existing);
+    for (const existing of before.groups) assert.deepEqual(after.groups.find((candidate: { id: string }) => candidate.id === existing.id), existing);
+    assert.deepEqual(await command("messages", "--bot", bot.id, "--limit", "10"), transcript);
+    const old = before.bots.find((candidate: { id: string }) => candidate.id === bot.id);
+    assert.ok(old.messages.some((message: { role: string; kind: string; text?: string }) => message.role === "bot" && message.kind === "text" && message.text?.includes("hello from fake claude")));
+    for (const message of old.messages.filter((message: { kind: string }) => message.kind === "text")) {
+      assert.ok(added.messages.some((copy: { text: string; id: string }) => copy.text === message.text && copy.id !== message.id));
+    }
+    await command("messages", "--bot", added.id, "--limit", "10");
+    await assert.rejects(post("/api/teams/import?mode=replace", backup), /Replacing your team/);
+    await assert.rejects(post("/api/teams/import", { ...backup, version: 999 }), /Invalid backup/);
+    assert.deepEqual(await request("/api/bots", {}, url), after);
+    // The copied history is usable for a fresh turn without resuming the
+    // original provider session or altering the original bot's transcript.
+    await command("send", "--bot", added.id, "--text", "Continue the imported conversation. Reply once.");
+    const resumed = await command("wait", "--bot", added.id, "--timeout", "30") as { status: string };
+    assert.equal(resumed.status, "settled");
+    await command("messages", "--bot", added.id, "--limit", "10");
+    assert.deepEqual(await command("messages", "--bot", bot.id, "--limit", "10"), transcript);
+    const result = { ok: true, existingBotsKept: before.bots.length, importedBots: imported.bots.length, originalConversationUnchanged: true, importedConversationContinued: true, logPath: fixture.info.logPath };
+    report(result);
+    return result;
+  } finally {
+    await fixture.close();
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  verifyTeamBackup((event) => console.log(JSON.stringify(event))).catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -3207,29 +3207,12 @@ describe("harness HTTP API", () => {
       expect(invalid.status).toBe(400);
       expect((await api("POST", "/api/teams/import?mode=erase", exported.body)).status).toBe(400);
 
-      const beforeReplace = (await api("GET", "/api/bots")).body.bots.filter(
-        (bot: { hidden?: boolean }) => !bot.hidden,
-      );
+      const beforeReplace = (await api("GET", "/api/bots")).body;
       const replaced = await api("POST", "/api/teams/import?mode=replace", exported.body);
-      expect(replaced.status).toBe(201);
-      expect(replaced.body.archived.map((bot: { id: string }) => bot.id).sort()).toEqual(
-        beforeReplace.map((bot: { id: string }) => bot.id).sort(),
-      );
-      expect(replaced.body.archivedBots.every((bot: { hidden?: boolean }) => bot.hidden)).toBe(true);
-      const afterReplace = (await api("GET", "/api/bots")).body.bots;
-      expect(afterReplace.filter((bot: { hidden?: boolean }) => !bot.hidden).map((bot: { id: string }) => bot.id).sort()).toEqual(
-        replaced.body.bots.map((bot: { id: string }) => bot.id).sort(),
-      );
+      expect(replaced.status).toBe(400);
+      expect(replaced.body.error).toContain("Replacing your team is no longer supported");
+      expect((await api("GET", "/api/bots")).body).toEqual(beforeReplace);
       expect((await api("GET", "/api/bots")).body.groups).toHaveLength(roomsBefore);
-
-      // Put the shared test harness back exactly as it was before exercising
-      // replace. This mirrors the UI's Undo action and preserves the seeded bot.
-      for (const bot of replaced.body.bots) await api("DELETE", `/api/bots/${bot.id}`);
-      for (const bot of replaced.body.archived.filter((item: { chiefOfStaff: boolean }) => !item.chiefOfStaff)) {
-        await api("PATCH", `/api/bots/${bot.id}`, { hidden: false });
-      }
-      const previousChief = replaced.body.archived.find((bot: { chiefOfStaff: boolean }) => bot.chiefOfStaff);
-      if (previousChief) await api("PATCH", `/api/bots/${previousChief.id}`, { hidden: false, chiefOfStaff: true });
 
       for (const bot of [first, second, hidden, ...imported.body.bots]) {
         expect((await api("DELETE", `/api/bots/${bot.id}`)).status).toBe(200);

--- a/server/index.ts
+++ b/server/index.ts
@@ -271,6 +271,8 @@ import { SPAWNED_PROXIES } from "./proxy-paths.ts";
 import { loadBundledSkills, loadUserSkills, mergeSkills, renderSkillInstructions, selectBundledSkills } from "./skill-library.ts";
 import { installedPlaybookInstructions } from "./installed-playbooks.ts";
 import { createBotPackageExport } from "./package-export.ts";
+import { createTeamBackup, importTeamBackup } from "./team-backup.ts";
+import { MAX_TEAM_BACKUP_BYTES } from "../shared/team-backup.ts";
 import { shouldMountLocalComputer } from "./local-routing.ts";
 import { resolveSurface } from "./surface.ts";
 import {
@@ -8816,8 +8818,11 @@ const server = createServer(async (req, res) => {
             ? `${profileName}'s Team`
             : "My OpenMaus Team";
       const memberIds = store.bots.filter((bot) => !bot.hidden).map((bot) => bot.id);
-      if (memberIds.length === 0) return json(res, 400, { error: "Create a bot before exporting your team" });
+      if ((body.format === "backup" ? store.bots.length : memberIds.length) === 0) return json(res, 400, { error: "Create a bot before exporting your team" });
       try {
+        if (body.format === "backup") {
+          return json(res, 200, createTeamBackup(store, routines!.listRoutines(), name));
+        }
         if (body.format === "package") {
           const document = createBotPackageExport({
             name,
@@ -8912,15 +8917,13 @@ const server = createServer(async (req, res) => {
       // GitHub, a shared file), so it must be structurally unable to reach
       // records the user already has: every member becomes a NEW bot with a
       // fresh id — a manifest cannot name, update, or merge into an existing
-      // bot or room, and importing the same file twice simply creates a
-      // second, freshly numbered set (an edit the user made to the first set
-      // is theirs and stays). Replace mode does hide the current team, but
-      // that archive is driven by the mode parameter the user chose and
-      // touches only hidden/chiefOfStaff on their own bots — nothing in the
-      // file decides what gets archived or how.
+      // bot or room. Repeated imports create freshly numbered copies.
       const importMode = url.searchParams.get("mode") ?? "add";
-      if (importMode !== "add" && importMode !== "replace" && importMode !== "project") {
-        return json(res, 400, { error: "Team import mode must be add, replace, or project" });
+      if (importMode === "replace") {
+        return json(res, 400, { error: "Replacing your team is no longer supported. Reopen Import in the updated app to add bots alongside your existing conversations." });
+      }
+      if (importMode !== "add" && importMode !== "project") {
+        return json(res, 400, { error: "Team import mode must be add or project" });
       }
       // `project` adds the team AND opens a caller-owned room on a folder.
       // Legacy team manifests remain people-only. Full bot packages may add
@@ -8936,7 +8939,20 @@ const server = createServer(async (req, res) => {
           projectCwd = validated.cwd;
         }
       }
-      const body = await readBody(req);
+      const body = await readBody(req, MAX_TEAM_BACKUP_BYTES);
+      if (body?.format === "openmaus.backup") {
+        if (importMode !== "add") return json(res, 400, { error: "Import backups alongside your existing bots; project mode is only for templates" });
+        try {
+          const imported = importTeamBackup(store, routines!, body, await defaultSelection());
+          const bots = imported.bots.map((bot) => publicBot(bot));
+          const groups = imported.groups.map((group) => ({ ...publicGroupState(group), ...messagePage(group.threadId, undefined) }));
+          for (const bot of bots) broadcast({ kind: "bot", bot });
+          for (const group of groups) broadcast({ kind: "group", group });
+          return json(res, 201, { ...imported, bots, groups });
+        } catch (error) {
+          return json(res, 400, { error: error instanceof Error ? error.message : "Backup could not be imported" });
+        }
+      }
       let packageDocument: ReturnType<typeof parseBotPackage> | null = null;
       let manifest: ReturnType<typeof parseTeamManifest> | null = null;
       try {
@@ -8951,23 +8967,12 @@ const server = createServer(async (req, res) => {
         ? pkg.agents.map((agent) => ({ member: packageAgentAsMember(agent), playbookKeys: agent.playbooks ?? [] }))
         : manifest!.team.members.map((member) => ({ member, playbookKeys: [] as string[] }));
 
-      // Snapshot before creating anything so replace never archives the new
-      // team. Old bots are hidden only after every new bot was created; a
-      // failed import therefore leaves the current workspace untouched.
-      const archived = importMode === "replace"
-        ? store.bots
-            .filter((bot) => !bot.hidden)
-            .map((bot) => ({ id: bot.id, chiefOfStaff: Boolean(bot.chiefOfStaff) }))
-        : [];
       const importedBots: ReturnType<typeof store.createBot>[] = [];
       const createdGroups: GroupRecord[] = [];
       const createdRoutineIds: string[] = [];
       // Names already in use, hidden bots included: an archived bot can be
       // un-archived later, and a revived duplicate would be just as
-      // ambiguous then. In replace mode this means re-importing your own
-      // export numbers the newcomers ("Mira 2") — the old team is only
-      // hidden, not gone, and Undo must never surface two bots wearing the
-      // same name.
+      // ambiguous then.
       const takenNames = new Set(store.bots.map((bot) => bot.name.trim().toLowerCase()));
       const memberIds = new Map<string, string>();
       let group: GroupRecord | undefined;
@@ -9003,6 +9008,7 @@ const server = createServer(async (req, res) => {
             },
             { seedMessages: false },
           );
+          importedBots.push(created);
           const installedPlaybooks = source.playbookKeys.flatMap((key) => {
             const playbook = playbookByKey.get(key);
             return playbook ? [{ ...playbook }] : [];
@@ -9021,7 +9027,6 @@ const server = createServer(async (req, res) => {
                 }
               : {}),
           });
-          importedBots.push(created);
           memberIds.set(member.key, created.id);
         }
 
@@ -9030,6 +9035,7 @@ const server = createServer(async (req, res) => {
         for (const room of pkg?.rooms ?? []) {
           const ids = room.members.map((key) => memberIds.get(key)!);
           let created = store.createGroup(room.name, ids, false, packageSection);
+          createdGroups.push(created);
           const defaultResponder = room.defaultResponder.kind === "agent"
             ? { kind: "member" as const, botId: memberIds.get(room.defaultResponder.agent)! }
             : { kind: room.defaultResponder.kind } as const;
@@ -9038,7 +9044,6 @@ const server = createServer(async (req, res) => {
             defaultResponder,
             setupCompletedAt: Date.now(),
           }) ?? created;
-          createdGroups.push(created);
         }
 
         for (const routine of pkg?.routines ?? []) {
@@ -9065,6 +9070,7 @@ const server = createServer(async (req, res) => {
         if (!pkg && importMode === "project" && importedBots.length > 0) {
           const roomName = url.searchParams.get("room")?.trim() || manifest!.team.name;
           group = store.createGroup(roomName, importedBots.map((bot) => bot.id));
+          createdGroups.push(group);
           if (projectCwd) {
             // `cwd` is the folder the room WANTS; the store pins it on the
             // first turn (pinGroupCwd). Setting the pin here would decide it
@@ -9072,25 +9078,14 @@ const server = createServer(async (req, res) => {
             group = store.patchGroup(group.id, { cwd: projectCwd }) ?? group;
           }
           broadcast({ kind: "group", group: publicGroupState(group) });
-          createdGroups.push(group);
         }
 
-        // Archive only after the complete new structure exists. A package
-        // that fails validation or persistence never disturbs the current
-        // workspace.
-        const archivedBots = archived.flatMap(({ id }) => {
-          const bot = store.patchBot(id, { hidden: true, chiefOfStaff: false });
-          return bot ? [publicBot(bot)] : [];
-        });
         const publicBots = importedBots.map((bot) => publicBot(store.bot(bot.id)!));
-        for (const bot of archivedBots) broadcast({ kind: "bot", bot });
         for (const bot of publicBots) broadcast({ kind: "bot", bot });
 
         return json(res, 201, {
           name: importName,
           bots: publicBots,
-          archivedBots,
-          archived,
           group,
           groups: createdGroups.map((created) => ({ ...created, messages: [] })),
           routines: createdRoutineIds.flatMap((id) => routines!.listRoutines().filter((routine) => routine.id === id)),

--- a/server/message-db.ts
+++ b/server/message-db.ts
@@ -133,6 +133,24 @@ export function insertMessage(threadId: string, message: Message): void {
     .run(threadId, message.id, message.at, message.role, message.kind, message.text ?? null, JSON.stringify(message));
 }
 
+/** A backup may only populate a fresh thread, never replace a transcript. */
+export function importThread(threadId: string, messages: Message[], activeLeafId: string | null): void {
+  const database = db();
+  database.exec("BEGIN IMMEDIATE");
+  try {
+    if (database.prepare("SELECT 1 FROM messages WHERE thread_id = ? LIMIT 1").get(threadId) ||
+        database.prepare("SELECT 1 FROM thread_state WHERE thread_id = ?").get(threadId)) {
+      throw new Error("Cannot import over an existing conversation");
+    }
+    for (const message of messages) insertMessage(threadId, message);
+    setActiveLeaf(threadId, activeLeafId);
+    database.exec("COMMIT");
+  } catch (error) {
+    database.exec("ROLLBACK");
+    throw error;
+  }
+}
+
 /** Persist a new message and the branch head as one crash-safe mutation. */
 export function appendMessage(threadId: string, message: Message): void {
   const database = db();

--- a/server/store.ts
+++ b/server/store.ts
@@ -1105,6 +1105,14 @@ export class Store {
     return this.thread(threadId).messages;
   }
 
+  /** Used only with newly allocated import threads. No live actions are
+   * replayed: the importer supplies inert text and freshly remapped IDs. */
+  importTranscript(threadId: string, messages: Message[], activeLeafId: string | null): void {
+    if (this.messagesFor(threadId).length) throw new Error("Cannot import over an existing conversation");
+    mdb.importThread(threadId, messages, activeLeafId);
+    this.threads.delete(threadId);
+  }
+
   activeLeaf(threadId: string): string | null {
     return this.thread(threadId).activeLeafId;
   }

--- a/server/team-backup-workflow.test.ts
+++ b/server/team-backup-workflow.test.ts
@@ -1,0 +1,6 @@
+import { expect, it } from "vitest";
+import { verifyTeamBackup } from "../scripts/verify-team-backup.ts";
+
+it("exports and imports through the real server, retains originals and continues the copied chat", async () => {
+  expect(await verifyTeamBackup()).toMatchObject({ ok: true, originalConversationUnchanged: true, importedConversationContinued: true });
+}, 90_000);

--- a/server/team-backup.test.ts
+++ b/server/team-backup.test.ts
@@ -1,0 +1,192 @@
+import { readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DATA_DIR } from "./config.ts";
+import { Store } from "./store.ts";
+import { RoutineManager } from "./routines.ts";
+import { createTeamBackup, importTeamBackup } from "./team-backup.ts";
+import { parseTeamBackup } from "../shared/team-backup.ts";
+
+const selection = () => ({ instanceId: "fixture", model: "fixture-model" });
+
+function fixture() {
+  const store = new Store(selection);
+  const routines = new RoutineManager({
+    botState: (id) => store.bot(id) ? "ready" : "missing",
+    goalState: (id, botId) => store.group(id)?.memberIds.includes(botId) ? "ready" : "missing",
+    createTask: (id, title) => store.createTask(id, title),
+    startTurn: async () => { throw new Error("Import must never run a bot"); },
+  });
+  const chief = store.createBot({ name: "Mira", section: "Engineering", description: "Full instructions\n".repeat(400) }, { seedMessages: false });
+  const scout = store.createBot({ name: "Scout", section: "Engineering", mascotBody: "circle" }, { seedMessages: false });
+  const otherChief = store.createBot({ name: "Ava", section: "Operations" }, { seedMessages: false });
+  const archived = store.createBot({ name: "Archived" }, { seedMessages: false });
+  store.patchBot(archived.id, { hidden: true });
+  store.patchBot(chief.id, { chiefOfStaff: true, autoApprove: true, approvalMode: "full", alwaysAllow: ["Bash"], cwd: "/private/old-workspace", composio: true,
+    playbooks: [{ key: "research", name: "Research", summary: "Find evidence", triggers: ["research"], instructions: "Cite sources" }] });
+  store.setChiefOfStaff(otherChief.id);
+  const root = store.appendMessage(chief.threadId, { role: "user", kind: "text", text: "Original question", at: 100 });
+  const answer = store.appendMessage(chief.threadId, { role: "bot", kind: "text", text: "Original answer", at: 101 });
+  store.branchMessage(chief.threadId, root.id, "Edited question");
+  store.setActiveLeaf(chief.threadId, answer.id);
+  store.renameTask(chief.id, chief.threadId, "First conversation");
+  const active = store.createTask(chief.id, "Second conversation")!;
+  store.appendMessage(active.threadId, { role: "user", kind: "text", text: "Current question", queued: true, queueId: "do-not-replay" });
+  store.appendMessage(active.threadId, { role: "bot", kind: "options", card: {
+    title: "Permission request", subtitle: "Old approval", options: ["Allow"], requestId: "do-not-resume", allowKey: "Bash",
+  } });
+  store.appendMessage(active.threadId, { role: "user", kind: "text", text: "An image", attachments: [{ kind: "image", path: "/private/image.png", mime: "image/png" }] });
+  const group = store.createGroup("Project room", [chief.id, scout.id], false, "Engineering", {
+    bulletin: "Build carefully", defaultResponder: { kind: "member", botId: chief.id }, completed: true,
+  });
+  store.appendMessage(group.threadId, { role: "bot", kind: "text", text: "Room answer", from: { botId: scout.id, name: scout.name, color: scout.color }, peerPost: { unattended: true } });
+  store.createGroupTask(group.id, "Second room task", false);
+  routines.create({ name: "Daily", prompt: "Report progress", botId: chief.id, enabled: true, schedule: { type: "daily", time: "09:00", weekdays: [1, 2, 3, 4, 5] } });
+  routines.create({ name: "Standup", prompt: "Discuss progress", target: "room-goal", groupId: group.id, botId: chief.id, enabled: true, schedule: { type: "interval", everyMinutes: 30, anchorAt: 0 } });
+  return { store, routines, chief, scout, otherChief, archived, group };
+}
+
+describe("additive portable team backups", () => {
+  beforeEach(() => rmSync(DATA_DIR, { recursive: true, force: true }));
+
+  it("round-trips all bots, sections, Chiefs, rooms, tasks and branches without changing originals", () => {
+    const { store, routines, chief, scout, otherChief, archived, group } = fixture();
+    const backup = createTeamBackup(store, routines.listRoutines(), "My team");
+    const originalBots = structuredClone(store.bots);
+    const originalGroups = structuredClone(store.groups);
+    const originalRoutines = routines.listRoutines();
+    const result = importTeamBackup(store, routines, JSON.parse(JSON.stringify(backup)), selection());
+    expect(result.bots).toHaveLength(4);
+    expect(result.groups).toHaveLength(1);
+    for (const bot of originalBots) expect(store.bot(bot.id)).toEqual(bot);
+    for (const room of originalGroups) expect(store.group(room.id)).toEqual(room);
+    for (const routine of originalRoutines) expect(routines.listRoutines().find((r) => r.id === routine.id)).toEqual(routine);
+    const importedChief = result.bots.find((bot) => bot.name === "Mira 2")!;
+    const importedScout = result.bots.find((bot) => bot.name === "Scout 2")!;
+    expect(importedChief).toMatchObject({ section: "Engineering 2", chiefOfStaff: true, description: chief.description, computer: "off", composio: false, browser: false, approvalMode: "ask", autoApprove: false, resumeCursors: {}, playbooks: chief.playbooks });
+    expect(result.bots.find((bot) => bot.name === "Ava 2")).toMatchObject({ section: "Operations 2", chiefOfStaff: true });
+    expect(result.bots.find((bot) => bot.name === "Archived 2")).toMatchObject({ hidden: true });
+    expect(importedChief).not.toHaveProperty("cwd");
+    expect(importedChief).not.toHaveProperty("alwaysAllow");
+    expect(store.bot(otherChief.id)?.chiefOfStaff).toBe(true);
+    expect(store.bot(archived.id)?.hidden).toBe(true);
+    expect(importedScout.mascotBody).toBe(scout.mascotBody);
+    expect(result.groups[0]).toMatchObject({ name: "Project room 2", section: "Engineering 2", memberIds: [importedChief.id, importedScout.id], defaultResponder: { kind: "member", botId: importedChief.id } });
+    expect(result.groups[0].tasks?.map((task) => [task.title, task.createdAt])).toEqual(group.tasks?.map((task) => [task.title, task.createdAt]));
+    const roomMessage = store.messagesFor(result.groups[0].threadId)[0];
+    expect(roomMessage).toMatchObject({ text: "Room answer", from: { botId: importedScout.id }, peerPost: { unattended: true } });
+    expect(result.routines.every((routine) => !routine.enabled && routine.nextRunAt === null)).toBe(true);
+    expect(result.routines.find((routine) => routine.target === "room-goal")).toMatchObject({ botId: importedChief.id, groupId: result.groups[0].id });
+    const firstTask = importedChief.tasks!.find((task) => task.title === "First conversation")!;
+    expect(store.messagesFor(firstTask.threadId).map((message) => message.text)).toEqual(["Original question", "Original answer", "Edited question"]);
+    expect(store.activePath(firstTask.threadId).map((message) => message.text)).toEqual(["Original question", "Original answer"]);
+    const importedHistory = store.messagesFor(importedChief.threadId);
+    expect(importedHistory.every((message) => message.kind === "text" && !message.queued && !message.card)).toBe(true);
+    expect(importedHistory[1].text).toContain("Permission request");
+    expect(importedHistory[2].text).toContain("file not included");
+    expect(JSON.stringify(backup)).not.toMatch(/do-not-replay|do-not-resume|\/private\/image|\/private\/old-workspace|alwaysAllow|autoApprove|modelSelection/);
+    const reloaded = new Store(selection);
+    expect(reloaded.activePath(firstTask.threadId)).toEqual(store.activePath(firstTask.threadId));
+    expect(reloaded.bot(importedChief.id)?.tasks).toEqual(importedChief.tasks);
+    expect(reloaded.messagesFor(chief.threadId)).toEqual(store.messagesFor(chief.threadId));
+    // Re-import makes another independent set, not updates to either set.
+    const second = importTeamBackup(store, routines, backup, selection());
+    expect(second.bots.find((bot) => bot.name === "Mira 3")).toMatchObject({ section: "Engineering 3", chiefOfStaff: true });
+    expect(store.bot(importedChief.id)).toEqual(importedChief);
+  });
+
+  it.each(["unknown-version", "duplicate-bot", "cycle", "dangling-room", "dangling-task", "duplicate-chief"])("rejects %s before any writes", (corruption) => {
+    const { store, routines } = fixture();
+    const backup = createTeamBackup(store, routines.listRoutines(), "My team");
+    const before = readFileSync(join(DATA_DIR, "bots.json"), "utf8");
+    const groupsBefore = readFileSync(join(DATA_DIR, "groups.json"), "utf8");
+    const source = backup.bots.find((bot) => bot.name === "Mira")!;
+    if (corruption === "unknown-version") Object.assign(backup, { version: 2 });
+    if (corruption === "duplicate-bot") backup.bots.push(source);
+    if (corruption === "cycle") source.tasks[0].messages[0].parentId = source.tasks[0].messages[0].id;
+    if (corruption === "dangling-room") backup.groups[0].memberIds.push("missing");
+    if (corruption === "dangling-task") source.activeTask = "missing";
+    if (corruption === "duplicate-chief") backup.bots.find((bot) => bot.name === "Scout")!.chiefOfStaff = true;
+    expect(() => importTeamBackup(store, routines, backup, selection())).toThrow("Invalid backup");
+    expect(readFileSync(join(DATA_DIR, "bots.json"), "utf8")).toBe(before);
+    expect(readFileSync(join(DATA_DIR, "groups.json"), "utf8")).toBe(groupsBefore);
+  });
+
+  it("strips injected permissions, IDs and live actions from untrusted files", () => {
+    const { store, routines, chief } = fixture();
+    const backup = createTeamBackup(store, routines.listRoutines(), "My team");
+    const source = backup.bots.find((bot) => bot.name === "Mira")!;
+    Object.assign(source, { id: chief.id, threadId: chief.threadId, cwd: "/tmp", composio: true, approvalMode: "full", autoApprove: true, browser: true, computer: "local", resumeCursors: { fixture: "secret-session" } });
+    Object.assign(source.tasks[0].messages[0], { kind: "options", queued: true, card: { requestId: "live-approval" }, attachments: [{ path: "/etc/passwd" }] });
+    const imported = importTeamBackup(store, routines, backup, selection()).bots.find((bot) => bot.name === "Mira 2")!;
+    expect(imported.id).not.toBe(chief.id);
+    expect(imported.threadId).not.toBe(chief.threadId);
+    expect(imported.approvalMode).toBe("ask");
+    expect(JSON.stringify(parseTeamBackup(backup))).not.toMatch(/live-approval|secret-session|\/etc\/passwd|approvalMode/);
+  });
+
+  it("rolls back fresh bots, rooms and transcripts after a late failure", () => {
+    const { store, routines } = fixture();
+    const backup = createTeamBackup(store, routines.listRoutines(), "My team");
+    const before = createTeamBackup(store, routines.listRoutines(), "My team");
+    const write = vi.spyOn(routines, "create").mockImplementationOnce(() => { throw new Error("fixture disk failure"); });
+    expect(() => importTeamBackup(store, routines, backup, selection())).toThrow("fixture disk failure");
+    write.mockRestore();
+    const after = createTeamBackup(new Store(selection), routines.listRoutines(), "My team");
+    expect({ ...after, exportedAt: 0 }).toEqual({ ...before, exportedAt: 0 });
+  });
+
+  it("refuses to populate a thread that already has history", () => {
+    const { store, chief } = fixture();
+    const before = structuredClone(store.messagesFor(chief.threadId));
+    expect(() => store.importTranscript(chief.threadId, [], null)).toThrow("existing conversation");
+    expect(store.messagesFor(chief.threadId)).toEqual(before);
+  });
+
+  it("also rolls back a creation that throws before returning its new record", () => {
+    const { store, routines } = fixture();
+    const backup = createTeamBackup(store, routines.listRoutines(), "My team");
+    const before = structuredClone(store.bots);
+    const create = store.createBot.bind(store);
+    const fail = vi.spyOn(store, "createBot").mockImplementationOnce((...args) => {
+      create(...args);
+      throw new Error("creation failed before returning");
+    });
+    expect(() => importTeamBackup(store, routines, backup, selection())).toThrow("creation failed");
+    fail.mockRestore();
+    expect(store.bots).toEqual(before);
+    expect(new Store(selection).bots.map((bot) => bot.id)).toEqual(before.map((bot) => bot.id));
+  });
+
+  it("keeps case-distinct sections and their Chiefs separate", () => {
+    const { store, routines } = fixture();
+    const second = store.createBot({ name: "Another chief", section: "engineering" }, { seedMessages: false });
+    store.setChiefOfStaff(second.id);
+    const imported = importTeamBackup(store, routines, createTeamBackup(store, routines.listRoutines(), "My team"), selection());
+    const chief = imported.bots.find((bot) => bot.name === "Mira 2")!;
+    const other = imported.bots.find((bot) => bot.name === "Another chief 2")!;
+    expect(chief.chiefOfStaff).toBe(true);
+    expect(other.chiefOfStaff).toBe(true);
+    expect(chief.section?.toLowerCase()).not.toBe(other.section?.toLowerCase());
+    const reloaded = new Store(selection);
+    expect(reloaded.bot(chief.id)?.chiefOfStaff).toBe(true);
+    expect(reloaded.bot(other.id)?.chiefOfStaff).toBe(true);
+  });
+
+  it("backs up room history even when old deletions left dangling memberships and routines", () => {
+    const { store, routines, chief, scout, group } = fixture();
+    const dm = store.createGroup("Old direct message", [chief.id, scout.id], true);
+    store.appendMessage(dm.threadId, { role: "bot", kind: "text", text: "Keep this old reply", from: { botId: chief.id, name: chief.name, color: chief.color } });
+    store.deleteBot(chief.id);
+    const backup = createTeamBackup(store, routines.listRoutines(), "My team");
+    expect(backup.warnings).toHaveLength(4);
+    expect(backup.routines).toEqual([]);
+    expect(backup.groups.find((room) => room.key === group.id)).toMatchObject({ memberIds: [scout.id], defaultResponder: { kind: "mentions" } });
+    expect(backup.groups.find((room) => room.key === dm.id)?.dm).toBe(false);
+    const restored = importTeamBackup(store, routines, backup, selection());
+    const restoredDm = restored.groups.find((room) => room.name === "Old direct message 2")!;
+    expect(store.messagesFor(restoredDm.threadId)[0]).toMatchObject({ text: "Mira:\nKeep this old reply" });
+    // Exporting never repairs or removes the original records in place.
+    expect(store.group(group.id)?.memberIds).toEqual([chief.id, scout.id]);
+  });
+});

--- a/server/team-backup.ts
+++ b/server/team-backup.ts
@@ -1,0 +1,172 @@
+import { newId, type ModelSelection } from "./contracts.ts";
+import { botMascotBody } from "../shared/mascot-bodies.ts";
+import { takeImportName } from "../shared/import-name.ts";
+import { MAX_TEAM_BACKUP_BYTES, parseTeamBackup, type BackupTask, type TeamBackup } from "../shared/team-backup.ts";
+import type { BotRecord, GroupRecord, Message, Store } from "./store.ts";
+import type { Routine, RoutineManager } from "./routines.ts";
+
+/** Preserve readable history without importing executable cards, live queue
+ * entries, approval requests, local paths or provider session handles. */
+function messageText(message: Message): string {
+  const parts = [message.text ?? ""];
+  if (message.card) parts.push(message.card.title, message.card.subtitle, ...message.card.options, message.card.answered ?? "");
+  if (message.tool) parts.push(`[${message.tool.name}${message.tool.ok === false ? ": failed" : ""}]`);
+  if (message.kind === "connector") parts.push("[Connection card — reconnect in Settings]");
+  if (message.kind === "secret") parts.push("[Secret request — not restored]");
+  if (message.routineRun) parts.push(`[Routine: ${message.routineRun.routineName} — ${message.routineRun.status}]`, message.routineRun.summary ?? "", message.routineRun.error ?? "");
+  if (message.goalRun) parts.push(`[Room goal: ${message.goalRun.status}]`, message.goalRun.goal, message.goalRun.detail ?? "");
+  if (message.kind === "screen" || message.attachments?.length) parts.push("[Image or attachment — file not included in this backup]");
+  return parts.filter(Boolean).join("\n");
+}
+
+export function createTeamBackup(store: Store, routines: Routine[], name: string): TeamBackup {
+  const botIds = new Set(store.bots.map((bot) => bot.id));
+  const warnings: string[] = [];
+  const history = (record: BotRecord | GroupRecord): BackupTask[] => {
+    const tasks = record.tasks?.length ? record.tasks : [{ threadId: record.threadId, title: "Conversation", createdAt: record.createdAt }];
+    return tasks.map((task) => ({
+      key: task.threadId, title: task.title, createdAt: task.createdAt,
+      activeLeafId: store.activeLeaf(task.threadId),
+      messages: store.messagesFor(task.threadId).map((message) => ({
+        id: message.id, role: message.role, text: messageText(message), at: message.at,
+        parentId: message.parentId ?? null, replyToId: message.replyToId,
+        from: message.from, peerPost: message.peerPost,
+      })),
+    }));
+  };
+  const groups = store.groups.map((group) => {
+    const memberIds = group.memberIds.filter((id) => botIds.has(id));
+    if (memberIds.length !== group.memberIds.length) warnings.push(`Room “${group.name}” contains deleted bots. Its conversation is included with the remaining members.`);
+    return {
+      key: group.id, name: group.name, section: group.section, dm: Boolean(group.dm) && memberIds.length === 2,
+      bulletin: group.bulletin, memberIds,
+      defaultResponder: group.defaultResponder.kind === "member" && !memberIds.includes(group.defaultResponder.botId)
+        ? { kind: "mentions" as const } : group.defaultResponder,
+      activeTask: group.threadId, tasks: history(group),
+    };
+  });
+  const validRoutines = routines.filter((routine) => {
+    const room = groups.find((group) => group.key === routine.groupId);
+    const valid = botIds.has(routine.botId) && (routine.target !== "room-goal" || (room && !room.dm && room.memberIds.includes(routine.botId)));
+    if (!valid) warnings.push(`Routine “${routine.name}” is not included because its bot, room or coordinator was deleted.`);
+    return valid;
+  });
+  const document = parseTeamBackup({
+    format: "openmaus.backup", version: 1, name, exportedAt: Date.now(),
+    warnings,
+    bots: store.bots.map((bot) => ({
+      key: bot.id, name: bot.name, title: bot.title, description: bot.description,
+      section: bot.section, color: bot.color,
+      mascotExpression: bot.mascotExpression ?? undefined, mascotBody: bot.mascotBody ?? undefined,
+      chiefOfStaff: Boolean(bot.chiefOfStaff), hidden: Boolean(bot.hidden), playbooks: bot.playbooks ?? [],
+      activeTask: bot.threadId, tasks: history(bot),
+    })),
+    groups,
+    routines: validRoutines.map((routine) => ({
+      name: routine.name, prompt: routine.prompt, target: routine.target, botId: routine.botId,
+      groupId: routine.groupId, runOn: routine.runOn, schedule: routine.schedule,
+      durationMinutes: routine.durationMinutes, timeoutMinutes: routine.timeoutMinutes,
+    })),
+  });
+  // Never download a file our own importer cannot read; never truncate history.
+  if (Buffer.byteLength(JSON.stringify(document)) > MAX_TEAM_BACKUP_BYTES) {
+    throw new Error("This backup exceeds the 50 MB portable-backup limit. Nothing was exported or changed.");
+  }
+  return document;
+}
+
+/** Import is always additive, including sections and Chiefs. Rollback owns
+ * only the fresh records below and cannot touch any pre-existing bot/chat. */
+export function importTeamBackup(store: Store, routines: RoutineManager, input: unknown, selection: ModelSelection) {
+  const backup = parseTeamBackup(input);
+  const bots: BotRecord[] = [];
+  const groups: GroupRecord[] = [];
+  const createdRoutines: Routine[] = [];
+  const existingBotIds = new Set(store.bots.map((bot) => bot.id));
+  const existingGroupIds = new Set(store.groups.map((group) => group.id));
+  const botIds = new Map<string, string>();
+  const groupIds = new Map<string, string>();
+  const takenNames = new Set(store.bots.map((bot) => bot.name.trim().toLowerCase()));
+  const takenGroups = new Set(store.groups.map((group) => group.name.trim().toLowerCase()));
+  const takenSections = new Set([...store.bots, ...store.groups].map((record) => record.section?.trim().toLowerCase() ?? ""));
+  const sections = new Map<string, string>();
+  const sectionFor = (section?: string) => {
+    const key = section?.trim() ?? "";
+    if (!sections.has(key)) sections.set(key, takeImportName(section?.trim() || "Imported bots", takenSections, 60));
+    return sections.get(key)!;
+  };
+  const restore = (task: BackupTask, threadId: string) => {
+    const ids = new Map(task.messages.map((message) => [message.id, newId()]));
+    const messages: Message[] = task.messages.map((message) => ({
+      id: ids.get(message.id)!, kind: "text", role: message.role, text: message.text, at: message.at,
+      parentId: message.parentId ? ids.get(message.parentId)! : null,
+      replyToId: message.replyToId ? ids.get(message.replyToId) : undefined,
+      // Removed historical senders retain their name in the text, never a
+      // link to an unrelated local bot with a colliding file key.
+      ...(message.from && botIds.has(message.from.botId)
+        ? { from: { ...message.from, botId: botIds.get(message.from.botId)! } }
+        : message.from ? { text: `${message.from.name}:\n${message.text}` } : {}),
+      peerPost: message.peerPost,
+    }));
+    store.importTranscript(threadId, messages, task.activeLeafId ? ids.get(task.activeLeafId)! : null);
+  };
+  try {
+    // Allocate all bot IDs before remapping any conversation participants.
+    for (const source of backup.bots) {
+      const bot = store.createBot({
+        name: takeImportName(source.name, takenNames), title: source.title, description: source.description,
+        color: source.color, mascotExpression: source.mascotExpression,
+        mascotBody: botMascotBody(source.mascotBody),
+        modelSelection: selection, section: sectionFor(source.section),
+      }, { seedMessages: false });
+      bots.push(bot);
+      botIds.set(source.key, bot.id);
+      store.patchBot(bot.id, { composio: false, computer: "off", browser: false, approvalMode: "ask", autoApprove: false,
+        hidden: source.hidden, chiefOfStaff: source.chiefOfStaff, playbooks: source.playbooks });
+    }
+    for (const source of backup.bots) {
+      const bot = store.bot(botIds.get(source.key)!)!;
+      const tasks = source.tasks.map((task, i) => ({
+        threadId: i === 0 ? bot.threadId : newId(), title: task.title, createdAt: task.createdAt, resumeCursors: {},
+      }));
+      // Own the task IDs before writing their transcripts, so rollback also
+      // removes partially imported history if persistence fails midway.
+      store.patchBot(bot.id, { tasks, threadId: tasks[source.tasks.findIndex((task) => task.key === source.activeTask)].threadId });
+      source.tasks.forEach((task, i) => restore(task, tasks[i].threadId));
+    }
+    for (const source of backup.groups) {
+      const group = store.createGroup(takeImportName(source.name, takenGroups), source.memberIds.map((id) => botIds.get(id)!), source.dm, sectionFor(source.section));
+      groups.push(group);
+      groupIds.set(source.key, group.id);
+      const responder = source.defaultResponder;
+      store.patchGroup(group.id, { bulletin: source.bulletin, setupCompletedAt: Date.now(), defaultResponder:
+        responder.kind === "member" ? { kind: "member", botId: botIds.get(responder.botId)! } : responder });
+      // Use the existing task APIs for rooms; direct-message rooms have one.
+      const threads = source.tasks.map((task, i) => {
+        if (i === 0) {
+          if (!source.dm) store.renameGroupTask(group.id, group.threadId, task.title);
+          return group.threadId;
+        }
+        return store.createGroupTask(group.id, task.title, false)!.threadId;
+      });
+      source.tasks.forEach((task, i) => restore(task, threads[i]));
+      if (!source.dm) {
+        group.tasks = source.tasks.map((task, i) => ({ threadId: threads[i], title: task.title, createdAt: task.createdAt }));
+        store.switchGroupTask(group.id, threads[source.tasks.findIndex((task) => task.key === source.activeTask)]);
+      }
+    }
+    for (const source of backup.routines) {
+      createdRoutines.push(routines.create({ ...source, botId: botIds.get(source.botId)!,
+        groupId: source.target === "room-goal" ? groupIds.get(source.groupId!) : undefined, enabled: false }));
+    }
+    return { name: backup.name, bots, groups, routines: createdRoutines };
+  } catch (error) {
+    for (const routine of createdRoutines) routines.remove(routine.id);
+    // createBot/createGroup can throw during persistence before returning.
+    // This synchronous import cannot interleave another writer, so include
+    // every fresh ID, even a record that never reached the result arrays.
+    for (const group of store.groups) if (!existingGroupIds.has(group.id)) store.deleteGroup(group.id);
+    for (const bot of store.bots) if (!existingBotIds.has(bot.id)) store.deleteBot(bot.id);
+    throw error;
+  }
+}

--- a/server/team-manifest.ts
+++ b/server/team-manifest.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { schemaIssue, type JsonValue } from "./schema.ts";
 import type { MausColor } from "./store.ts";
 import { botMascotBody, type MascotBodyId } from "../shared/mascot-bodies.ts";
+import { takeImportName } from "../shared/import-name.ts";
 
 export const TEAM_MANIFEST_FORMAT = "openmaus.team" as const;
 export const TEAM_MANIFEST_VERSION = 2 as const;
@@ -209,8 +210,6 @@ export interface ImportedMemberProfile {
   mascotBody?: MascotBodyId;
 }
 
-const MAX_MEMBER_NAME = 100;
-
 /** Everything an untrusted manifest may seed into a brand-new bot — and
  * nothing else.
  *
@@ -246,13 +245,7 @@ export function importedMemberProfile(
   member: TeamManifestMember,
   takenNames: Set<string>,
 ): ImportedMemberProfile {
-  const base = member.name.trim();
-  let name = base;
-  for (let n = 2; takenNames.has(name.toLowerCase()); n++) {
-    const tag = ` ${n}`;
-    name = `${base.slice(0, MAX_MEMBER_NAME - tag.length).trimEnd()}${tag}`;
-  }
-  takenNames.add(name.toLowerCase());
+  const name = takeImportName(member.name, takenNames);
   const profile: ImportedMemberProfile = {
     name,
     title: member.title,

--- a/shared/import-name.ts
+++ b/shared/import-name.ts
@@ -1,0 +1,11 @@
+/** Shared by import and preview, including names reserved by archived bots. */
+export function takeImportName(value: string, taken: Set<string>, maxLength = 100): string {
+  const base = value.trim().slice(0, maxLength);
+  let name = base;
+  for (let n = 2; taken.has(name.toLowerCase()); n++) {
+    const suffix = ` ${n}`;
+    name = `${base.slice(0, maxLength - suffix.length).trimEnd()}${suffix}`;
+  }
+  taken.add(name.toLowerCase());
+  return name;
+}

--- a/shared/team-backup.ts
+++ b/shared/team-backup.ts
@@ -1,0 +1,143 @@
+import { z } from "zod";
+
+export const MAX_TEAM_BACKUP_BYTES = 50 * 1024 * 1024;
+export const TEAM_BACKUP_CONTENTS = "Bot profiles, instructions, sections, rooms, playbooks, routines and conversation text (all tasks and branches).";
+export const TEAM_BACKUP_EXCLUSIONS = "Files, images, custom avatars, workspace memory, account connections, model settings and permissions are not included. Action cards are saved as text. Imported routines start paused.";
+
+const key = z.string().min(1).max(200);
+const name = z.string().trim().min(1).max(200);
+const timestamp = z.number().finite().nonnegative();
+const color = z.enum(["green", "blue", "red", "orange", "purple", "cyan", "pink", "yellow", "teal", "coral"]);
+const message = z.object({
+  id: key,
+  role: z.enum(["bot", "user"]),
+  text: z.string().max(2_000_000),
+  at: timestamp,
+  parentId: key.nullable(),
+  replyToId: key.optional(),
+  from: z.object({ botId: key, name, color: z.string().max(40) }).optional(),
+  peerPost: z.object({ unattended: z.boolean().optional() }).optional(),
+});
+const task = z.object({
+  key,
+  title: z.string().max(2_000),
+  createdAt: timestamp,
+  activeLeafId: key.nullable(),
+  messages: z.array(message).max(100_000),
+});
+const owner = {
+  key,
+  name,
+  section: z.string().max(200).optional(),
+  activeTask: key,
+  tasks: z.array(task).min(1).max(10_000),
+};
+const playbook = z.object({
+  key, name, summary: z.string().max(24_000),
+  triggers: z.array(z.string().max(2_000)).max(100),
+  instructions: z.string().max(200_000),
+});
+const schedule = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("once"), at: timestamp }),
+  z.object({ type: z.literal("daily"), time: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/), weekdays: z.array(z.number().int().min(0).max(6)).min(1).max(7) }),
+  z.object({ type: z.literal("interval"), everyMinutes: z.number().int().min(5).max(1440), anchorAt: z.number().int().min(0).max(8_640_000_000_000_000) }),
+]);
+const backupSchema = z.object({
+  format: z.literal("openmaus.backup"),
+  version: z.literal(1),
+  name,
+  exportedAt: timestamp,
+  warnings: z.array(z.string().max(2_000)).max(4_000).default([]),
+  bots: z.array(z.object({
+    ...owner,
+    title: z.string().max(2_000),
+    description: z.string().max(200_000),
+    color,
+    mascotExpression: z.string().max(80).optional(),
+    mascotBody: z.string().max(40).optional(),
+    chiefOfStaff: z.boolean(),
+    hidden: z.boolean(),
+    playbooks: z.array(playbook).max(200),
+  })).min(1).max(200),
+  groups: z.array(z.object({
+    ...owner,
+    memberIds: z.array(key).max(200),
+    dm: z.boolean(),
+    bulletin: z.string().max(200_000),
+    defaultResponder: z.discriminatedUnion("kind", [
+      z.object({ kind: z.literal("member"), botId: key }),
+      z.object({ kind: z.literal("everyone") }),
+      z.object({ kind: z.literal("mentions") }),
+    ]),
+  })).max(2_000),
+  routines: z.array(z.object({
+    name, prompt: z.string().trim().min(1).max(200_000),
+    target: z.enum(["bot", "room-goal"]), botId: key, groupId: key.optional(),
+    runOn: z.enum(["maus", "cloud"]), schedule,
+    durationMinutes: z.number().finite().positive(),
+    timeoutMinutes: z.number().int().min(5).max(240).optional(),
+  })).max(2_000),
+});
+
+export type TeamBackup = z.infer<typeof backupSchema>;
+export type BackupTask = z.infer<typeof task>;
+
+/** Validate the whole reference graph before an import can write anything.
+ * All keys are file-local; none are ever used as destination record IDs. */
+export function parseTeamBackup(input: unknown): TeamBackup {
+  const parsed = backupSchema.safeParse(input);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    throw new Error(`Invalid backup: ${issue.path.join(".") || "file"}: ${issue.message}`);
+  }
+  const backup = parsed.data;
+  const unique = (keys: string[], label: string) => {
+    const set = new Set(keys);
+    if (set.size !== keys.length) throw new Error(`Invalid backup: duplicate ${label}`);
+    return set;
+  };
+  const bots = unique(backup.bots.map((bot) => bot.key), "bot key");
+  const groups = unique(backup.groups.map((group) => group.key), "room key");
+  const chiefs = new Set<string>();
+  for (const bot of backup.bots) {
+    if (!bot.chiefOfStaff) continue;
+    // Persisted section identity is its exact trimmed display label.
+    const section = bot.section?.trim() ?? "";
+    if (chiefs.has(section) || bot.hidden) throw new Error("Invalid backup: a section must have at most one visible Chief of Staff");
+    chiefs.add(section);
+  }
+  for (const group of backup.groups) {
+    if (group.memberIds.some((id) => !bots.has(id))) throw new Error("Invalid backup: unknown room member");
+    unique(group.memberIds, "room member");
+    if (group.defaultResponder.kind === "member" && !group.memberIds.includes(group.defaultResponder.botId)) {
+      throw new Error("Invalid backup: room responder is not a member");
+    }
+    if (group.dm && (group.memberIds.length !== 2 || group.tasks.length !== 1)) throw new Error("Invalid backup: invalid direct-message room");
+  }
+  for (const routine of backup.routines) {
+    if (!bots.has(routine.botId)) throw new Error("Invalid backup: unknown routine bot");
+    if (routine.target === "room-goal") {
+      if (routine.runOn !== "maus") throw new Error("Invalid backup: room goals must run on this computer");
+      const group = backup.groups.find((candidate) => candidate.key === routine.groupId);
+      if (!groups.has(routine.groupId ?? "") || !group || group.dm || !group.memberIds.includes(routine.botId)) {
+        throw new Error("Invalid backup: unknown routine room or coordinator");
+      }
+    }
+  }
+  for (const entry of [...backup.bots, ...backup.groups]) {
+    const tasks = unique(entry.tasks.map((task) => task.key), "task key");
+    if (!tasks.has(entry.activeTask)) throw new Error("Invalid backup: unknown active task");
+    for (const task of entry.tasks) {
+      const messages = unique(task.messages.map((message) => message.id), "message key");
+      const seen = new Set<string>();
+      for (const message of task.messages) {
+        // Parents must precede children: rejects cycles and dangling branches.
+        if (message.parentId !== null && !seen.has(message.parentId)) throw new Error("Invalid backup: invalid conversation branch");
+        if (message.replyToId && !messages.has(message.replyToId)) throw new Error("Invalid backup: unknown reply");
+        seen.add(message.id);
+      }
+      if (task.activeLeafId !== null && !messages.has(task.activeLeafId)) throw new Error("Invalid backup: unknown conversation head");
+    }
+  }
+  return backup;
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -39,7 +39,7 @@ import { nextRename } from "@/lib/rename";
 import { downloadAllBots } from "@/lib/team-files";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
 import { MIN_QUERY, SearchResults } from "./SearchResults";
-import { TeamLibraryPanel, type TeamImportResult } from "./TeamLibraryPanel";
+import { TeamLibraryPanel } from "./TeamLibraryPanel";
 import { RenameTitle } from "./RenameTitle";
 import { BotPickerList } from "./BotPickerList";
 import {
@@ -993,7 +993,6 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
   const [teamFeedback, setTeamFeedback] = useState<{
     error: boolean;
     text: string;
-    undo?: TeamImportResult;
     restoreBot?: { id: string; name: string };
   } | null>(null);
   const [query, setQuery] = useState("");
@@ -1071,8 +1070,8 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
     setTeamFeedback(null);
     try {
       const exported = await downloadAllBots();
-      track("team_exported", { members: exported.members, scope: "all_visible" });
-      setTeamFeedback({ error: false, text: `${exported.members} bots exported` });
+      track("team_exported", { members: exported.members, scope: "backup" });
+      setTeamFeedback({ error: false, text: `Backup downloaded · ${exported.members} bots and conversation text. ${exported.warnings.length ? `${exported.warnings.length} backup notes about deleted bots/rooms—review them when importing. ` : ""}Keep this file private.` });
     } catch (cause) {
       setTeamFeedback({
         error: true,
@@ -1083,59 +1082,6 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
     }
   };
 
-  const undoTeamLoad = async (result: TeamImportResult) => {
-    setTeamFeedback(null);
-    try {
-      await Promise.all([
-        ...result.importedRoutineIds.map((routineId) =>
-          api(`/api/routines/${routineId}`, { method: "DELETE" }).then(() =>
-            dispatch({ type: "routineDeleted", routineId }),
-          ),
-        ),
-        ...result.importedGroupIds.map((groupId) =>
-          api(`/api/groups/${groupId}`, { method: "DELETE" }).then(() =>
-            dispatch({ type: "groupDeleted", groupId }),
-          ),
-        ),
-      ]);
-      const archiveNew = await Promise.all(
-        result.importedBotIds.map((botId) =>
-          api(`/api/bots/${botId}`, {
-            method: "PATCH",
-            body: JSON.stringify({ hidden: true, chiefOfStaff: false }),
-          }),
-        ),
-      );
-      for (const response of archiveNew) dispatch({ type: "botPatched", bot: response.bot });
-
-      const previousChiefs = result.archived.filter((bot) => bot.chiefOfStaff);
-      const restoreOthers = await Promise.all(
-        result.archived
-          .filter((bot) => !bot.chiefOfStaff)
-          .map((bot) =>
-            api(`/api/bots/${bot.id}`, {
-              method: "PATCH",
-              body: JSON.stringify({ hidden: false }),
-            }),
-          ),
-      );
-      for (const response of restoreOthers) dispatch({ type: "botPatched", bot: response.bot });
-      const restoredChiefs = await Promise.all(
-        previousChiefs.map((previousChief) =>
-          api(`/api/bots/${previousChief.id}`, {
-            method: "PATCH",
-            body: JSON.stringify({ hidden: false, chiefOfStaff: true }),
-          }),
-        ),
-      );
-      for (const response of restoredChiefs) dispatch({ type: "botPatched", bot: response.bot });
-      const first = result.archived[0];
-      if (first) dispatch({ type: "select", id: first.id });
-      setTeamFeedback({ error: false, text: "Previous team restored" });
-    } catch (cause) {
-      setTeamFeedback({ error: true, text: cause instanceof Error ? cause.message : String(cause) });
-    }
-  };
 
   const archiveBot = async (bot: Bot) => {
     const activeBots = state.bots.filter((candidate) => !candidate.hidden);
@@ -1303,7 +1249,6 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
   };
   const activeBotCount = state.bots.filter((bot) => !bot.hidden).length;
   const archivedBots = state.bots.filter((bot) => bot.hidden);
-  const pendingTeamUndo = teamFeedback?.undo;
   const pendingBotUndo = teamFeedback?.restoreBot;
 
   return (
@@ -1435,10 +1380,11 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
                     void exportAllBots();
                   }}
                   disabled={exportingTeam}
+                  title="Private backup of bot setup and conversation text. Files, images, workspace memory and connections are not included."
                   className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-ink hover:bg-raised/70"
                 >
                   {exportingTeam ? <Loader2 size={16} className="animate-spin text-ink-secondary" /> : <ArrowDownToLine size={16} className="text-ink-secondary" />}
-                  {exportingTeam ? "Exporting…" : "Export all bots"}
+                  {exportingTeam ? "Exporting…" : "Export backup"}
                 </button>
                 <button
                   onClick={() => {
@@ -1790,18 +1736,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
           onImported={(result) => {
             setTeamLibraryOpen(false);
             setTeamInstallUrl(null);
-            setTeamFeedback(
-              result.archived.length > 0
-                ? {
-                    error: false,
-                    text: `${result.name} loaded · ${result.members} ${result.members === 1 ? "bot" : "bots"}`,
-                    undo: result,
-                  }
-                : {
-                    error: false,
-                    text: `${result.name} loaded · ${result.members} ${result.members === 1 ? "bot" : "bots"}`,
-                  },
-            );
+            setTeamFeedback({ error: false, text: `${result.members} ${result.members === 1 ? "bot" : "bots"} added · existing bots and chats kept` });
           }}
         />
       )}
@@ -1818,14 +1753,6 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
           >
             <div className="flex items-center gap-3">
               <span>{teamFeedback.text}</span>
-              {pendingTeamUndo && (
-                <button
-                  onClick={() => void undoTeamLoad(pendingTeamUndo)}
-                  className="rounded-md px-1.5 py-0.5 font-medium text-accent hover:bg-raised"
-                >
-                  Undo
-                </button>
-              )}
               {pendingBotUndo && (
                 <button
                   onClick={() => void undoBotArchive(pendingBotUndo)}

--- a/src/components/TeamLibraryPanel.tsx
+++ b/src/components/TeamLibraryPanel.tsx
@@ -24,7 +24,8 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
-const MAX_TEAM_FILE_BYTES = 1_000_000;
+import { MAX_TEAM_BACKUP_BYTES, TEAM_BACKUP_EXCLUSIONS } from "../../shared/team-backup";
+import { takeImportName } from "../../shared/import-name";
 const COMMUNITY_TEAMS_REPOSITORY = "https://github.com/milind-soni/openmausbot-teams";
 
 interface TeamCatalogEntry {
@@ -48,23 +49,13 @@ interface TeamCatalog {
   teams: TeamCatalogEntry[];
 }
 
-export interface ArchivedTeamBot {
-  id: string;
-  chiefOfStaff: boolean;
-}
-
 export interface TeamImportResult {
   name: string;
   members: number;
-  importedBotIds: string[];
-  importedGroupIds: string[];
-  importedRoutineIds: string[];
-  archived: ArchivedTeamBot[];
 }
 
 type ImportSource = "library" | "file" | "github";
 type TeamTab = "explore" | "import" | "scout";
-type ImportMode = "replace" | "add";
 
 /** the scout endpoint's answer, as far as this panel renders it — the
  * manifest itself stays opaque and goes back to the server verbatim */
@@ -141,7 +132,6 @@ export function TeamLibraryPanel({
   const [githubLoading, setGithubLoading] = useState(false);
   const [importing, setImporting] = useState(false);
   const [dragging, setDragging] = useState(false);
-  const [importMode, setImportMode] = useState<ImportMode>("replace");
   const [search, setSearch] = useState("");
   const [error, setError] = useState("");
   const [scoutFolder, setScoutFolder] = useState("");
@@ -161,6 +151,8 @@ export function TeamLibraryPanel({
   const scoutRequest = useRef(0);
 
   const currentBotCount = state.bots.filter((bot) => !bot.hidden).length;
+  const takenNames = new Set(state.bots.map((bot) => bot.name.trim().toLowerCase()));
+  const importedNames = pending?.members.map((member) => takeImportName(member.name, takenNames)) ?? [];
 
   const loadCatalog = useCallback(async () => {
     setCatalogLoading(true);
@@ -218,19 +210,18 @@ export function TeamLibraryPanel({
   const previewManifest = (preview: PendingTeamImport, nextSource: ImportSource) => {
     setPending(preview);
     setSource(nextSource);
-    setImportMode(currentBotCount > 0 ? "replace" : "add");
     setError("");
   };
 
   const readFile = async (file: File) => {
-    if (file.size > MAX_TEAM_FILE_BYTES) throw new Error("That team file is too large.");
+    if (file.size > MAX_TEAM_BACKUP_BYTES) throw new Error("That file exceeds the 50 MB import limit.");
     const raw = await file.text();
     let manifest: unknown = raw;
     if (!file.name.toLowerCase().endsWith(".md")) {
       try {
         manifest = JSON.parse(raw);
       } catch (cause) {
-        if (cause instanceof SyntaxError) throw new Error("That legacy team file is not valid JSON.");
+        if (cause instanceof SyntaxError) throw new Error("That backup or team file is not valid JSON.");
         throw cause;
       }
     }
@@ -286,30 +277,23 @@ export function TeamLibraryPanel({
     setError("");
     try {
       // SAFETY: this endpoint is owned by the app and returns imported bots.
-      const response = (await api(`/api/teams/import?mode=${importMode}`, {
+      const response = (await api("/api/teams/import?mode=add", {
         method: "POST",
         body: JSON.stringify(pending.manifest),
       })) as {
         bots: Bot[];
         groups?: Group[];
         routines?: Routine[];
-        archivedBots?: Bot[];
-        archived?: ArchivedTeamBot[];
       };
-      for (const bot of response.archivedBots ?? []) dispatch({ type: "botPatched", bot });
       for (const bot of response.bots) dispatch({ type: "botAdded", bot });
       for (const group of response.groups ?? []) dispatch({ type: "groupPatched", group });
       for (const routine of response.routines ?? []) dispatch({ type: "routinePatched", routine });
-      const first = response.bots[0];
+      const first = response.bots.find((bot) => !bot.hidden);
       if (first) dispatch({ type: "select", id: first.id });
-      track("team_imported", { members: response.bots.length, source, mode: importMode });
+      track("team_imported", { members: response.bots.length, source, mode: "add", format: pending.kind });
       onImported({
         name: pending.name,
         members: response.bots.length,
-        importedBotIds: response.bots.map((bot) => bot.id),
-        importedGroupIds: (response.groups ?? []).map((group) => group.id),
-        importedRoutineIds: (response.routines ?? []).map((routine) => routine.id),
-        archived: response.archived ?? [],
       });
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
@@ -400,10 +384,6 @@ export function TeamLibraryPanel({
       onImported({
         name: room,
         members: response.bots.length,
-        importedBotIds: response.bots.map((bot) => bot.id),
-        importedGroupIds: response.group ? [response.group.id] : [],
-        importedRoutineIds: [],
-        archived: [],
       });
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
@@ -455,7 +435,9 @@ export function TeamLibraryPanel({
             </div>
             <p className={cn("mt-1 text-[13px] text-ink-secondary", pending && "ml-9")}>
                 {pending
-                  ? pending.kind === "package"
+                  ? pending.kind === "backup"
+                    ? `${pending.members.length} ${pending.members.length === 1 ? "bot" : "bots"} · ${pending.conversations} ${pending.conversations === 1 ? "conversation" : "conversations"} · portable backup`
+                    : pending.kind === "package"
                     ? `${pending.members.length} bots · portable Markdown playbook`
                     : `${pending.members.length} ready-to-load bots`
                   : "Start with a complete playbook or bring your own."}
@@ -490,13 +472,17 @@ export function TeamLibraryPanel({
               {pending.description && (
                 <p className="max-w-2xl text-[13.5px] leading-relaxed text-ink-secondary">{pending.description}</p>
               )}
-              {pending.kind === "package" && (
+              {Boolean(pending.warnings?.length) && <div className="mt-4 rounded-xl border border-hairline px-4 py-3 text-[12.5px] text-ink-secondary">
+                <div className="mb-2 font-medium text-ink">Backup notes</div>
+                {pending.warnings?.map((warning, index) => <p key={index}>{warning}</p>)}
+              </div>}
+              {(pending.kind === "package" || pending.kind === "backup") && (
                 <div className="mt-5 flex flex-wrap gap-2 text-[11.5px] text-ink-secondary">
                   {pending.chiefOfStaff && <span className="flex items-center gap-1.5 rounded-full bg-raised px-3 py-1.5"><Crown size={13} />{pending.chiefOfStaff} leads</span>}
                   <span className="flex items-center gap-1.5 rounded-full bg-raised px-3 py-1.5"><MessageSquare size={13} />{pending.rooms} {pending.rooms === 1 ? "room" : "rooms"}</span>
                   <span className="flex items-center gap-1.5 rounded-full bg-raised px-3 py-1.5"><BookOpen size={13} />{pending.playbooks} playbooks</span>
                   <span className="flex items-center gap-1.5 rounded-full bg-raised px-3 py-1.5"><CalendarClock size={13} />{pending.routines} paused routines</span>
-                  <span className="flex items-center gap-1.5 rounded-full bg-raised px-3 py-1.5"><Plug size={13} />{pending.apps.length} connections</span>
+                  {pending.kind === "package" && <span className="flex items-center gap-1.5 rounded-full bg-raised px-3 py-1.5"><Plug size={13} />{pending.apps.length} connections</span>}
                 </div>
               )}
               <div className="mt-6 text-[12px] font-medium text-ink-secondary">Team members</div>
@@ -507,7 +493,8 @@ export function TeamLibraryPanel({
                       {member.name.slice(0, 1).toUpperCase()}
                     </div>
                     <div className="min-w-0">
-                      <div className="truncate text-[14px] font-medium text-ink">{member.name}</div>
+                      <div className="truncate text-[14px] font-medium text-ink">{importedNames[index]}</div>
+                      {importedNames[index] !== member.name && <div className="text-[11.5px] text-ink-secondary">New copy of {member.name}</div>}
                       <div className="mt-0.5 truncate text-[12.5px] text-ink-secondary">{member.title || "General assistant"}</div>
                     </div>
                   </div>
@@ -516,7 +503,9 @@ export function TeamLibraryPanel({
               <div className="mt-6 flex items-start gap-2.5 rounded-xl bg-raised/45 px-4 py-3 text-[12.5px] leading-relaxed text-ink-secondary">
                 <Check size={15} className="mt-0.5 shrink-0 text-success" />
                 <p>
-                  {pending.kind === "package"
+                  {pending.kind === "backup"
+                    ? `${TEAM_BACKUP_EXCLUSIONS} ${pending.archivedBots ? `${pending.archivedBots} archived bots will remain archived.` : ""}`
+                    : pending.kind === "package"
                     ? "Bots, Chief of Staff, rooms, and reviewed playbooks are loaded. Suggested routines arrive paused, and connected apps stay off until you approve them. Conversations, credentials, permissions, and computer access stay private."
                     : "Only roles and appearance are loaded. Your conversations, account connections, permissions, and computer access stay private."}
                 </p>
@@ -526,21 +515,8 @@ export function TeamLibraryPanel({
 
             <footer className="flex flex-col gap-3 border-t border-hairline/35 px-6 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-8">
               <div className="text-[12.5px] text-ink-secondary">
-                {currentBotCount > 0 ? (
-                  importMode === "replace" ? (
-                    <>
-                      Replaces your {currentBotCount} current {currentBotCount === 1 ? "bot" : "bots"}. They&apos;ll be archived with conversations intact.{" "}
-                      <button onClick={() => setImportMode("add")} className="font-medium text-ink hover:underline">Add alongside instead</button>
-                    </>
-                  ) : (
-                    <>
-                      This team will be added alongside your current bots.{" "}
-                      <button onClick={() => setImportMode("replace")} className="font-medium text-ink hover:underline">Replace current team instead</button>
-                    </>
-                  )
-                ) : (
-                  pending.kind === "package" ? "Review the complete setup, then activate the playbook." : "No channel is created—you can make one later if you want."
-                )}
+                Your {currentBotCount > 0 ? `${currentBotCount} existing ${currentBotCount === 1 ? "bot and its" : "bots and their"}` : "existing"} conversations stay unchanged.
+                Imported bots are added as new copies; duplicate names and backup sections get numbered.
               </div>
               <button
                 onClick={() => void importTeam()}
@@ -549,14 +525,8 @@ export function TeamLibraryPanel({
               >
                 {importing && <Loader2 size={15} className="animate-spin" />}
                 {importing
-                  ? "Loading…"
-                  : pending.kind === "package" && currentBotCount === 0
-                    ? "Activate playbook"
-                    : currentBotCount === 0
-                    ? "Load team"
-                    : importMode === "replace"
-                      ? "Replace team"
-                      : "Add team"}
+                  ? "Importing…"
+                  : pending.kind === "backup" ? "Import backup" : "Add team"}
               </button>
             </footer>
           </>
@@ -678,7 +648,7 @@ export function TeamLibraryPanel({
                   <input
                     ref={fileInputRef}
                     type="file"
-                    accept=".md,.json,.mausteam.json,text/markdown,application/json"
+                    accept=".md,.json,.mausbackup.json,.mausteam.json,text/markdown,application/json"
                     className="hidden"
                     onChange={(event) => {
                       const file = event.currentTarget.files?.[0];
@@ -709,8 +679,8 @@ export function TeamLibraryPanel({
                       )}
                     >
                       <UploadCloud size={27} className="text-accent" />
-                      <span className="mt-3 text-[14px] font-medium text-ink">Choose a team file</span>
-                      <span className="mt-1 text-[12.5px] text-ink-secondary">or drop a BotMRR .md / legacy .mausteam.json here</span>
+                      <span className="mt-3 text-[14px] font-medium text-ink">Choose a backup or team file</span>
+                      <span className="mt-1 text-[12.5px] text-ink-secondary">Drop a .mausbackup.json, BotMRR .md or legacy .mausteam.json here. You’ll preview it before anything is added.</span>
                     </button>
 
                     <div className="flex min-h-56 flex-col justify-center rounded-2xl bg-raised/25 px-6">

--- a/src/lib/team-files.ts
+++ b/src/lib/team-files.ts
@@ -1,35 +1,26 @@
 import { api } from "@/state/store";
+import { parseTeamBackup } from "../../shared/team-backup";
 
-interface ExportedPlaybook {
-  name: string;
-  members: number;
-  markdown: string;
-}
-
-function downloadPlaybook(playbook: ExportedPlaybook): { name: string; members: number } {
+/** Private portable backup; shareable Markdown remains a separate API format. */
+export async function downloadAllBots(): Promise<{ name: string; members: number; warnings: string[] }> {
+  const backup = parseTeamBackup(await api("/api/teams/export", {
+    method: "POST",
+    body: JSON.stringify({ format: "backup" }),
+  }));
   const slug =
-    playbook.name
+    backup.name
       .trim()
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-|-$/g, "") || "botmrr-team";
-  const blob = new Blob([playbook.markdown], { type: "text/markdown;charset=utf-8" });
+      .replace(/^-|-$/g, "") || "openmaus";
+  const blob = new Blob([JSON.stringify(backup)], { type: "application/json" });
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
   link.href = url;
-  link.download = `${slug}.md`;
+  link.download = `${slug}-${new Date(backup.exportedAt).toISOString().slice(0, 10)}.mausbackup.json`;
   document.body.appendChild(link);
   link.click();
   link.remove();
   window.setTimeout(() => URL.revokeObjectURL(url), 60_000);
-  return { name: playbook.name, members: playbook.members };
-}
-
-/** Export every active sidebar bot as one portable Chief-of-Staff Markdown. */
-export async function downloadAllBots(): Promise<{ name: string; members: number }> {
-  const playbook = (await api("/api/teams/export", {
-    method: "POST",
-    body: JSON.stringify({ format: "package" }),
-  })) as ExportedPlaybook;
-  return downloadPlaybook(playbook);
+  return { name: backup.name, members: backup.bots.length, warnings: backup.warnings };
 }

--- a/src/lib/team-import.test.ts
+++ b/src/lib/team-import.test.ts
@@ -1,8 +1,32 @@
 import { describe, expect, it } from "vitest";
 
 import { teamImportPreview } from "./team-import";
+import { takeImportName } from "../../shared/import-name";
 
 describe("team import preview", () => {
+  it("previews numbered copies using the same name allocator as the importer", () => {
+    const taken = new Set(["scout", "scout 2", "archived"]);
+    expect(takeImportName("SCOUT", taken)).toBe("SCOUT 3");
+    expect(takeImportName("Scout", taken)).toBe("Scout 4");
+    expect(takeImportName("Archived", taken)).toBe("Archived 2");
+    const long = "a".repeat(100);
+    taken.add(long);
+    expect(takeImportName(long, taken)).toBe(`${"a".repeat(98)} 2`);
+  });
+  it("previews portable backups and validates their references before confirmation", () => {
+    const backup = {
+      format: "openmaus.backup", version: 1, name: "Saved team", exportedAt: 0,
+      bots: [{ key: "bot", name: "Scout", title: "Research", description: "", color: "cyan", chiefOfStaff: false,
+        hidden: true, playbooks: [], activeTask: "thread", tasks: [{ key: "thread", title: "Chat", createdAt: 0,
+          activeLeafId: "message", messages: [{ id: "message", parentId: null, role: "user", text: "Hello", at: 0 }] }] }],
+      groups: [], routines: [],
+    };
+    expect(teamImportPreview(backup)).toMatchObject({ kind: "backup", name: "Saved team", rooms: 0, conversations: 1, archivedBots: 1, members: [{ name: "Scout", title: "Research" }] });
+    expect(() => teamImportPreview({ ...backup, version: 999 })).toThrow("Invalid backup");
+    backup.bots[0].activeTask = "unknown";
+    expect(() => teamImportPreview(backup)).toThrow("unknown active task");
+  });
+
   it.each([1, 2])("previews version %s team files", (version) => {
     const preview = teamImportPreview({
       format: "openmaus.team",

--- a/src/lib/team-import.ts
+++ b/src/lib/team-import.ts
@@ -1,8 +1,9 @@
 import { parse as parseYaml } from "yaml";
+import { parseTeamBackup, TEAM_BACKUP_CONTENTS } from "../../shared/team-backup";
 
 export interface PendingTeamImport {
   manifest: unknown;
-  kind: "team" | "package";
+  kind: "team" | "package" | "backup";
   name: string;
   description: string;
   members: Array<{ name: string; title: string }>;
@@ -11,6 +12,9 @@ export interface PendingTeamImport {
   playbooks: number;
   routines: number;
   apps: Array<{ label: string; optional: boolean }>;
+  conversations?: number;
+  archivedBots?: number;
+  warnings?: string[];
 }
 
 /** Small client-side preview only; the server remains the trust boundary. */
@@ -20,8 +24,20 @@ export function teamImportPreview(manifest: unknown): PendingTeamImport {
     throw new Error("This file does not contain a team.");
   }
   const root = manifest as Record<string, unknown>;
+  if (root.format === "openmaus.backup") {
+    const backup = parseTeamBackup(manifest);
+    return {
+      manifest: backup, kind: "backup", name: backup.name, description: TEAM_BACKUP_CONTENTS,
+      members: backup.bots.map((bot) => ({ name: bot.name, title: bot.title })),
+      rooms: backup.groups.length, playbooks: backup.bots.reduce((total, bot) => total + bot.playbooks.length, 0),
+      routines: backup.routines.length, apps: [],
+      conversations: [...backup.bots, ...backup.groups].reduce((total, owner) => total + owner.tasks.length, 0),
+      archivedBots: backup.bots.filter((bot) => bot.hidden).length,
+      warnings: backup.warnings,
+    };
+  }
   if (root.format === "openmaus.package") return packagePreview(root, manifest);
-  if (root.format !== "openmaus.team") throw new Error("This is not a BotMRR playbook or legacy OpenMaus team.");
+  if (root.format !== "openmaus.team") throw new Error("This is not an OpenMaus backup, BotMRR playbook or legacy team.");
   if (root.version !== 1 && root.version !== 2) throw new Error(`Team file version ${String(root.version)} is not supported.`);
   if (!root.team || typeof root.team !== "object" || Array.isArray(root.team)) {
     throw new Error("This team file is missing its team definition.");


### PR DESCRIPTION
## Summary
- Remove Replace team from both the UI and server. All imports add independent copies without archiving or changing existing bots or chats.
- Add dated portable backups containing bot profiles, instructions, sections, Chiefs, rooms, playbooks, routine definitions and conversation text across tasks and branches.
- Preview numbered copies before importing; restore routines paused and permissions off; validate references and roll back failed imports.
- Keep legacy team JSON and BotMRR Markdown imports working. Document exclusions and recovery through Archived bots.

## Backup scope
Files, images, custom avatars, workspace memory, connections, model settings and permissions are excluded. Action cards become inert text. Deleted-member and orphaned-routine cases produce explicit backup notes.

## Verification
- 108 focused regression tests, including a real-server isolated fake-engine export/import/continue-conversation workflow.
- 6 focused HTTP team/package/scout tests.
- Production build, targeted lint, and locale checks.
- Browser export, upload of the downloaded backup, additive import and reload verified against an isolated fixture. Live user data was never used.

Rebased onto the latest main before submission; focused tests and production build are being rechecked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added portable team backups using `.mausbackup.json` files.
  - Backups preserve bots, groups, routines, tasks, and conversation history while excluding sensitive or executable data.
  - Added backup previews, validation, warnings, size limits, and automatic name handling for duplicates.
  - Imported backups create independent copies, allowing conversations to continue without changing originals.

- **Changes**
  - Team imports now use additive mode only; replacing existing teams and import undo are no longer supported.
  - Export messaging now highlights backup privacy and included warnings.

- **Documentation**
  - Added documentation covering backup contents, limitations, recovery, and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->