### PR TITLE
feat(approvals): bring native provider permission modes to parity

### DIFF
--- a/docs/approval-levels.md
+++ b/docs/approval-levels.md
@@ -6,8 +6,8 @@ when that provider resumes an existing native thread.
 | Level | Behavior |
 | --- | --- |
 | **Ask for approval** | The provider asks before actions outside its normal workspace or network permissions. |
-| **Approve for me** | OpenMausBot approves ordinary permission requests. Potentially destructive or sensitive actions, unattended work, and questions still wait for you. |
-| **Full access** | Codex only. Codex runs without its native sandbox or approval prompts, including destructive, sensitive, unattended, and selected-computer actions. Normal question cards still wait for you; unsupported structured forms are declined. |
+| **Approve for me** | Uses native automatic review on Codex, Claude, and Cursor. Other providers fall back to Ask. Requests the native reviewer leaves for you are not overridden by OpenMausBot. Unattended Auto runs use Ask. |
+| **Full access** | Enables the provider's permissive mode for commands, edits, and selected-computer actions, including potentially destructive or sensitive work. Some providers still ask for approval. Questions and separate OpenMausBot confirmations still wait for you. |
 | **Custom (`config.toml`)** | Codex only. OpenMausBot reads and reapplies the effective approval and sandbox settings from your Codex configuration. |
 
 Full access is an elevated-risk standing approval. Full and Custom can only be
@@ -18,8 +18,40 @@ system privacy controls, authentication, CAPTCHA or MFA, service permissions,
 or OpenMausBot's separate confirmations for credentials, routines, skills, and
 peer communication.
 
-Existing bots that used the old **Auto mode** keep the same behavior under
-**Approve for me**. They are never migrated to Full access automatically.
+Existing bots that used the old **Auto mode** keep that selection under
+**Approve for me**, but now use native review rather than the app's heuristic
+auto-approval. Providers without native review ask instead. No bot is migrated
+to Full access automatically.
 The selected bot level also overrides older provider-instance bypass settings
 for each app turn, so **Ask for approval** cannot silently inherit a Grok,
 Cursor, Claude, or other engine's legacy full-auto mode.
+
+## Provider mappings
+
+| Provider | Auto | Full access |
+| --- | --- | --- |
+| Codex | Native automatic reviewer; workspace sandbox | No native approval prompts; unrestricted native sandbox |
+| Claude | Native `auto` mode | Native `bypassPermissions` |
+| Cursor | Native `--auto-review` | Native `--force` |
+| Antigravity | Ask | Native `yolo`; remaining native requests still appear |
+| Grok Build | Ask | Native `bypassPermissions`; remaining native requests still appear |
+| OpenCode | Ask | Approve individual ACP permission requests, never task questions |
+| Other/custom engines | Ask | Not offered until a provider mapping is implemented |
+
+These settings apply on each turn, including resumed conversations. Switching
+to a different provider while elevated requires choosing Ask or Auto first.
+Native modes require a CLI version that supports them; OpenMausBot does not
+silently substitute unrestricted access when a mode is rejected.
+
+The mapping follows the provider-boundary approach in
+[T3 Code's permission modes](https://github.com/pingdotgg/t3code/blob/bc8584bf8e967ecc1cd215d42bd7a47faf51a862/docs/user/permission-modes.md).
+OpenMausBot keeps its own opt-in desktop confirmation; Full access is not the default.
+
+## Verification for contributors
+
+Run `pnpm exec electron scripts/smoke-approval-modes.cjs` to exercise the real
+private desktop-to-server grant protocol in a disposable fixture. It verifies
+HTTP elevation rejection, Full → Auto → Ask on resumed Claude turns, and
+Antigravity approval cards that remain answerable even in Full access. Provider
+processes are scripted fakes; this does not verify live account eligibility or
+the quality of a provider's automatic reviewer. No live user data is used.

--- a/scripts/smoke-approval-modes.cjs
+++ b/scripts/smoke-approval-modes.cjs
@@ -1,0 +1,124 @@
+// Run with `pnpm exec electron scripts/smoke-approval-modes.cjs`.
+// Exercises the real private Electron utility-process grant protocol using
+// only a disposable home and fake Claude/Antigravity CLIs. Never uses the live app.
+const { app, utilityProcess } = require("electron");
+const assert = require("node:assert/strict");
+const { randomUUID, createHash } = require("node:crypto");
+const { mkdtempSync, mkdirSync, copyFileSync, chmodSync, writeFileSync, readFileSync, rmSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const { join, resolve } = require("node:path");
+const { createServer } = require("node:net");
+const { once } = require("node:events");
+const { setTimeout: delay } = require("node:timers/promises");
+const { createTrustedApprovalModeCoordinator } = require("../electron/approval-trusted-mode.cjs");
+
+const root = resolve(__dirname, "..");
+const home = mkdtempSync(join(tmpdir(), "omb-approval-smoke-"));
+app.setPath("userData", join(home, "electron"));
+let child;
+let logs = "";
+
+async function freePort() {
+  const server = createServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const port = server.address().port;
+  await new Promise((done) => server.close(done));
+  return port;
+}
+
+async function until(check) {
+  const deadline = Date.now() + 30_000;
+  do {
+    const result = await check();
+    if (result) return result;
+    await delay(50);
+  } while (Date.now() < deadline);
+  throw new Error(`Fixture timed out. ${logs.slice(-2000)}`);
+}
+
+app.whenReady().then(async () => {
+  const port = await freePort();
+  let webhookPort = await freePort();
+  while (webhookPort === port) webhookPort = await freePort();
+  const agy = join(home, "fake-antigravity.ts");
+  copyFileSync(join(root, "server/testing/fake-acp-cli.ts"), agy);
+  const harness = join(home, process.platform === "win32" ? "localharness_external.exe" : "localharness_external");
+  writeFileSync(harness, "fake harness");
+  if (process.platform !== "win32") { chmodSync(agy, 0o755); chmodSync(harness, 0o755); }
+  const auth = join(home, "providers/antigravity", createHash("sha256").update("agy").digest("hex"), "antigravity-acp");
+  mkdirSync(auth, { recursive: true });
+  writeFileSync(join(auth, "acp_token.json"), "{}");
+  writeFileSync(join(home, "config.json"), JSON.stringify({ instances: {
+    claude: { driver: "claudeAgent", config: { cli: join(root, "server/testing/fake-claude-cli.ts") } },
+    agy: { driver: "antigravityAgent", config: { cli: agy } },
+  } }));
+  const dump = join(home, "claude-argv.json");
+  const coordinator = createTrustedApprovalModeCoordinator({ randomId: randomUUID });
+  child = utilityProcess.fork(join(root, "server/index.ts"), [], {
+    cwd: root,
+    execArgv: ["--experimental-strip-types"],
+    env: {
+      HOME: home, USERPROFILE: home, OMB_DATA_DIR: home, PATH: "",
+      ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
+      OMB_PORT: String(port), OMB_WEBHOOK_PORT: String(webhookPort),
+      FAKE_CLAUDE_MODE: "happy", FAKE_CLAUDE_DUMP: dump,
+      FAKE_ACP_MODE: "permission", FAKE_ACP_AUTH_METHOD: "oauth-personal",
+      FAKE_ACP_MODELS: "gemini-3.8-flash-high", FAKE_ACP_MODES: "default,yolo",
+    },
+    stdio: "pipe",
+  });
+  child.stdout.on("data", (chunk) => { logs += chunk; });
+  child.stderr.on("data", (chunk) => { logs += chunk; });
+  child.on("message", (message) => coordinator.receive(child, message));
+  child.on("exit", () => coordinator.rejectProcess(child));
+  const api = async (path, method = "GET", body) => {
+    const response = await fetch(`http://127.0.0.1:${port}${path}`, {
+      method, headers: { "content-type": "application/json" },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+    return { status: response.status, body: await response.json() };
+  };
+  await until(() => api("/api/health").catch(() => null));
+  const created = await api("/api/bots", "POST", { modelSelection: { instanceId: "claude", model: "claude-sonnet-5" } });
+  assert.equal(created.status, 201);
+  const id = created.body.bot.id;
+  assert.equal((await api(`/api/bots/${id}`, "PATCH", { approvalMode: "full", acknowledgeFullAccess: true })).status, 403);
+  for (const [mode, native] of [["full", "bypassPermissions"], ["auto", "auto"], ["ask", "default"]]) {
+    await coordinator.request(child, id, mode);
+    await until(async () => (await api("/api/bots?messages=0")).body.bots.find((bot) => bot.id === id)?.approvalMode === mode);
+    assert.equal((await api(`/api/bots/${id}/messages`, "POST", { text: `Verify ${mode}` })).status, 202);
+    await until(async () => !(await api("/api/bots?messages=0")).body.bots.find((bot) => bot.id === id)?.busy);
+    const argv = JSON.parse(readFileSync(dump, "utf8")).argv;
+    assert.equal(argv[argv.indexOf("--permission-mode") + 1], native);
+    if (mode !== "full") assert.ok(argv.includes("--resume"));
+    console.log(JSON.stringify({ mode, native, privateGrant: true, turnSettled: true }));
+  }
+  await assert.rejects(coordinator.request(child, id, "custom"), /only for Codex/);
+  const agyBot = (await api("/api/bots", "POST", { modelSelection: { instanceId: "agy", model: "gemini-3.8-flash-high" } })).body.bot;
+  for (const mode of ["full", "auto", "ask"]) {
+    await coordinator.request(child, agyBot.id, mode);
+    await until(async () => (await api("/api/bots?messages=0")).body.bots.find((bot) => bot.id === agyBot.id)?.approvalMode === mode);
+    assert.equal((await api(`/api/bots/${agyBot.id}/messages`, "POST", { text: `Verify native ${mode} approval` })).status, 202);
+    const card = await until(async () => {
+      const bot = (await api("/api/bots")).body.bots.find((bot) => bot.id === agyBot.id);
+      return bot.messages.find((message) => message.card?.requestId && !message.card.answered && !message.card.dismissed)?.card;
+    });
+    if (mode !== "ask") assert.equal(card.held, "The provider requires your approval for this action.");
+    assert.equal((await api(`/api/bots/${agyBot.id}/respond`, "POST", { requestId: card.requestId, behavior: "allow" })).status, 200);
+    await until(async () => !(await api("/api/bots?messages=0")).body.bots.find((bot) => bot.id === agyBot.id)?.busy);
+    console.log(JSON.stringify({ provider: "antigravity", mode, nativeApprovalShown: true, humanApproved: true }));
+  }
+  console.log("Approval smoke passed; HTTP elevation rejected, private grant and resumed mode transitions verified.");
+}).catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+}).finally(async () => {
+  if (child?.pid) {
+    const exited = once(child, "exit");
+    child.kill();
+    await exited;
+  }
+  rmSync(home, { recursive: true, force: true });
+  app.exit(process.exitCode || 0);
+});

--- a/server/approval-mode.test.ts
+++ b/server/approval-mode.test.ts
@@ -3,11 +3,25 @@ import { describe, expect, it } from "vitest";
 import {
   APPROVAL_MODES,
   approvalModeFor,
+  supportsApprovalMode,
+  hasNativeAutoReview,
+  requiresNativeApproval,
   isEmergencyApprovalDowngrade,
   isApprovalMode,
 } from "../shared/approval-mode.ts";
 
 describe("approval modes", () => {
+  it("only exposes implemented provider capabilities", () => {
+    for (const driver of ["codex", "claudeAgent", "antigravityAgent", "cursorAgent", "grokAgent", "opencodeGo"]) {
+      expect(supportsApprovalMode(driver, "full")).toBe(true);
+      expect(supportsApprovalMode(driver, "custom")).toBe(driver === "codex");
+      expect(hasNativeAutoReview(driver)).toBe(["codex", "claudeAgent", "cursorAgent"].includes(driver));
+      expect(requiresNativeApproval(driver, "auto")).toBe(true);
+    }
+    for (const driver of [undefined, "customAgent", "pi"]) expect(supportsApprovalMode(driver, "full")).toBe(false);
+    expect(requiresNativeApproval("antigravityAgent", "full")).toBe(true);
+    expect(requiresNativeApproval("opencodeGo", "full")).toBe(false);
+  });
   it("recognizes only the four durable values", () => {
     expect(APPROVAL_MODES).toEqual(["ask", "auto", "full", "custom"]);
     for (const mode of APPROVAL_MODES) expect(isApprovalMode(mode)).toBe(true);

--- a/server/auto-approve.test.ts
+++ b/server/auto-approve.test.ts
@@ -7,10 +7,18 @@ import { describe, expect, it } from "vitest";
 import {
   approvalKey,
   autoDecision,
+  autoVerdict,
   looksDestructive,
   looksSensitive,
   rememberableApprovalKey,
 } from "./auto-approve.ts";
+
+describe("native permission decisions", () => {
+  it.each(["auto", "full"] as const)("does not override a native %s approval request, even with a remembered grant", (approvalMode) => {
+    expect(autoVerdict({ approvalMode, alwaysAllow: ["Read"] }, "Read", "README.md", { nativeApproval: true }))
+      .toEqual({ approve: null, source: "native-approval" });
+  });
+});
 
 describe("looksDestructive", () => {
   const dangerous = [

--- a/server/auto-approve.ts
+++ b/server/auto-approve.ts
@@ -86,6 +86,7 @@ export type AutoVerdictSource =
   | "always-allow"
   | "auto-mode"
   | "full-access"
+  | "native-approval"
   | "explicit-approval-block"
   | "unattended-block"
   | "local-computer-block"
@@ -142,6 +143,8 @@ export function autoVerdict(
   context?: {
     /** the turn was started by an outside event, with nobody at the keyboard */
     unattended?: boolean;
+    /** Respect the native reviewer (including a provider with no Auto mode). */
+    nativeApproval?: boolean;
     /** the request controls the user's active desktop */
     scope?: "local-computer";
     /** The provider is asking to widen its configured sandbox rather than
@@ -150,6 +153,7 @@ export function autoVerdict(
   },
 ): AutoVerdict {
   const mode = approvalModeFor(bot);
+  if (context?.nativeApproval) return { approve: null, source: "native-approval" };
   // This branch intentionally precedes every guard. Entering Full access is
   // separately consent-gated by the bot PATCH endpoint, and its promise is
   // literal: even destructive, sensitive, unattended, and host-computer

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -46,6 +46,7 @@ import type {
 import { newEventId, newId } from "../../contracts.ts";
 import { computerProxyEnv } from "../../container-computer.ts";
 import { augmentedPath } from "../../env-path.ts";
+import { supportsApprovalMode } from "../../../shared/approval-mode.ts";
 
 // Resolved from the server root, never relative to this file: bundling inlines
 // this module two directories up, so the `".."` pair here would climb past the
@@ -419,9 +420,9 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
         // embedders and tests outside the harness.
         const turnConfig = turn.approvalMode === undefined
           ? config
-          : { ...config, fullAuto: false };
+          : { ...config, fullAuto: turn.approvalMode === "full" && supportsApprovalMode(DRIVER_KIND, "full") };
         const controlsHost = turn.integrations?.localComputer?.scope === "local-computer";
-        if (controlsHost && turnConfig.fullAuto) {
+        if (controlsHost && turnConfig.fullAuto && turn.approvalMode !== "full") {
           throw new Error("local computer control requires interactive provider approvals");
         }
         const turnId = newId();
@@ -621,7 +622,7 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
 
           const toolCall = params.toolCall ?? {};
           const isQuestion = String(toolCall.toolCallId ?? "").startsWith("interaction_");
-          if (turnConfig.fullAuto && !isQuestion) {
+          if (turnConfig.fullAuto && turn.approvalMode === undefined && !isQuestion) {
             const allow = optionFor("allow");
             if (!allow) missing("allow");
             return send({

--- a/server/drivers/acp/cursor.test.ts
+++ b/server/drivers/acp/cursor.test.ts
@@ -219,7 +219,7 @@ describe("CursorAgentDriver", () => {
     });
     const recorder = recordEvents(instance.adapter);
     try {
-      await instance.adapter.sendTurn({ threadId: "t-cursor", text: "hi", model: "gpt-5.3-codex" });
+      await instance.adapter.sendTurn({ threadId: "t-cursor", text: "hi", model: "gpt-5.3-codex", approvalMode: "full" });
       await recorder.until((e) => e.type === "turn.completed");
 
       const seen = JSON.parse(readFileSync(dump, "utf8"));
@@ -231,6 +231,11 @@ describe("CursorAgentDriver", () => {
       expect(applied).toEqual([
         { method: "session/set_model", params: { sessionId: "fake-acp-session", modelId: "gpt-5.3-codex" } },
       ]);
+      for (const approvalMode of ["auto", "ask"] as const) {
+        const { turnId } = await instance.adapter.sendTurn({ threadId: "t-cursor", text: "continue", approvalMode, resumeCursor: "fake-acp-session" });
+        await recorder.until((e) => e.type === "turn.completed" && e.turnId === turnId);
+        expect(JSON.parse(readFileSync(dump, "utf8")).argv).toEqual(approvalMode === "auto" ? ["--auto-review", "acp"] : ["acp"]);
+      }
     } finally {
       recorder.stop();
       await instance.dispose();

--- a/server/drivers/acp/cursor.ts
+++ b/server/drivers/acp/cursor.ts
@@ -353,7 +353,7 @@ const support = (run: typeof execCli): AcpSupport => ({
   // `--force` is the documented auto-approve switch (`--yolo` is an alias);
   // `--model` is the reliable pin — ACP session/set_model is best-effort below.
   spawnArgs: (config, turn) => [
-    ...(config.fullAuto ? ["--force"] : []),
+    ...(config.fullAuto ? ["--force"] : turn.approvalMode === "auto" ? ["--auto-review"] : []),
     ...(turn.model ? ["--model", turn.model] : []),
     "acp",
   ],

--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -490,7 +490,7 @@ describe("Antigravity driver over shared ACP", () => {
     expect(antigravityPermissionMode(true)).toBe("yolo");
   });
 
-  it("runs an authenticated turn, selects model and mode, and keeps MCP session-scoped", async () => {
+  it.each(["ask", "auto", "full"] as const)("runs an authenticated %s turn with explicit mode and session-scoped MCP", async (approvalMode) => {
     ensureDirs();
     const fake = fakeRuntime();
     const dump = join(fake.directory, "dump.json");
@@ -516,6 +516,8 @@ describe("Antigravity driver over shared ACP", () => {
     const { turnId } = await instance.adapter.sendTurn({
       threadId: "thread-antigravity",
       text: "hello",
+      approvalMode,
+      resumeCursor: "fake-acp-session",
       model: "gemini-3.8-flash-low",
       integrations: {
         custom: { docs: { command: "docs-mcp", args: ["serve"], env: { TOKEN: "scoped" } } },
@@ -534,7 +536,7 @@ describe("Antigravity driver over shared ACP", () => {
     const calls = JSON.parse(readFileSync(`${dump}.config.json`, "utf8"));
     expect(calls).toEqual([
       { method: "session/set_config_option", params: { sessionId: "fake-acp-session", configId: "model", value: "gemini-3.8-flash-low" } },
-      { method: "session/set_config_option", params: { sessionId: "fake-acp-session", configId: "mode", value: "default" } },
+      { method: "session/set_config_option", params: { sessionId: "fake-acp-session", configId: "mode", value: approvalMode === "full" ? "yolo" : "default" } },
     ]);
     const mcp = JSON.parse(readFileSync(`${dump}.mcp.json`, "utf8"));
     expect(mcp).toEqual([{ name: "docs", command: "docs-mcp", args: ["serve"], env: [{ name: "TOKEN", value: "scoped" }] }]);
@@ -573,7 +575,11 @@ describe("Antigravity driver over shared ACP", () => {
     )).toBe(true);
   });
 
-  it("keeps Antigravity questions interactive even in full-auto mode", async () => {
+  it.each([
+    ["question", undefined],
+    ["question", "full"],
+    ["permission", "full"],
+  ] as const)("keeps Antigravity %s requests interactive with mode %s", async (requestKind, approvalMode) => {
     ensureDirs();
     const fake = fakeRuntime();
     const instanceId = "antigravity-question";
@@ -584,7 +590,7 @@ describe("Antigravity driver over shared ACP", () => {
       instanceId,
       displayName: undefined,
       environment: {
-        FAKE_ACP_MODE: "question",
+        FAKE_ACP_MODE: requestKind,
         FAKE_ACP_PAD_QUESTION_OPTION: "1",
         FAKE_ACP_AUTH_METHOD: "oauth-personal",
         FAKE_ACP_MODELS: "gemini-3.8-flash-high",
@@ -594,15 +600,16 @@ describe("Antigravity driver over shared ACP", () => {
       config: { cli: fake.executable, fullAuto: true },
     });
     recorder = recordEvents(instance.adapter);
-    await instance.adapter.sendTurn({ threadId: "thread-question", text: "ask me", cwd: fake.directory });
+    await instance.adapter.sendTurn({ threadId: "thread-question", text: "ask me", cwd: fake.directory, approvalMode });
     const opened = await recorder.until((event) => event.type === "request.opened");
-    expect(opened).toMatchObject({ requestType: "question", summary: "Which color?", choices: ["Blue", "Green"] });
+    expect(opened).toMatchObject({ requestType: requestKind });
+    if (requestKind === "question") expect(opened).toMatchObject({ summary: "Which color?", choices: ["Blue", "Green"] });
     await instance.adapter.respondToRequest("thread-question", (opened as { requestId: string }).requestId, {
-      behavior: "answer",
+      behavior: requestKind === "question" ? "answer" : "allow",
       message: "Green",
     });
     expect(await recorder.until((event) => event.type === "request.resolved")).toMatchObject({
-      behavior: "answer",
+      behavior: requestKind === "question" ? "answer" : "allow",
       source: "user",
     });
     expect(await recorder.until((event) => event.type === "turn.completed")).toMatchObject({ ok: true });

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -376,8 +376,41 @@ describe("ClaudeDriver turns (fake CLI)", () => {
 
     const seen = JSON.parse(readFileSync(dump, "utf8"));
     expect(seen.argv).toContain("--permission-mode");
-    expect(seen.argv[seen.argv.indexOf("--permission-mode") + 1]).toBe("acceptEdits");
+    expect(seen.argv[seen.argv.indexOf("--permission-mode") + 1]).toBe("default");
     expect(seen.argv).toContain("--permission-prompt-tool");
+  });
+
+  it("reapplies Full, Auto, and Ask on the same resumed conversation", async () => {
+    await create(undefined, {}, { permissionMode: "bypassPermissions" });
+    const dump = join(scratch, "approval-transitions.json");
+    process.env.FAKE_CLAUDE_DUMP = dump;
+    for (const [approvalMode, nativeMode] of [["full", "bypassPermissions"], ["auto", "auto"], ["ask", "default"]] as const) {
+      const { turnId } = await instance.adapter.sendTurn({
+        threadId: "t-mode-transitions",
+        text: "hello",
+        approvalMode,
+        resumeCursor: "11111111-1111-4111-8111-111111111111",
+      });
+      await recorder.until((e) => e.type === "turn.completed" && e.turnId === turnId);
+      const seen = JSON.parse(readFileSync(dump, "utf8"));
+      expect(seen.argv[seen.argv.indexOf("--permission-mode") + 1]).toBe(nativeMode);
+      expect(seen.argv.includes("--permission-prompt-tool")).toBe(approvalMode !== "full");
+      expect(seen.argv).toContain("--resume");
+    }
+  });
+
+  it("keeps questions answerable in per-bot Full access", async () => {
+    await create("hang");
+    await instance.adapter.sendTurn({ threadId: "t-full-question", text: "go", approvalMode: "full" });
+    const conn = await connectSocket(permissionSocketPath("t-full-question"));
+    try {
+      conn.write(JSON.stringify({ t: "ask", kind: "question", id: "full-question", tool: "ask_user", input: { question: "Which account?" } }) + "\n");
+      const opened = await recorder.until((e) => e.type === "request.opened");
+      expect(opened).toMatchObject({ requestType: "question" });
+      expect(await instance.adapter.respondToRequest("t-full-question", (opened as { requestId: string }).requestId, { behavior: "answer", message: "Work" })).toBe("answered");
+    } finally {
+      conn.destroy();
+    }
   });
 
   it("sends attached images as native blocks before text without logging their bytes", async () => {

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -698,11 +698,10 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       // per-turn mode keep the legacy adapter behavior.
       const permissionMode = turn.approvalMode === undefined
         ? config.permissionMode
-        : config.permissionMode === "bypassPermissions"
-          ? "acceptEdits"
-          : config.permissionMode;
+        : turn.approvalMode === "full" ? "bypassPermissions"
+          : turn.approvalMode === "auto" ? "auto" : "default";
       const controlsHost = turn.integrations?.localComputer?.scope === "local-computer";
-      if (controlsHost && permissionMode === "bypassPermissions") {
+      if (controlsHost && permissionMode === "bypassPermissions" && turn.approvalMode !== "full") {
         throw new Error("local computer control requires the interactive approval broker");
       }
       // Materialize before creating a broker or process. A missing/corrupt
@@ -727,7 +726,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         // token-level streaming: content_block_delta events between the
         // whole-message frames, so the bubble grows as the model writes
         "--include-partial-messages",
-        "--permission-mode", permissionMode === "auto" ? "acceptEdits" : permissionMode,
+        "--permission-mode", permissionMode,
       ];
       if (config.tools !== undefined) args.push("--tools", config.tools.join(","));
       if (config.disallowedTools?.length) {
@@ -812,17 +811,15 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         if (name in mcpServers) continue;
         mcpServers[name] = { ...server };
       }
-      // permission broker: anything acceptEdits would silently deny becomes
-      // an Allow/Deny card in chat, and the agent gets ask_user. Skipped in
-      // bypassPermissions (fullAuto) — nothing would ever ask.
+      // Keep ask_user available even in Full access. Native bypass skips
+      // permission prompts, not questions requiring a person's answer.
       let broker: Awaited<ReturnType<typeof createPermissionBroker>> | undefined;
-      let socketPath: string | null = null;
+      const socketPath = permissionSocketPath(threadId);
       if (permissionMode !== "bypassPermissions") {
-        socketPath = permissionSocketPath(threadId);
         args.push("--permission-prompt-tool", "mcp__ogb__approve");
-        mcpServers.ogb = { command: process.execPath, args: [PERM_PROXY_PATH, socketPath], env: { ...NODE_ENV_FLAG }, alwaysLoad: true };
-        allowed.push("mcp__ogb");
       }
+      mcpServers.ogb = { command: process.execPath, args: [PERM_PROXY_PATH, socketPath], env: { ...NODE_ENV_FLAG }, alwaysLoad: true };
+      allowed.push("mcp__ogb");
       // The MCP config carries credentials — a Composio consumer key in a
       // header, the box token in the computer proxy's env, the comms token in
       // the agents proxy's env. On argv every one of those is world-readable

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -183,12 +183,12 @@ describe("CodexDriver turns (fake app-server)", () => {
       }>;
       expect(calls.find((call) => call.method === "thread/start")?.params).toMatchObject({
         approvalPolicy,
-        approvalsReviewer: "user",
+        approvalsReviewer: approvalMode === "auto" ? "auto_review" : "user",
         sandbox,
       });
       expect(calls.find((call) => call.method === "turn/start")?.params).toMatchObject({
         approvalPolicy,
-        approvalsReviewer: "user",
+        approvalsReviewer: approvalMode === "auto" ? "auto_review" : "user",
         sandboxPolicy: { type: turnSandbox },
       });
     },

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -246,12 +246,12 @@ function namedApprovalParams(mode: Exclude<ApprovalMode, "custom">): CodexApprov
   return {
     thread: {
       approvalPolicy: "on-request",
-      approvalsReviewer: "user",
+      approvalsReviewer: mode === "auto" ? "auto_review" : "user",
       sandbox: "workspace-write",
     },
     turn: {
       approvalPolicy: "on-request",
-      approvalsReviewer: "user",
+      approvalsReviewer: mode === "auto" ? "auto_review" : "user",
       sandboxPolicy: { type: "workspaceWrite" },
     },
   };

--- a/server/group-goal-run.e2e.test.ts
+++ b/server/group-goal-run.e2e.test.ts
@@ -16,6 +16,7 @@ const FAKE_CLAUDE = join(SERVER_DIR, "testing", "fake-claude-cli.ts");
 let child: ChildProcess;
 let home = "";
 let stopScopedWorkerFinishGate = "";
+let busyWorkerFinishGate = "";
 let base = "";
 let stderr = "";
 
@@ -46,6 +47,7 @@ const api = async (method: string, path: string, body?: unknown): Promise<{ stat
 beforeAll(async () => {
   home = mkdtempSync(join(tmpdir(), "omb-goal-run-"));
   stopScopedWorkerFinishGate = join(home, "stop-scoped-worker-finish");
+  busyWorkerFinishGate = join(home, "busy-worker-finish");
   const data = join(home, ".openmausbot");
   const staticDir = join(home, "static");
   mkdirSync(data, { recursive: true });
@@ -121,6 +123,7 @@ beforeAll(async () => {
         displayName: "Busy worker fixture",
         environment: {
           FAKE_CLAUDE_MODE: "slow",
+          FAKE_CLAUDE_SLOW_FINISH_GATE: busyWorkerFinishGate,
           FAKE_CLAUDE_REPLIES: JSON.stringify([
             "The unrelated direct research is complete.",
             "Evidence gathered for the coordinator.",
@@ -386,6 +389,10 @@ describe("goal-driven channel runs", () => {
         roomBusyBotId: null,
         workerDirectBusy: true,
       });
+
+      // Keep the worker occupied until the waiting state is observed, even
+      // when CI takes longer than the fake driver's default 800 ms turn.
+      writeFileSync(busyWorkerFinishGate, "release");
 
       await expect.poll(async () => {
         const state = (await api("GET", "/api/bots?messages=30")).body;

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -3082,7 +3082,7 @@ describe("harness HTTP API", () => {
       for (const seeded of trustedBots) {
         const rejected = await isolatedApi("PATCH", `/api/bots/${seeded.id}/model`, targetSelection);
         expect(rejected.status, seeded.approvalMode).toBe(400);
-        expect(rejected.body.error).toMatch(/requires a Codex provider.*Ask or Auto first/i);
+        expect(rejected.body.error).toMatch(/requires choosing Ask or Auto first/i);
         const unchanged = (await isolatedApi("GET", "/api/bots?messages=0")).body.bots.find(
           (candidate: { id: string }) => candidate.id === seeded.id,
         );
@@ -4515,7 +4515,7 @@ describe("harness HTTP API", () => {
     }
   });
 
-  it("does not offer Full or Custom approval modes to non-Codex bots", async () => {
+  it("requires private desktop consent for Claude Full and rejects Codex-only Custom", async () => {
     const bot = (await api("POST", "/api/bots", {
       modelSelection: { instanceId: "claude", model: "fixture-claude-model" },
     })).body.bot;
@@ -4525,8 +4525,8 @@ describe("harness HTTP API", () => {
           approvalMode,
           acknowledgeFullAccess: true,
         });
-        expect(rejected.status, approvalMode).toBe(400);
-        expect(rejected.body.error).toMatch(/only for Codex/i);
+        expect(rejected.status, approvalMode).toBe(approvalMode === "full" ? 403 : 400);
+        expect(rejected.body.error).toMatch(approvalMode === "full" ? /desktop app/i : /does not support/i);
       }
       const stored = (await api("GET", "/api/bots")).body.bots.find(
         (candidate: { id: string }) => candidate.id === bot.id,

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,6 +10,8 @@ import { z } from "zod";
 import { botAvatarUrlFromStoredPath } from "../shared/bot-avatar.ts";
 import {
   approvalModeFor,
+  supportsApprovalMode,
+  requiresNativeApproval,
   isEmergencyApprovalDowngrade,
   isApprovalMode,
   type ApprovalMode,
@@ -1152,17 +1154,17 @@ const wireTrustedApprovalBot = (bot: NonNullable<ReturnType<typeof store.bot>>) 
 };
 
 /** Defense in depth for hand-edited/corrupt durable records: elevated
- * approval semantics belong only to Codex. The trusted transition enforces
+ * approval semantics require an implemented provider mapping. The trusted transition enforces
  * this too, but no provider dispatch or later permission callback relies on
  * persistence having been produced exclusively by that route. */
 const approvalModeForTurn = (bot: BotRecord): ApprovalMode => {
   const mode = approvalModeFor(bot);
-  if (
-    (mode === "full" || mode === "custom") &&
-    registry.cliTarget(bot.modelSelection.instanceId)?.driverKind !== "codex"
-  ) {
+  if (!supportsApprovalMode(registry.cliTarget(bot.modelSelection.instanceId)?.driverKind, mode)) {
     return "ask";
   }
+  // Native reviewers can approve before a permission reaches this process.
+  // Unattended Auto must therefore downgrade before spawning the provider.
+  if (mode === "auto" && isUnattended(bot.id)) return "ask";
   return mode;
 };
 
@@ -1190,7 +1192,7 @@ function handleDesktopTrustedApprovalMessage(raw: unknown): boolean {
       bot.approvalGrant.phase === "committed" &&
       bot.approvalMode === mode &&
       !bot.busy &&
-      registry.cliTarget(bot.modelSelection.instanceId)?.driverKind === "codex"
+      supportsApprovalMode(registry.cliTarget(bot.modelSelection.instanceId)?.driverKind, mode)
     ) {
       store.patchBot(botId, { approvalGrant: undefined });
     } else if (bot?.approvalGrant?.requestId === requestId) {
@@ -1226,9 +1228,9 @@ function handleDesktopTrustedApprovalMessage(raw: unknown): boolean {
       bot.approvalGrant.phase === "prepared" &&
       bot.approvalMode === mode
     ) {
-      if (registry.cliTarget(bot.modelSelection.instanceId)?.driverKind !== "codex") {
+      if (!supportsApprovalMode(registry.cliTarget(bot.modelSelection.instanceId)?.driverKind, mode)) {
         store.patchBot(botId, { approvalMode: "ask", autoApprove: false, approvalGrant: undefined });
-        confirm(false, "Full and Custom approval levels require a Codex bot");
+        confirm(false, "This provider does not support the selected approval level");
         return true;
       }
       store.patchBot(botId, {
@@ -1273,11 +1275,11 @@ function handleDesktopTrustedApprovalMessage(raw: unknown): boolean {
       bot.approvalGrant.phase === "confirmed" &&
       bot.approvalMode === mode
     ) {
-      if (bot.busy || registry.cliTarget(bot.modelSelection.instanceId)?.driverKind !== "codex") {
+      if (bot.busy || !supportsApprovalMode(registry.cliTarget(bot.modelSelection.instanceId)?.driverKind, mode)) {
         store.patchBot(botId, { approvalMode: "ask", autoApprove: false, approvalGrant: undefined });
         activate(false, bot.busy
           ? "Stop this bot's turn before changing its approval level"
-          : "Full and Custom approval levels require a Codex bot");
+          : "This provider does not support the selected approval level");
         return true;
       }
       // Still inert: Electron must receive this acknowledgement and request
@@ -1320,7 +1322,7 @@ function handleDesktopTrustedApprovalMessage(raw: unknown): boolean {
       bot.approvalGrant.phase === "activated" &&
       bot.approvalMode === mode &&
       !bot.busy &&
-      registry.cliTarget(bot.modelSelection.instanceId)?.driverKind === "codex"
+      supportsApprovalMode(registry.cliTarget(bot.modelSelection.instanceId)?.driverKind, mode)
     ) {
       // Durable but still inert. Electron must observe this exact ACK before
       // sending the one-way commit release that clears the journal.
@@ -1372,14 +1374,11 @@ function handleDesktopTrustedApprovalMessage(raw: unknown): boolean {
     respond({ ok: false, error: "Stop this bot's turn before changing its approval level" });
     return true;
   }
-  if (
-    (mode === "full" || mode === "custom") &&
-    registry.cliTarget(existing.modelSelection.instanceId)?.driverKind !== "codex"
-  ) {
+  if (!supportsApprovalMode(registry.cliTarget(existing.modelSelection.instanceId)?.driverKind, mode)) {
     respond({
       ok: false,
       error: mode === "full"
-        ? "Full access is available only for Codex bots"
+        ? "This provider does not support Full access"
         : "Custom approval settings are available only for Codex bots",
     });
     return true;
@@ -2786,6 +2785,7 @@ bus.subscribe((event: RuntimeEvent) => {
             unattended,
             scope: event.approvalScope,
             requiresExplicitApproval: event.requiresExplicitApproval,
+            nativeApproval: requiresNativeApproval(event.provider, approvalModeForTurn(asker)),
           })
         : null;
       if (verdict?.approve && asker && event.requestId) {
@@ -2885,11 +2885,12 @@ bus.subscribe((event: RuntimeEvent) => {
                 requiresExplicitApproval: event.requiresExplicitApproval,
               })
             : undefined,
-          // In safe Auto a card can only mean a guard stopped it — say so.
-          // Full access has no guard-card path; only a failed delivery above
-          // can hand its permission back to the human.
+          // Explain native approval requests without implying that Full
+          // access bypasses a provider's own remaining checks.
           held:
-            permission && event.requiresExplicitApproval
+            verdict?.source === "native-approval"
+              ? "The provider requires your approval for this action."
+              : permission && event.requiresExplicitApproval
               ? "This changes the provider sandbox, so only Full access can approve it automatically."
               : permission && asker && approvalModeFor(asker) === "auto"
                 ? "This action needs you, so Approve for me stopped to ask."
@@ -9685,10 +9686,11 @@ const server = createServer(async (req, res) => {
       const existingApprovalMode = approvalModeFor(existing);
       if (
         (existingApprovalMode === "full" || existingApprovalMode === "custom") &&
-        registry.cliTarget(checked.selection.instanceId)?.driverKind !== "codex"
+        (!supportsApprovalMode(registry.cliTarget(checked.selection.instanceId)?.driverKind, existingApprovalMode) ||
+          registry.cliTarget(checked.selection.instanceId)?.driverKind !== registry.cliTarget(existing.modelSelection.instanceId)?.driverKind)
       ) {
         return json(res, 400, {
-          error: `${existingApprovalMode === "full" ? "Full access" : "Custom approval settings"} requires a Codex provider; choose Ask or Auto first`,
+          error: "Changing providers with elevated permissions requires choosing Ask or Auto first",
         });
       }
       // patchBot persists first and emits the canonical bot change, which the
@@ -9913,10 +9915,11 @@ const server = createServer(async (req, res) => {
       if (
         (requestedApprovalMode === "full" || requestedApprovalMode === "custom") &&
         (body.approvalMode !== undefined || normalizedSelection !== undefined) &&
-        (!targetSelection || registry.cliTarget(targetSelection.instanceId)?.driverKind !== "codex")
+        (!targetSelection || !supportsApprovalMode(registry.cliTarget(targetSelection.instanceId)?.driverKind, requestedApprovalMode) ||
+          (existingBot && normalizedSelection && registry.cliTarget(normalizedSelection.instanceId)?.driverKind !== registry.cliTarget(existingBot.modelSelection.instanceId)?.driverKind))
       ) {
         return json(res, 400, {
-          error: `${requestedApprovalMode === "full" ? "Full access" : "Custom approval settings"} ${requestedApprovalMode === "full" ? "is" : "are"} available only for Codex bots`,
+          error: "This provider does not support the selected approval level, or changing providers requires choosing Ask or Auto first",
         });
       }
       const requiresPrivateApprovalTransition =

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -384,6 +384,9 @@ function handle(msg: any) {
       break;
     }
     case "session/resume": {
+      if (process.env.FAKE_ACP_DUMP) {
+        writeFileSync(`${process.env.FAKE_ACP_DUMP}.mcp.json`, JSON.stringify(msg.params?.mcpServers ?? []));
+      }
       const opts = configOptions();
       const mdls = sessionModels();
       result(msg.id, { ...(opts ? { configOptions: opts } : {}), ...(mdls ? { models: mdls } : {}) });

--- a/shared/approval-mode.ts
+++ b/shared/approval-mode.ts
@@ -3,6 +3,24 @@ export const APPROVAL_MODES = ["ask", "auto", "full", "custom"] as const;
 
 export type ApprovalMode = (typeof APPROVAL_MODES)[number];
 
+/** Only providers with an implemented permission mapping may expose elevation. */
+export function supportsApprovalMode(driverKind: string | undefined, mode: ApprovalMode): boolean {
+  if (mode === "custom") return driverKind === "codex";
+  if (mode !== "full") return true;
+  return ["codex", "claudeAgent", "antigravityAgent", "cursorAgent", "grokAgent", "opencodeGo"].includes(driverKind ?? "");
+}
+
+export function hasNativeAutoReview(driverKind: string | undefined): boolean {
+  return ["codex", "claudeAgent", "cursorAgent"].includes(driverKind ?? "");
+}
+
+/** A native reviewer has already declined to decide, or Auto has no native
+ * equivalent. Never second-guess that request with the app's heuristic rules.
+ * OpenCode's Full mode is implemented by approving individual ACP requests. */
+export function requiresNativeApproval(driverKind: string, mode: ApprovalMode): boolean {
+  return mode === "auto" || (mode === "full" && ["claudeAgent", "antigravityAgent", "cursorAgent", "grokAgent"].includes(driverKind));
+}
+
 export function isApprovalMode(value: unknown): value is ApprovalMode {
   return typeof value === "string" && (APPROVAL_MODES as readonly string[]).includes(value);
 }

--- a/src/components/ApprovalModeSelector.test.ts
+++ b/src/components/ApprovalModeSelector.test.ts
@@ -17,7 +17,7 @@ describe("approval mode selector", () => {
       {
         mode: "auto",
         label: "Approve for me",
-        description: "Only ask for actions detected as potentially unsafe",
+        description: "The provider reviews routine actions and asks about others",
       },
       {
         mode: "full",
@@ -32,7 +32,7 @@ describe("approval mode selector", () => {
     ]);
   });
 
-  it("offers Full access and config.toml only when the bot uses Codex", () => {
+  it("offers provider-supported Full access but keeps config.toml Codex-only", () => {
     expect(approvalModeOptionsFor("codex").map((option) => option.mode)).toEqual([
       "ask",
       "auto",
@@ -42,7 +42,18 @@ describe("approval mode selector", () => {
     expect(approvalModeOptionsFor("claudeAgent").map((option) => option.mode)).toEqual([
       "ask",
       "auto",
+      "full",
     ]);
+  });
+
+  it.each(["antigravityAgent", "cursorAgent", "grokAgent", "opencodeGo"])("offers Full access for %s", (kind) => {
+    expect(approvalModeOptionsFor(kind).map((option) => option.mode)).toEqual(["ask", "auto", "full"]);
+    expect(approvalModeOptionsFor(kind, false).map((option) => option.mode)).toEqual(["ask", "auto"]);
+  });
+
+  it("explains Auto fallbacks and does not elevate unknown providers", () => {
+    expect(approvalModeOptionsFor("antigravityAgent").find((option) => option.mode === "auto")?.description).toContain("behaves like Ask");
+    expect(approvalModeOptionsFor("customAgent").map((option) => option.mode)).toEqual(["ask", "auto"]);
   });
 
   it("hides trusted modes when the packaged desktop bridge is unavailable", () => {

--- a/src/components/ApprovalModeSelector.tsx
+++ b/src/components/ApprovalModeSelector.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Check, Hand, Settings, ShieldAlert, ShieldCheck } from "lucide-react";
 
-import { approvalModeFor, type ApprovalMode } from "../../shared/approval-mode";
+import { approvalModeFor, hasNativeAutoReview, supportsApprovalMode, type ApprovalMode } from "../../shared/approval-mode";
 import { cn } from "@/lib/cn";
 import { APPROVAL_LEVELS_URL, openExternalLink } from "@/lib/app-links";
 
@@ -23,7 +23,7 @@ export const APPROVAL_MODE_OPTIONS: ReadonlyArray<{
     mode: "auto",
     label: "Approve for me",
     chip: "Auto",
-    description: "Only ask for actions detected as potentially unsafe",
+    description: "The provider reviews routine actions and asks about others",
     Icon: ShieldCheck,
   },
   {
@@ -43,9 +43,12 @@ export const APPROVAL_MODE_OPTIONS: ReadonlyArray<{
 ];
 
 export function approvalModeOptionsFor(driverKind: string, trustedModesAvailable = true) {
-  return driverKind === "codex" && trustedModesAvailable
-    ? APPROVAL_MODE_OPTIONS
-    : APPROVAL_MODE_OPTIONS.filter((option) => option.mode === "ask" || option.mode === "auto");
+  return APPROVAL_MODE_OPTIONS
+    .filter((option) => supportsApprovalMode(driverKind, option.mode)
+      && (trustedModesAvailable || option.mode === "ask" || option.mode === "auto"))
+    .map((option) => option.mode === "auto" && !hasNativeAutoReview(driverKind)
+      ? { ...option, description: "This provider has no automatic review; behaves like Ask" }
+      : option);
 }
 
 export function approvalModeSelectionRequiresLocalDesktop(

--- a/src/components/FullAccessWarning.tsx
+++ b/src/components/FullAccessWarning.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from "react";
 import { ShieldAlert } from "lucide-react";
 
 export const FULL_ACCESS_WARNING =
-  "This bot can read, edit, delete files, use the internet, and control its selected computer without asking—even for potentially destructive or sensitive actions. Normal question cards still wait for you; unsupported structured forms are declined rather than filled automatically.";
+  "This bot can read, edit, delete files, use the internet, and control its selected computer without asking—even for potentially destructive or sensitive actions. Some providers may still require approval. Questions and separate OpenMausBot confirmations still wait for you. This does not grant operating-system permissions or access to accounts you have not connected.";
 
 export function FullAccessWarning({
   open,


### PR DESCRIPTION
## Summary
- Keep Ask / Auto / Full / Custom, with provider-specific support and explicit local desktop consent for elevated modes.
- Add Full access mappings for Claude, Antigravity, Cursor, Grok and OpenCode alongside Codex. Custom remains Codex-only.
- Use native Auto review for Codex, Claude and Cursor; unsupported providers fall back to Ask. Preserve native escalations, user questions and unattended safeguards.
- Require returning to Ask or Auto before changing providers with elevated permissions.
- Document behavior and add a durable isolated Electron smoke test for private grant transitions and resumed approval modes.

## Verification
- Full suite: 3,611 passed; 20 skipped; 1 todo (309 passing test files).
- Electron tests: 134 passed.
- Typecheck and production build passed.
- Isolated control fixture and Electron approval smoke passed; HTTP elevation rejected and Full → Auto → Ask transitions verified.
- Provider CLIs in integration smoke are fakes; live provider accounts were not exercised.

## Scope
Core permission handling parity, not an exact copy of every T3 permission option. Full access remains opt-in, Custom stays Codex-only, and remote elevation remains disabled. No version bump or release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Approval modes now use each provider’s native review and permission controls.
  - Auto mode is available across more supported providers, with clear fallbacks to Ask where native automatic review is unavailable.
  - Full access is supported for additional providers, with provider-specific behavior.
  - Approval requests and native provider confirmations are surfaced more clearly.

- **Documentation**
  - Added provider mappings, contributor verification steps, and updated migration guidance for existing Auto-mode bots.
  - Clarified Full access limitations, including questions, confirmations, and operating-system permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->