### PR TITLE
fix(desktop): keep a remote server's page away from this computer

### DIFF
--- a/electron/android-device.mjs
+++ b/electron/android-device.mjs
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
+import localOriginModule from "./local-origin.cjs";
 
 const execFileAsync = promisify(execFile);
 const STATUS_TTL_MS = 750;
@@ -235,7 +236,9 @@ export function createAndroidDeviceController(options = {}) {
 
   const registerIpc = (ipcMain) => {
     const protect = (handler) => async (event, ...args) => {
-      if (!trustedMainFrame(event)) throw new Error("Android device access is limited to the main app");
+      if (!trustedMainFrame(event) || !localOriginModule.isLocalSender(event)) {
+        throw new Error("Android device access is limited to the local app");
+      }
       return handler(...args);
     };
     ipcMain.handle("android-device:status", protect(() => status({ fresh: true })));

--- a/electron/capabilities.cjs
+++ b/electron/capabilities.cjs
@@ -166,8 +166,9 @@ function desktopCapabilities({
       session: hostSession,
       packaged: Boolean(packaged),
       // so the renderer can show paths as ~/… without a Node builtin in
-      // the sandboxed preload
-      homeDir,
+      // the sandboxed preload; a remote server's page learns nothing about
+      // this computer's users
+      homeDir: remote ? "" : homeDir,
     },
     windowChrome: isMac ? "mac-inset" : "native",
     screenPreview,

--- a/electron/capabilities.node-test.mjs
+++ b/electron/capabilities.node-test.mjs
@@ -18,4 +18,6 @@ test("a remote server's page is told this computer offers no screen, voice or lo
   assert.equal(remote.localComputer.enabled, false);
   assert.equal(remote.localComputer.reasonCode, "remote-server");
   assert.equal(remote.host.platform, "darwin");
+  assert.equal(remote.host.homeDir, "");
+  assert.notEqual(local.host.homeDir, "");
 });

--- a/electron/cua.mjs
+++ b/electron/cua.mjs
@@ -21,6 +21,10 @@ import fs from "node:fs";
 import net from "node:net";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import localOriginModule from "./local-origin.cjs";
+
+// Local control answers only the local server's UI (electron/local-origin.cjs).
+const { localOnly } = localOriginModule;
 
 const require = createRequire(import.meta.url);
 const { createCuaConnectionStore } = require("./cua-connection.cjs");
@@ -296,14 +300,14 @@ export async function stopCua() {
 }
 
 export function registerCuaIpc() {
-  ipcMain.handle("cua:connection", () => connectionStore.get());
-  ipcMain.handle("cua:permissions", () => cuaPermissionsStatus());
-  ipcMain.handle("cua:linux-status", () =>
+  ipcMain.handle("cua:connection", localOnly("cua:connection", () => connectionStore.get()));
+  ipcMain.handle("cua:permissions", localOnly("cua:permissions", () => cuaPermissionsStatus()));
+  ipcMain.handle("cua:linux-status", localOnly("cua:linux-status", () =>
     process.platform === "linux"
       ? ensureLinuxRuntime().getStatus()
       : { enabled: false, status: "unavailable", reasonCode: "unsupported-platform" },
-  );
-  ipcMain.handle("cua:linux-enable", async () => {
+  ));
+  ipcMain.handle("cua:linux-enable", localOnly("cua:linux-enable", async () => {
     if (process.platform !== "linux") {
       return { enabled: false, status: "unavailable", reasonCode: "unsupported-platform" };
     }
@@ -313,8 +317,8 @@ export function registerCuaIpc() {
       console.error("[cua] Linux enable failed:", error);
     }
     return ensureLinuxRuntime().getStatus();
-  });
-  ipcMain.handle("cua:linux-disable", async () => {
+  }));
+  ipcMain.handle("cua:linux-disable", localOnly("cua:linux-disable", async () => {
     if (process.platform !== "linux") {
       return { enabled: false, status: "unavailable", reasonCode: "unsupported-platform" };
     }
@@ -324,8 +328,8 @@ export function registerCuaIpc() {
       console.error("[cua] Linux disable failed:", error);
     }
     return ensureLinuxRuntime().getStatus();
-  });
-  ipcMain.handle("cua:linux-retry", async () => {
+  }));
+  ipcMain.handle("cua:linux-retry", localOnly("cua:linux-retry", async () => {
     if (process.platform === "darwin") {
       try {
         await stopCua();
@@ -356,5 +360,5 @@ export function registerCuaIpc() {
       console.error("[cua] Linux retry failed:", error);
     }
     return ensureLinuxRuntime().getStatus();
-  });
+  }));
 }

--- a/electron/local-origin.cjs
+++ b/electron/local-origin.cjs
@@ -1,0 +1,51 @@
+// Which page is asking. The main window shows either the local server's UI or
+// a paired remote server's UI; anything that touches THIS computer (screen,
+// files, logins, helpers, updater, local control) answers only the former.
+// main.mjs sets the local origin once it knows the port; every IPC module
+// wraps its handlers with localOnly(). Pure, so it is unit-tested.
+let localOrigin = null;
+
+function setLocalOrigin(origin) {
+  localOrigin = typeof origin === "string" && origin ? origin : null;
+}
+
+function getLocalOrigin() {
+  return localOrigin;
+}
+
+/** The origin of the frame that sent an IPC message, or null when unknown. */
+function senderOrigin(event) {
+  const url = event?.senderFrame?.url ?? (typeof event?.sender?.getURL === "function" ? event.sender.getURL() : "");
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+}
+
+function isLocalSender(event) {
+  // Until the local origin is known nothing is local: fail closed.
+  return localOrigin !== null && senderOrigin(event) === localOrigin;
+}
+
+/** Wrap an ipcMain.handle handler so a page that is not the local server's
+ * UI gets a clear error instead of an answer. */
+function localOnly(channel, handler) {
+  return (event, ...args) => {
+    if (!isLocalSender(event)) throw new Error(`${channel} is only available while using the local server`);
+    return handler(event, ...args);
+  };
+}
+
+/** Same for ipcMain.on / sendSync: answer `denied` and stop. */
+function localOnlySync(channel, handler, denied = false) {
+  return (event, ...args) => {
+    if (!isLocalSender(event)) {
+      event.returnValue = denied;
+      return;
+    }
+    return handler(event, ...args);
+  };
+}
+
+module.exports = { getLocalOrigin, isLocalSender, localOnly, localOnlySync, senderOrigin, setLocalOrigin };

--- a/electron/local-origin.node-test.mjs
+++ b/electron/local-origin.node-test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const lo = require("./local-origin.cjs");
+
+const from = (url) => ({ senderFrame: { url }, sender: { getURL: () => url } });
+
+test("nothing is local until the origin is known, then only that origin is", () => {
+  lo.setLocalOrigin(null);
+  assert.equal(lo.isLocalSender(from("http://127.0.0.1:8799/")), false);
+  lo.setLocalOrigin("http://127.0.0.1:8799");
+  assert.equal(lo.isLocalSender(from("http://127.0.0.1:8799/chat?x=1")), true);
+  assert.equal(lo.isLocalSender(from("https://mini.example/")), false);
+  assert.equal(lo.isLocalSender(from("http://127.0.0.1:8800/")), false);
+  assert.equal(lo.isLocalSender(from("about:blank")), false);
+  assert.equal(lo.isLocalSender({ sender: { getURL: () => "http://127.0.0.1:8799/" } }), true);
+  assert.equal(lo.isLocalSender({}), false);
+});
+
+test("localOnly answers the local page and refuses a remote one by name", async () => {
+  lo.setLocalOrigin("http://127.0.0.1:8799");
+  const handler = lo.localOnly("screen:frame", async (_event, x) => `frame:${x}`);
+  assert.equal(await handler(from("http://127.0.0.1:8799/"), 1), "frame:1");
+  assert.throws(() => handler(from("https://mini.example/"), 1), /screen:frame is only available while using the local server/);
+  const sync = lo.localOnlySync("screen:preview-intent", (event) => { event.returnValue = "ok"; });
+  const remote = from("https://mini.example/");
+  sync(remote);
+  assert.equal(remote.returnValue, false);
+  const local = from("http://127.0.0.1:8799/");
+  sync(local);
+  assert.equal(local.returnValue, "ok");
+});

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -73,6 +73,7 @@ import {
 } from "./companion-account-service.mjs";
 import capabilitiesModule from "./capabilities.cjs";
 import environmentsModule from "./environments.cjs";
+import localOriginModule from "./local-origin.cjs";
 import { buildApplicationMenu } from "./menu.mjs";
 import { acquireDataDirLease } from "./data-dir-lease.mjs";
 
@@ -230,6 +231,17 @@ nativeAutoUpdater.on("before-quit-for-update", () => releaseSingleInstanceLock(a
 function deliverPackageInstall(win) {
   if (!pendingPackageInstallUrl || !win || win.isDestroyed()) return;
   if (win.webContents.isLoadingMainFrame()) return;
+  // A package installs into THIS computer's workspace, so it is handed to the
+  // local UI only. Showing a remote server: switch back to Local first; the
+  // pending link is delivered when that page finishes loading.
+  let showingLocal = false;
+  try {
+    showingLocal = new URL(win.webContents.getURL()).origin === rendererOrigin();
+  } catch {}
+  if (!showingLocal) {
+    if (activeEnvironment(environmentsState)) switchEnvironment(LOCAL_ID);
+    return;
+  }
   win.webContents.send("package:install", pendingPackageInstallUrl);
   pendingPackageInstallUrl = null;
 }
@@ -1544,9 +1556,9 @@ ipcMain.handle("browser:forget-profile", localOnly("browser:forget-profile", asy
   return { dropped };
 }));
 
-ipcMain.on("screen:preview-intent", (event) => {
+ipcMain.on("screen:preview-intent", localOnlySync("screen:preview-intent", (event) => {
   event.returnValue = displayMediaGuard.begin(event.senderFrame);
-});
+}));
 
 ipcMain.on("desktop:unread-count", (event, value) => {
   const sender = BrowserWindow.fromWebContents(event.sender);
@@ -1594,24 +1606,12 @@ function activeOrigin() {
   return activeEnvironment(environmentsState)?.origin ?? rendererOrigin();
 }
 
-function senderIsLocal(event) {
-  const url = event?.senderFrame?.url ?? event?.sender?.getURL?.() ?? "";
-  try {
-    return new URL(url).origin === rendererOrigin();
-  } catch {
-    return false;
-  }
-}
-
 /** IPC that controls this computer, its files, its logins or its updater is
- * answered only for the local server's UI. A remote server's page gets a
- * reduced bridge (preload.cjs) in the first place; this is the second wall. */
-function localOnly(channel, handler) {
-  return (event, ...args) => {
-    if (!senderIsLocal(event)) throw new Error(`${channel} is only available while using the local server`);
-    return handler(event, ...args);
-  };
-}
+ * answered only for the local server's UI (electron/local-origin.cjs). A
+ * remote server's page gets a reduced bridge (preload.cjs) in the first
+ * place; this is the second wall, shared with cua.mjs, updater.mjs and
+ * android-device.mjs. */
+const { isLocalSender: senderIsLocal, localOnly, localOnlySync, setLocalOrigin } = localOriginModule;
 
 function refreshApplicationMenu() {
   Menu.setApplicationMenu(
@@ -1684,6 +1684,12 @@ async function forgetEnvironment(id) {
   });
   if (response !== 0) return;
   persistEnvironments(withoutEnvironment(environmentsState, id));
+  try {
+    // Revoke the session on the server while the cookie is still here.
+    await session.defaultSession.fetch(`${env.origin}/api/auth/logout`, { method: "POST", signal: AbortSignal.timeout(5_000) });
+  } catch (error) {
+    slog(`forget server: logout skipped (${error?.message ?? error})`);
+  }
   try {
     await session.defaultSession.clearStorageData({ origin: env.origin, storages: ["cookies", "localstorage", "indexdb", "serviceworkers", "cachestorage"] });
   } catch (error) {
@@ -1808,6 +1814,22 @@ function createWindow() {
   };
   win.webContents.on("will-navigate", guardNavigation);
   win.webContents.on("will-redirect", guardNavigation);
+  // Subframes: a page may not embed the local server, or any other saved
+  // server, inside this preload-bearing window.
+  win.webContents.on("will-frame-navigate", (details) => {
+    if (details.isMainFrame) return;
+    let target = null;
+    let page = null;
+    try {
+      target = new URL(details.url).origin;
+      page = new URL(win.webContents.getURL()).origin;
+    } catch {}
+    if (!target || !page || target === page) return;
+    if (target === rendererOrigin() || allowedOrigins(environmentsState, rendererOrigin()).has(target)) {
+      details.preventDefault();
+      slog(`blocked subframe navigation to ${details.url}`);
+    }
+  });
   win.webContents.on("did-fail-load", (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
     if (!isMainFrame || errorCode === -3) return; // -3: aborted by a newer navigation
     const remote = activeEnvironment(environmentsState);
@@ -2235,7 +2257,7 @@ function relaunchAfterDesktopRemoteChange() {
 }
 
 ipcMain.handle("desktop-remote:state", () => publicDesktopRemoteState());
-ipcMain.handle("desktop-remote:pair", async (event, endpoint, code) => {
+ipcMain.handle("desktop-remote:pair", localOnly("desktop-remote:pair", async (event, endpoint, code) => {
   requireMainWindowSender(event);
   const access = await pairDesktopCompanion({
     endpoint,
@@ -2246,14 +2268,14 @@ ipcMain.handle("desktop-remote:pair", async (event, endpoint, code) => {
   desktopRemoteAccess = access;
   relaunchAfterDesktopRemoteChange();
   return publicDesktopRemoteState();
-});
-ipcMain.handle("desktop-remote:disconnect", async (event) => {
+}));
+ipcMain.handle("desktop-remote:disconnect", localOnly("desktop-remote:disconnect", async (event) => {
   requireMainWindowSender(event);
   await updateSecureCredentialDocument(withoutDesktopCompanionAccess);
   desktopRemoteAccess = null;
   relaunchAfterDesktopRemoteChange();
   return { active: false };
-});
+}));
 
 // Auth and connector credentials never cross this boundary. Every handler
 // returns the same deliberately tiny, secret-free public account state.
@@ -2378,14 +2400,19 @@ ipcMain.handle("approvals:set-trusted-mode", localOnly("approvals:set-trusted-mo
 }));
 
 async function broadcastDesktopCapabilities() {
-  const capabilities = desktopCapabilities({
-    platform: process.platform,
-    env: process.env,
-    packaged: app.isPackaged,
-    localConnection: await cuaReady,
-  });
+  const localConnection = await cuaReady;
+  const build = (remote) =>
+    desktopCapabilities({ remote, platform: process.platform, env: process.env, packaged: app.isPackaged, localConnection });
+  const local = build(false);
+  let redacted = null;
   for (const window of BrowserWindow.getAllWindows()) {
-    if (!window.isDestroyed()) window.webContents.send("desktop:capabilities-changed", capabilities);
+    if (window.isDestroyed()) continue;
+    let isLocal = false;
+    try {
+      isLocal = new URL(window.webContents.getURL()).origin === rendererOrigin();
+    } catch {}
+    if (!isLocal) redacted ??= build(true);
+    window.webContents.send("desktop:capabilities-changed", isLocal ? local : redacted);
   }
 }
 
@@ -2533,6 +2560,23 @@ app.whenReady().then(async () => {
   if (!desktopRemoteAccess && serverReady && companionEnabledAtRest()) {
     void startDesktopCompanion({ waitForHosted: false, remember: false });
   }
+  setLocalOrigin(rendererOrigin());
+  // Device permissions (microphone, camera, notifications, …) are for the
+  // local UI only; a remote server's page in this window is refused without
+  // a prompt. Client mode's loopback relay is the local UI.
+  const localPermission = (url) => {
+    try {
+      return new URL(String(url)).origin === rendererOrigin();
+    } catch {
+      return false;
+    }
+  };
+  session.defaultSession.setPermissionRequestHandler((contents, _permission, callback, details) =>
+    callback(localPermission(details?.requestingUrl ?? contents?.getURL?.() ?? "")),
+  );
+  session.defaultSession.setPermissionCheckHandler((contents, _permission, requestingOrigin) =>
+    localPermission(requestingOrigin || contents?.getURL?.() || ""),
+  );
   environmentsState = readEnvironments();
   createWindow();
   // Reconcile incomplete setup and resume interrupted sign-out only after the

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -22,7 +22,7 @@ ipcRenderer.on("package:install", (_event, url) => {
 // helpers here. Main enforces the same rule on the sensitive channels.
 const localOrigin = process.argv.find((arg) => arg.startsWith("--omb-local-origin="))?.slice("--omb-local-origin=".length) ?? null;
 const isLocalPage = !localOrigin || location.origin === localOrigin;
-const REMOTE_SAFE = new Set(["platform", "getCapabilities", "onCapabilitiesChanged", "applySkin", "setUnreadCount", "openExternal", "getPathForFile", "permStatus", "environments"]);
+const REMOTE_SAFE = new Set(["platform", "getCapabilities", "onCapabilitiesChanged", "applySkin", "setUnreadCount", "permStatus"]);
 
 const bridge = {
   /** Host platform ("darwin" | "win32" | "linux") — for platform-aware UI. */

--- a/electron/updater.mjs
+++ b/electron/updater.mjs
@@ -7,6 +7,7 @@
 // electron-updater is vendored (electron/vendor/electron-updater.cjs) because
 // the packaged app ships no node_modules.
 import { app, clipboard, ipcMain } from "electron";
+import localOriginModule from "./local-origin.cjs";
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { join } from "node:path";
@@ -71,11 +72,14 @@ function setState(patch) {
   }
 }
 
+// The updater changes THIS app: only the local server's UI may drive it.
+const { localOnly } = localOriginModule;
+
 export function registerUpdaterIpc() {
-  ipcMain.handle("update:get-state", () => state);
-  ipcMain.handle("update:check", () => updaterCoordinator?.check(true));
-  ipcMain.handle("update:download", () => updaterCoordinator?.download());
-  ipcMain.handle("update:install", () => updaterCoordinator?.install());
+  ipcMain.handle("update:get-state", localOnly("update:get-state", () => state));
+  ipcMain.handle("update:check", localOnly("update:check", () => updaterCoordinator?.check(true)));
+  ipcMain.handle("update:download", localOnly("update:download", () => updaterCoordinator?.download()));
+  ipcMain.handle("update:install", localOnly("update:install", () => updaterCoordinator?.install()));
 }
 
 // macOS keeps the process (and updater) alive after its window closes.

--- a/electron/updater.test.mjs
+++ b/electron/updater.test.mjs
@@ -1,4 +1,9 @@
 import { afterEach, expect, it, vi } from "vitest";
+import localOriginModule from "./local-origin.cjs";
+
+// The updater channels answer only the local UI (electron/local-origin.cjs).
+localOriginModule.setLocalOrigin("http://127.0.0.1:8799");
+const localEvent = { senderFrame: { url: "http://127.0.0.1:8799/" } };
 
 const { updater, handlers } = vi.hoisted(() => ({
   updater: { on: vi.fn(), downloadUpdate: vi.fn() },
@@ -45,12 +50,12 @@ it("sends updater progress to a reopened window without restarting the updater",
     return ["/unused-staged-update.zip"];
   });
 
-  await handlers.get("update:download")();
+  await handlers.get("update:download")(localEvent);
 
   expect(first.webContents.send).not.toHaveBeenCalled();
   expect(reopened.webContents.send.mock.calls.map(([, state]) => state.status))
     .toEqual(["downloading", "downloading", "downloaded"]);
-  expect(handlers.get("update:get-state")()).toMatchObject({ status: "downloaded", version: "2.0.0" });
+  expect(handlers.get("update:get-state")(localEvent)).toMatchObject({ status: "downloaded", version: "2.0.0" });
   expect(updater.on.mock.calls).toHaveLength(listenerCount);
   expect(vi.getTimerCount()).toBe(timerCount);
 });


### PR DESCRIPTION
Follow-up to #694 (Server menu) and #753 (desktop client mode), closing the desktop findings from the adversarial review of the remote surfaces. Premise: when the main window shows a paired remote server's UI, that page is untrusted as far as this computer is concerned.

## What changes

- **One local-origin predicate** (`electron/local-origin.cjs`, unit-tested) shared by every IPC module; fail-closed until the port is final. It now also gates `cua:*`, `update:*`, `android-device:*`, `desktop-remote:*` and the sendSync `screen:preview-intent`, which the earlier gate in main.mjs did not reach.
- **Device permissions** (microphone, camera, notifications) are granted only to the local origin; a remote page is refused without a prompt. Client mode's loopback relay counts as local, so #753's Mac-local dictation keeps working.
- **Capabilities broadcast** is redacted per window the same way the request path already was, and the remote variant no longer includes the home directory.
- **Remote bridge subset** loses `openExternal` and `getPathForFile`.
- **Subframes** cannot embed the local server or another saved server inside the preload-bearing window; **deep links** (package installs) are delivered only to the local UI, switching back to Local first if a remote server is showing.
- **Forget** signs out of the server (`POST /api/auth/logout`) before clearing its cookies and storage.

## Verified

| check | result |
|---|---|
| `node --test electron/*.node-test.mjs` (incl. new local-origin and capabilities cases) | ✅ 136/136 |
| `vitest electron` (incl. #753's relay/gateway suites; updater test now passes a local sender) | ✅ 371 passed, 4 skipped |
| `check:electron` (111 modules), `lint`, renderer `tsc -b` | ✅ |

Not launched locally on purpose (a running instance takes port 8799 and the single-instance lock); CI's packaged Linux smoke exercises the same startup path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Restricted device access, screen sharing, updater controls, permissions, and remote pairing actions to the local application.
  - Blocked cross-origin subframe navigation.
  - Redacted the computer’s home-directory information from remote views.
  - Limited sensitive preload APIs to local pages.

- **Bug Fixes**
  - Ensured package deep links return to the local view before opening.
  - Added server-side logout handling when forgetting a remote environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->