### PR TITLE
fix(computer-control): add executeToolSafely error boundary wrapper

### DIFF
--- a/server/computer-control.ts
+++ b/server/computer-control.ts
@@ -186,3 +186,22 @@ export class ComputerControl {
     return snapshot;
   }
 }
+
+/** Safely executes an async tool or desktop control call, catching runtime exceptions gracefully. */
+export async function executeToolSafely<T>(
+  toolName: string,
+  fn: () => Promise<T>
+): Promise<{ success: boolean; data?: T; error?: string }> {
+  try {
+    const data = await fn();
+    return { success: true, data };
+  } catch (err: any) {
+    const errorMessage = err?.message || String(err) || 'Unknown execution error';
+    console.error(`[Tool Execution Error] Name: ${toolName} | Details: ${errorMessage}`);
+    return {
+      success: false,
+      error: `Tool '${toolName}' failed to execute: ${errorMessage}`
+    };
+  }
+}
+


### PR DESCRIPTION
<!--
Please read CONTRIBUTING.md first — it's short. One concern per PR;
big changes should have an issue agreeing on the approach before code.
-->

## What changed

## Why

## How it was verified

<!-- commands run, platforms tested on, what you clicked through -->

## Screenshots (UI changes)

<!-- before/after images; video for anything animated -->

## Checklist

- [ ] `pnpm typecheck` and `pnpm test` pass locally
- [ ] Server behavior changes come with tests (see CONTRIBUTING.md → Tests)
- [ ] No `dist-server/` edits (it's build output)
- [ ] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [ ] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for computer-control operations.
  - Failed operations now return a clear error result instead of causing an unhandled failure.
  - Successful operations continue to return their results normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->