### PR TITLE
fix(approvals): say why Auto stopped when nobody started the turn

### DIFF
--- a/server/auto-approve.test.ts
+++ b/server/auto-approve.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  approvalHeldReason,
   approvalKey,
   autoDecision,
   autoVerdict,
@@ -229,5 +230,44 @@ describe("unattended turns", () => {
   it("still auto-approves the same action when a person started the turn", () => {
     expect(autoDecision(bot, "Bash", "git status")).toBeTruthy();
     expect(autoDecision(bot, "Bash", "git status", { unattended: false })).toBeTruthy();
+  });
+});
+
+// The report behind this: Auto mode "still asks for many commands" once a
+// fleet is running. The cards were right to appear — Auto is switched off
+// entirely for a turn nobody started — but they explained themselves as if
+// this one action were special, so the mode looked broken instead of paused.
+describe("approvalHeldReason", () => {
+  const auto = { permission: true, mode: "auto" as const, fullAccessAvailable: true };
+
+  it("says Auto is paused, not picky, when nobody started the turn", () => {
+    const held = approvalHeldReason({ ...auto, unattended: true });
+    expect(held).toContain("every action asks");
+    expect(held).toContain("Full access");
+    expect(held).not.toContain("This action needs you");
+  });
+
+  it("still blames the action when a person is driving the turn", () => {
+    expect(approvalHeldReason({ ...auto, unattended: false }))
+      .toBe("This action needs you, so Approve for me stopped to ask.");
+  });
+
+  it("does not offer Full access to a provider that cannot reach it", () => {
+    const held = approvalHeldReason({ ...auto, unattended: true, fullAccessAvailable: false });
+    expect(held).toContain("every action asks");
+    expect(held).not.toContain("Full access");
+  });
+
+  it("keeps the native and sandbox notes ahead of any mode explanation", () => {
+    expect(approvalHeldReason({ ...auto, unattended: true, source: "native-approval" }))
+      .toBe("The provider requires your approval for this action.");
+    expect(approvalHeldReason({ ...auto, unattended: true, requiresExplicitApproval: true }))
+      .toContain("only Full access can approve it automatically");
+  });
+
+  it("explains nothing for questions or for modes that always ask", () => {
+    expect(approvalHeldReason({ ...auto, unattended: true, permission: false })).toBeUndefined();
+    expect(approvalHeldReason({ ...auto, unattended: true, mode: "ask" })).toBeUndefined();
+    expect(approvalHeldReason({ ...auto, unattended: true, mode: "full" })).toBeUndefined();
   });
 });

--- a/server/auto-approve.ts
+++ b/server/auto-approve.ts
@@ -228,3 +228,36 @@ export function autoDecision(
 ): string | null {
   return autoVerdict(bot, tool, summary, context).approve;
 }
+
+/** The note a card shows above its buttons, explaining why the bot stopped
+ * rather than answering for itself.
+ *
+ * The unattended case is the one users misread. A turn a webhook or another
+ * bot started never runs Auto at all — approvalModeForTurn downgrades it to
+ * Ask before the provider spawns — so "this action needs you" would name the
+ * wrong cause and imply the next action might pass. It will not: with a fleet
+ * delegating between bots, every card looks like this until someone answers.
+ * Say that plainly, and name the mode that keeps running. */
+export function approvalHeldReason(context: {
+  /** Native and sandbox notes outrank any mode explanation, so a provider's
+   * own remaining checks are never described as something Full access skips. */
+  source?: AutoVerdictSource;
+  /** Questions are not permissions and are never held for a mode reason. */
+  permission: boolean;
+  requiresExplicitApproval?: boolean;
+  /** The durable mode, not the downgraded one this turn ran under. */
+  mode: ApprovalMode;
+  unattended: boolean;
+  /** Suppress the Full access hint on providers that cannot offer it. */
+  fullAccessAvailable: boolean;
+}): string | undefined {
+  if (context.source === "native-approval") return "The provider requires your approval for this action.";
+  if (!context.permission) return undefined;
+  if (context.requiresExplicitApproval) {
+    return "This changes the provider sandbox, so only Full access can approve it automatically.";
+  }
+  if (context.mode !== "auto") return undefined;
+  if (!context.unattended) return "This action needs you, so Approve for me stopped to ask.";
+  const hint = context.fullAccessAvailable ? " Full access keeps working unattended." : "";
+  return `A webhook or another bot started this turn, so Approve for me is paused and every action asks.${hint}`;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -26,7 +26,7 @@ import {
   type CredentialTargetId,
 } from "../shared/credential-request.ts";
 
-import { autoVerdict, rememberableApprovalKey } from "./auto-approve.ts";
+import { approvalHeldReason, autoVerdict, rememberableApprovalKey } from "./auto-approve.ts";
 import { requestReview, resolveAutoReviewMode, shouldReview } from "./auto-review.ts";
 import { updateClaudeCli } from "./claude-update.ts";
 import {
@@ -2901,16 +2901,18 @@ bus.subscribe((event: RuntimeEvent) => {
                 requiresExplicitApproval: event.requiresExplicitApproval,
               })
             : undefined,
-          // Explain native approval requests without implying that Full
-          // access bypasses a provider's own remaining checks.
-          held:
-            verdict?.source === "native-approval"
-              ? "The provider requires your approval for this action."
-              : permission && event.requiresExplicitApproval
-              ? "This changes the provider sandbox, so only Full access can approve it automatically."
-              : permission && asker && approvalModeFor(asker) === "auto"
-                ? "This action needs you, so Approve for me stopped to ask."
-              : undefined,
+          // A card can outlive the bot record that raised it. Without one
+          // there is no mode to explain, but the sandbox note still applies.
+          held: approvalHeldReason({
+            source: verdict?.source,
+            permission,
+            requiresExplicitApproval: event.requiresExplicitApproval,
+            mode: asker ? approvalModeFor(asker) : "ask",
+            unattended: Boolean(unattended),
+            fullAccessAvailable: asker
+              ? supportsApprovalMode(registry.cliTarget(asker.modelSelection.instanceId)?.driverKind, "full")
+              : false,
+          }),
           approvalScope: event.approvalScope,
         },
       });

--- a/src/components/ApprovalModeSelector.test.ts
+++ b/src/components/ApprovalModeSelector.test.ts
@@ -17,7 +17,7 @@ describe("approval mode selector", () => {
       {
         mode: "auto",
         label: "Approve for me",
-        description: "The provider reviews routine actions and asks about others",
+        description: "The provider reviews routine actions and asks about others; unattended turns always ask",
       },
       {
         mode: "full",

--- a/src/components/ApprovalModeSelector.tsx
+++ b/src/components/ApprovalModeSelector.tsx
@@ -23,7 +23,7 @@ export const APPROVAL_MODE_OPTIONS: ReadonlyArray<{
     mode: "auto",
     label: "Approve for me",
     chip: "Auto",
-    description: "The provider reviews routine actions and asks about others",
+    description: "The provider reviews routine actions and asks about others; unattended turns always ask",
     Icon: ShieldCheck,
   },
   {


### PR DESCRIPTION
Follow-up to @cwill11's report that Auto mode "still asks for many commands" once a fleet is running ([Discord, 2026-09-03](https://discord.com/channels/1496552238640926740/1496552239077261322/1545187549960609862)).

## Not a missing mode

The "yolo" tier already shipped as **Full access** (#792, #801). This PR fixes the other half of that report: *why* Auto appeared broken.

## The actual cause

Auto is switched off entirely for an unattended turn. A webhook — or a bot delegating to another bot — marks the asker unattended (`server/index.ts:3744`), and `approvalModeForTurn` downgrades Auto to Ask before the provider spawns:

```js
// Native reviewers can approve before a permission reaches this process.
// Unattended Auto must therefore downgrade before spawning the provider.
if (mode === "auto" && isUnattended(bot.id)) return "ask";
```

That is deliberate and stays. The bug is what the resulting card *said*:

> This action needs you, so Approve for me stopped to ask.

That names the wrong cause and implies the next action might pass. It will not — with a fleet delegating between bots, every card looks like this until someone answers. So Auto reads as broken rather than paused, which is exactly the report.

## The fix

Say what actually happened, and name the mode that keeps running:

> A webhook or another bot started this turn, so Approve for me is paused and every action asks. Full access keeps working unattended.

The Full access hint is suppressed on providers where `supportsApprovalMode(driverKind, "full")` is false, so the card never points at a setting the user cannot pick.

The mode picker carries the same caveat, so the trade-off is visible before a fleet is running rather than only once it stalls:

> The provider reviews routine actions and asks about others; unattended turns always ask

## Refactor

The held text was a four-branch nested ternary inline in the `request.opened` fold. It moves to `approvalHeldReason` in `auto-approve.ts`, beside the verdict logic it describes — an if/else chain, unit tested, with the native and sandbox notes still ahead of any mode explanation. A card whose bot record is gone keeps the sandbox note it had before.

**No decision logic changes.** Only the explanatory copy and where it is computed.

## Verification

Five unit tests on `approvalHeldReason`. Confirmed they are genuine regression tests by restoring the old copy — 2 fail:

```
× says Auto is paused, not picky, when nobody started the turn
× does not offer Full access to a provider that cannot reach it
```

Drove the isolated fake-engine fixture per `docs/verification/README.md` — `doctor`, `new-bot`, `send`, `wait`, `messages` — and a live turn still settles with the change in place:

```
wait result= settled
user/text: hello
bot/text: hello from fake claude
```

**Limitation, stated plainly:** the shared control surface cannot set approval modes or fire an unattended webhook turn, so the new card copy itself is proven by unit tests and the wiring by typecheck — not end-to-end by that harness. Adding a map entry for it would need a new control command.

Full suite: **3666 passed**, 1 unrelated load flake (`group-goal-run.e2e.test.ts` timed out at 20s while taking 173s under full-suite load; passes isolated both with and without this change, and asserts nothing on `held`). `pnpm typecheck` clean; `oxlint` clean apart from one warning pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer explanations when permission requests are paused, including approval mode, unattended activity, sandbox restrictions, provider approval, and Full access availability.
  - Approval messages now provide more relevant context for questions and actions that always require approval.
  - Peer-initiated activity no longer inherits a person’s Full or Custom approval permissions.

- **Documentation**
  - Updated the Auto approval mode description to clarify that unattended turns always require approval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->