### PR TITLE
fix(desktop): hoist the local-origin helpers above the IPC registrations (packaged startup)

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -455,6 +455,15 @@ import {
   stopCompanion,
 } from "./companion.mjs";
 
+/** IPC that controls this computer, its files, its logins or its updater is
+ * answered only for the local server's UI (electron/local-origin.cjs). A
+ * remote server's page gets a reduced bridge (preload.cjs) in the first
+ * place; this is the second wall, shared with cua.mjs, updater.mjs and
+ * android-device.mjs. Declared before any handler registration below: a
+ * const declared later would be in its temporal dead zone at module load.
+ */
+const { isLocalSender: senderIsLocal, localOnly, localOnlySync, setLocalOrigin } = localOriginModule;
+
 let companionPowerBlocker = null;
 
 function syncCompanionKeepAwake(companionEnabled, keepAwake) {
@@ -1606,12 +1615,6 @@ function activeOrigin() {
   return activeEnvironment(environmentsState)?.origin ?? rendererOrigin();
 }
 
-/** IPC that controls this computer, its files, its logins or its updater is
- * answered only for the local server's UI (electron/local-origin.cjs). A
- * remote server's page gets a reduced bridge (preload.cjs) in the first
- * place; this is the second wall, shared with cua.mjs, updater.mjs and
- * android-device.mjs. */
-const { isLocalSender: senderIsLocal, localOnly, localOnlySync, setLocalOrigin } = localOriginModule;
 
 function refreshApplicationMenu() {
   Menu.setApplicationMenu(


### PR DESCRIPTION
#802 auto-merged its earlier head about two minutes before the follow-up commit that fixed CI's packaged-smoke failure landed on its branch, so `main` has the bug and not the fix: `electron/main.mjs` destructures `localOnly`/`localOnlySync` from `local-origin.cjs` mid-file, below `ipcMain.handle(...)` registrations that run at module load. A packaged build from current `main` throws `ReferenceError: Cannot access 'localOnly' before initialization` at startup (CI's "package + smoke (Ubuntu)" on the merge commit shows it). No release tag was cut in between.

This is the same one-line hoist as `d55721fc` on the original branch, cherry-picked: the destructuring moves next to the imports. Verified: syntax, declaration precedes every use, 136 Electron node tests. CI's packaged smoke is the real proof and runs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal documentation around local-only IPC boundaries.
* **Refactor**
  * Reorganized internal module initialization without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->