### PR TITLE
fix(memory): keep the message store open when SQLite has no FTS5

### DIFF
--- a/server/message-db.test.ts
+++ b/server/message-db.test.ts
@@ -12,6 +12,7 @@ import {
   insertMessage,
   readMessageText,
   readThread,
+  recallIndexAvailable,
   recallMessages,
   searchMessages,
   setActiveLeaf,
@@ -199,7 +200,11 @@ describe("message-db", () => {
     expect(readMessageText("dm", "m-bot")!.peer).toBeUndefined();
   });
 
-  it("recall indexes rows that predate the index", () => {
+  // Backfill is a property of the index itself, so this case only has meaning
+  // where FTS5 exists. Without it the DROP TABLE below has no table to drop and
+  // nothing to rebuild — recall still answers from the LIKE fallback, which the
+  // suite at the end of this file covers.
+  it.skipIf(!recallIndexAvailable())("recall indexes rows that predate the index", () => {
     // simulate a database written before messages_fts existed
     insertMessage("t-old", msg("m1", "legacy row about the quarterly forecast"));
     closeMessageDb();
@@ -271,5 +276,49 @@ describe("message-db", () => {
     expect(path.at(-1)?.text).toBe("edited");
     // both branches survive in the tree
     expect(reloaded.messagesFor(bot.threadId).filter((m) => m.parentId === first.parentId)).toHaveLength(2);
+  });
+});
+
+// The recall index is an accelerator, not a prerequisite. Electron ships Node
+// 24 with FTS5; `pnpm dev:server` and this suite run on whatever Node the
+// contributor has, and node:sqlite carried no FTS5 before Node 24. These cases
+// assert behaviour rather than which path answered, so they hold on both.
+describe("recall without an FTS5 runtime", () => {
+  it("opens the store and persists messages whether or not the index exists", () => {
+    // The regression this guards: CREATE VIRTUAL TABLE … USING fts5 threw
+    // inside open(), so on Node 22 the whole message store failed — not just
+    // recall — and a checkout could neither run the dev server nor this suite.
+    expect(() => insertMessage("own-a", msg("k1", "the idle timer removes the container"))).not.toThrow();
+
+    expect(readThread("own-a", legacy("own-a")).messages.map((m) => m.id)).toContain("k1");
+  });
+
+  it("reports which path is active instead of pretending", () => {
+    expect(typeof recallIndexAvailable()).toBe("boolean");
+  });
+
+  it("recalls, scopes and caps the same way on either path", () => {
+    insertMessage("own-a", msg("k1", "the idle timer removes the Local VM container"));
+    insertMessage("own-b", msg("k2", "Search Console shows the screener is not indexed"));
+    insertMessage("stranger", msg("k3", "a container question in a thread we cannot see"));
+
+    const hits = recallMessages("container", ["own-a", "own-b"]);
+
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits.every((hit) => hit.threadId !== "stranger")).toBe(true);
+    expect(hits[0]?.snippet.length).toBeGreaterThan(0);
+    expect(recallMessages("container", ["own-a"], 1).length).toBeLessThanOrEqual(1);
+  });
+
+  it("drops stop-words on either path, so a common word still matches", () => {
+    insertMessage("own-a", msg("k1", "the archive reference on the shelf"));
+
+    expect(recallMessages("archive reference on", ["own-a"]).length).toBeGreaterThan(0);
+  });
+
+  it("never throws on the FTS syntax a model might type", () => {
+    insertMessage("own-a", msg("k1", "pricing audit for the quarter"));
+
+    expect(() => recallMessages('audit AND NOT "links" OR pricing:* (', ["own-a"])).not.toThrow();
   });
 });

--- a/server/message-db.ts
+++ b/server/message-db.ts
@@ -63,7 +63,51 @@ function open(): DatabaseSync {
 // is no more of a dependency than the table it indexes. The sidebar's LIKE
 // search below stays as it is — substring find over a single thread wants
 // every occurrence, not a relevance ranking.
+/** Whether this runtime's SQLite has FTS5, decided once per handle.
+ *
+ * Not a given: Electron ships Node 24 with FTS5, but `pnpm dev:server` and
+ * `vitest` run on whatever Node the contributor has, and `node:sqlite` did not
+ * carry FTS5 before Node 24. Without a guard, `CREATE VIRTUAL TABLE … USING
+ * fts5` throws inside `open()` and the whole message store fails to open — not
+ * just recall — so a Node 22 checkout cannot run the tests or the dev server.
+ */
+let recallIndexReady = false;
+
+/** Whether this runtime can build the recall index at all.
+ *
+ * Answered by an in-memory probe rather than by `recallIndexReady`, because a
+ * caller may ask before any transcript has been opened — a test deciding
+ * whether an index-only case applies, for instance — and "not opened yet" is
+ * not the same answer as "this Node has no FTS5". Memoised: one throwaway
+ * database per process. */
+let ftsSupported: boolean | null = null;
+
+export function recallIndexAvailable(): boolean {
+  if (ftsSupported === null) {
+    try {
+      const probe = new DatabaseSync(":memory:");
+      probe.exec("CREATE VIRTUAL TABLE probe USING fts5(x)");
+      probe.close();
+      ftsSupported = true;
+    } catch {
+      ftsSupported = false;
+    }
+  }
+  return ftsSupported;
+}
+
 function ensureRecallIndex(db: DatabaseSync): void {
+  try {
+    createRecallIndex(db);
+    recallIndexReady = true;
+  } catch {
+    // No FTS5 here. Transcripts still load, write and search from the sidebar;
+    // `recallMessages` falls back to the LIKE scan below.
+    recallIndexReady = false;
+  }
+}
+
+function createRecallIndex(db: DatabaseSync): void {
   const existed = db
     .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'messages_fts'")
     .get();
@@ -395,6 +439,7 @@ export function readMessageText(
 export function recallMessages(query: string, threadIds: readonly string[], limit = 12): RecallHit[] {
   const match = ftsQuery(query);
   if (!match || !threadIds.length) return [];
+  if (!recallIndexReady) return recallWithoutIndex(query, threadIds, limit);
   const placeholders = threadIds.map(() => "?").join(", ");
   const rows = db()
     .prepare(
@@ -423,6 +468,80 @@ export function recallMessages(query: string, threadIds: readonly string[], limi
       at: row.at,
       role: row.role,
       snippet: row.snippet.replace(/\s+/g, " ").trim(),
+      ...(row.from_name ? { from: row.from_name } : {}),
+      ...(peer ? { peer } : {}),
+    };
+  });
+}
+
+/** Recall on a runtime whose SQLite has no FTS5.
+ *
+ * Same contract as the indexed path — same scoping, same shape, same cap — so
+ * a caller never has to ask which one answered. It gives up relevance ranking
+ * for recency and a hand-cut window for FTS5's snippet, which is the honest
+ * trade: correct and slower beats the tool not existing. Terms come from the
+ * same `ftsQuery` tokens, so both paths agree on what a query means and
+ * stop-words are dropped identically.
+ *
+ * A LIKE scan is what `searchMessages` has always done over the same rows. */
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+function recallWithoutIndex(query: string, threadIds: readonly string[], limit: number): RecallHit[] {
+  const terms = query
+    .split(/\s+/)
+    .map((token) => token.replace(/"/g, "").trim())
+    .filter(Boolean);
+  const content = terms.filter((token) => !STOP_WORDS.has(token.toLowerCase()));
+  const wanted = (content.length ? content : terms).slice(0, 8).map((term) => term.toLowerCase());
+  if (!wanted.length) return [];
+
+  const placeholders = threadIds.map(() => "?").join(", ");
+  const patterns = wanted.map((term) => `%${term.replace(/([\\%_])/g, "\\$1")}%`);
+  // AND, not OR: `ftsQuery` emits space-separated quoted terms, which FTS5
+  // reads as "every term must appear". The fallback has to mean the same, or a
+  // multi-word query returns a wider set here than it does on Electron.
+  const allTerms = patterns.map(() => "lower(m.text) LIKE ? ESCAPE '\\'").join(" AND ");
+  const rows = db()
+    .prepare(
+      "SELECT m.thread_id, m.id, m.at, m.role, m.text, json_extract(m.json, '$.from.name') AS from_name, " +
+        `json_extract(m.json, '$.peerAsk.name') AS peer_name, substr(m.text, 1, ${PEER_NOTE_HEAD_CHARS}) AS head ` +
+        "FROM messages m " +
+        `WHERE m.kind = 'text' AND m.text IS NOT NULL AND m.thread_id IN (${placeholders}) AND (${allTerms}) ` +
+        "ORDER BY m.at DESC LIMIT ?",
+    )
+    .all(...threadIds, ...patterns, limit) as unknown as Array<{
+    thread_id: string;
+    id: string;
+    at: number;
+    role: string;
+    text: string;
+    from_name: string | null;
+    peer_name: string | null;
+    head: string;
+  }>;
+
+  return rows.map((row) => {
+    const hitAt = Math.max(0, row.text.toLowerCase().indexOf(wanted[0]));
+    const start = Math.max(0, hitAt - 80);
+    const end = Math.min(row.text.length, hitAt + 220);
+    const window = row.text.slice(start, end).replace(/\s+/g, " ").trim();
+    // FTS5's snippet() brackets the matched terms; callers render that, so the
+    // fallback marks them too rather than returning a differently-shaped hit.
+    const marked = wanted.reduce(
+      (text, term) => text.replace(new RegExp(`(?<![\\w[])(${escapeRegExp(term)})(?![\\w\\]])`, "giu"), "[$1]"),
+      window,
+    );
+    const snippet = (start > 0 ? "…" : "") + marked + (end < row.text.length ? "…" : "");
+    // Same authorship resolution as the indexed path: a relayed line must
+    // name the bot behind it on either runtime, or recall attributes a
+    // teammate's words to the person.
+    const peer = peerAuthor(row.peer_name, row.head);
+    return {
+      threadId: row.thread_id,
+      messageId: row.id,
+      at: row.at,
+      role: row.role,
+      snippet,
       ...(row.from_name ? { from: row.from_name } : {}),
       ...(peer ? { peer } : {}),
     };


### PR DESCRIPTION
Follow-up to #754 — small, and only the guard.

## The bug

`ensureRecallIndex()` runs inside `open()`, and `CREATE VIRTUAL TABLE … USING fts5` is not available on every runtime. Where it is missing the throw escapes `open()`, so **the whole message store fails — not just recall.**

On Node 22, a fresh checkout can neither run the dev server nor the tests:

```
$ node --experimental-strip-types -e "…appendMessage('t1', …)"
THROWS: no such module: fts5

$ pnpm vitest run server/message-db.test.ts
Tests  11 failed (11)
```

`node:sqlite` did not carry FTS5 before Node 24. Electron ships Node 24, so a packaged user never sees this — a contributor on Node 22 sees nothing else. `engines` asks for `>=24`, but the failure mode is a store that will not open rather than a version warning.

Verified on both runtimes here:

```
node22 recallIndexAvailable: false
node24 recallIndexAvailable: true      (Electron's node, ELECTRON_RUN_AS_NODE=1)
```

## The fix

Index creation is guarded, and `recallMessages` falls back to a LIKE scan over the same rows — which is what `searchMessages` has always done, and what the comment above it already argued was adequate for a local transcript.

The fallback deliberately **matches the indexed path** rather than merely returning something:

- **AND across terms**, because `ftsQuery` emits space-separated quoted terms and FTS5 reads those as "every term must appear". OR would answer a wider question on one runtime than the other — a tool whose meaning depends on the runtime is worse than a slow one.
- **the same stop-word list**, so `"archive reference on"` behaves identically.
- **matched terms bracketed** the way `snippet()` marks them, so a caller renders one shape of hit.

It gives up relevance ranking for recency. That is the honest trade.

## `recallIndexAvailable()`

Answers from an in-memory probe, not from whether a transcript has been opened. A caller can ask before any database exists — a test deciding whether an index-only case applies — and "not opened yet" is not the same answer as "this Node has no FTS5".

The one case that tests the index itself (backfilling rows that predate it) skips where there is no index to backfill. Everything else asserts behaviour rather than which path answered, and runs on both.

## Verification

```
before (main, Node 22)   Tests  11 failed (11)
after                    Tests  15 passed | 1 skipped (16)
message-db + store       Tests  78 passed | 1 skipped (79)
FTS5 path on Node 24     ranked recall intact, "[container]" snippet unchanged
tsc -p tsconfig.server.json   clean
oxlint on both files          no findings
```

Not run locally: the full `pnpm test`. `server/drivers/*` needs agent CLIs this machine lacks, and those suites fail identically on `main`.

---

Unrelated but worth saying: I had an overlapping `session_search` PR open (#777) and closed it — #754 was open a day before I started and I failed to check. Sorry for the duplicated review time. This is the one piece from that work that still applies, rebased onto yours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with environments that do not support advanced full-text search.
  - Message storage now opens and saves messages even when full-text indexing is unavailable.
  - Message recall continues to support scoped searches, result limits, stop-word handling, and search terms containing special syntax.
  - Search results include relevant matching excerpts when full-text search is unavailable.
  - Recall results and message details now identify the original peer for relayed user messages.

- **Tests**
  - Added coverage to verify consistent recall behavior across supported search modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->