### PR TITLE
fix(computer): restore cloud previews and clarify destination choices

### DIFF
--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -45,6 +45,9 @@ built-in browser panel, and updater UI—is not proven by this first harness.
 Use the relevant Electron/package smoke test and state that limitation. Add a
 map entry only after the shared control surface can really drive it.
 
+The [cloud preview fixture](cloud-preview.md) mounts the real Computer panel
+against an isolated server for image decoding, loading, and recovery UI checks.
+
 ## Evidence
 
 Keep the JSON from `wait` and `messages`, the exact command sequence, and the

--- a/docs/verification/cloud-preview.md
+++ b/docs/verification/cloud-preview.md
@@ -1,0 +1,41 @@
+# Cloud screen preview
+
+Start the isolated renderer fixture directly in a terminal:
+
+```sh
+node --experimental-strip-types scripts/verify-cloud-preview.ts
+```
+
+Open the printed `previewUrl` in a browser or an isolated Electron window.
+The fixture starts the standard fake-engine harness in a temporary home,
+creates its own test bot through the mapped control command, and mounts the
+real `ComputerPanel`. Only the cloud transport is simulated. It never needs
+a Box API key and never contacts a cloud provider. Ctrl-C stops both servers
+and removes their temporary data; the printed harness log remains.
+
+Verify these transitions with computer use:
+
+1. On initial connection, **Cloud screen connected** appears. The fixture
+   deliberately injects an old blank SSE frame before mounting the connection;
+   that frame must not hide the new screenshot. The old implementation fails
+   this check by continuing to display a black rectangle.
+2. Select **corrupt**, then **Reconnect panel**. The panel must show an image
+   error and **Retry preview**, rather than a blank image with an Open button.
+3. Select **slow**, then **Retry preview**. The panel immediately shows
+   **Connecting to the screen…**, then displays the image after 12 seconds.
+4. Select **failed**, then **Reconnect panel**. The provider error appears
+   inside the preview. Select **connected**, then **Retry preview** to recover.
+5. Turn **Busy** on, then **Publish live frame**. The new live frame appears.
+   Stop publishing: within 14 seconds, screenshot polling resumes and restores
+   **Cloud screen connected**, even though the bot is still busy.
+6. Select **timeout**, then **Reconnect panel**. After 90 seconds, the loader
+   becomes a timeout error with **Retry preview**. Choose **connected** and
+   retry; the connection must recover without restarting the app.
+7. While **slow** is pending, switch to **connected** and **Reconnect panel**.
+   The new connection must display immediately; the cancelled request must
+   neither block it nor overwrite its frame later.
+
+The fixture tests actual image decoding, request cancellation, fresh frame
+selection, and renderer feedback. It does not prove real Box provisioning,
+native viewer windows, or account authentication. Test those separately with
+an explicitly isolated provider fixture when changing those paths.

--- a/scripts/testing/cloud-preview.tsx
+++ b/scripts/testing/cloud-preview.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { ComputerPanel } from "../../src/components/ComputerPanel";
+import { StoreProvider, useStore } from "../../src/state/store";
+import { applySkin, readSkin } from "../../src/lib/skins";
+import "../../src/styles.css";
+
+// Deliberately inject a valid but blank cached SSE image before connecting.
+// The pre-fix panel keeps showing this even after successful screenshot polls.
+const blank = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+function frame(label: string, color: string) {
+  const canvas = document.createElement("canvas");
+  canvas.width = 640;
+  canvas.height = 400;
+  const context = canvas.getContext("2d")!;
+  context.fillStyle = color;
+  context.fillRect(0, 0, 640, 400);
+  context.fillStyle = "white";
+  context.font = "28px sans-serif";
+  context.fillText(label, 70, 210);
+  return canvas.toDataURL("image/png").split(",")[1];
+}
+const screenshot = frame("Cloud screen connected", "#134e4a");
+let mode = "connected";
+const originalFetch = window.fetch.bind(window);
+window.fetch = async (input, init) => {
+  const path = typeof input === "string" ? input : "";
+  const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), {
+    status, headers: { "content-type": "application/json" },
+  });
+  if (/^\/api\/bots\/[\w-]+\/computer$/.test(path)) return json({ configured: true, box: { state: "idle" } });
+  if (path.endsWith("/computer/provision")) return json({ state: "idle" });
+  if (path.endsWith("/computer/screenshot")) {
+    const selectedMode = mode;
+    if (selectedMode === "slow" || selectedMode === "timeout") {
+      await new Promise<void>((resolve, reject) => {
+        const abort = () => { clearTimeout(timer); reject(init?.signal?.reason); };
+        const timer = setTimeout(() => {
+          init?.signal?.removeEventListener("abort", abort);
+          resolve();
+        }, selectedMode === "slow" ? 12_000 : 120_000);
+        if (init?.signal?.aborted) abort();
+        else init?.signal?.addEventListener("abort", abort, { once: true });
+      });
+    }
+    if (selectedMode === "failed") return json({ error: "The computer is temporarily unavailable" }, 503);
+    return json({ png: selectedMode === "corrupt" ? "bm90IGFuIGltYWdl" : screenshot, format: "png" });
+  }
+  // Never allow the fixture's viewer/sleep actions to reach a real provider.
+  if (path.endsWith("/computer/join") || path.endsWith("/computer/sleep")) {
+    return json({ error: "This fixture tests previews only" }, 409);
+  }
+  return originalFetch(input, init);
+};
+
+function Fixture() {
+  const { state, dispatch } = useStore();
+  const bot = state.bots[0];
+  const [busy, setBusy] = useState(false);
+  const [generation, setGeneration] = useState(0);
+  useEffect(() => {
+    if (bot) dispatch({ type: "screenFrame", botId: bot.id, png: blank, mime: "image/png" });
+  }, [bot?.id, dispatch]);
+  return <div className="flex h-screen justify-center">
+    <div className="fixed left-2 top-2 grid max-w-32 gap-3 text-sm">
+      <label>Screenshot response<select aria-label="Screenshot response" defaultValue={mode} onChange={(e) => { mode = e.target.value; }}>
+        {["connected", "slow", "failed", "corrupt", "timeout"].map((value) => <option key={value}>{value}</option>)}
+      </select></label>
+      <button onClick={() => setGeneration((n) => n + 1)}>Reconnect panel</button>
+      <button onClick={() => setBusy(!busy)}>Busy: {String(busy)}</button>
+      <button disabled={!bot} onClick={() => dispatch({ type: "screenFrame", botId: bot.id, png: frame("New live frame", "#312e81"), mime: "image/png" })}>Publish live frame</button>
+    </div>
+    {bot ? <ComputerPanel key={generation} bot={{ ...bot, computer: "cloud", cloudBackend: "box", busy }} /> : "Loading fixture…"}
+  </div>;
+}
+applySkin(readSkin());
+createRoot(document.getElementById("root")!).render(<StoreProvider><Fixture /></StoreProvider>);

--- a/scripts/testing/cloud-preview.tsx
+++ b/scripts/testing/cloud-preview.tsx
@@ -59,7 +59,10 @@ function Fixture() {
   const [busy, setBusy] = useState(false);
   const [generation, setGeneration] = useState(0);
   useEffect(() => {
-    if (bot) dispatch({ type: "screenFrame", botId: bot.id, png: blank, mime: "image/png" });
+    if (bot) {
+      dispatch({ type: "screenFrame", botId: bot.id, png: blank, mime: "image/png" });
+      dispatch({ type: "updateBot", botId: bot.id, patch: { computer: "cloud", cloudBackend: "box" } });
+    }
   }, [bot?.id, dispatch]);
   return <div className="flex h-screen justify-center">
     <div className="fixed left-2 top-2 grid max-w-32 gap-3 text-sm">
@@ -70,7 +73,7 @@ function Fixture() {
       <button onClick={() => setBusy(!busy)}>Busy: {String(busy)}</button>
       <button disabled={!bot} onClick={() => dispatch({ type: "screenFrame", botId: bot.id, png: frame("New live frame", "#312e81"), mime: "image/png" })}>Publish live frame</button>
     </div>
-    {bot ? <ComputerPanel key={generation} bot={{ ...bot, computer: "cloud", cloudBackend: "box", busy }} /> : "Loading fixture…"}
+    {bot ? <ComputerPanel key={generation} bot={{ ...bot, busy }} /> : "Loading fixture…"}
   </div>;
 }
 applySkin(readSkin());

--- a/scripts/verify-cloud-preview.ts
+++ b/scripts/verify-cloud-preview.ts
@@ -1,0 +1,40 @@
+// Real ComputerPanel + isolated fake-engine server, with only its cloud
+// transport simulated. No Box account or user's app data is contacted.
+// Run: node --experimental-strip-types scripts/verify-cloud-preview.ts
+import { fileURLToPath } from "node:url";
+import { createServer } from "vite";
+import { launchVerificationServer, runControlOmb } from "./control-omb.ts";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const fixture = await launchVerificationServer();
+let ui: Awaited<ReturnType<typeof createServer>> | undefined;
+const close = async () => {
+  await ui?.close();
+  await fixture.close();
+};
+try {
+  await runControlOmb(["new-bot", "--name", "Box Preview Test", "--url", fixture.info.url]);
+  ui = await createServer({
+    root,
+    server: { host: "127.0.0.1", port: 0, proxy: { "/api": { target: fixture.info.url } } },
+    plugins: [{
+      name: "isolated-cloud-preview",
+      configureServer(server) {
+        server.middlewares.use((req, res, next) => {
+          if (req.url !== "/__cloud-preview.html") return next();
+          void server.transformIndexHtml(req.url, '<html><head><title>Isolated Box Preview Test</title></head><body><div id="root"></div><script type="module" src="/scripts/testing/cloud-preview.tsx"></script></body></html>')
+            .then((html) => { res.setHeader("content-type", "text/html"); res.end(html); })
+            .catch(next);
+        });
+      },
+    }],
+  });
+  await ui.listen();
+  console.log(JSON.stringify({ ...fixture.info, previewUrl: `${ui.resolvedUrls!.local[0]}__cloud-preview.html` }, null, 2));
+  await new Promise<void>((resolve) => {
+    process.once("SIGINT", resolve);
+    process.once("SIGTERM", resolve);
+  });
+} finally {
+  await close();
+}

--- a/src/components/CloudBackendPicker.tsx
+++ b/src/components/CloudBackendPicker.tsx
@@ -7,18 +7,22 @@ import { cn } from "@/lib/cn";
 
 export function CloudBackendPicker({
   value,
+  compact = false,
   vpsSupported,
   onChange,
 }: {
   value: CloudBackend;
+  compact?: boolean;
   vpsSupported: boolean;
   onChange: (backend: CloudBackend) => void;
 }) {
   return (
     <div className="mt-3 rounded-lg bg-inset p-3">
-      <div className="text-[12px] font-medium text-ink">Cloud backend</div>
+      <div className="text-[12px] font-medium text-ink">{compact ? "Cloud provider" : "Cloud backend"}</div>
       <div className="mt-0.5 text-[11.5px] text-ink-secondary">
-        {value === "vps"
+        {compact
+          ? value === "vps" ? "Your own server, connected over SSH." : "A hosted computer managed by Box."
+          : value === "vps"
           ? "Auto reuses a running VPS by default. Enable Start VPS automatically to let Auto create or wake its managed container, or choose Cloud to do it explicitly. Open the live desktop securely from the computer panel."
           : "Box is the default hosted computer. Choose Self-hosted VPS to use your SSH-configured Linux Docker host."}
       </div>

--- a/src/components/CloudScreenPreview.test.ts
+++ b/src/components/CloudScreenPreview.test.ts
@@ -1,0 +1,51 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { CloudScreenPreview } from "./CloudScreenPreview";
+
+const defaults = {
+  src: null,
+  name: "Test bot",
+  error: null,
+  starting: false,
+  opening: false,
+  disabled: false,
+  onOpen: vi.fn(),
+  onRetry: vi.fn(),
+};
+
+describe("cloud screen connection feedback", () => {
+  it("announces connecting before the first response", () => {
+    const html = renderToStaticMarkup(createElement(CloudScreenPreview, defaults));
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain("Connecting to the screen…");
+  });
+
+  it("does not present an undecoded image as an openable desktop", () => {
+    const html = renderToStaticMarkup(createElement(CloudScreenPreview, {
+      ...defaults, src: "data:image/jpeg;base64,bm90IGFuIGltYWdl",
+    }));
+    expect(html).toContain("Connecting to the screen…");
+    expect(html).toMatch(/<button[^>]*disabled=""/);
+    expect(html).toContain("invisible");
+    expect(html).not.toContain('>Open</span>');
+  });
+
+  it("distinguishes starting the computer from waiting for a frame", () => {
+    const html = renderToStaticMarkup(createElement(CloudScreenPreview, { ...defaults, starting: true }));
+    expect(html).toContain("Starting your bot&#x27;s computer…");
+    expect(html).not.toContain("Connecting to the screen…");
+  });
+
+  it("surfaces request failures with a retry action instead of a permanent loader", () => {
+    const html = renderToStaticMarkup(createElement(CloudScreenPreview, {
+      ...defaults, error: "The computer took too long to send a frame. Try again.",
+    }));
+    expect(html).toContain('role="alert"');
+    expect(html).toContain("took too long");
+    expect(html).toContain("Retry preview");
+    expect(html).not.toContain('role="status"');
+    expect(html).toContain('aria-busy="false"');
+  });
+});

--- a/src/components/CloudScreenPreview.tsx
+++ b/src/components/CloudScreenPreview.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { Loader2, Maximize2, Monitor } from "lucide-react";
+
+/** A connection is only visible once the browser has decoded its first frame. */
+export function CloudScreenPreview({ src, name, error, starting, opening, disabled, onOpen, onRetry }: {
+  src: string | null;
+  name: string;
+  error: string | null;
+  starting: boolean;
+  opening: boolean;
+  disabled: boolean;
+  onOpen: () => void;
+  onRetry: () => void;
+}) {
+  const [loaded, setLoaded] = useState<string | null>(null);
+  const [failed, setFailed] = useState<string | null>(null);
+  const visible = Boolean(src && loaded === src && failed !== src);
+  const problem = error ?? (src && failed === src ? "The screen image could not be displayed." : null);
+
+  return (
+    <div className="relative h-full w-full" aria-busy={!problem && (!visible || opening)}>
+      {src && (
+        <button
+          type="button"
+          onClick={onOpen}
+          disabled={disabled || starting || opening || !visible}
+          className="group absolute inset-0 flex h-full w-full items-center justify-center disabled:cursor-wait"
+          aria-label={`Open ${name}'s live desktop`}
+          title="Open live desktop"
+        >
+          <img
+            src={src}
+            alt={`${name}'s screen`}
+            onLoad={() => { setLoaded(src); setFailed(null); }}
+            onError={() => setFailed(src)}
+            className={`h-full w-full object-contain transition group-hover:brightness-75 ${visible ? "" : "invisible"}`}
+          />
+          {visible && (
+            <span className="absolute right-2 top-2 flex items-center gap-1 rounded-md bg-black/70 px-2 py-1 text-[11px] font-medium text-white">
+              {opening ? <Loader2 size={12} className="animate-spin" /> : <Maximize2 size={12} />}
+              {opening ? "Connecting to live desktop…" : "Open"}
+            </span>
+          )}
+        </button>
+      )}
+      {!visible && !problem && (
+        <div role="status" className="absolute inset-0 flex flex-col items-center justify-center gap-2 px-6 text-center text-[12px] text-ink-secondary">
+          <Loader2 size={18} className="animate-spin" />
+          {starting ? "Starting your bot's computer…" : "Connecting to the screen…"}
+        </div>
+      )}
+      {problem && (
+        <div role="alert" className={`absolute inset-x-0 flex flex-col items-center justify-center gap-2 bg-card/95 p-4 text-center text-[12px] text-ink-secondary ${visible ? "bottom-0" : "inset-y-0"}`}>
+          {!visible && <Monitor size={22} />}
+          <span>{visible ? "Screen updates paused. " : "Couldn't connect to the screen. "}{problem}</span>
+          <button type="button" onClick={onRetry} className="rounded-md bg-control px-3 py-1.5 text-ink hover:bg-control-hover">
+            Retry preview
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -29,6 +29,7 @@ import type { Routine } from "@/lib/routines";
 import { ApiKeyRow } from "./ApiKeys";
 import { cn } from "@/lib/cn";
 import { usePageVisible } from "@/lib/page-visible";
+import { CloudScreenPreview } from "./CloudScreenPreview";
 import { CloudBackendPicker } from "./CloudBackendPicker";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
 import { RoutineEditor } from "./RoutinesPage";
@@ -261,6 +262,8 @@ export function ComputerPanel({
   }, [bot.id, bot.computer, cloudBackend, flushBotPatches]);
   const [boxState, setBoxState] = useState<string | null>(null);
   const [polledFrame, setPolledFrame] = useState<{ png: string; mime: string } | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [previewRetry, setPreviewRetry] = useState(0);
   const [vmFrame, setVmFrame] = useState<string | null>(null);
   // The Local VM's interactive noVNC viewer (passworded, autoconnect). The
   // preview below is a periodic screenshot that swallows clicks — this URL is
@@ -386,6 +389,7 @@ export function ComputerPanel({
     setResolvedComputerSelection(null);
     setPhase("checking");
     setPolledFrame(null);
+    setPreviewError(null);
     setVmFrame(null);
     setVmViewerUrl(null);
     setVmStatus(null);
@@ -625,35 +629,64 @@ export function ComputerPanel({
     computerSelectionPersisted,
   ]);
 
-  // cloud preview: SSE frames win while the bot works; otherwise poll.
-  // Every preview poll below gates on visibility and slows way down for an
-  // idle bot — a drawer left open overnight must not keep shooting.
+  // Only frames received during this connection may replace its preview.
+  // A cached SSE frame must never mask every subsequent screenshot poll.
   const pageVisible = usePageVisible();
   const live = state.screens[bot.id];
-  const sseFlowing = Boolean(bot.busy && live);
-  const inFlight = useRef(false);
+  const latestLive = useRef({ frame: live, at: 0 });
   useEffect(() => {
-    if (panelView !== "computer" || !cloudPreviewReady || sseFlowing || viewerOpen || !pageVisible) return;
-    let alive = true;
+    if (!cloudPreviewReady) {
+      latestLive.current = { frame: live, at: 0 };
+      return;
+    }
+    if (latestLive.current.frame === live) return;
+    latestLive.current = { frame: live, at: 0 };
+    if (cloudPreviewReady && live) {
+      latestLive.current.at = Date.now();
+      setPolledFrame(live);
+      setPreviewError(null);
+    }
+  }, [live, cloudPreviewReady]);
+
+  useEffect(() => {
+    if (panelView !== "computer" || !cloudPreviewReady || viewerOpen || !pageVisible) return;
+    let inFlight = false;
+    const controller = new AbortController();
+    setPreviewError(null);
     const shoot = async () => {
-      if (inFlight.current) return;
-      inFlight.current = true;
+      if (inFlight) return;
+      // Resume polling if a busy bot stops publishing frames. A single old
+      // SSE event is not evidence of a working stream for the whole turn.
+      if (bot.busy && Date.now() - latestLive.current.at < 10_000) return;
+      inFlight = true;
+      const startedAt = Date.now();
       try {
-        const { png, format } = await api(`/api/bots/${bot.id}/computer/screenshot`, { method: "POST" });
-        if (alive) setPolledFrame({ png, mime: format === "jpeg" ? "image/jpeg" : "image/png" });
-      } catch {
-        /* box mid-command or asleep — next tick */
+        const { png, format } = await api(`/api/bots/${bot.id}/computer/screenshot`, {
+          method: "POST",
+          signal: AbortSignal.any([controller.signal, AbortSignal.timeout(90_000)]),
+        });
+        if (!controller.signal.aborted && latestLive.current.at <= startedAt) {
+          if (typeof png !== "string" || !png.trim()) throw new Error("The computer returned an empty screen image.");
+          setPolledFrame({ png, mime: format === "jpeg" ? "image/jpeg" : "image/png" });
+          setPreviewError(null);
+        }
+      } catch (e) {
+        if (!controller.signal.aborted && latestLive.current.at <= startedAt) {
+          setPreviewError(e instanceof Error && e.name === "TimeoutError"
+            ? "The computer took too long to send a frame. Try again."
+            : e instanceof Error ? e.message : "The screen is temporarily unavailable.");
+        }
       } finally {
-        inFlight.current = false;
+        inFlight = false;
       }
     };
     void shoot();
     const timer = setInterval(shoot, bot.busy ? 4000 : 30_000);
     return () => {
-      alive = false;
+      controller.abort();
       clearInterval(timer);
     };
-  }, [panelView, cloudPreviewReady, sseFlowing, bot.id, viewerOpen, pageVisible, bot.busy]);
+  }, [panelView, cloudPreviewReady, bot.id, cloudBackend, viewerOpen, pageVisible, bot.busy, previewRetry]);
 
   // Local VM preview comes directly from Cua Driver through the harness. It
   // does not use the password-protected noVNC viewer or cloud endpoints.
@@ -709,18 +742,13 @@ export function ComputerPanel({
     };
   }, [panelView, phase, isLinux, pageVisible, bot.busy, bot.id]);
 
-  const lastScreenMessage = [...bot.messages].reverse().find((m) => m.kind === "screen" && m.png);
-  const cloudFrame =
-    live ??
-    polledFrame ??
-    (lastScreenMessage ? { png: lastScreenMessage.png!, mime: lastScreenMessage.mime ?? "image/png" } : null);
   const frameSrc =
     phase === "vm"
       ? vmFrame
       : phase === "local" && !isLinux
       ? localFrame
       : cloudPreviewReady || (bot.computer === "cloud" && phase === "starting")
-        ? cloudFrame && `data:${cloudFrame.mime};base64,${cloudFrame.png}`
+        ? polledFrame && `data:${polledFrame.mime};base64,${polledFrame.png}`
         : null;
   const previewOpensDesktop = Boolean(
     frameSrc &&
@@ -1082,8 +1110,25 @@ export function ComputerPanel({
             )}
             {computerStatusCurrent && bot.computer === "cloud" && cloudBackend === "vps" && (phase === "ready" || phase === "starting") && <span className="text-[11px]">self-hosted VPS</span>}
         </div>
-        <div className="flex aspect-[16/10] w-full items-center justify-center overflow-hidden rounded-xl bg-card">
-          {frameSrc && previewOpensDesktop ? (
+        <div className="relative flex aspect-[16/10] w-full items-center justify-center overflow-hidden rounded-xl bg-card">
+          {cloudPreviewReady || (bot.computer === "cloud" && phase === "starting") ? (
+            <CloudScreenPreview
+              key={`${bot.id}:${cloudBackend}:${previewRetry}`}
+              src={frameSrc}
+              name={bot.name}
+              error={previewError}
+              starting={phase === "starting"}
+              opening={pending === "join"}
+              disabled={controlPending}
+              onOpen={() => void openDesktop()}
+              onRetry={() => {
+                latestLive.current.at = 0;
+                setPolledFrame(null);
+                setPreviewError(null);
+                setPreviewRetry((n) => n + 1);
+              }}
+            />
+          ) : frameSrc && previewOpensDesktop ? (
             <button
               type="button"
               onClick={() => void openDesktop()}

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -11,6 +11,10 @@ import {
   CalendarClock,
   CalendarDays,
   Columns2,
+  Box,
+  Check,
+  Cloud,
+  Sparkles,
   Globe,
   Hand,
   Loader2,
@@ -44,7 +48,6 @@ import { LocalComputerAutoWarning } from "./LocalComputerAutoWarning";
 import {
   autoSelectsLocalComputer,
   instanceSupportsLocalComputer,
-  linuxAutoDescription,
   localComputerDisabledReason,
   localComputerSelectable,
   persistedComputerSelectionMatches,
@@ -1435,31 +1438,19 @@ export function ComputerPanel({
         {/* Computer source */}
           <div className="mt-4 rounded-xl bg-card p-4">
             <div className="text-[15px] font-medium text-ink">Works on</div>
-            <div className="mt-0.5 text-[13px] text-ink-secondary">
-              {!bot.computer &&
-                (isLinux || !localSelectable
-                  ? cloudBackend === "vps"
-                    ? "Auto reuses a ready VPS when one is configured; otherwise computer use stays off. "
-                    : `${linuxAutoDescription()} `
-                  : cloudBackend === "vps"
-                    ? "Auto reuses a ready VPS when one exists, otherwise this computer. "
-                    : "Auto uses a cloud box when one exists, otherwise this computer. ")}
-              Pick where this bot works. <b className="text-ink">Local VM</b> is a Cua-controlled Linux desktop
-              in a container on this machine — free and separate from your own desktop. Set it up in App
-              Settings → Computers. <b className="text-ink">Browser</b> is the built-in browser tab only; no desktop.
-          </div>
-          <div className="mt-3 flex overflow-hidden rounded-lg border border-hairline/40">
-            {(
-              [
-                [null, "Auto"],
-                ["cloud", "Cloud"],
-                ["vm", "Local VM"],
-                ["local", "This computer"],
-                ["browser", "Browser"],
-                ["off", "Off"],
-              ] as const
-            ).map(([mode, label], i) => (
-              (() => {
+            <p className="mt-1 text-[12px] leading-5 text-ink-secondary">
+              Choose where this bot can use a computer.
+            </p>
+          <div role="group" aria-label="Computer destination" className="mt-3 grid auto-rows-fr grid-cols-2 gap-2">
+            {([
+              [null, "Auto", "Choose automatically", Sparkles],
+              ["cloud", "Cloud", "Hosted desktop", Cloud],
+              ["vm", "Local VM", "Isolated local desktop", Box],
+              ["local", "This computer", "Your screen and apps", Monitor],
+              ["browser", "Browser", "Web pages only", Globe],
+              ["off", "Off", "No computer access", Power],
+            ] as const).map(([mode, label, description, Icon]) => {
+                const selected = mode === null ? !bot.computer : bot.computer === mode;
                 const disabled =
                   (mode === "cloud" && !cloudSupported) ||
                   (mode === "vm" && !vmSupported) ||
@@ -1490,33 +1481,61 @@ export function ComputerPanel({
                   else if (mode === "browser") updateComputerSelection({ computer: mode, browser: true });
                   else updateComputerSelection({ computer: mode });
                 }}
+                type="button"
+                aria-pressed={selected}
                 className={cn(
-                  "flex-1 py-1.5 text-[13px]",
-                  i > 0 && "border-l border-hairline/40",
-                  disabled && "cursor-not-allowed opacity-40",
-                  (mode === null ? bot.computer === undefined : bot.computer === mode)
-                    ? "bg-control text-ink"
-                    : "text-ink-secondary hover:bg-control/60 hover:text-ink",
+                  "min-w-0 rounded-lg border px-2.5 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-card",
+                  selected
+                    ? "border-accent/60 bg-accent/10 text-ink"
+                    : "border-hairline/50 bg-panel/30 text-ink-secondary",
+                  disabled
+                    ? "cursor-not-allowed"
+                    : "hover:border-accent/40 hover:bg-control/60",
                 )}
               >
-                {label}
+                <span className="flex items-center gap-2 text-[12px] font-medium leading-4">
+                  {selected ? <Check size={14} className="shrink-0 text-accent" /> : <Icon size={14} className="shrink-0 text-ink-secondary" />}
+                  <span>{label}</span>
+                </span>
+                <span className="mt-1.5 block text-[11px] leading-4 text-ink-secondary">
+                  {disabled ? "Unavailable here" : description}
+                </span>
               </button>
                 );
-              })()
-            ))}
+            })}
           </div>
           {bot.computer === "cloud" && (
             <>
               <CloudBackendPicker
+                compact
                 value={cloudBackend}
                 vpsSupported={vpsSupported}
                 onChange={(backend) => updateComputerSelection({ cloudBackend: backend })}
               />
             </>
           )}
-          {!bot.computer && (
-            <div className="mt-3 rounded-lg bg-inset px-3 py-2.5 text-[11.5px] leading-relaxed text-ink-secondary">
-              Auto is selected. Opening this panel only checks for an existing computer; it never creates or wakes one. Choose Cloud to configure or start a cloud computer.
+          {bot.computer !== "cloud" && (
+            <div className="mt-3 border-t border-hairline/40 pt-3 text-[11.5px] leading-5 text-ink-secondary" aria-live="polite">
+              {!bot.computer ? (
+                cloudBackend === "vps" && bot.autoStartVps
+                  ? "Uses your VPS and starts it when needed."
+                  : localSelectable && !isLinux
+                    ? "Prefers an existing cloud computer; otherwise uses this computer. Select Cloud to start a cloud computer."
+                    : "Uses an existing cloud computer. Select Cloud to create or wake one."
+              ) : bot.computer === "vm" ? (
+                <>
+                  A private Linux desktop on this device, separate from your own screen.
+                  <button type="button" onClick={openVmSettings} className="mt-1 block font-medium text-accent hover:underline">
+                    Local VM settings →
+                  </button>
+                </>
+              ) : bot.computer === "local" ? (
+                "Uses your screen, mouse, and keyboard."
+              ) : bot.computer === "browser" ? (
+                "Uses the built-in browser without access to your desktop."
+              ) : (
+                "This bot can still chat and use its other tools."
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
A cached screen event could permanently hide newer Box screenshots, leaving the Computer panel blank even when the provider returned a valid desktop image. A single cached event also disabled screenshot polling for the entire time a bot was busy.

The destination selector is now a two-column grid with equal card dimensions and consistent label typography. Each option has a short description, a clear selected state, and contextual help instead of a long introductory paragraph. Cloud provider details appear only when Cloud is selected.

The preview now displays newly received frames, resumes polling when live frames stop arriving, cancels obsolete requests, and bounds screenshot requests. It shows connecting feedback until an image decodes, with visible errors and a Retry preview action for failed requests or corrupt images. Opening the interactive desktop also shows descriptive connection feedback.

Validation: production build and typecheck pass; all 678 renderer tests pass; computer-use checks in an isolated Chromium fixture cover the old blank-frame failure, valid JPEG display, live frame updates and fallback, slow responses, request failures, corrupt-image retry, the real 90-second timeout, retry after timeout, and cancellation of an obsolete request. Read-only provider checks authenticated successfully and downloaded a valid screenshot. No live app or cloud computer was mutated for verification.

Includes a reusable isolated renderer fixture and the verification recipe in docs/verification/cloud-preview.md. The destination grid was also checked with computer use at the minimum panel width: all six cards had identical dimensions and 12px labels, and Auto selection persisted correctly. Native viewer launch and Box provisioning are outside this renderer fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cloud desktop preview with loading states, live screen updates, error handling, and retry support.
  * Added clearer computer destination cards with icons, descriptions, and selected-state styling.

* **Bug Fixes**
  * Improved preview recovery and prevented stale frames from masking newer screen updates.
  * Stopped unnecessary polling while recent live frames are available.

* **Documentation**
  * Added instructions for running and validating the cloud preview, including supported scenarios and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->