### PR TITLE
fix(remote): default-deny client scope, sessions end their streams, safer pairing

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -288,6 +288,8 @@ import { describeEdition, editionStatus, loadEnterpriseLayer } from "./enterpris
 import { environmentDescriptor, loadEnvironmentId } from "./environment.ts";
 import {
   clearSessionCookie,
+  clientBotPatchViolation,
+  clientGroupPatchViolation,
   labelFromUserAgent,
   requestOrigin,
   requestSource,
@@ -1962,8 +1964,22 @@ interface SseClient {
    * while a bot works. A client that isn't showing the computer panel —
    * a phone on cellular, most of all — should not pay for them. */
   screens: boolean;
+  /** The paired session behind this stream, when there is one: revoking or
+   * expiring it must end the stream, not just future requests. */
+  sessionId?: string;
 }
 const sseClients = new Set<SseClient>();
+sessions.onSessionRevoked((sessionId) => {
+  for (const client of sseClients) {
+    if (client.sessionId !== sessionId) continue;
+    sseClients.delete(client);
+    try {
+      client.res.end();
+    } catch {
+      /* already gone */
+    }
+  }
+});
 
 /** Every frame is numbered, and the last few hundred are kept, so a client
  * whose connection dropped can ask for what it missed instead of
@@ -7203,11 +7219,18 @@ const server = createServer(async (req, res) => {
       return json(res, 200, environmentDescriptor({ environmentId: ENVIRONMENT_ID, desktopManaged: DESKTOP_MANAGED }));
     }
     if (method === "POST" && path === "/api/auth/pair") {
+      // JSON only: a cross-site HTML form cannot send this content type
+      // without a preflight, so a stray unused code cannot be planted as a
+      // session in someone else's browser.
+      if (!/^application\/json\b/i.test(String(req.headers["content-type"] ?? ""))) {
+        return json(res, 415, { error: "send the pairing code as JSON (content-type: application/json)" });
+      }
       const body = await readBody(req);
       const code = typeof body?.code === "string" ? body.code : "";
       const wantsCookie = body?.cookie === true;
       const label = typeof body?.label === "string" ? body.label : "";
-      const result = sessions.exchange({ code, label, source: requestSource(req), fallbackLabel: labelFromUserAgent(req.headers["user-agent"]) });
+      const attemptId = typeof body?.attemptId === "string" ? body.attemptId : undefined;
+      const result = sessions.exchange({ code, label, attemptId, source: requestSource(req), fallbackLabel: labelFromUserAgent(req.headers["user-agent"]) });
       if (!result.ok) {
         console.warn(`pairing refused from ${requestSource(req)}: ${result.error}`);
         return json(res, result.status, { error: result.error });
@@ -8324,6 +8347,7 @@ const server = createServer(async (req, res) => {
     // ── events stream ──
     if (method === "GET" && path === "/api/events") {
       const client: SseClient = { res, screens: url.searchParams.get("screens") !== "off" };
+      if (auth.kind === "session") client.sessionId = auth.session.id;
       res.writeHead(200, {
         "content-type": "text/event-stream",
         "cache-control": "no-cache",
@@ -8374,6 +8398,11 @@ const server = createServer(async (req, res) => {
       // data frame is visible to EventSource clients and resets their own
       // liveness watchdog. Heartbeats carry no id and never advance replay.
       const keepalive = setInterval(() => {
+        // an expired session's stream ends at the next heartbeat
+        if (client.sessionId && !sessions.isLive(client.sessionId)) {
+          res.end();
+          return;
+        }
         try {
           res.write(`: keepalive\n\ndata: ${JSON.stringify({ kind: "ping" })}\n\n`);
         } catch {}
@@ -9257,6 +9286,10 @@ const server = createServer(async (req, res) => {
     m = path.match(/^\/api\/groups\/([\w-]+)$/);
     if (m && method === "PATCH") {
       const body = await readBody(req);
+      if (auth.kind === "session" && !auth.scopes.includes("admin")) {
+        const field = clientGroupPatchViolation(body);
+        if (field) return json(res, 403, { error: `forbidden: this session may rename or mark a room, not change "${field}" (needs the admin scope)` });
+      }
       if (!body || typeof body !== "object" || Array.isArray(body)) {
         return json(res, 400, { error: "body must be a JSON object" });
       }
@@ -9732,6 +9765,10 @@ const server = createServer(async (req, res) => {
       const body = await readBody(req);
       if (!body || typeof body !== "object" || Array.isArray(body)) {
         return json(res, 400, { error: "body must be a JSON object" });
+      }
+      if (auth.kind === "session" && !auth.scopes.includes("admin")) {
+        const field = clientBotPatchViolation(body);
+        if (field) return json(res, 403, { error: `forbidden: this session may change how a bot looks, not "${field}" (needs the admin scope)` });
       }
       const existingBot = store.bot(m[1]);
       if (body.requireAvailableModel !== undefined && typeof body.requireAvailableModel !== "boolean") {
@@ -11353,7 +11390,18 @@ const server = createServer(async (req, res) => {
 
     // ── app config (API keys — never echoed back, booleans only) ──
     if (method === "GET" && path === "/api/config") {
-      return json(res, 200, configStatus());
+      const status = configStatus();
+      if (auth.kind === "session" && !auth.scopes.includes("admin")) {
+        // configured-or-not is fine; an SSH alias, an email, a browser
+        // partition id are not a client's business
+        return json(res, 200, {
+          ...status,
+          vps: { configured: status.vps.configured, sshAlias: "" },
+          profile: { name: status.profile.name, email: "" },
+          browserProfiles: status.browserProfiles.map((profile) => Object.fromEntries(Object.entries(profile).filter(([key]) => key !== "partitionId"))),
+        });
+      }
+      return json(res, 200, status);
     }
     if ((method === "PUT" || method === "PATCH") && path === "/api/config") {
       const body = await readBody(req);

--- a/server/remote-sessions.test.ts
+++ b/server/remote-sessions.test.ts
@@ -9,6 +9,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { LOCKOUT } from "./sessions.ts";
 import { removeTempDir, waitForExit } from "./testing/cleanup.ts";
 import { openSse } from "./testing/sse.ts";
 
@@ -94,7 +95,9 @@ beforeAll(async () => {
       OMB_APP_VERSION: "9.9.9-test",
       OMB_ENVIRONMENT_LABEL: "cab mini",
       OMB_BROWSER_CONNECTION: join(home, "browser-test-connection.json"),
-      OMB_SSE_HEARTBEAT_MS: "50",
+      // Slow heartbeat on purpose: the revocation test must prove the stream is
+      // ended by the revoke itself, not by the next heartbeat noticing.
+      OMB_SSE_HEARTBEAT_MS: "4000",
     },
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -179,11 +182,8 @@ describe("pairing", () => {
     expect(paired.body.token).toMatch(/^omb_sess_/);
     expect(paired.body.session.label).toBe("Safari on Mac");
     expect(paired.body.environment.label).toBe("cab mini");
-    // a retry from the same address (lost response) replays the same session; another address is refused
-    const replay = await call("/api/auth/pair", { method: "POST", headers: remote("10.0.0.3"), body: JSON.stringify({ code: opened.code }) });
-    expect(replay.status).toBe(200);
-    expect(replay.body.token).toBe(paired.body.token);
-    const again = await call("/api/auth/pair", { method: "POST", headers: remote("10.0.0.33"), body: JSON.stringify({ code: opened.code }) });
+    // a plain retry (no attempt id) is a second use of a consumed code: refused
+    const again = await call("/api/auth/pair", { method: "POST", headers: remote("10.0.0.3"), body: JSON.stringify({ code: opened.code }) });
     expect(again.status).toBe(401);
 
     const bearer = remote("10.0.0.3", { authorization: `Bearer ${paired.body.token}` });
@@ -243,15 +243,86 @@ describe("pairing", () => {
     expect((await call("/api/bots", { headers: remote("10.0.0.4", { cookie }) })).status).toBe(401);
   });
 
-  it("locks a source out after five bad codes and says how long", async () => {
-    for (let i = 0; i < 5; i++) {
+  it("only accepts JSON for the exchange, and replays a lost response by attempt id", async () => {
+    const opened = await pairingCode();
+    const form = await call("/api/auth/pair", { method: "POST", headers: { ...remote("10.0.0.20"), "content-type": "application/x-www-form-urlencoded" }, body: `code=${opened.code}` });
+    expect(form.status).toBe(415);
+    const first = await call("/api/auth/pair", { method: "POST", headers: remote("10.0.0.20"), body: JSON.stringify({ code: opened.code, attemptId: "attempt-first-0001" }) });
+    expect(first.status).toBe(200);
+    const replay = await call("/api/auth/pair", { method: "POST", headers: remote("10.0.0.21"), body: JSON.stringify({ code: opened.code, attemptId: "attempt-first-0001" }) });
+    expect(replay.status).toBe(200);
+    expect(replay.body.token).toBe(first.body.token);
+    const other = await call("/api/auth/pair", { method: "POST", headers: remote("10.0.0.20"), body: JSON.stringify({ code: opened.code, attemptId: "attempt-other-0002" }) });
+    expect(other.status).toBe(401);
+  });
+
+  it("ends a live event stream the moment its session is revoked", async () => {
+    const opened = await pairingCode();
+    const paired = await call("/api/auth/pair", { method: "POST", headers: remote("10.0.0.30"), body: JSON.stringify({ code: opened.code, label: "stream" }) });
+    const bearer = remote("10.0.0.30", { authorization: `Bearer ${paired.body.token}` });
+    const ticket = await call("/api/auth/stream-ticket", { method: "POST", headers: bearer });
+    const ended = new Promise<{ hello: boolean; endedMs: number }>((resolve, reject) => {
+      const startedAt = Date.now();
+      let hello = false;
+      const req = request({ host: "127.0.0.1", port: PORT, path: `/api/events?ticket=${ticket.body.ticket}`, method: "GET", headers: { accept: "text/event-stream", ...remote("10.0.0.30") } }, (res) => {
+        res.setEncoding("utf8");
+        res.on("data", (chunk: string) => {
+          if (chunk.includes('"kind":"hello"')) {
+            hello = true;
+            void call(`/api/auth/sessions/${paired.body.session.id}`, { method: "DELETE" }).then((r) => {
+              if (r.status !== 200) reject(new Error(`revoke returned ${r.status}`));
+            });
+          }
+        });
+        res.on("end", () => resolve({ hello, endedMs: Date.now() - startedAt }));
+        res.on("error", reject);
+      });
+      req.on("error", reject);
+      req.end();
+      setTimeout(() => reject(new Error("stream did not end after revocation")), 8_000).unref();
+    });
+    const outcome = await ended;
+    expect(outcome.hello).toBe(true);
+    // well under the 4 s heartbeat: the revoke closed it, not the heartbeat
+    expect(outcome.endedMs).toBeLessThan(2_500);
+  });
+
+  it("gives a client-scope session chat but not the machine: allow-list, display-only edits, stripped config", async () => {
+    const opened = await pairingCode(["client"]);
+    const paired = await call("/api/auth/pair", { method: "POST", headers: remote("10.0.0.40"), body: JSON.stringify({ code: opened.code, label: "viewer" }) });
+    expect(paired.status).toBe(200);
+    const h = (extra: Record<string, string> = {}) => remote("10.0.0.40", { authorization: `Bearer ${paired.body.token}`, ...extra });
+    expect((await call("/api/bots", { headers: h() })).status).toBe(200);
+    for (const [method, path] of [["POST", "/api/cli-test"], ["GET", "/api/instances"], ["POST", "/api/webhooks"], ["GET", "/api/mcp/servers"], ["POST", "/api/local-computer/run"]] as const) {
+      const r = await call(path, { method, headers: h(), body: method === "POST" ? "{}" : undefined });
+      expect(r.status, `${method} ${path}`).toBe(403);
+      expect(r.body.error, `${method} ${path}`).toContain("admin scope");
+    }
+    const created = await call("/api/bots", { method: "POST", body: JSON.stringify({ name: "Scoped" }) });
+    const botId = created.body?.id ?? created.body?.bot?.id;
+    if (botId) {
+      const cosmetic = await call(`/api/bots/${botId}`, { method: "PATCH", headers: h(), body: JSON.stringify({ unread: true }) });
+      expect(cosmetic.status).toBe(200);
+      const smuggled = await call(`/api/bots/${botId}`, { method: "PATCH", headers: h(), body: JSON.stringify({ unread: true, autoApprove: true }) });
+      expect(smuggled.status).toBe(403);
+      expect(smuggled.body.error).toContain('"autoApprove"');
+    }
+    const config = await call("/api/config", { headers: h() });
+    expect(config.status).toBe(200);
+    expect(config.body.vps.sshAlias).toBe("");
+    expect(config.body.profile.email).toBe("");
+    expect(JSON.stringify(config.body)).not.toContain("partitionId");
+  });
+
+  it("locks a source out after repeated bad codes and says how long", async () => {
+    for (let i = 0; i < LOCKOUT.failures; i++) {
       const r = await call("/api/auth/pair", { method: "POST", headers: remote("10.0.0.99"), body: JSON.stringify({ code: `BAD${i}-BADB-ADBA` }) });
       expect(r.status).toBe(401);
     }
     const opened = await pairingCode();
     const locked = await call("/api/auth/pair", { method: "POST", headers: remote("10.0.0.99"), body: JSON.stringify({ code: opened.code }) });
     expect(locked.status).toBe(429);
-    expect(locked.body.error).toMatch(/try again in \d+ min/);
+    expect(locked.body.error).toMatch(/from your address; try again in \d+s/);
     // the code itself is untouched: another source can still use it
     expect((await call("/api/auth/pair", { method: "POST", headers: remote("10.0.0.100"), body: JSON.stringify({ code: opened.code }) })).status).toBe(200);
     expect(stderr).toMatch(/pairing refused from 10\.0\.0\.99/);

--- a/server/request-auth.test.ts
+++ b/server/request-auth.test.ts
@@ -6,6 +6,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   clearSessionCookie,
+  clientBotPatchViolation,
+  clientGroupPatchViolation,
   isAllowedOrigin,
   isLoopbackHost,
   isProxied,
@@ -14,6 +16,7 @@ import {
   requestOrigin,
   requestSource,
   requiredScope,
+  sanitizeSource,
   resolveRequestAuth,
   serializeSessionCookie,
   sessionCookieName,
@@ -71,33 +74,51 @@ describe("request source for the lockout", () => {
   const withPeer = (peer: string, headers: Record<string, string>) =>
     // SAFETY: only headers and the socket peer are read
     ({ headers, method: "POST", socket: { remoteAddress: peer } }) as unknown as IncomingMessage;
-  it("takes the forwarded address only from a proxy on this machine", () => {
-    expect(requestSource(withPeer("127.0.0.1", { "x-forwarded-for": "203.0.113.9, 10.0.0.1" }))).toBe("203.0.113.9");
+  it("takes the LAST forwarded hop, only from a proxy on this machine, and sanitises it", () => {
+    // the last hop is the one our own proxy wrote; earlier hops are client-supplied
+    expect(requestSource(withPeer("127.0.0.1", { "x-forwarded-for": "1.2.3.4, 203.0.113.9" }))).toBe("203.0.113.9");
     expect(requestSource(withPeer("::ffff:127.0.0.1", { "x-forwarded-for": "203.0.113.9" }))).toBe("203.0.113.9");
     expect(requestSource(withPeer("127.0.0.1", {}))).toBe("127.0.0.1");
     expect(requestSource(withPeer("100.64.0.7", { "x-forwarded-for": "1.1.1.1" }))).toBe("100.64.0.7");
+    expect(requestSource(withPeer("127.0.0.1", { "x-forwarded-for": "evil\n\u0007 <script>" + "x".repeat(200) }))).toMatch(/^[\w.:%[\]-]{1,64}$/);
+    expect(sanitizeSource("")).toBe("unknown");
   });
 });
 
 describe("scopes", () => {
-  it("needs admin for pairing, session management and configuration writes; client elsewhere", () => {
-    expect(requiredScope("POST", "/api/auth/pairing")).toBe("admin");
-    expect(requiredScope("DELETE", "/api/auth/sessions/abc")).toBe("admin");
-    expect(requiredScope("PUT", "/api/config")).toBe("admin");
-    expect(requiredScope("GET", "/api/config")).toBe("client");
-    expect(requiredScope("POST", "/api/instances")).toBe("admin");
-    expect(requiredScope("GET", "/api/instances")).toBe("client");
-    expect(requiredScope("POST", "/api/mcp/servers")).toBe("admin");
-    expect(requiredScope("POST", "/api/mcp/servers/github/test")).toBe("admin");
-    expect(requiredScope("GET", "/api/mcp/servers")).toBe("client");
-    expect(requiredScope("GET", "/api/computers/boxes")).toBe("client");
-    expect(requiredScope("POST", "/api/computers/boxes/bx_23456789/sleep")).toBe("admin");
-    expect(requiredScope("POST", "/api/computers/boxes/bx_23456789/delete")).toBe("admin");
-    expect(requiredScope("GET", "/api/computers/vps")).toBe("client");
-    expect(requiredScope("POST", "/api/computers/vps/openmausbot-vps-one/remove")).toBe("admin");
-    expect(requiredScope("POST", "/api/bots/x/messages")).toBe("client");
-    expect(requiredScope("POST", "/api/auth/pair")).toBe("client");
-    expect(requiredScope("POST", "/api/auth/stream-ticket")).toBe("client");
+  it("is default deny: chat, approvals, rooms, attachments, routines and own session are client; everything else admin", () => {
+    for (const [method, path] of [
+      ["POST", "/api/bots/x/messages"], ["POST", "/api/bots/x/respond"], ["POST", "/api/threads/t/respond"],
+      ["PATCH", "/api/bots/x/cards/m"], ["POST", "/api/groups/g/messages"], ["PATCH", "/api/groups/g"],
+      ["PATCH", "/api/bots/x"], ["PATCH", "/api/bots/x/profile"], ["POST", "/api/attachments"],
+      ["GET", "/api/attachments/a.png"], ["POST", "/api/routines"], ["POST", "/api/routines/r/run"],
+      ["GET", "/api/bots"], ["GET", "/api/threads/t/messages"], ["GET", "/api/search"], ["GET", "/api/events"],
+      ["GET", "/api/config"], ["GET", "/api/webhooks"], ["POST", "/api/tts/speak"],
+      ["GET", "/api/auth/session"], ["POST", "/api/auth/stream-ticket"], ["POST", "/api/auth/logout"],
+    ] as const) expect(requiredScope(method, path), `${method} ${path}`).toBe("client");
+    for (const [method, path] of [
+      ["POST", "/api/cli-test"], ["GET", "/api/cli-candidates"], ["GET", "/api/instances"], ["PATCH", "/api/instances/claude"],
+      ["POST", "/api/bots/x/computer/exec"], ["POST", "/api/bots/x/computer/join"], ["POST", "/api/local-computer/run"],
+      ["GET", "/api/computers/boxes"], ["POST", "/api/computers/boxes/bx_23456789/delete"],
+      ["POST", "/api/webhooks"], ["POST", "/api/webhooks/w/rotate"], ["POST", "/api/bots/x/skills"], ["PATCH", "/api/bots/x/skills/s"],
+      ["PATCH", "/api/bots/x/model"], ["PATCH", "/api/groups/g/setup"], ["POST", "/api/teams/import"], ["GET", "/api/teams/scout"],
+      ["GET", "/api/bots/x/memory"], ["PUT", "/api/bots/x/memory"], ["PUT", "/api/section-context"], ["GET", "/api/threads/t/events"],
+      ["POST", "/api/bots/x/checkpoints/restore"], ["GET", "/api/mcp/servers"], ["POST", "/api/mcp/servers"], ["POST", "/api/connectors/slack/authorize"],
+      ["PUT", "/api/config"], ["POST", "/api/auth/pairing"], ["GET", "/api/auth/sessions"], ["DELETE", "/api/auth/sessions/abc"],
+      ["POST", "/api/auth/pair"], // handled before the gate; the gate itself never grants it
+      ["GET", "/api/something-new"], // anything unlisted is admin until listed
+    ] as const) expect(requiredScope(method, path), `${method} ${path}`).toBe("admin");
+  });
+
+  it("limits a client's bot and room edits to display fields, naming the field it refused", () => {
+    expect(clientBotPatchViolation({ unread: true })).toBeNull();
+    expect(clientBotPatchViolation({ pinned: true, color: "green" })).toBeNull();
+    expect(clientBotPatchViolation({ unread: true, autoApprove: true })).toBe("autoApprove");
+    expect(clientBotPatchViolation({ cwd: "/" })).toBe("cwd");
+    expect(clientBotPatchViolation([])).toBe("body");
+    expect(clientGroupPatchViolation({ name: "Ops", unread: false })).toBeNull();
+    expect(clientGroupPatchViolation({ cwd: "/tmp" })).toBe("cwd");
+    expect(clientGroupPatchViolation({ memberIds: [] })).toBe("memberIds");
   });
 });
 

--- a/server/request-auth.ts
+++ b/server/request-auth.ts
@@ -100,8 +100,18 @@ export function isSameOrigin(req: IncomingMessage): boolean {
 export function requestSource(req: IncomingMessage): string {
   const peer = req.socket?.remoteAddress || "unknown";
   const viaLocalProxy = peer === "127.0.0.1" || peer === "::1" || peer === "::ffff:127.0.0.1";
-  const forwarded = viaLocalProxy ? headerValue(req.headers["x-forwarded-for"])?.split(",")[0]?.trim() : undefined;
-  return forwarded || peer;
+  // The LAST hop is the one the adjacent (trusted, same-machine) proxy wrote;
+  // earlier hops are whatever the client or an outer proxy put there.
+  const hops = viaLocalProxy ? (headerValue(req.headers["x-forwarded-for"]) ?? "").split(",").map((h) => h.trim()).filter(Boolean) : [];
+  const forwarded = hops.length ? hops[hops.length - 1] : undefined;
+  return sanitizeSource(forwarded || peer);
+}
+
+/** Only what an address can contain, bounded, so a hostile header cannot
+ * carry control characters into logs or grow the lockout map without limit. */
+export function sanitizeSource(value: string): string {
+  const clean = value.replace(/[^\w.:%[\]-]/g, "");
+  return (clean || "unknown").slice(0, 64);
 }
 
 /** "Safari on iPhone" beats "Unnamed device" in the sessions list. */

--- a/server/request-auth.ts
+++ b/server/request-auth.ts
@@ -164,25 +164,102 @@ export function clearSessionCookie(name: string): string {
   return `${name}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0`;
 }
 
-/** Route → scope. Anything not listed needs `client`, which every session has;
- * the listed routes change who can get in or what the server runs, so they
- * need `admin`. Loopback holds both scopes, while packaged loopback mutations
- * separately prove the private desktop capability below. Keep this table next
- * to the routes it names when adding one. */
-const ADMIN_ROUTES: ReadonlyArray<{ methods: readonly string[] | null; path: RegExp }> = [
-  { methods: null, path: /^\/api\/auth\/pairing(\/|$)/ },
-  { methods: null, path: /^\/api\/auth\/sessions(\/|$)/ },
-  { methods: ["PUT", "PATCH", "DELETE"], path: /^\/api\/config$/ },
-  { methods: ["POST", "PUT", "PATCH", "DELETE"], path: /^\/api\/(instances|engines|mcp-servers|mcp\/servers|custom-engines)(\/|$)/ },
-  { methods: ["POST"], path: /^\/api\/computers\/(boxes|vps)(\/|$)/ },
+/** What a `client` session may do: chat, rooms, approvals, attachments,
+ * routines, its own session, and reads that carry no secrets. Everything
+ * else needs `admin`: default deny, so a new route is admin-only until it is
+ * deliberately listed here. Two client-allowed PATCH routes carry a body
+ * filter in the handler (bot and room edits: display fields only). Loopback
+ * holds both scopes. */
+export const CLIENT_ALLOW: ReadonlyArray<{ methods: readonly string[]; path: RegExp }> = [
+  // own session
+  { methods: ["GET"], path: /^\/api\/auth\/session$/ },
+  { methods: ["POST"], path: /^\/api\/auth\/stream-ticket$/ },
+  { methods: ["POST"], path: /^\/api\/auth\/logout$/ },
+  // liveness, identity, the stream
+  { methods: ["GET"], path: /^\/api\/health$/ },
+  { methods: ["GET"], path: /^\/api\/edition$/ },
+  { methods: ["GET"], path: /^\/api\/brand$/ },
+  { methods: ["GET"], path: /^\/api\/events$/ },
+  // reads: fleet, transcripts, search (no secrets in any of these)
+  { methods: ["GET"], path: /^\/api\/bots$/ },
+  { methods: ["GET"], path: /^\/api\/team-map$/ },
+  { methods: ["GET"], path: /^\/api\/search$/ },
+  { methods: ["GET"], path: /^\/api\/threads\/[\w-]+\/messages$/ },
+  { methods: ["GET"], path: /^\/api\/threads\/[\w-]+\/messages\/[\w-]+\/image$/ },
+  { methods: ["GET"], path: /^\/api\/threads\/[\w-]+\/export$/ },
+  { methods: ["POST"], path: /^\/api\/threads\/[\w-]+\/messages\/[\w-]+\/file$/ },
+  // chat, one to one
+  { methods: ["POST"], path: /^\/api\/bots\/[\w-]+\/messages$/ },
+  { methods: ["POST"], path: /^\/api\/bots\/[\w-]+\/messages\/[\w-]+\/edit$/ },
+  { methods: ["POST"], path: /^\/api\/bots\/[\w-]+\/active-branch$/ },
+  { methods: ["POST"], path: /^\/api\/bots\/[\w-]+\/interrupt$/ },
+  { methods: ["POST"], path: /^\/api\/bots\/[\w-]+\/read$/ },
+  { methods: ["DELETE"], path: /^\/api\/bots\/[\w-]+\/queue\/[\w-]+$/ },
+  { methods: ["POST"], path: /^\/api\/bots\/[\w-]+\/tasks$/ },
+  { methods: ["POST", "PATCH", "DELETE"], path: /^\/api\/bots\/[\w-]+\/tasks\/[\w-]+$/ },
+  { methods: ["PATCH"], path: /^\/api\/bots\/[\w-]+\/profile$/ },
+  { methods: ["PATCH"], path: /^\/api\/bots\/[\w-]+$/ }, // display fields only: see clientBotPatchViolation
+  // approvals and cards
+  { methods: ["POST"], path: /^\/api\/bots\/[\w-]+\/respond$/ },
+  { methods: ["POST"], path: /^\/api\/threads\/[\w-]+\/respond$/ },
+  { methods: ["PATCH"], path: /^\/api\/bots\/[\w-]+\/cards\/[\w-]+$/ },
+  { methods: ["POST"], path: /^\/api\/bots\/[\w-]+\/secret-cards\/[\w-]+\/(?:resume|dismiss)$/ },
+  { methods: ["GET"], path: /^\/api\/bots\/[\w-]+\/connector-cards\/[\w-]+\/status$/ },
+  { methods: ["POST"], path: /^\/api\/bots\/[\w-]+\/connector-cards\/[\w-]+\/(?:resume|dismiss)$/ },
+  { methods: ["POST"], path: /^\/api\/bots\/[\w-]+\/always-allow$/ }, // must match a pending card
+  // rooms
+  { methods: ["POST"], path: /^\/api\/groups$/ },
+  { methods: ["POST"], path: /^\/api\/groups\/[\w-]+\/messages$/ },
+  { methods: ["POST"], path: /^\/api\/groups\/[\w-]+\/interrupt$/ },
+  { methods: ["POST"], path: /^\/api\/groups\/[\w-]+\/read$/ },
+  { methods: ["DELETE"], path: /^\/api\/groups\/[\w-]+\/queue\/[\w-]+$/ },
+  { methods: ["POST"], path: /^\/api\/groups\/[\w-]+\/tasks$/ },
+  { methods: ["POST", "PATCH", "DELETE"], path: /^\/api\/groups\/[\w-]+\/tasks\/[\w-]+$/ },
+  { methods: ["PATCH"], path: /^\/api\/groups\/[\w-]+$/ }, // display fields only: see clientGroupPatchViolation
+  { methods: ["POST"], path: /^\/api\/threads\/[\w-]+\/messages\/[\w-]+\/reactions$/ },
+  // attachments
+  { methods: ["POST"], path: /^\/api\/attachments$/ },
+  { methods: ["GET"], path: /^\/api\/attachments\/[\w.-]+$/ },
+  { methods: ["POST"], path: /^\/api\/files$/ },
+  // voice: labels and audio, never the key
+  { methods: ["GET"], path: /^\/api\/tts\/voices$/ },
+  { methods: ["POST"], path: /^\/api\/tts\/prepare$/ },
+  { methods: ["POST"], path: /^\/api\/tts\/speak$/ },
+  // routines: a scheduled message; the input carries no cwd or permission field
+  { methods: ["GET"], path: /^\/api\/routines$/ },
+  { methods: ["POST"], path: /^\/api\/routines$/ },
+  { methods: ["PATCH", "DELETE"], path: /^\/api\/routines\/[\w-]+$/ },
+  { methods: ["POST"], path: /^\/api\/routines\/[\w-]+\/run$/ },
+  { methods: ["POST"], path: /^\/api\/routine-runs\/[\w-]+\/(?:cancel|seen)$/ },
+  // webhook list is secret-free; creating or rotating one is not
+  { methods: ["GET"], path: /^\/api\/webhooks$/ },
+  // configured-or-not booleans; the handler strips the few identifying fields for clients
+  { methods: ["GET"], path: /^\/api\/config$/ },
 ];
 
 export function requiredScope(method: string, path: string): Scope {
   const upper = method.toUpperCase();
-  for (const rule of ADMIN_ROUTES) {
-    if (rule.path.test(path) && (rule.methods === null || rule.methods.includes(upper))) return "admin";
+  for (const rule of CLIENT_ALLOW) {
+    if (rule.path.test(path) && rule.methods.includes(upper)) return "client";
   }
-  return "client";
+  return "admin";
+}
+
+/** Fields a client session may change on a bot: how it looks in the list,
+ * never what it may do. Returns the first offending field, or null. */
+const CLIENT_BOT_PATCH_FIELDS = new Set(["unread", "pinned", "pinnedMessageId", "color", "mascotExpression", "mascotBody"]);
+export function clientBotPatchViolation(body: unknown): string | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return "body";
+  for (const key of Object.keys(body)) if (!CLIENT_BOT_PATCH_FIELDS.has(key)) return key;
+  return null;
+}
+
+/** Same for a room: name and reading state, never its folder or who answers. */
+const CLIENT_GROUP_PATCH_FIELDS = new Set(["name", "bulletin", "unread", "pinnedMessageId", "section"]);
+export function clientGroupPatchViolation(body: unknown): string | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return "body";
+  for (const key of Object.keys(body)) if (!CLIENT_GROUP_PATCH_FIELDS.has(key)) return key;
+  return null;
 }
 
 export interface ResolveOptions {

--- a/server/sessions.test.ts
+++ b/server/sessions.test.ts
@@ -7,7 +7,6 @@ import {
   EXCHANGE_REPLAY_MS,
   formatPairingCode,
   generatePairingCode,
-  GLOBAL_LOCKOUT,
   LOCKOUT,
   normalizePairingCode,
   PAIRING_CODE_ALPHABET,
@@ -53,9 +52,8 @@ describe("pairing codes", () => {
     const first = registry.exchange({ code: formatPairingCode(code).toLowerCase(), label: "", source: "a" });
     expect(first.ok).toBe(true);
     if (first.ok) expect(first.session.label).toBe("phone");
-    // the same source retrying gets the same answer (lost-response replay); anyone else is refused
-    expect(registry.exchange({ code, label: "x", source: "a" })).toEqual(first);
-    const again = registry.exchange({ code, label: "x", source: "someone-else" });
+    // without an attempt id there is no replay: the same source asking again is refused too
+    const again = registry.exchange({ code, label: "x", source: "a" });
     expect(again.ok).toBe(false);
     if (!again.ok) expect(again.error).toMatch(/wrong or has expired/);
     const { code: stale } = registry.openPairing();
@@ -73,7 +71,7 @@ describe("pairing codes", () => {
     expect(locked.ok).toBe(false);
     if (!locked.ok) {
       expect(locked.status).toBe(429);
-      expect(locked.error).toMatch(/try again in 10 min/);
+      expect(locked.error).toMatch(/from your address; try again in 60s/);
     }
     // a different source is unaffected, and the code is still unused
     expect(registry.exchange({ code, label: "", source: "friend" }).ok).toBe(true);
@@ -82,28 +80,30 @@ describe("pairing codes", () => {
     expect(registry.exchange({ code: fresh, label: "", source: "attacker" }).ok).toBe(true);
   });
 
-  it("answers a lost-response retry with the same session for a minute, from the same source only", () => {
+  it("answers a lost-response retry with the same session for a minute, keyed on the client's attempt id", () => {
     const { code } = registry.openPairing();
-    const first = registry.exchange({ code, label: "phone", source: "a" });
-    const retry = registry.exchange({ code, label: "phone", source: "a" });
-    expect(retry).toEqual(first);
+    const first = registry.exchange({ code, label: "phone", source: "a", attemptId: "attempt-0001-abcd" });
+    expect(first.ok).toBe(true);
+    // same attempt id: the same answer, even from another address (the phone changed networks)
+    expect(registry.exchange({ code, label: "phone", source: "b", attemptId: "attempt-0001-abcd" })).toEqual(first);
     expect(registry.list()).toHaveLength(1);
-    const stranger = registry.exchange({ code, label: "x", source: "b" });
-    expect(stranger.ok).toBe(false);
+    // a different attempt id, or none, is a new attempt against a consumed code
+    expect(registry.exchange({ code, label: "x", source: "a", attemptId: "attempt-0002-efgh" }).ok).toBe(false);
+    expect(registry.exchange({ code, label: "x", source: "a" }).ok).toBe(false);
+    // malformed attempt ids never replay
+    const { code: c2 } = registry.openPairing();
+    expect(registry.exchange({ code: c2, label: "p", source: "a", attemptId: "no" }).ok).toBe(true);
+    expect(registry.exchange({ code: c2, label: "p", source: "a", attemptId: "no" }).ok).toBe(false);
     clock += EXCHANGE_REPLAY_MS + 1;
-    expect(registry.exchange({ code, label: "phone", source: "a" }).ok).toBe(false);
+    expect(registry.exchange({ code, label: "phone", source: "a", attemptId: "attempt-0001-abcd" }).ok).toBe(false);
   });
 
-  it("caps failures across all sources so rotating the forwarded address does not help", () => {
-    for (let i = 0; i < GLOBAL_LOCKOUT.failures; i++) {
-      expect(registry.exchange({ code: "AAAAAAAAAAAA", label: "", source: `rotating-${i}` }).ok).toBe(false);
-    }
-    const { code } = registry.openPairing();
-    const blocked = registry.exchange({ code, label: "", source: "fresh-address" });
-    expect(blocked.ok).toBe(false);
-    if (!blocked.ok) expect(blocked.error).toMatch(/across all clients/);
-    clock += GLOBAL_LOCKOUT.lockMs + 1;
-    expect(registry.exchange({ code, label: "", source: "fresh-address" }).ok).toBe(true);
+  it("forgets a source's failures once its window and lock have passed", () => {
+    registry.exchange({ code: "AAAAAAAAAAAA", label: "", source: "flaky" });
+    expect(registry.failureSources()).toContain("flaky");
+    clock += LOCKOUT.windowMs + 1;
+    registry.openPairing(); // any registry activity prunes
+    expect(registry.failureSources()).not.toContain("flaky");
   });
 
   it("names the device from the client, else the code's label, else the user agent", () => {

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -21,13 +21,20 @@ export const PAIRING_CODE_LENGTH = 12;
 export const PAIRING_CODE_TTL_MS = 5 * 60_000;
 export const SESSION_TTL_MS = 30 * 24 * 60 * 60_000;
 export const STREAM_TICKET_TTL_MS = 5 * 60_000;
-export const LOCKOUT = { failures: 5, windowMs: 60_000, lockMs: 10 * 60_000 } as const;
-/** Every source together: a client rotating its forwarded address still
- * cannot try more than this many codes a minute. */
-export const GLOBAL_LOCKOUT = { failures: 30, windowMs: 60_000, lockMs: 60_000 } as const;
-/** A consumed code presented again by the same source within this window
- * gets the same answer, so a lost response does not strand the device. */
+/** Per-source slow-down only. A 60-bit code cannot be guessed online in
+ * five minutes whatever the rate, so the lock exists to make noise visible,
+ * not to protect the secret; it is kept short because sources are shared
+ * (an office NAT, a proxy) and a long lock would let one bad neighbour keep
+ * everyone else from pairing. */
+export const LOCKOUT = { failures: 10, windowMs: 60_000, lockMs: 60_000 } as const;
+/** A consumed code presented again with the SAME attempt id within this
+ * window gets the same answer, so a lost response does not strand the
+ * device. The attempt id is a random value the client made up for that one
+ * attempt: without it there is no replay, and sharing an address with the
+ * device is not enough to obtain its token. */
 export const EXCHANGE_REPLAY_MS = 60_000;
+/** Outstanding stream tickets per session; issuing more retires the oldest. */
+export const MAX_STREAM_TICKETS_PER_SESSION = 5;
 const LAST_SEEN_WRITE_INTERVAL_MS = 60_000;
 
 const scopeSchema = z.enum(["admin", "client"]);
@@ -129,8 +136,8 @@ export class SessionRegistry {
   private pairings: PairingCode[] = [];
   private tickets = new Map<string, { sessionId: string; expiresAt: number }>();
   private failures = new Map<string, { count: number; windowStart: number; lockedUntil: number }>();
-  private globalFailures = { count: 0, windowStart: 0, lockedUntil: 0 };
-  private replays: Array<{ codeHash: string; source: string; result: ExchangeResult; expiresAt: number }> = [];
+  private replays: Array<{ codeHash: string; attemptId: string; result: ExchangeResult; expiresAt: number }> = [];
+  private readonly onRevoked = new Set<(sessionId: string) => void>();
   private lastSeenWrites = new Map<string, number>();
   private readonly now: () => number;
   private readonly options: { file: string; now?: () => number };
@@ -170,11 +177,28 @@ export class SessionRegistry {
     this.pairings = this.pairings.filter((p) => p.expiresAt > now);
     this.replays = this.replays.filter((r) => r.expiresAt > now);
     for (const [hash, ticket] of this.tickets) if (ticket.expiresAt <= now) this.tickets.delete(hash);
-    const live = this.sessions.filter((s) => s.expiresAt > now);
-    if (live.length !== this.sessions.length) {
-      this.sessions = live;
+    for (const [source, entry] of this.failures) {
+      if (entry.lockedUntil <= now && now - entry.windowStart > LOCKOUT.windowMs) this.failures.delete(source);
+    }
+    const expired = this.sessions.filter((s) => s.expiresAt <= now);
+    if (expired.length) {
+      this.sessions = this.sessions.filter((s) => s.expiresAt > now);
+      for (const s of expired) this.forget(s.id);
       this.persist();
     }
+  }
+
+  /** Called with a session id whenever it stops being valid (revoked,
+   * logged out, expired), so open streams can be closed. */
+  onSessionRevoked(listener: (sessionId: string) => void): () => void {
+    this.onRevoked.add(listener);
+    return () => this.onRevoked.delete(listener);
+  }
+
+  private forget(sessionId: string): void {
+    this.lastSeenWrites.delete(sessionId);
+    for (const [hash, ticket] of this.tickets) if (ticket.sessionId === sessionId) this.tickets.delete(hash);
+    for (const listener of this.onRevoked) listener(sessionId);
   }
 
   // ── pairing ────────────────────────────────────────────────────────────
@@ -217,17 +241,6 @@ export class SessionRegistry {
 
   private recordFailure(source: string): void {
     const now = this.now();
-    const g = this.globalFailures;
-    if (now - g.windowStart > GLOBAL_LOCKOUT.windowMs) {
-      g.count = 0;
-      g.windowStart = now;
-    }
-    g.count += 1;
-    if (g.count >= GLOBAL_LOCKOUT.failures) {
-      g.lockedUntil = now + GLOBAL_LOCKOUT.lockMs;
-      g.count = 0;
-      g.windowStart = now;
-    }
     const entry = this.failures.get(source) ?? { count: 0, windowStart: now, lockedUntil: 0 };
     if (now - entry.windowStart > LOCKOUT.windowMs) {
       entry.count = 0;
@@ -247,19 +260,17 @@ export class SessionRegistry {
   /** `label` is what the client asked to be called; the code's own label
    * (set by whoever minted it) comes next; `fallbackLabel` (derived from the
    * user agent) last. */
-  exchange(input: { code: string; label: string; source: string; fallbackLabel?: string }): ExchangeResult {
+  exchange(input: { code: string; label: string; source: string; fallbackLabel?: string; attemptId?: string }): ExchangeResult {
     this.prune();
     const now = this.now();
     const presented = sha256(normalizePairingCode(input.code));
-    const replay = this.replays.find((r) => r.source === input.source && sameDigest(r.codeHash, presented));
+    const attemptId = typeof input.attemptId === "string" && /^[\w-]{8,64}$/.test(input.attemptId) ? input.attemptId : null;
+    const replay = attemptId ? this.replays.find((r) => r.attemptId === attemptId && sameDigest(r.codeHash, presented)) : undefined;
     if (replay) return replay.result;
     const lock = this.lockState(input.source);
     if (lock.locked) {
-      const minutes = Math.ceil(lock.retryAfterMs / 60_000);
-      return { ok: false, status: 429, error: `too many failed pairing attempts; try again in ${minutes} min` };
-    }
-    if (this.globalFailures.lockedUntil > now) {
-      return { ok: false, status: 429, error: "too many failed pairing attempts across all clients; try again in a minute" };
+      const seconds = Math.ceil(lock.retryAfterMs / 1000);
+      return { ok: false, status: 429, error: `too many failed pairing attempts from your address; try again in ${seconds}s` };
     }
     const index = this.pairings.findIndex((p) => sameDigest(p.codeHash, presented));
     if (index < 0) {
@@ -282,7 +293,7 @@ export class SessionRegistry {
     this.lastSeenWrites.set(record.id, now); // the exchange itself was the first sighting
     this.persist();
     const result: ExchangeResult = { ok: true, token, session: publicSession(record) };
-    this.replays.push({ codeHash: presented, source: input.source, result, expiresAt: now + EXCHANGE_REPLAY_MS });
+    if (attemptId) this.replays.push({ codeHash: presented, attemptId, result, expiresAt: now + EXCHANGE_REPLAY_MS });
     return result;
   }
 
@@ -311,8 +322,8 @@ export class SessionRegistry {
   revoke(id: string): boolean {
     const before = this.sessions.length;
     this.sessions = this.sessions.filter((s) => s.id !== id);
-    for (const [hash, ticket] of this.tickets) if (ticket.sessionId === id) this.tickets.delete(hash);
     if (this.sessions.length === before) return false;
+    this.forget(id);
     this.persist();
     return true;
   }
@@ -321,6 +332,8 @@ export class SessionRegistry {
 
   issueStreamTicket(sessionId: string): { ticket: string; expiresAt: number } {
     this.prune();
+    const mine = [...this.tickets].filter(([, t]) => t.sessionId === sessionId).sort((a, b) => a[1].expiresAt - b[1].expiresAt);
+    for (const [hash] of mine.slice(0, Math.max(0, mine.length - (MAX_STREAM_TICKETS_PER_SESSION - 1)))) this.tickets.delete(hash);
     const ticket = `omb_tick_${randomBytes(24).toString("base64url")}`;
     const expiresAt = this.now() + STREAM_TICKET_TTL_MS;
     this.tickets.set(sha256(ticket), { sessionId, expiresAt });

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -231,6 +231,12 @@ export class SessionRegistry {
     return this.pairings.length !== before;
   }
 
+  /** Sources with recent failures (for tests and diagnostics; never the codes). */
+  failureSources(): string[] {
+    this.prune();
+    return [...this.failures.keys()];
+  }
+
   private lockState(source: string): { locked: boolean; retryAfterMs: number } {
     const entry = this.failures.get(source);
     if (!entry) return { locked: false, retryAfterMs: 0 };
@@ -312,6 +318,12 @@ export class SessionRegistry {
       this.persist();
     }
     return record;
+  }
+
+  /** Still valid right now (prunes expiry first). */
+  isLive(sessionId: string): boolean {
+    this.prune();
+    return this.sessions.some((s) => s.id === sessionId);
   }
 
   list(): PublicSession[] {

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -58,8 +58,15 @@ export function defaultDeviceLabel(userAgent: string = navigator.userAgent): str
   return os ? `${browser} on ${os}` : browser;
 }
 
+/** One random id per pairing attempt. Re-sending the same id after a lost
+ * response returns the same session instead of "code already used"; nobody
+ * who merely shares this device's address can guess it. */
+export function newAttemptId(): string {
+  return typeof crypto?.randomUUID === "function" ? crypto.randomUUID() : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 14)}`;
+}
+
 export async function pairWithCode(
-  input: { code: string; label: string },
+  input: { code: string; label: string; attemptId?: string },
   fetchImpl: typeof fetch = fetch,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   let res: Response;
@@ -68,7 +75,7 @@ export async function pairWithCode(
       method: "POST",
       credentials: "same-origin",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ code: input.code, label: input.label, cookie: true }),
+      body: JSON.stringify({ code: input.code, label: input.label, cookie: true, attemptId: input.attemptId ?? newAttemptId() }),
     });
   } catch (error) {
     return { ok: false, error: `could not reach the server (${error instanceof Error ? error.message : String(error)})` };

--- a/src/pair/PairPage.tsx
+++ b/src/pair/PairPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { defaultDeviceLabel, pairWithCode, readSessionState, type EnvironmentDescriptor, type SessionState } from "../lib/session";
+import { defaultDeviceLabel, newAttemptId, pairWithCode, readSessionState, type EnvironmentDescriptor, type SessionState } from "../lib/session";
 
 /** The page a pairing link opens: /pair#code=XXXX-XXXX-XXXX. Also what the
  * app shows instead of itself when a remote browser has no session yet. */
@@ -11,6 +11,8 @@ export function PairPage({ initialCode, reason }: { initialCode: string | null; 
   const [session, setSession] = useState<SessionState | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // one id per code typed: a retry after a lost response reuses it, a new code gets a new one
+  const [attemptId, setAttemptId] = useState(() => newAttemptId());
 
   useEffect(() => {
     void fetch("/.well-known/openmausbot/environment")
@@ -26,7 +28,7 @@ export function PairPage({ initialCode, reason }: { initialCode: string | null; 
     e.preventDefault();
     setBusy(true);
     setError(null);
-    const result = await pairWithCode({ code, label });
+    const result = await pairWithCode({ code, label, attemptId });
     setBusy(false);
     if (result.ok) {
       location.replace("/");
@@ -59,7 +61,10 @@ export function PairPage({ initialCode, reason }: { initialCode: string | null; 
             <input
               id="pair-code"
               value={code}
-              onChange={(e) => setCode(e.target.value)}
+              onChange={(e) => {
+                setCode(e.target.value);
+                setAttemptId(newAttemptId());
+              }}
               placeholder="XXXX-XXXX-XXXX"
               autoComplete="one-time-code"
               autoCapitalize="characters"


### PR DESCRIPTION
Follow-up to #693 from the adversarial review of the remote surfaces (server side; the desktop side is #802).

## What changes

- **Client scope is an allow-list now.** `CLIENT_ALLOW` in `server/request-auth.ts` names what a `client` session may do: chat, answer cards, rooms, attachments, routines, its own session, and secret-free reads (fleet, transcripts, search, webhook list, configured-or-not flags). Everything else is admin, so a new route is admin-only until someone lists it. The old four-rule deny-list let a `--client` session reach `/api/cli-test` (runs any host binary), computer `exec`, the local VM runtime, webhook creation (returns the secret), skill installs and the bot-permission PATCH. Default pairing is admin, so only codes minted with `--client` were exposed.
- **Two client-writable PATCH routes carry a body filter**: a bot edit may touch `unread`, `pinned`, `pinnedMessageId`, `color`, `mascotExpression`, `mascotBody`; a room edit `name`, `bulletin`, `unread`, `pinnedMessageId`, `section`. Anything else is refused with the field named. `GET /api/config` drops the SSH alias, the profile email and browser partition ids for clients.
- **A session's live event stream ends when the session does** (revoke, logout, expiry) via `SessionRegistry.onSessionRevoked` plus a heartbeat check, instead of only future requests being refused.
- **Pairing exchange is JSON-only** (no cross-site form posts) and **replays a lost response only for the same client-generated attempt id**, never for whoever shares the address. The pair page generates one id per attempt.
- **Lockout**: the global lock is gone (a 60-bit code needs no global lock, and it was a pairing denial-of-service vector); per-source is 10 failures a minute for 60 s; the source is the **last** `X-Forwarded-For` hop, honoured only from a proxy on this machine, sanitised before logs; failure entries are pruned; stream tickets capped at 5 per session.

## Verified

| check | result |
|---|---|
| gate + registry unit tests | ✅ 26/26 |
| end-to-end over a real harness with non-loopback `Host`: client-scope session refused on cli-test/instances/webhooks/MCP/local-computer, display-only bot PATCH accepted and a smuggled `autoApprove` refused by name, stripped config, stream ended < 2.5 s after revocation (heartbeat set to 4 s so the revoke path is what is measured), JSON-only pairing, attempt-id replay | ✅ 11/11 |
| existing API suite | ✅ 181/181 |
| mutations: default-allow, no body filter, revoke keeps stream, any content type, replay ignores attempt id | ✅ each breaks a test |
| typecheck, lint | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pairing retries now reliably recover from lost responses while preventing replay across different attempts.
  - Live session streams close promptly when access is revoked or expires.
  - Non-administrative sessions have restricted access to protected settings and editing actions.
- **Bug Fixes**
  - Sensitive configuration values are hidden from non-administrative sessions.
  - Pairing requests now require JSON content and provide clearer lockout timing.
  - Session cleanup and stream-ticket limits improve reliability and security.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->