### PR TITLE
Bind the local-origin gate before the handlers that use it

### DIFF
--- a/electron/local-only-hoist.node-test.mjs
+++ b/electron/local-only-hoist.node-test.mjs
@@ -1,0 +1,25 @@
+// The local-origin gate is bound with a `const` destructure while ipcMain
+// handlers are registered at module top level. If that binding ever sits
+// below the first `localOnly(...)` again, the packaged app dies at boot with
+// "Cannot access 'localOnly' before initialization" — which only the Linux
+// package smoke sees, long after the unit legs are green. This pins the
+// order statically so the failure is a red test, not a red release.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const main = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "main.mjs"), "utf8").split("\n");
+const declaration = main.findIndex((line) => /^const \{[^}]*\blocalOnly\b[^}]*\} = localOriginModule;/.test(line));
+const code = (line) => !/^\s*(?:\/\/|\/?\*)/.test(line);
+const firstUse = main.findIndex((line) => code(line) && /\blocalOnly(?:Sync)?\(/.test(line) && !line.startsWith("const {"));
+
+test("localOnly is bound before the first top-level handler that calls it", () => {
+  assert.ok(declaration >= 0, "the local-origin destructure is missing from main.mjs");
+  assert.ok(firstUse >= 0, "no top-level localOnly(...) use found");
+  assert.ok(
+    declaration < firstUse,
+    `localOnly is bound on line ${declaration + 1} but first called on line ${firstUse + 1}: the packaged app will crash at boot`,
+  );
+});

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -74,6 +74,19 @@ import {
 import capabilitiesModule from "./capabilities.cjs";
 import environmentsModule from "./environments.cjs";
 import localOriginModule from "./local-origin.cjs";
+/** IPC that controls this computer, its files, its logins or its updater is
+ * answered only for the local server's UI (electron/local-origin.cjs). A
+ * remote server's page gets a reduced bridge (preload.cjs) in the first
+ * place; this is the second wall, shared with cua.mjs, updater.mjs and
+ * android-device.mjs.
+ *
+ * Bound here, beside the import, on purpose: the ipcMain registrations
+ * below wrap their handlers with this gate while the module is still
+ * evaluating, so a `const` declared further down is in its temporal dead
+ * zone when the first one runs and the packaged app dies at boot with
+ * "Cannot access 'localOnly' before initialization". The import itself is
+ * hoisted; the binding must be too. */
+const { isLocalSender: senderIsLocal, localOnly, localOnlySync, setLocalOrigin } = localOriginModule;
 import { buildApplicationMenu } from "./menu.mjs";
 import { acquireDataDirLease } from "./data-dir-lease.mjs";
 
@@ -1605,13 +1618,6 @@ function writeEnvironments(state) {
 function activeOrigin() {
   return activeEnvironment(environmentsState)?.origin ?? rendererOrigin();
 }
-
-/** IPC that controls this computer, its files, its logins or its updater is
- * answered only for the local server's UI (electron/local-origin.cjs). A
- * remote server's page gets a reduced bridge (preload.cjs) in the first
- * place; this is the second wall, shared with cua.mjs, updater.mjs and
- * android-device.mjs. */
-const { isLocalSender: senderIsLocal, localOnly, localOnlySync, setLocalOrigin } = localOriginModule;
 
 function refreshApplicationMenu() {
   Menu.setApplicationMenu(


### PR DESCRIPTION
## In plain terms

Since this morning's #802, the packaged desktop app crashes at launch on Linux, and main's own "package + smoke" job has been red. Nothing in the unit legs catches it, so every open pull request now fails that job through no fault of its own (#754 among them).

## Cause

#802 turned the hoisted `function localOnly` into a `const { … localOnly … } = localOriginModule` destructure and left it below the `ipcMain.handle(..., localOnly(...))` registrations. Those run while the module evaluates, so the binding is still in its temporal dead zone when the first one calls it:

```
ReferenceError: Cannot access 'localOnly' before initialization
    at app.asar/electron/main.mjs:1491:37
    at ModuleJob.run
```

## Change

One move: the destructure now sits beside its import (the import is hoisted; the binding has to be too), with a comment saying why. A small node test pins the order statically so the next time someone moves it the failure is a red unit test rather than a red release.

## Test plan

- [x] `electron/local-only-hoist.node-test.mjs` passes; moving the binding back below the handlers turns it red with the line numbers in the message.
- [x] `pnpm check:electron` (112 modules), `pnpm test:electron` green, oxlint clean on both files.
- [ ] The "package + smoke (Ubuntu 24.04 x64)" job on this PR is the real proof; it is the job that has been failing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
