### PR TITLE
feat(cli): `openmausbot serve --tunnel` — a public address with no domain, proxy or open port

### DIFF
--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - server/cli.ts
+      - server/tunnel.ts
       - server/tailscale.ts
       - server/pair-cli.ts
       - scripts/build-npm-package.mjs
@@ -46,6 +47,14 @@ jobs:
           OMB_PORT=18799 node cli.js status | grep -q "ci ·"
           OMB_PORT=18799 node cli.js pair --label "CI phone" | grep -q "open or scan:  https://ci.example/pair#code="
           OMB_PORT=18799 node cli.js sessions | grep -q "no paired devices yet"
+          # --tunnel fails closed without an account, and ships its own pieces
+          test -f dist-server/tunnel-guardian.js && test -f dist-server/prepare-cloudflared.js
+          if HOME=/tmp/omb-pack/home node cli.js serve --tunnel --port 18798 --data-dir /tmp/omb-pack/data2 2> tunnel.err; then echo "serve --tunnel ran without an account" && exit 1; fi
+          grep -q "run \`openmausbot login\` first" tunnel.err
+          # --tunnel ships its own processes and fails closed without an account
+          test -f dist-server/tunnel-guardian.js && test -f dist-server/prepare-cloudflared.js
+          if HOME=/tmp/omb-pack/home node cli.js serve --tunnel --port 18798 --data-dir /tmp/omb-pack/data2 > tunnel.log 2>&1; then echo "serve --tunnel should refuse without login"; exit 1; fi
+          grep -q "run \`openmausbot login\` first" tunnel.log
           kill %1; wait %1 || true
       - name: Publish to npm (release tags only)
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -47,10 +47,6 @@ jobs:
           OMB_PORT=18799 node cli.js status | grep -q "ci ·"
           OMB_PORT=18799 node cli.js pair --label "CI phone" | grep -q "open or scan:  https://ci.example/pair#code="
           OMB_PORT=18799 node cli.js sessions | grep -q "no paired devices yet"
-          # --tunnel fails closed without an account, and ships its own pieces
-          test -f dist-server/tunnel-guardian.js && test -f dist-server/prepare-cloudflared.js
-          if HOME=/tmp/omb-pack/home node cli.js serve --tunnel --port 18798 --data-dir /tmp/omb-pack/data2 2> tunnel.err; then echo "serve --tunnel ran without an account" && exit 1; fi
-          grep -q "run \`openmausbot login\` first" tunnel.err
           # --tunnel ships its own processes and fails closed without an account
           test -f dist-server/tunnel-guardian.js && test -f dist-server/prepare-cloudflared.js
           if HOME=/tmp/omb-pack/home node cli.js serve --tunnel --port 18798 --data-dir /tmp/omb-pack/data2 > tunnel.log 2>&1; then echo "serve --tunnel should refuse without login"; exit 1; fi

--- a/docs/plans/remote-workspace.md
+++ b/docs/plans/remote-workspace.md
@@ -109,9 +109,14 @@ desktop-first agent app and adopt these points as requirements:
    SSH tunnel, or a private network. First to ship.
 2. **Private network helper**: detect a Tailscale MagicDNS name and offer
    `tailscale serve` for HTTPS with the server's actual port (TLS is
-   Tailscale's; the server never terminates TLS). Optional, later.
+   Tailscale's; the server never terminates TLS). Shipped for the command
+   line as `openmausbot serve --tailscale`.
 3. **Managed tunnel**: the cloudflared managed-tunnel channel the companion
    already uses — zero network configuration. Rides on the same sessions.
+   Shipped for the command line as `openmausbot login` + `serve --tunnel`
+   (`server/tunnel.ts`): the tunnel gateway forwards to a second, IPC
+   listener on the harness, on which every request is "through a proxy" by
+   construction.
 
 Base URLs are resolved per connection at runtime. Nothing bakes an origin
 into the renderer bundle; the served UI keeps using relative paths.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -49,6 +49,22 @@ laptop. Sign the engine CLIs in on the same machine as usual (`claude`,
   own certificate and the link uses this machine's MagicDNS name, so only
   devices on your tailnet can reach it. Needs Tailscale signed in and HTTPS
   certificates enabled for the tailnet (admin console → DNS).
+- **A public address, no domain, no proxy, no open port:**
+
+  ```sh
+  npx openmausbot login          # once: an emailed code signs this machine in
+  npx openmausbot serve --tunnel
+  ```
+
+  `login` reserves an address like `https://c-….openmausbot.com` for this
+  machine; `serve --tunnel` connects it through a Cloudflare tunnel (the same
+  one the desktop app uses for its companion) and prints the pairing link at
+  that address. The first run downloads `cloudflared` (pinned version and
+  digest) into the data dir. Only traffic through the tunnel reaches the
+  server, and it still has to pair: the tunnel lands on a separate listener
+  the server treats as "through a proxy", never as the owner. `npx openmausbot
+  logout` releases the address. The account credentials live in
+  `~/.openmausbot/tunnel-account.json` (mode 0600).
 - **Behind your own proxy or domain:** `npx openmausbot serve --public-url
   https://maus.example.com`, with the proxy rules from "Putting a proxy in
   front".

--- a/docs/superpowers/plans/2026-08-31-05-headless-harness.md
+++ b/docs/superpowers/plans/2026-08-31-05-headless-harness.md
@@ -14,6 +14,7 @@
 
 See [the roadmap](2026-08-31-00-control-plane-roadmap.md#global-constraints). Load-bearing here:
 
+- **Superseded (Sep 2026):** the harness now authenticates remote clients itself (`docs/plans/remote-workspace.md`: pairing codes, sessions, and a "through a proxy" rule for forwarded requests), and `openmausbot serve --tunnel` (`server/tunnel.ts`) opens a second, IPC listener for the tunnel gateway on which every request is remote by construction. The loopback bind and its owner trust are unchanged; the sidecar is no longer the only door.
 - **The loopback bind is not negotiable.** The harness listens on `127.0.0.1` and rejects any request whose `Host` is not loopback, defeating DNS rebinding. Headless must not add a second bind to the harness. Network exposure stays entirely in the companion sidecar, which is the design `companion/README.md` argues for at length — do not relitigate it.
 - **Fail closed on absent capability.** A headless host has no desktop session, no `safeStorage`, and on Linux may have no seat at all. Every capability that is unavailable must report unavailable, never "off" and never "on".
 - **The capability rule** applies to platform capabilities too: the client must not offer local computer control for a machine that cannot do it.

--- a/electron/companion-account-service.d.mts
+++ b/electron/companion-account-service.d.mts
@@ -1,0 +1,56 @@
+// Types for companion-account-service.mjs as the headless server uses it
+// (server/tunnel.ts). Keep in step with the implementation.
+import type { ControlPlaneClient } from "./control-plane-client.mjs";
+
+export declare const DEFAULT_COMPANION_CONTROL_PLANE_URL: string;
+export declare const COMPANION_CLIENT_INSTANCE_FIELD: string;
+export declare const COMPANION_ACCOUNT_TOKEN_FIELD: string;
+export declare const COMPANION_ACCOUNT_USER_ID_FIELD: string;
+export declare const COMPANION_ACCOUNT_EMAIL_FIELD: string;
+export declare const COMPANION_INSTALLATION_ID_FIELD: string;
+export declare const COMPANION_INSTALLATION_CREDENTIAL_FIELD: string;
+export declare const COMPANION_INSTALLATION_EXPIRY_FIELD: string;
+export declare const COMPANION_ACCOUNT_CLEANUP_PENDING_FIELD: string;
+
+export type CredentialDocument = Record<string, unknown>;
+
+export declare function resolveCompanionControlPlaneURL(options?: {
+  isPackaged?: boolean;
+  environment?: NodeJS.ProcessEnv;
+}): string;
+export declare function companionAccountCleanupPending(credentials: CredentialDocument): boolean;
+export declare function friendlyCompanionAccountError(error: unknown): string;
+
+export interface CompanionAccountState {
+  available: boolean;
+  status: string;
+  email?: string;
+  endpoint?: string;
+  message?: string;
+}
+
+export interface CompanionAccountService {
+  state(): Promise<CompanionAccountState>;
+  requestCode(email: string): Promise<CompanionAccountState>;
+  verifyCode(email: string, code: string): Promise<CompanionAccountState>;
+  retry(): Promise<CompanionAccountState>;
+  signOut(): Promise<CompanionAccountState>;
+  restore(): Promise<CompanionAccountState>;
+}
+
+export declare function createCompanionAccountService(options: {
+  client: ControlPlaneClient | null;
+  readCredentials: () => CredentialDocument;
+  updateCredentials: (
+    derive: (current: CredentialDocument) => CredentialDocument,
+    afterPersist?: (next: CredentialDocument) => Promise<void> | void,
+  ) => Promise<unknown>;
+  identity: { name: string; platform: string; appVersion?: string };
+  newClientInstanceId: () => string;
+  activatePersistedEndpoint?: () => Promise<{ status: string; ready: boolean }>;
+  stopManagedEndpoint?: () => Promise<void>;
+  managedConnectionState?: () => { status: string; ready: boolean };
+  companionIsOn?: () => boolean;
+  now?: () => number;
+  healthCacheMs?: number;
+}): CompanionAccountService;

--- a/electron/companion-origin-gateway.d.mts
+++ b/electron/companion-origin-gateway.d.mts
@@ -1,0 +1,18 @@
+// Types for companion-origin-gateway.mjs as the headless server uses it
+// (server/tunnel.ts). Keep in step with the implementation.
+export declare const MANAGED_COMPANION_ORIGIN_HOST: string;
+export declare const MANAGED_COMPANION_ORIGIN_PORT: number;
+
+export interface CompanionOriginEndpoint {
+  readonly pid: number;
+  readonly socketPath: string;
+  readonly directory: string | null;
+}
+
+export declare function validCompanionOriginTarget(target: unknown, platform?: NodeJS.Platform): boolean;
+export declare function createCompanionOriginEndpoint(options?: {
+  platform?: NodeJS.Platform;
+  processId?: number;
+  temporaryRoot?: string;
+}): CompanionOriginEndpoint;
+export declare function cleanupCompanionOriginEndpoint(endpoint: CompanionOriginEndpoint): void;

--- a/electron/control-plane-client.d.mts
+++ b/electron/control-plane-client.d.mts
@@ -1,0 +1,67 @@
+// Types for control-plane-client.mjs as the headless server uses it
+// (server/tunnel.ts). Keep in step with the implementation.
+export declare class ControlPlaneError extends Error {
+  readonly code: string;
+  readonly status: number;
+  readonly requestId: string;
+  constructor(code: string, status?: number, requestId?: string);
+}
+
+export declare function normalizeControlPlaneURL(value: unknown): string;
+export declare function normalizeAccountEmail(value: unknown): string;
+
+export interface ControlPlaneUser {
+  id: string;
+  email: string;
+  name?: string;
+  emailVerified?: boolean;
+}
+
+export interface ControlPlaneInstallation {
+  id: string;
+  clientInstanceId: string;
+  name: string;
+  platform: string;
+  appVersion?: string | null;
+  createdAt?: number;
+  updatedAt?: number;
+  lastSeenAt?: number | null;
+}
+
+export interface ControlPlaneEndpoint {
+  url: string;
+  hostname: string;
+  status: string;
+  generation?: number;
+  updatedAt?: number;
+  lastReconciledAt?: number | null;
+  lastErrorCode?: string | null;
+}
+
+export interface ControlPlaneClient {
+  health(): Promise<unknown>;
+  requestOTP(email: string): Promise<unknown>;
+  verifyOTP(email: string, otp: string): Promise<{ accountToken: string; user: ControlPlaneUser }>;
+  me(accountToken: string): Promise<ControlPlaneUser>;
+  listInstallations(accountToken: string): Promise<ControlPlaneInstallation[]>;
+  ensureInstallation(input: {
+    accountToken: string;
+    currentCredential: string;
+    clientInstanceId: string;
+    name: string;
+    platform: string;
+    appVersion?: string;
+  }): Promise<{ installation: ControlPlaneInstallation; credential: string; credentialExpiresAt: number | null }>;
+  ensureEndpoint(installationCredential: string): Promise<{ endpoint: ControlPlaneEndpoint; connectorToken: string }>;
+  deleteEndpoint(installationCredential: string): Promise<void>;
+  revokeInstallation(accountToken: string, installationId: string): Promise<void>;
+  signOut(accountToken: string): Promise<void>;
+}
+
+export declare function createControlPlaneClient(options: {
+  baseURL: string;
+  fetchImpl?: typeof fetch;
+  timeoutSignal?: (milliseconds: number) => AbortSignal;
+  timeoutMs?: number;
+  healthTimeoutMs?: number;
+}): ControlPlaneClient;

--- a/electron/managed-companion-tunnel.d.mts
+++ b/electron/managed-companion-tunnel.d.mts
@@ -1,0 +1,56 @@
+// Types for managed-companion-tunnel.mjs as the headless server uses it
+// (server/tunnel.ts). Keep in step with the implementation.
+export declare const MANAGED_COMPANION_ENDPOINT_FIELD: string;
+export declare const MANAGED_COMPANION_TOKEN_FIELD: string;
+
+export interface ManagedTunnelAccess {
+  endpoint: string;
+  token: string;
+}
+
+export interface ManagedTunnelState {
+  status: string;
+  ready: boolean;
+  configured?: boolean;
+  error?: string;
+  retryInMs?: number;
+}
+
+export interface ManagedTunnelOriginTarget {
+  pid: number;
+  socketPath: string;
+}
+
+export interface ManagedTunnel {
+  start(access: ManagedTunnelAccess & { originTarget: ManagedTunnelOriginTarget }): Promise<ManagedTunnelState>;
+  stop(): Promise<ManagedTunnelState>;
+  shutdown(): Promise<ManagedTunnelState>;
+}
+
+export declare function normalizeManagedCompanionEndpoint(value: unknown): string;
+export declare function managedCompanionTunnelAccess(credentials: Record<string, unknown>): ManagedTunnelAccess | null;
+export declare function resolveCloudflaredBinary(options?: {
+  isPackaged?: boolean;
+  resourcesPath?: string;
+  appPath?: string;
+  platform?: NodeJS.Platform;
+  arch?: string;
+  environment?: NodeJS.ProcessEnv;
+  exists?: (candidate: string) => boolean;
+}): string | null;
+export declare function createManagedCompanionTunnel(options: {
+  binaryPath: string | null;
+  guardianEntry: string | null;
+  runtimeExecutable?: string;
+  originPort?: number;
+  runtimeRoot: string;
+  environment?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  verifyTimeoutMs?: number;
+  verifyRequestTimeoutMs?: number;
+  verifyIntervalMs?: number;
+  stopGraceMs?: number;
+  maxRetryMs?: number;
+  onChange?: (state: ManagedTunnelState) => void;
+  log?: (line: string) => void;
+}): ManagedTunnel;

--- a/electron/secure-credential-state.d.mts
+++ b/electron/secure-credential-state.d.mts
@@ -1,0 +1,17 @@
+// Types for secure-credential-state.mjs as the headless server uses it
+// (server/tunnel.ts). Keep in step with the implementation.
+export type CredentialDocument = Record<string, unknown>;
+
+export interface SecureCredentialState {
+  read(): CredentialDocument;
+  update(
+    derive: (current: CredentialDocument) => CredentialDocument,
+    afterPersist?: (next: CredentialDocument) => Promise<void> | void,
+  ): Promise<unknown>;
+}
+
+export declare function createSecureCredentialState(
+  initialCredentials: CredentialDocument,
+  persist: (next: CredentialDocument) => Promise<void> | void,
+  options?: { writable?: boolean },
+): SecureCredentialState;

--- a/scripts/bundle-server.mjs
+++ b/scripts/bundle-server.mjs
@@ -92,6 +92,37 @@ await build({
   logLevel: "info",
 });
 
+// `openmausbot serve --tunnel` (server/tunnel.ts) spawns the connector guardian
+// as its own process, so it has to exist as a file beside the server, not only
+// as code inlined into the bundle that imports its neighbours. Bundled under
+// its own name: the same file the desktop app ships as
+// electron/managed-companion-guardian.mjs, so a fix lands in both.
+await build({
+  entryPoints: [join(root, "electron", "managed-companion-guardian.mjs")],
+  bundle: true,
+  platform: "node",
+  target: "node20",
+  format: "esm",
+  outfile: join(root, "dist-server", "tunnel-guardian.js"),
+  allowOverwrite: true,
+  logLevel: "info",
+});
+
+// `serve --tunnel` downloads cloudflared on first use by running the same
+// pinned-digest script the release build uses, as its own process (it runs
+// itself when executed directly, so it must never be inlined into another
+// entry).
+await build({
+  entryPoints: [join(root, "scripts", "prepare-cloudflared.mjs")],
+  bundle: true,
+  platform: "node",
+  target: "node20",
+  format: "esm",
+  outfile: join(root, "dist-server", "prepare-cloudflared.js"),
+  allowOverwrite: true,
+  logLevel: "info",
+});
+
 // pi-mcp-extension.ts is NOT an OpenMausBot entry point: it is loaded by the
 // external `pi` process (pi's own jiti), which resolves its
 // @earendil-works/pi-coding-agent and typebox imports from pi's install. Ship

--- a/scripts/prepare-cloudflared.mjs
+++ b/scripts/prepare-cloudflared.mjs
@@ -75,9 +75,21 @@ export function targetsForPreparation({
 }
 
 export function parsePrepareCloudflaredArgs(args = []) {
-  if (args.length === 0) return { current: false };
-  if (args.length === 1 && args[0] === "--current") return { current: true };
-  throw new Error("Usage: node scripts/prepare-cloudflared.mjs [--current]");
+  const options = { current: false };
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    const next = args[index + 1];
+    if (argument === "--current" && !options.current) {
+      options.current = true;
+    } else if (argument === "--root" && !options.root && typeof next === "string" && next !== "") {
+      // `openmausbot serve --tunnel` stages into its data dir, not a checkout.
+      options.root = next;
+      index += 1;
+    } else {
+      throw new Error("Usage: node scripts/prepare-cloudflared.mjs [--current] [--root DIR]");
+    }
+  }
+  return options;
 }
 
 export function sha256(value) {

--- a/scripts/prepare-cloudflared.test.mjs
+++ b/scripts/prepare-cloudflared.test.mjs
@@ -88,6 +88,10 @@ describe("pinned cloudflared packaging", () => {
     expect(parsePrepareCloudflaredArgs(["--current"])).toEqual({ current: true });
     expect(() => parsePrepareCloudflaredArgs(["--all"])).toThrow(/Usage:/);
     expect(() => parsePrepareCloudflaredArgs(["--current", "--current"])).toThrow(/Usage:/);
+    // `openmausbot serve --tunnel` stages into its data dir
+    expect(parsePrepareCloudflaredArgs(["--current", "--root", "/srv/omb"])).toEqual({ current: true, root: "/srv/omb" });
+    expect(() => parsePrepareCloudflaredArgs(["--root"])).toThrow(/Usage:/);
+    expect(() => parsePrepareCloudflaredArgs(["--root", "/a", "--root", "/b"])).toThrow(/Usage:/);
   });
 
   it("stages the current target for development without narrowing package preparation", () => {

--- a/server/cli.test.ts
+++ b/server/cli.test.ts
@@ -1,12 +1,13 @@
-import { spawn } from "node:child_process";
-import { mkdtempSync } from "node:fs";
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { formatSessions, pairingBlock, parseArgs, qrToString, serverEntry } from "./cli.ts";
+import { formatSessions, pairingBlock, parseArgs, qrToString, runLogin, serverEntry } from "./cli.ts";
 import { removeTempDir, waitForExit } from "./testing/cleanup.ts";
+import { startControlPlaneStub } from "./testing/control-plane-stub.ts";
 
 const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
 
@@ -23,6 +24,10 @@ describe("openmausbot command line", () => {
     expect(parseArgs(["serve", "--port", "70000"], {})).toEqual({ error: "--port must be 1-65535" });
     expect(parseArgs(["pair", "--public-url", "mini.example"], {})).toEqual({ error: "--public-url must start with http:// or https://" });
     expect(parseArgs(["serve", "--bogus"], {})).toEqual({ error: 'unknown argument "--bogus"' });
+    expect(parseArgs(["serve", "--tunnel"], {})).toMatchObject({ command: "serve", tunnel: true });
+    expect(parseArgs(["login", "--email", "a@b.test"], {})).toMatchObject({ command: "login", email: "a@b.test" });
+    expect(parseArgs(["logout"], {})).toMatchObject({ command: "logout" });
+    expect(parseArgs(["serve", "--tailscale", "--tunnel"], {})).toEqual({ error: "choose one of --tailscale (your tailnet) and --tunnel (a public address)" });
   });
 
   it("prints a scannable block with the link, or says where to type the code", () => {
@@ -91,4 +96,119 @@ describe("openmausbot command line", () => {
     }
     expect(dead).toBe(true);
   }, 90_000);
+});
+
+const exited = (child: ChildProcess) => (child.exitCode !== null ? Promise.resolve(child.exitCode) : new Promise<number | null>((done) => child.once("exit", (code) => done(code))));
+
+describe.skipIf(process.platform === "win32")("serve --tunnel", () => {
+  const cli = (args: string[], env: NodeJS.ProcessEnv) =>
+    spawn(process.execPath, ["--experimental-strip-types", join(SERVER_DIR, "openmausbot.ts"), ...args], {
+      cwd: join(SERVER_DIR, ".."),
+      env: { PATH: process.env.PATH ?? "", ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+  it("refuses without an account and says what to do; no local-only fallback", async () => {
+    const home = mkdtempSync(join(tmpdir(), "omb-cli-tunnel-none-"));
+    const port = 21000 + Math.floor(Math.random() * 9000);
+    const child = cli(["serve", "--tunnel", "--port", String(port), "--data-dir", join(home, "data")], { HOME: home, USERPROFILE: home });
+    let err = "";
+    child.stderr?.on("data", (chunk) => (err += String(chunk)));
+    try {
+      expect(await exited(child)).toBe(1);
+      expect(err).toContain("run `openmausbot login` first");
+      let dead = false;
+      try {
+        await fetch(`http://127.0.0.1:${port}/api/health`);
+      } catch {
+        dead = true;
+      }
+      expect(dead).toBe(true);
+    } finally {
+      await removeTempDir(home);
+    }
+  }, 30_000);
+
+  it("serves at the account's public address through the gateway, where every request is remote", async () => {
+    const home = mkdtempSync(join(tmpdir(), "omb-cli-tunnel-"));
+    const dataDir = join(home, "data");
+    mkdirSync(dataDir, { recursive: true });
+    const stub = await startControlPlaneStub();
+    const fake = join(home, "cloudflared");
+    writeFileSync(fake, "#!/bin/sh\nexec sleep 300\n", { mode: 0o755 });
+    // sign this data dir in, in-process, against the stub
+    vi.stubEnv("OMB_CONTROL_PLANE_URL", stub.url);
+    const quiet = { log: () => undefined, error: () => undefined, ask: async () => stub.otp };
+    expect(await runLogin({ command: "login", port: 1, dataDir, tailscale: false, tunnel: false, client: false, pair: true, json: false, email: "cli@example.test" }, quiet)).toBe(0);
+    vi.unstubAllEnvs();
+    const port = 21000 + Math.floor(Math.random() * 9000);
+    const originPort = 31000 + Math.floor(Math.random() * 9000);
+    const child = cli(["serve", "--tunnel", "--port", String(port), "--data-dir", dataDir, "--label", "tunnel test"], {
+      HOME: home,
+      USERPROFILE: home,
+      OMB_WEBHOOK_PORT: String(port + 1),
+      OMB_BROWSER_CONNECTION: join(home, "browser-connection.json"),
+      OMB_CONTROL_PLANE_URL: stub.url,
+      OMB_CLOUDFLARED_PATH: fake,
+      OMB_TUNNEL_ORIGIN_PORT: String(originPort),
+    });
+    let out = "";
+    child.stdout?.on("data", (chunk) => (out += String(chunk)));
+    child.stderr?.on("data", (chunk) => (out += String(chunk)));
+    const gateway = `http://127.0.0.1:${originPort}`;
+    try {
+      const deadline = Date.now() + 60_000;
+      while (!out.includes("open or scan:") && Date.now() < deadline && child.exitCode === null) await new Promise((r) => setTimeout(r, 200));
+      expect(out).toContain(`OpenMausBot is running on http://127.0.0.1:${port}, reachable at ${stub.endpointUrl}`);
+      expect(out).toContain(`open or scan:  ${stub.endpointUrl}/pair#code=`);
+      // a fresh connector token was fetched for this run
+      expect(stub.calls).toContain("POST /v1/installations/self/endpoint");
+
+      // the gateway comes up with the guardian; through it the harness is reachable...
+      let descriptor: Response | null = null;
+      const gatewayDeadline = Date.now() + 20_000;
+      while (Date.now() < gatewayDeadline) {
+        try {
+          descriptor = await fetch(`${gateway}/.well-known/openmausbot/environment`);
+          if (descriptor.status === 200) break;
+        } catch {
+          descriptor = null;
+        }
+        await new Promise((r) => setTimeout(r, 250));
+      }
+      expect(descriptor?.status).toBe(200);
+      // ...but a request with no headers at all, which the loopback listener would take as the owner, is a stranger here
+      const stranger = await fetch(`${gateway}/api/bots`);
+      expect(stranger.status).toBe(403);
+      expect(((await stranger.json()) as { error: string }).error).toMatch(/through a proxy/);
+      expect(await (await fetch(`${gateway}/api/health`)).json()).toEqual({ app: "openmausbot" });
+      expect(typeof ((await (await fetch(`http://127.0.0.1:${port}/api/health`)).json()) as { pid: unknown }).pid).toBe("number");
+      // the printed code pairs a device through the gateway, and its session is honoured there
+      const match = /pairing code:  ([A-Z2-9-]+)/.exec(out);
+      expect(match).toBeTruthy();
+      const paired = await fetch(`${gateway}/api/auth/pair`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-forwarded-for": "203.0.113.9" },
+        body: JSON.stringify({ code: match?.[1] ?? "", label: "phone" }),
+      });
+      expect(paired.status).toBe(200);
+      const { token } = (await paired.json()) as { token: string };
+      const mine = await fetch(`${gateway}/api/auth/session`, { headers: { authorization: `Bearer ${token}` } });
+      expect(mine.status).toBe(200);
+    } finally {
+      child.kill("SIGTERM");
+      await exited(child);
+      await stub.close();
+      await removeTempDir(home);
+    }
+    for (const url of [`${gateway}/api/health`, `http://127.0.0.1:${port}/api/health`]) {
+      let dead = false;
+      try {
+        await fetch(url);
+      } catch {
+        dead = true;
+      }
+      expect(dead, url).toBe(true);
+    }
+  }, 120_000);
 });

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -5,44 +5,67 @@
 // file next to the server.
 //
 //   openmausbot serve [--port 8799] [--data-dir ~/.openmausbot] [--label "cab mini"]
-//                     [--public-url https://host] [--tailscale] [--no-pair]
+//                     [--public-url https://host] [--tailscale | --tunnel] [--no-pair]
 //   openmausbot pair  [--label "My MacBook"] [--client] [--public-url https://host]
 //   openmausbot sessions [revoke <id>]
 //   openmausbot status
+//   openmausbot login [--email you@example.com]
+//   openmausbot logout
 //
 // `serve` starts the server, waits for it, and prints a pairing link with a
 // QR code: scan it with the phone or open it on a laptop. `--tailscale` asks
 // Tailscale to terminate HTTPS for it and uses the MagicDNS name in the link.
+// `--tunnel` (after `login`) serves at a public https://….openmausbot.com
+// address through a Cloudflare tunnel: no domain, no proxy, no open port.
 //
 // This module only exports; openmausbot.ts is the entry that runs main(), so
 // bundling this file into other entries (pair-cli.ts) never runs it twice.
 import { spawn, type ChildProcess } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { createInterface } from "node:readline/promises";
 import { fileURLToPath } from "node:url";
 import qrcode from "qrcode-terminal";
 
 import { explainTailscaleFailure, tailscaleServe, tailscaleServeOff, tailscaleStatus, type TailscaleStatus } from "./tailscale.ts";
+import {
+  cleanupTunnelOrigin,
+  createTunnelAccount,
+  createTunnelOrigin,
+  describeTunnelAccount,
+  describeTunnelState,
+  ensureCloudflared,
+  guardianEntry,
+  startTunnel,
+  tunnelAccess,
+  type CompanionOriginEndpoint,
+  type ManagedTunnelAccess,
+  type RunningTunnel,
+} from "./tunnel.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
 export interface CliOptions {
-  command: "serve" | "pair" | "sessions" | "status" | "help";
+  command: "serve" | "pair" | "sessions" | "status" | "login" | "logout" | "help";
   port: number;
   dataDir: string;
   label?: string;
   publicUrl?: string;
   tailscale: boolean;
+  tunnel: boolean;
   client: boolean;
   pair: boolean;
   revoke?: string;
+  email?: string;
   json: boolean;
 }
 
+const COMMANDS = ["serve", "pair", "sessions", "status", "login", "logout", "help", "--help", "-h"];
+
 export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): CliOptions | { error: string } {
   const [command = "help", ...rest] = argv;
-  if (!["serve", "pair", "sessions", "status", "help", "--help", "-h"].includes(command)) {
+  if (!COMMANDS.includes(command)) {
     return { error: `unknown command "${command}"` };
   }
   const options: CliOptions = {
@@ -50,6 +73,7 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
     port: Number(env.OMB_PORT || 8799),
     dataDir: env.OMB_DATA_DIR || join(homedir(), ".openmausbot"),
     tailscale: false,
+    tunnel: false,
     client: false,
     pair: true,
     json: false,
@@ -68,9 +92,11 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
       else if (arg === "--label") options.label = value();
       else if (arg === "--public-url") options.publicUrl = value().replace(/\/+$/, "");
       else if (arg === "--tailscale") options.tailscale = true;
+      else if (arg === "--tunnel") options.tunnel = true;
       else if (arg === "--client") options.client = true;
       else if (arg === "--no-pair") options.pair = false;
       else if (arg === "--json") options.json = true;
+      else if (arg === "--email") options.email = value();
       else if (options.command === "sessions" && arg === "revoke") options.revoke = value();
       else return { error: `unknown argument "${arg}"` };
     } catch (error) {
@@ -79,26 +105,71 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
   }
   if (!Number.isInteger(options.port) || options.port < 1 || options.port > 65_535) return { error: "--port must be 1-65535" };
   if (options.publicUrl && !/^https?:\/\//.test(options.publicUrl)) return { error: "--public-url must start with http:// or https://" };
+  if (options.tailscale && options.tunnel) return { error: "choose one of --tailscale (your tailnet) and --tunnel (a public address)" };
   return options;
 }
 
 export const USAGE = `openmausbot — run the server anywhere, pair devices to it
 
   openmausbot serve [--port 8799] [--data-dir DIR] [--label NAME]
-                    [--public-url https://host] [--tailscale] [--no-pair]
+                    [--public-url https://host] [--tailscale | --tunnel] [--no-pair]
   openmausbot pair  [--label NAME] [--client] [--public-url https://host]
   openmausbot sessions [revoke ID]
   openmausbot status
+  openmausbot login [--email you@example.com]
+  openmausbot logout
 
 serve   starts the server and prints a pairing link + QR code
 pair    mints a pairing code against a running server (--client: chat only)
 sessions lists paired devices; "sessions revoke ID" signs one out
 status  what the server says about itself
+login   signs this machine in to an OpenMausBot account (an emailed code)
+        and reserves its public address for --tunnel
+logout  releases that address and signs out
 
 --tailscale  serve over your tailnet: Tailscale terminates HTTPS and the
              link uses this machine's MagicDNS name (needs Tailscale signed in
              and HTTPS certificates enabled for the tailnet)
+--tunnel     serve at a public https://….openmausbot.com address through a
+             Cloudflare tunnel: no domain, no proxy, no open port. Run
+             \`openmausbot login\` once on this machine first.
 `;
+
+/** Terminal in, terminal out; tests substitute all three. */
+export interface CliIo {
+  log(line: string): void;
+  error(line: string): void;
+  ask(question: string): Promise<string>;
+}
+
+export function defaultIo(): CliIo {
+  return {
+    log: (line) => console.log(line),
+    error: (line) => console.error(line),
+    ask: async (question) => {
+      const rl = createInterface({ input: process.stdin, output: process.stdout });
+      try {
+        return await rl.question(question);
+      } finally {
+        rl.close();
+      }
+    },
+  };
+}
+
+/** The version this command ships with: package.json is one level up in the
+ * npm package (dist-server/), the image and a checkout (server/). */
+export function serverVersion(here = HERE): string {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(resolve(here, "..", "package.json"), "utf8"));
+    const version = typeof parsed === "object" && parsed !== null ? Reflect.get(parsed, "version") : undefined;
+    return typeof version === "string" && version ? version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+const message = (error: unknown) => (error instanceof Error ? error.message : String(error));
 
 // ── talking to a running server (loopback = owner) ────────────────────
 async function api(port: number, path: string, init: { method?: string; body?: string } = {}): Promise<{ status: number; body: any }> {
@@ -199,16 +270,86 @@ export function formatSessions(sessions: Array<{ id: string; label: string; scop
   return [line(head), ...rows.map(line), "", "revoke one with: openmausbot sessions revoke <id>"].join("\n");
 }
 
-export async function runStatus(options: CliOptions): Promise<number> {
+export async function runStatus(options: CliOptions, io: CliIo = defaultIo()): Promise<number> {
+  let code = 0;
   try {
     const res = await fetch(`http://127.0.0.1:${options.port}/.well-known/openmausbot/environment`);
     const body: any = await res.json();
-    console.log(options.json ? JSON.stringify(body, null, 2) : `${body.label} · OpenMausBot ${body.version} on ${body.platform} · id ${body.environmentId}`);
-    return 0;
+    io.log(options.json ? JSON.stringify(body, null, 2) : `${body.label} · OpenMausBot ${body.version} on ${body.platform} · id ${body.environmentId}`);
   } catch {
-    console.error(`no OpenMausBot server on http://127.0.0.1:${options.port}`);
+    io.error(`no OpenMausBot server on http://127.0.0.1:${options.port}`);
+    code = 1;
+  }
+  if (!options.json) {
+    const account = describeTunnelAccount(createTunnelAccount({ dataDir: options.dataDir, version: serverVersion() }).credentials.read());
+    if (account.address) io.log(`public address: ${account.address} (signed in as ${account.email ?? "?"}; serve it with --tunnel)`);
+  }
+  return code;
+}
+
+export async function runLogin(options: CliOptions, io: CliIo = defaultIo()): Promise<number> {
+  const account = createTunnelAccount({ dataDir: options.dataDir, version: serverVersion() });
+  if (account.credentials.status === "unavailable") {
+    io.error(`${account.credentials.file} exists but could not be read; fix or remove it, then try again`);
     return 1;
   }
+  if (!account.controlPlane) {
+    io.error("OMB_CONTROL_PLANE_URL is set but is not an https address");
+    return 1;
+  }
+  const existing = describeTunnelAccount(account.credentials.read());
+  if (existing.address) io.log(`already signed in as ${existing.email ?? "?"} (${existing.address}); signing in again refreshes it`);
+  const email = (options.email ?? (await io.ask("Email for your OpenMausBot account: "))).trim();
+  if (!email) {
+    io.error("an email address is needed: openmausbot login --email you@example.com");
+    return 1;
+  }
+  try {
+    await account.service.requestCode(email);
+  } catch (error) {
+    io.error(`could not send a sign-in code: ${message(error)}`);
+    return 1;
+  }
+  const code = (await io.ask(`Enter the 8-digit code we emailed to ${email}: `)).trim();
+  let state;
+  try {
+    state = await account.service.verifyCode(email, code);
+  } catch (error) {
+    io.error(`sign-in failed: ${message(error)}`);
+    return 1;
+  }
+  const signedIn = describeTunnelAccount(account.credentials.read());
+  if (!signedIn.address) {
+    io.error(`signed in, but no public address was issued${state.message ? `: ${state.message}` : ""}`);
+    return 1;
+  }
+  io.log(`Signed in as ${signedIn.email ?? email}.`);
+  io.log(`This machine's public address: ${signedIn.address}`);
+  io.log("Serve there with:  openmausbot serve --tunnel");
+  return 0;
+}
+
+export async function runLogout(options: CliOptions, io: CliIo = defaultIo()): Promise<number> {
+  const account = createTunnelAccount({ dataDir: options.dataDir, version: serverVersion() });
+  const before = describeTunnelAccount(account.credentials.read());
+  if (!before.email) {
+    io.log("this machine is not signed in");
+    return 0;
+  }
+  let state;
+  try {
+    state = await account.service.signOut();
+  } catch (error) {
+    io.error(`sign-out failed: ${message(error)}`);
+    return 1;
+  }
+  const after = describeTunnelAccount(account.credentials.read());
+  if (after.email) {
+    io.error(`still signed in${state.message ? `: ${state.message}` : ""}`);
+    return 1;
+  }
+  io.log(`Signed out ${before.email}${before.address ? `; ${before.address} is released` : ""}.`);
+  return 0;
 }
 
 /** Where the server bundle lives relative to this file: next to it in the
@@ -227,6 +368,41 @@ export function serverEntry(here = HERE): { command: string; args: string[]; sta
   return { command: process.execPath, args: ["--experimental-strip-types", source], staticDir, skillsDir: existsSync(join(root, "skills")) ? join(root, "skills") : null };
 }
 
+interface TunnelPlan {
+  access: ManagedTunnelAccess;
+  binary: string;
+  guardian: string;
+  origin: CompanionOriginEndpoint;
+}
+
+/** Everything `--tunnel` needs before the server starts, or the one reason
+ * it cannot have it. Fails closed: no silent fallback to a local-only server. */
+async function planTunnel(options: CliOptions, log: (line: string) => void): Promise<TunnelPlan | { error: string }> {
+  const account = createTunnelAccount({ dataDir: options.dataDir, version: serverVersion() });
+  if (account.credentials.status === "unavailable") return { error: `${account.credentials.file} exists but could not be read; fix or remove it` };
+  if (!describeTunnelAccount(account.credentials.read()).email) {
+    return { error: "no account on this machine yet: run `openmausbot login` first, then `openmausbot serve --tunnel`" };
+  }
+  // A fresh connector token when the control plane answers; the saved one otherwise.
+  try {
+    const state = await account.service.retry();
+    if (state.message && !tunnelAccess(account.credentials.read())) log(`tunnel: ${state.message}`);
+  } catch (error) {
+    log(`tunnel: control plane not reachable right now (${message(error)}); using the saved address`);
+  }
+  const access = tunnelAccess(account.credentials.read());
+  if (!access) return { error: "this machine has no public address; run `openmausbot login` again" };
+  let binary: string;
+  try {
+    binary = await ensureCloudflared({ dataDir: options.dataDir, log });
+  } catch (error) {
+    return { error: `--tunnel: ${message(error)}` };
+  }
+  const guardian = guardianEntry();
+  if (!guardian) return { error: "--tunnel: the connector guardian is missing from this install" };
+  return { access, binary, guardian, origin: createTunnelOrigin() };
+}
+
 export async function runServe(options: CliOptions, log: (line: string) => void = console.log): Promise<number> {
   if (await serverUp(options.port)) {
     console.error(`something already answers on http://127.0.0.1:${options.port}; use \`openmausbot pair\` against it, or --port for a second server`);
@@ -242,6 +418,17 @@ export async function runServe(options: CliOptions, log: (line: string) => void 
     }
     tailscale = probe.status;
   }
+  let plan: TunnelPlan | null = null;
+  if (options.tunnel) {
+    const planned = await planTunnel(options, log);
+    if ("error" in planned) {
+      console.error(planned.error);
+      return 1;
+    }
+    plan = planned;
+    if (publicUrl && publicUrl !== plan.access.endpoint) log(`note: --public-url is ignored with --tunnel; the address is ${plan.access.endpoint}`);
+    publicUrl = plan.access.endpoint;
+  }
   const entry = serverEntry();
   if (!entry.staticDir) log("note: no built UI found next to the server; the API runs but browsers get no page (build with `pnpm exec vite build`)");
   const env: NodeJS.ProcessEnv = {
@@ -253,6 +440,7 @@ export async function runServe(options: CliOptions, log: (line: string) => void 
   if (entry.staticDir) env.OMB_STATIC_DIR = entry.staticDir;
   if (entry.skillsDir && !process.env.OMB_SKILLS_DIR) env.OMB_SKILLS_DIR = entry.skillsDir;
   if (options.label && !process.env.OMB_ENVIRONMENT_LABEL) env.OMB_ENVIRONMENT_LABEL = options.label;
+  if (plan) env.OMB_TUNNEL_SOCKET = plan.origin.socketPath;
   if (tailscale) {
     const served = await tailscaleServe(tailscale, options.port);
     if ("failure" in served) {
@@ -269,9 +457,17 @@ export async function runServe(options: CliOptions, log: (line: string) => void 
   child.on("exit", (code) => {
     exited = code ?? 1;
   });
-  const stop = async () => {
-    if (tailscale) await tailscaleServeOff(tailscale).catch(() => undefined);
-    if (exited === null) child.kill("SIGTERM");
+  let tunnel: RunningTunnel | null = null;
+  let stopping: Promise<void> | null = null;
+  const stop = () => {
+    stopping ??= (async () => {
+      // The gateway stops accepting before the server it forwards to goes away.
+      if (tunnel) await tunnel.stop().catch(() => undefined);
+      if (tailscale) await tailscaleServeOff(tailscale).catch(() => undefined);
+      if (exited === null) child.kill("SIGTERM");
+      if (plan) cleanupTunnelOrigin(plan.origin);
+    })();
+    return stopping;
   };
   process.on("SIGINT", () => void stop());
   process.on("SIGTERM", () => void stop());
@@ -281,11 +477,25 @@ export async function runServe(options: CliOptions, log: (line: string) => void 
     if (await serverUp(options.port)) break;
     await new Promise((r) => setTimeout(r, 250));
   }
-  if (exited !== null) return exited;
+  if (exited !== null) {
+    if (plan) cleanupTunnelOrigin(plan.origin);
+    return exited;
+  }
   if (!(await serverUp(options.port))) {
     console.error("the server did not answer within a minute; see its output above");
     await stop();
     return 1;
+  }
+  if (plan && child.pid) {
+    tunnel = startTunnel({
+      dataDir: options.dataDir,
+      access: plan.access,
+      originTarget: { pid: child.pid, socketPath: plan.origin.socketPath },
+      binaryPath: plan.binary,
+      guardian: plan.guardian,
+      onState: (state) => log(describeTunnelState(state, plan.access.endpoint)),
+    });
+    tunnel.started.catch((error: unknown) => log(`tunnel: ${message(error)}`));
   }
   log("");
   log(`OpenMausBot is running on http://127.0.0.1:${options.port}${publicUrl ? `, reachable at ${publicUrl}` : ""}`);
@@ -298,7 +508,9 @@ export async function runServe(options: CliOptions, log: (line: string) => void 
   }
   log("stop with Ctrl+C");
   return await new Promise<number>((resolveExit) => {
-    child.on("exit", (code) => resolveExit(code ?? 0));
+    child.on("exit", (code) => {
+      void stop().finally(() => resolveExit(code ?? 0));
+    });
   });
 }
 
@@ -317,6 +529,10 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
       return runSessions(options);
     case "status":
       return runStatus(options);
+    case "login":
+      return runLogin(options);
+    case "logout":
+      return runLogout(options);
     default:
       console.log(USAGE);
       return 0;

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -284,7 +284,7 @@ const uploadAvatar = async (mime = "image/png"): Promise<string> => {
 
 const statusWithHeaders = (headers: Record<string, string>): Promise<number> =>
   new Promise((resolve, reject) => {
-    const req = request({ hostname: "127.0.0.1", port: PORT, path: "/api/health", headers }, (res) => {
+    const req = request({ hostname: "127.0.0.1", port: PORT, path: "/api/bots", headers }, (res) => {
       res.resume();
       resolve(res.statusCode ?? 0);
     });
@@ -866,6 +866,20 @@ describe("harness HTTP API", () => {
 
   it("rejects non-loopback authorities while accepting IPv4 and IPv6 loopback forms", async () => {
     expect(await statusWithHeaders({ host: "example.com" })).toBe(403);
+    // The one exception: the reachability probe answers strangers with the app name and nothing else
+    // (the phone's route race and the tunnel verifier need it before they can pair).
+    // (node's fetch drops a custom Host header, so this goes through http.request)
+    const probe = await new Promise<{ status: number; body: unknown }>((resolve, reject) => {
+      const req = request({ hostname: "127.0.0.1", port: PORT, path: "/api/health", headers: { host: "example.com" } }, (res) => {
+        let raw = "";
+        res.on("data", (chunk) => (raw += chunk));
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, body: JSON.parse(raw) }));
+      });
+      req.on("error", reject);
+      req.end();
+    });
+    expect(probe.status).toBe(200);
+    expect(probe.body).toEqual({ app: "openmausbot" });
     expect(await statusWithHeaders({ origin: "https://example.com" })).toBe(403);
     expect(await statusWithHeaders({ host: `127.0.0.2:${PORT}` })).toBe(200);
     expect(await statusWithHeaders({ host: `[::1]:${PORT}` })).toBe(200);

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,7 +2,7 @@
 // (upstream rule): the React app dispatches typed commands over HTTP and
 // folds one SSE event stream; every provider process runs here.
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
-import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, unlinkSync } from "node:fs";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { extname, join } from "node:path";
 
@@ -7212,7 +7212,7 @@ function readBody(req: IncomingMessage, limit = 1_000_000): Promise<any> {
 // onto it. Reject non-loopback Hosts outright (defeats rebinding) and
 // origins outside loopback (blocks remote-web CSRF).
 
-const server = createServer(async (req, res) => {
+const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
   const url = new URL(req.url ?? "/", `http://localhost:${PORT}`);
   const path = url.pathname;
   const method = req.method ?? "GET";
@@ -7259,6 +7259,13 @@ const server = createServer(async (req, res) => {
       url,
       loopbackMutationToken: desktopMutationToken,
     });
+    // Reachability probe, public: the phone races it across a server's
+    // addresses before it has a session, and the tunnel verifier polls it.
+    // A stranger learns only the app name; pid (the desktop boot probe keys
+    // on it) and the static flag stay behind the gate below.
+    if (method === "GET" && path === "/api/health" && !gate.auth) {
+      return json(res, 200, { app: "openmausbot" });
+    }
     if (!gate.auth) return json(res, gate.status, { error: gate.error });
     const auth = gate.auth;
 
@@ -12224,7 +12231,9 @@ const server = createServer(async (req, res) => {
     const status = (e as any)?.status ?? 500;
     return json(res, status, { error: e instanceof Error ? e.message : String(e) });
   }
-});
+};
+
+const server = createServer(handleRequest);
 
 calendarCalls.start();
 
@@ -12235,6 +12244,21 @@ console.log(describeBrand(loadBrand()));
 server.listen(PORT, "127.0.0.1", () => {
   console.log(`openmausbot server on http://127.0.0.1:${PORT}`);
 });
+
+// A second listener for `openmausbot serve --tunnel` (server/tunnel.ts): the
+// connector gateway on this machine forwards public traffic to this IPC path.
+// Nothing changes about the loopback bind above. Requests arriving here have
+// no peer address, which request-auth treats as "through a proxy": a session
+// is required, never loopback trust, whatever headers the request carries.
+const TUNNEL_SOCKET = process.env.OMB_TUNNEL_SOCKET?.trim() || null;
+let tunnelListener: ReturnType<typeof createServer> | null = null;
+if (TUNNEL_SOCKET) {
+  if (process.platform !== "win32") rmSync(TUNNEL_SOCKET, { force: true });
+  tunnelListener = createServer(handleRequest);
+  tunnelListener.listen(TUNNEL_SOCKET, () => {
+    console.log(`openmausbot tunnel listener on ${TUNNEL_SOCKET}`);
+  });
+}
 
 const gracefulShutdown = createGracefulShutdown({
   cleanup: [
@@ -12249,6 +12273,7 @@ const gracefulShutdown = createGracefulShutdown({
       routines?.stop();
       calendarCalls?.stop();
       webhookIngress?.server.close();
+      tunnelListener?.close();
     },
     () => releaseAllBrowserCapabilities(),
     () => registry.disposeAll(),

--- a/server/request-auth.test.ts
+++ b/server/request-auth.test.ts
@@ -8,6 +8,7 @@ import {
   clearSessionCookie,
   clientBotPatchViolation,
   clientGroupPatchViolation,
+  ipcPeer,
   isAllowedOrigin,
   isLoopbackHost,
   isProxied,
@@ -16,8 +17,8 @@ import {
   requestOrigin,
   requestSource,
   requiredScope,
-  sanitizeSource,
   resolveRequestAuth,
+  sanitizeSource,
   serializeSessionCookie,
   sessionCookieName,
 } from "./request-auth.ts";
@@ -263,5 +264,41 @@ describe("resolveRequestAuth", () => {
     expect(remote.error).toMatch(/expired or was revoked; pair this device again/);
     // the owner on the same machine keeps working even with a stale cookie
     expect(resolve({ host: "127.0.0.1:8799", cookie: `${cookieName}=${token}` }).auth?.kind).toBe("loopback");
+  });
+});
+
+describe("an IPC listener (openmausbot serve --tunnel) is remote by construction", () => {
+  // SAFETY: only headers, method and the socket peer are read; a unix-socket peer has no address
+  const overSocket = (headers: Record<string, string>) => ({ headers, method: "GET", socket: {} }) as unknown as IncomingMessage;
+
+  it("counts as proxied whatever the headers say; a bare mock without a socket does not", () => {
+    expect(ipcPeer(overSocket({ host: "127.0.0.1:8799" }))).toBe(true);
+    expect(isProxied(overSocket({ host: "localhost" }))).toBe(true);
+    expect(ipcPeer(request({ host: "127.0.0.1:8799" }))).toBe(false);
+    expect(isProxied(request({ host: "127.0.0.1:8799" }))).toBe(false);
+  });
+
+  it("attributes pairing attempts to the address the tunnel forwarded", () => {
+    expect(requestSource(overSocket({ "x-forwarded-for": "203.0.113.9" }))).toBe("203.0.113.9");
+    expect(requestSource(overSocket({}))).toBe("unknown");
+  });
+
+  it("never grants loopback trust over the socket, even with a loopback Host and no forwarded headers; a session works", () => {
+    const dir = mkdtempSync(join(tmpdir(), "omb-auth-ipc-"));
+    try {
+      const sessions = new SessionRegistry({ file: join(dir, "sessions.json") });
+      const gate = { sessions, cookieName: "omb_session_test", streamPath: "/api/events", url: new URL("/api/bots", "http://x") };
+      const denied = resolveRequestAuth(overSocket({ host: "127.0.0.1:8799" }), gate);
+      expect(denied.auth).toBeNull();
+      expect(denied.status).toBe(403);
+      expect(denied.error).toMatch(/through a proxy/);
+      const { code } = sessions.openPairing({ scopes: ["admin", "client"] });
+      const paired = sessions.exchange({ code, label: "phone", source: "203.0.113.9" });
+      if (!paired.ok) throw new Error(paired.error);
+      const admitted = resolveRequestAuth(overSocket({ host: "c-1.openmausbot.com", authorization: `Bearer ${paired.token}` }), gate);
+      expect(admitted.auth?.kind).toBe("session");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/server/request-auth.ts
+++ b/server/request-auth.ts
@@ -81,7 +81,17 @@ export function requestOrigin(req: IncomingMessage): string | null {
  * must not turn a remote client into the owner. */
 export function isProxied(req: IncomingMessage): boolean {
   const h = req.headers;
-  return Boolean(h["x-forwarded-for"] || h["x-forwarded-proto"] || h["x-forwarded-host"] || h["forwarded"]);
+  return ipcPeer(req) || Boolean(h["x-forwarded-for"] || h["x-forwarded-proto"] || h["x-forwarded-host"] || h["forwarded"]);
+}
+
+/** A request over an IPC listener (a unix socket or a named pipe) has no peer
+ * address. Only a gateway on this machine can reach such a listener, and it
+ * is there to forward traffic from elsewhere (`openmausbot serve --tunnel`),
+ * so the request is remote by construction: whatever headers it carries or
+ * lacks, it never gets loopback trust. */
+export function ipcPeer(req: IncomingMessage): boolean {
+  const socket = req.socket;
+  return Boolean(socket) && socket.remoteAddress === undefined && socket.remoteFamily === undefined;
 }
 
 /** Origin absent (non-browser) or equal to this request's own origin. */
@@ -99,7 +109,8 @@ export function isSameOrigin(req: IncomingMessage): boolean {
  * an interface) is the source itself, and its forwarded header is ignored. */
 export function requestSource(req: IncomingMessage): string {
   const peer = req.socket?.remoteAddress || "unknown";
-  const viaLocalProxy = peer === "127.0.0.1" || peer === "::1" || peer === "::ffff:127.0.0.1";
+  // An IPC listener's only peer is the tunnel gateway on this machine.
+  const viaLocalProxy = ipcPeer(req) || peer === "127.0.0.1" || peer === "::1" || peer === "::ffff:127.0.0.1";
   // The LAST hop is the one the adjacent (trusted, same-machine) proxy wrote;
   // earlier hops are whatever the client or an outer proxy put there.
   const hops = viaLocalProxy ? (headerValue(req.headers["x-forwarded-for"]) ?? "").split(",").map((h) => h.trim()).filter(Boolean) : [];

--- a/server/testing/control-plane-stub.ts
+++ b/server/testing/control-plane-stub.ts
@@ -1,0 +1,151 @@
+// A stand-in for cloudflare/control-plane for tests of `openmausbot login`
+// and `serve --tunnel`: the routes the desktop's control-plane client uses,
+// answering in the shapes its validators accept. Authorization is only "is
+// this a credential this stub issued". Records every call so a test can
+// assert what the client did, not only what it got.
+import { randomBytes, randomUUID } from "node:crypto";
+import { createServer, type IncomingMessage } from "node:http";
+
+interface StubInstallation {
+  id: string;
+  clientInstanceId: string;
+  name: string;
+  platform: string;
+  appVersion: string | null;
+  credential: string;
+}
+
+export interface ControlPlaneStub {
+  url: string;
+  otp: string;
+  endpointUrl: string;
+  connectorToken: string;
+  /** "METHOD /path", in order. */
+  calls: string[];
+  installations: Map<string, StubInstallation>;
+  close(): Promise<void>;
+}
+
+const NINETY_DAYS = 90 * 24 * 60 * 60 * 1000;
+
+const newCredential = () => `omb_install_${randomBytes(16).toString("base64url")}.${randomBytes(32).toString("base64url")}`;
+
+async function readJson(req: IncomingMessage): Promise<Record<string, unknown>> {
+  let raw = "";
+  for await (const chunk of req) raw += chunk;
+  const parsed: unknown = raw ? JSON.parse(raw) : {};
+  return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed) ? Object.fromEntries(Object.entries(parsed)) : {};
+}
+
+export async function startControlPlaneStub(options: { otp?: string; endpointUrl?: string } = {}): Promise<ControlPlaneStub> {
+  const otp = options.otp ?? "24681357";
+  const endpointUrl = options.endpointUrl ?? "https://c-stub.openmausbot.invalid";
+  const connectorToken = `stub-connector-${randomBytes(48).toString("base64url")}`;
+  const accountTokens = new Set<string>();
+  const installations = new Map<string, StubInstallation>();
+  const calls: string[] = [];
+  const publicView = (inst: StubInstallation) => ({
+    id: inst.id,
+    clientInstanceId: inst.clientInstanceId,
+    name: inst.name,
+    platform: inst.platform,
+    appVersion: inst.appVersion,
+    createdAt: 1,
+    updatedAt: 1,
+    lastSeenAt: null,
+  });
+  const endpoint = () => ({
+    url: endpointUrl,
+    hostname: new URL(endpointUrl).hostname,
+    status: "active",
+    generation: 1,
+    updatedAt: 1,
+    lastReconciledAt: 1,
+    lastErrorCode: null,
+  });
+
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", "http://stub");
+    const method = req.method ?? "GET";
+    const path = url.pathname;
+    calls.push(`${method} ${path}`);
+    const bearer = /^Bearer (.+)$/.exec(req.headers.authorization ?? "")?.[1] ?? "";
+    const send = (status: number, body?: unknown, headers: Record<string, string> = {}) => {
+      res.writeHead(status, { "content-type": "application/json", ...headers });
+      res.end(body === undefined ? "" : JSON.stringify(body));
+    };
+    const byCredential = () => [...installations.values()].find((inst) => inst.credential === bearer) ?? null;
+    const account = accountTokens.has(bearer);
+
+    if (method === "GET" && path === "/healthz") return send(200, { ok: true, service: "openmausbot-control-plane" });
+    if (method === "POST" && path === "/api/auth/email-otp/send-verification-otp") {
+      await readJson(req);
+      return send(200, { success: true });
+    }
+    if (method === "POST" && path === "/api/auth/sign-in/email-otp") {
+      const body = await readJson(req);
+      if (body.otp !== otp) return send(401, { error: "invalid_otp", message: "Invalid code" });
+      const token = `acct_${randomBytes(24).toString("base64url")}`;
+      accountTokens.add(token);
+      return send(200, { token: "db-token-never-used", user: { id: "user_stub", email: body.email, name: "stub", emailVerified: true } }, { "set-auth-token": token });
+    }
+    if (method === "POST" && path === "/api/auth/sign-out") return send(200, { success: true });
+    if (method === "GET" && path === "/v1/me") {
+      return account ? send(200, { user: { id: "user_stub", email: "stub@example.test", name: "stub", emailVerified: true } }) : send(401, { error: "unauthorized" });
+    }
+    if (path === "/v1/installations" && method === "GET") {
+      return account ? send(200, { installations: [...installations.values()].map(publicView) }) : send(401, { error: "unauthorized" });
+    }
+    if (path === "/v1/installations" && method === "POST") {
+      if (!account) return send(401, { error: "unauthorized" });
+      const body = await readJson(req);
+      const inst: StubInstallation = {
+        id: randomUUID(),
+        clientInstanceId: String(body.clientInstanceId ?? ""),
+        name: String(body.name ?? "This computer"),
+        platform: String(body.platform ?? "linux"),
+        appVersion: typeof body.appVersion === "string" ? body.appVersion : null,
+        credential: newCredential(),
+      };
+      installations.set(inst.id, inst);
+      return send(201, { installation: publicView(inst), credential: inst.credential, credentialExpiresAt: Date.now() + NINETY_DAYS });
+    }
+    const rotate = /^\/v1\/installations\/([^/]+)\/credentials\/rotate$/.exec(path);
+    if (rotate && method === "POST") {
+      if (!account) return send(401, { error: "unauthorized" });
+      const inst = installations.get(decodeURIComponent(rotate[1]));
+      if (!inst) return send(404, { error: "not_found" });
+      inst.credential = newCredential();
+      return send(201, { credential: inst.credential, createdAt: Date.now(), credentialExpiresAt: Date.now() + NINETY_DAYS });
+    }
+    if (path === "/v1/installations/self" && method === "GET") {
+      const inst = byCredential();
+      return inst ? send(200, { installation: publicView(inst), credentialExpiresAt: Date.now() + NINETY_DAYS }) : send(401, { error: "unauthorized" });
+    }
+    if (path === "/v1/installations/self/endpoint") {
+      if (!byCredential()) return send(401, { error: "unauthorized" });
+      if (method === "GET") return send(200, { endpoint: endpoint() });
+      if (method === "POST") return send(200, { endpoint: endpoint(), connectorToken });
+      if (method === "DELETE") return send(204);
+    }
+    const one = /^\/v1\/installations\/([^/]+)$/.exec(path);
+    if (one && method === "DELETE") {
+      if (!account) return send(401, { error: "unauthorized" });
+      installations.delete(decodeURIComponent(one[1]));
+      return send(204);
+    }
+    return send(404, { error: "not_found" });
+  });
+  await new Promise<void>((done) => server.listen(0, "127.0.0.1", done));
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    otp,
+    endpointUrl,
+    connectorToken,
+    calls,
+    installations,
+    close: () => new Promise<void>((done) => server.close(() => done())),
+  };
+}

--- a/server/tunnel.test.ts
+++ b/server/tunnel.test.ts
@@ -1,0 +1,203 @@
+import { chmodSync, existsSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runLogin, runLogout, runStatus, type CliIo, type CliOptions } from "./cli.ts";
+import { removeTempDir } from "./testing/cleanup.ts";
+import { startControlPlaneStub, type ControlPlaneStub } from "./testing/control-plane-stub.ts";
+import {
+  cleanupTunnelOrigin,
+  createTunnelOrigin,
+  describeTunnelAccount,
+  describeTunnelState,
+  guardianEntry,
+  openTunnelCredentials,
+  platformName,
+  prepareEntry,
+  startTunnel,
+  TUNNEL_CREDENTIALS_FILE,
+  tunnelAccess,
+} from "./tunnel.ts";
+
+const posix = process.platform !== "win32";
+
+function options(dataDir: string, extra: Partial<CliOptions> = {}): CliOptions {
+  return { command: "login", port: 1, dataDir, tailscale: false, tunnel: false, client: false, pair: true, json: false, ...extra };
+}
+
+function fakeIo(answers: string[]) {
+  const out: string[] = [];
+  const err: string[] = [];
+  const io: CliIo = { log: (line) => out.push(line), error: (line) => err.push(line), ask: async () => answers.shift() ?? "" };
+  return { io, out, err };
+}
+
+describe("tunnel credentials: a private file, and unreadable is not empty", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "omb-tunnel-cred-"));
+  });
+  afterEach(() => removeTempDir(dir));
+
+  it("starts empty, writes 0600, and re-tightens a loosened file on open", async () => {
+    const fresh = openTunnelCredentials(dir);
+    expect(fresh.status).toBe("empty");
+    await fresh.update((doc) => ({ ...doc, hello: "world" }));
+    const file = join(dir, TUNNEL_CREDENTIALS_FILE);
+    expect(JSON.parse(readFileSync(file, "utf8"))).toEqual({ hello: "world" });
+    if (posix) {
+      expect(statSync(file).mode & 0o777).toBe(0o600);
+      chmodSync(file, 0o644);
+      expect(openTunnelCredentials(dir).status).toBe("ok");
+      expect(statSync(file).mode & 0o777).toBe(0o600);
+    }
+    expect(openTunnelCredentials(dir).read()).toEqual({ hello: "world" });
+  });
+
+  it("refuses to write over a file it could not read, so a real account is never replaced by a fresh one", async () => {
+    writeFileSync(join(dir, TUNNEL_CREDENTIALS_FILE), "{not json");
+    const broken = openTunnelCredentials(dir);
+    expect(broken.status).toBe("unavailable");
+    await expect(broken.update((doc) => ({ ...doc, x: 1 }))).rejects.toThrow(/could not be read/);
+    expect(readFileSync(join(dir, TUNNEL_CREDENTIALS_FILE), "utf8")).toBe("{not json");
+  });
+});
+
+describe("login and logout against the control plane", () => {
+  let dir: string;
+  let stub: ControlPlaneStub;
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "omb-tunnel-login-"));
+    stub = await startControlPlaneStub();
+    vi.stubEnv("OMB_CONTROL_PLANE_URL", stub.url);
+  });
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await stub.close();
+    await removeTempDir(dir);
+  });
+
+  it("an emailed code signs this machine in and reserves its public address; logout releases it", async () => {
+    const wrong = fakeIo(["00000000"]);
+    expect(await runLogin(options(dir, { email: "milind@example.test" }), wrong.io)).toBe(1);
+    expect(wrong.err.join("\n")).toMatch(/sign-in failed/);
+    expect(describeTunnelAccount(openTunnelCredentials(dir).read()).email).toBeNull();
+
+    const right = fakeIo([stub.otp]);
+    expect(await runLogin(options(dir, { email: "milind@example.test" }), right.io)).toBe(0);
+    expect(right.out.join("\n")).toContain(`This machine's public address: ${stub.endpointUrl}`);
+    const doc = openTunnelCredentials(dir).read();
+    expect(describeTunnelAccount(doc)).toMatchObject({ email: "milind@example.test", address: stub.endpointUrl });
+    expect(tunnelAccess(doc)?.token).toBe(stub.connectorToken);
+    expect(stub.calls).toContain("POST /v1/installations");
+    expect(stub.calls).toContain("POST /v1/installations/self/endpoint");
+    expect([...stub.installations.values()][0]).toMatchObject({ platform: platformName() });
+    if (posix) expect(statSync(join(dir, TUNNEL_CREDENTIALS_FILE)).mode & 0o777).toBe(0o600);
+
+    // status mentions the address without touching the network
+    const status = fakeIo([]);
+    await runStatus(options(dir, { command: "status" }), status.io);
+    expect(status.out.join("\n")).toContain(`public address: ${stub.endpointUrl}`);
+
+    const bye = fakeIo([]);
+    expect(await runLogout(options(dir, { command: "logout" }), bye.io)).toBe(0);
+    expect(bye.out.join("\n")).toContain("is released");
+    expect(describeTunnelAccount(openTunnelCredentials(dir).read()).email).toBeNull();
+    expect(stub.calls).toContain("DELETE /v1/installations/self/endpoint");
+    expect(stub.calls).toContain("POST /api/auth/sign-out");
+  });
+
+  it("an unusable control-plane override is a clear error, not a silent default", async () => {
+    vi.stubEnv("OMB_CONTROL_PLANE_URL", "ftp://nope");
+    const io = fakeIo([]);
+    expect(await runLogin(options(dir, { email: "a@b.test" }), io.io)).toBe(1);
+    expect(io.err.join("\n")).toMatch(/OMB_CONTROL_PLANE_URL/);
+  });
+});
+
+describe("where the pieces are", () => {
+  it("names the platform the control plane's way and prefers the bundled guardian and downloader", () => {
+    expect(platformName("darwin")).toBe("darwin");
+    expect(platformName("win32")).toBe("windows");
+    expect(platformName("linux")).toBe("linux");
+    const bundled = mkdtempSync(join(tmpdir(), "omb-tunnel-bundled-"));
+    try {
+      expect(guardianEntry(bundled)).toBeNull();
+      writeFileSync(join(bundled, "tunnel-guardian.js"), "");
+      expect(guardianEntry(bundled)).toBe(join(bundled, "tunnel-guardian.js"));
+      expect(prepareEntry(bundled)).toMatch(/scripts[\\/]prepare-cloudflared\.mjs$/);
+      writeFileSync(join(bundled, "prepare-cloudflared.js"), "");
+      expect(prepareEntry(bundled)).toBe(join(bundled, "prepare-cloudflared.js"));
+    } finally {
+      void removeTempDir(bundled);
+    }
+    // a checkout: the source files
+    expect(guardianEntry()).toMatch(/managed-companion-guardian\.mjs$/);
+  });
+
+  it("describes tunnel states in one line each", () => {
+    expect(describeTunnelState({ status: "starting", ready: false }, "https://c-1.example")).toBe("tunnel: connecting…");
+    expect(describeTunnelState({ status: "ready", ready: true }, "https://c-1.example")).toBe("tunnel: live at https://c-1.example");
+    expect(describeTunnelState({ status: "retrying", ready: false, error: "The secure connection could not be verified.", retryInMs: 4000 }, "x")).toBe(
+      "tunnel: The secure connection could not be verified. retrying in 4s",
+    );
+    expect(describeTunnelState({ status: "unavailable", ready: false, error: "no connector" }, "x")).toBe("tunnel: no connector");
+  });
+});
+
+describe.skipIf(!posix)("startTunnel: guardian, gateway and connector, verified through the gateway", () => {
+  it("forwards the public address to the harness socket (no peer address = remote) and tears everything down on stop", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "omb-tunnel-run-"));
+    const origin = createTunnelOrigin();
+    const pidFile = join(dir, "connector.pid");
+    const fake = join(dir, "cloudflared");
+    writeFileSync(fake, `#!/bin/sh\necho $$ > "${pidFile}"\nexec sleep 300\n`, { mode: 0o755 });
+    const harness = createServer((req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ app: "openmausbot", url: req.url, peer: req.socket.remoteAddress ?? null }));
+    });
+    await new Promise<void>((done) => harness.listen(origin.socketPath, done));
+    const originPort = 20000 + Math.floor(Math.random() * 20000);
+    const endpoint = "https://c-stub.openmausbot.invalid";
+    const guardian = guardianEntry();
+    expect(guardian).toBeTruthy();
+    const states: string[] = [];
+    const tunnel = startTunnel({
+      dataDir: dir,
+      access: { endpoint, token: `connector-${"t".repeat(60)}` },
+      originTarget: { pid: process.pid, socketPath: origin.socketPath },
+      binaryPath: fake,
+      guardian: guardian ?? "",
+      env: { ...process.env, OMB_TUNNEL_ORIGIN_PORT: String(originPort) },
+      // the public address does not exist here; verify through the gateway instead
+      fetchImpl: (input, init) => fetch(String(input).replace(endpoint, `http://127.0.0.1:${originPort}`), init),
+      onState: (state) => states.push(state.status),
+    });
+    try {
+      const settled = await tunnel.started;
+      expect(settled.status, states.join(",")).toBe("ready");
+      const viaGateway: any = await (await fetch(`http://127.0.0.1:${originPort}/api/health`)).json();
+      expect(viaGateway.app).toBe("openmausbot");
+      expect(viaGateway.peer).toBeNull();
+      // the connector is spawned right after the gateway binds; its shell writes the pid a moment later
+      let connectorPid = 0;
+      for (let tries = 0; tries < 50 && !connectorPid; tries += 1) {
+        connectorPid = existsSync(pidFile) ? Number(readFileSync(pidFile, "utf8").trim()) : 0;
+        if (!connectorPid) await new Promise((r) => setTimeout(r, 100));
+      }
+      expect(connectorPid).toBeGreaterThan(0);
+      await tunnel.stop();
+      expect(tunnel.state().status).toBe("stopped");
+      await new Promise((r) => setTimeout(r, 300));
+      expect(() => process.kill(connectorPid, 0)).toThrow();
+      await expect(fetch(`http://127.0.0.1:${originPort}/api/health`)).rejects.toThrow();
+    } finally {
+      await tunnel.stop().catch(() => undefined);
+      harness.close();
+      cleanupTunnelOrigin(origin);
+      await removeTempDir(dir);
+    }
+  }, 30_000);
+});

--- a/server/tunnel.ts
+++ b/server/tunnel.ts
@@ -1,0 +1,288 @@
+// Rung three of the hosting ladder: `openmausbot serve --tunnel` gives a
+// server a public HTTPS address (https://c-<id>.openmausbot.com) with no
+// domain, no proxy and no open port, through the same control plane and
+// Cloudflare tunnel the desktop app already uses. Headless, so:
+//
+//   - the account and connector credentials live in a 0600 JSON file under
+//     the data dir instead of the OS keychain (a server has none; a key kept
+//     next to the ciphertext would be theatre), and its mode is re-tightened
+//     on every open;
+//   - cloudflared is fetched once into the data dir, by the same pinned
+//     version + digest script the release build uses, when nothing usable is
+//     on the machine;
+//   - the tunnel's loopback gateway forwards to an IPC listener the harness
+//     opens for it (OMB_TUNNEL_SOCKET), so to request-auth every public
+//     request is "through a proxy" by construction and needs a paired
+//     session — the loopback bind and its owner trust are untouched.
+//
+// Everything network- and process-shaped is the desktop's own code
+// (electron/control-plane-client.mjs, companion-account-service.mjs,
+// managed-companion-tunnel.mjs and the connector guardian): one
+// implementation, so a fix lands in both.
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
+import { hostname } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  COMPANION_ACCOUNT_EMAIL_FIELD,
+  COMPANION_INSTALLATION_ID_FIELD,
+  createCompanionAccountService,
+  resolveCompanionControlPlaneURL,
+  type CompanionAccountService,
+  type CredentialDocument,
+} from "../electron/companion-account-service.mjs";
+import {
+  cleanupCompanionOriginEndpoint,
+  createCompanionOriginEndpoint,
+  MANAGED_COMPANION_ORIGIN_PORT,
+  type CompanionOriginEndpoint,
+} from "../electron/companion-origin-gateway.mjs";
+import { createControlPlaneClient } from "../electron/control-plane-client.mjs";
+import {
+  createManagedCompanionTunnel,
+  managedCompanionTunnelAccess,
+  resolveCloudflaredBinary,
+  type ManagedTunnelAccess,
+  type ManagedTunnelState,
+} from "../electron/managed-companion-tunnel.mjs";
+import { createSecureCredentialState } from "../electron/secure-credential-state.mjs";
+import { writeFileAtomic } from "./atomic.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export const TUNNEL_CREDENTIALS_FILE = "tunnel-account.json";
+export const TUNNEL_RUNTIME_DIR = "tunnel-runtime";
+
+export type { CompanionOriginEndpoint, ManagedTunnelAccess, ManagedTunnelState };
+
+// ── credentials: a private file, and "unreadable" is not "empty" ─────────
+export interface TunnelCredentials {
+  file: string;
+  /** `unavailable` = the file exists but could not be read: nothing may be
+   * written over it, or a real account would be replaced by a fresh one. */
+  status: "ok" | "empty" | "unavailable";
+  read(): CredentialDocument;
+  update(
+    derive: (current: CredentialDocument) => CredentialDocument,
+    afterPersist?: (next: CredentialDocument) => Promise<void> | void,
+  ): Promise<unknown>;
+}
+
+function plainDocument(value: unknown): CredentialDocument | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  const document: CredentialDocument = {};
+  for (const [key, entry] of Object.entries(value)) document[key] = entry;
+  return document;
+}
+
+export function openTunnelCredentials(dataDir: string): TunnelCredentials {
+  const file = join(dataDir, TUNNEL_CREDENTIALS_FILE);
+  let initial: CredentialDocument = {};
+  let status: TunnelCredentials["status"] = "empty";
+  if (existsSync(file)) {
+    try {
+      // A file someone loosened (or an old umask) is tightened, not trusted as is.
+      if (process.platform !== "win32" && (statSync(file).mode & 0o077) !== 0) chmodSync(file, 0o600);
+      const parsed = plainDocument(JSON.parse(readFileSync(file, "utf8")));
+      if (!parsed) throw new Error("not a JSON object");
+      initial = parsed;
+      status = "ok";
+    } catch {
+      status = "unavailable";
+    }
+  }
+  const persist = (next: CredentialDocument) => {
+    mkdirSync(dataDir, { recursive: true, mode: 0o700 });
+    writeFileAtomic(file, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+  };
+  const state = createSecureCredentialState(initial, persist, { writable: status !== "unavailable" });
+  return {
+    file,
+    status,
+    read: () => state.read(),
+    update: (derive, afterPersist) => state.update(derive, afterPersist),
+  };
+}
+
+// ── the account this machine is signed in to ──────────────────────────
+export interface TunnelAccountSummary {
+  email: string | null;
+  address: string | null;
+  installationId: string | null;
+}
+
+function stringField(document: CredentialDocument, field: string): string | null {
+  const value = document[field];
+  return typeof value === "string" && value ? value : null;
+}
+
+export function describeTunnelAccount(document: CredentialDocument): TunnelAccountSummary {
+  return {
+    email: stringField(document, COMPANION_ACCOUNT_EMAIL_FIELD),
+    address: managedCompanionTunnelAccess(document)?.endpoint ?? null,
+    installationId: stringField(document, COMPANION_INSTALLATION_ID_FIELD),
+  };
+}
+
+export function tunnelAccess(document: CredentialDocument): ManagedTunnelAccess | null {
+  return managedCompanionTunnelAccess(document);
+}
+
+/** The control plane's platform vocabulary. */
+export function platformName(platform: NodeJS.Platform = process.platform): "darwin" | "windows" | "linux" {
+  return platform === "darwin" ? "darwin" : platform === "win32" ? "windows" : "linux";
+}
+
+export interface TunnelAccount {
+  service: CompanionAccountService;
+  credentials: TunnelCredentials;
+  /** "" when OMB_CONTROL_PLANE_URL is set to something unusable. */
+  controlPlane: string;
+}
+
+/** The desktop honours OMB_CONTROL_PLANE_URL only in development builds; a
+ * server's operator owns its environment, so it is honoured here always and
+ * the caller says so in its output. */
+export function createTunnelAccount(options: {
+  dataDir: string;
+  version: string;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  machineName?: string;
+}): TunnelAccount {
+  const env = options.env ?? process.env;
+  const credentials = openTunnelCredentials(options.dataDir);
+  const controlPlane = resolveCompanionControlPlaneURL({ isPackaged: true, environment: env });
+  const client = controlPlane ? createControlPlaneClient({ baseURL: controlPlane, fetchImpl: options.fetchImpl }) : null;
+  const service = createCompanionAccountService({
+    client,
+    readCredentials: () => credentials.read(),
+    updateCredentials: (derive, afterPersist) => credentials.update(derive, afterPersist),
+    identity: { name: options.machineName ?? hostname(), platform: platformName(), appVersion: options.version },
+    newClientInstanceId: () => randomUUID(),
+  });
+  return { service, credentials, controlPlane };
+}
+
+// ── cloudflared and the guardian: where they are, or how to get them ──────
+/** OMB_CLOUDFLARED_PATH, then the copy this command downloaded into the data
+ * dir, then PATH. */
+export function cloudflaredPath(dataDir: string, env: NodeJS.ProcessEnv = process.env): string | null {
+  return resolveCloudflaredBinary({ isPackaged: false, appPath: dataDir, environment: env });
+}
+
+/** The pinned-download script: bundled beside the server in a package or
+ * image, the source in a checkout. */
+export function prepareEntry(here = HERE): string {
+  const bundled = join(here, "prepare-cloudflared.js");
+  return existsSync(bundled) ? bundled : resolve(here, "..", "scripts", "prepare-cloudflared.mjs");
+}
+
+/** The connector guardian (the process that owns the gateway and cloudflared
+ * and tears both down if this process dies), same rule. */
+export function guardianEntry(here = HERE): string | null {
+  const bundled = join(here, "tunnel-guardian.js");
+  if (existsSync(bundled)) return bundled;
+  const source = resolve(here, "..", "electron", "managed-companion-guardian.mjs");
+  return existsSync(source) ? source : null;
+}
+
+export async function ensureCloudflared(options: {
+  dataDir: string;
+  env?: NodeJS.ProcessEnv;
+  log: (line: string) => void;
+  here?: string;
+}): Promise<string> {
+  const env = options.env ?? process.env;
+  const found = cloudflaredPath(options.dataDir, env);
+  if (found) return found;
+  options.log(`downloading cloudflared once (pinned version and digest, about 40 MB) into ${options.dataDir}`);
+  await new Promise<void>((done, fail) => {
+    const child = spawn(process.execPath, [prepareEntry(options.here), "--current", "--root", options.dataDir], {
+      env,
+      stdio: ["ignore", "inherit", "inherit"],
+    });
+    child.on("error", fail);
+    child.on("exit", (code) => (code === 0 ? done() : fail(new Error(`the cloudflared download failed (exit ${code ?? "signal"})`))));
+  });
+  const staged = cloudflaredPath(options.dataDir, env);
+  if (!staged) throw new Error("cloudflared was downloaded but is not where it should be; remove the data dir's dist-native folder and try again");
+  return staged;
+}
+
+// ── the origin: an IPC path the harness listens on for the gateway ────────
+export function createTunnelOrigin(): CompanionOriginEndpoint {
+  return createCompanionOriginEndpoint({ processId: process.pid });
+}
+
+export function cleanupTunnelOrigin(origin: CompanionOriginEndpoint): void {
+  cleanupCompanionOriginEndpoint(origin);
+}
+
+// ── the tunnel itself ────────────────────────────────────────────────────
+export interface RunningTunnel {
+  address: string;
+  state(): ManagedTunnelState;
+  /** Resolves with the first settled attempt: ready, or the reason it is retrying. */
+  started: Promise<ManagedTunnelState>;
+  stop(): Promise<void>;
+}
+
+/** The gateway listens on 127.0.0.1:<originPort> (the control plane points
+ * the tunnel at 8812; OMB_TUNNEL_ORIGIN_PORT exists for tests) and forwards
+ * to the harness's IPC socket. Verification polls the public address until
+ * it answers as this app, then retries with backoff forever if it never does. */
+export function startTunnel(options: {
+  dataDir: string;
+  access: ManagedTunnelAccess;
+  originTarget: { pid: number; socketPath: string };
+  binaryPath: string;
+  guardian: string;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  onState?: (state: ManagedTunnelState) => void;
+}): RunningTunnel {
+  const env = options.env ?? process.env;
+  const originPort = Number(env.OMB_TUNNEL_ORIGIN_PORT || MANAGED_COMPANION_ORIGIN_PORT);
+  let current: ManagedTunnelState = { status: "stopped", ready: false };
+  const tunnel = createManagedCompanionTunnel({
+    binaryPath: options.binaryPath,
+    guardianEntry: options.guardian,
+    runtimeRoot: join(options.dataDir, TUNNEL_RUNTIME_DIR),
+    originPort,
+    environment: env,
+    fetchImpl: options.fetchImpl,
+    onChange: (state) => {
+      current = state;
+      options.onState?.(state);
+    },
+  });
+  const started = tunnel.start({ endpoint: options.access.endpoint, token: options.access.token, originTarget: options.originTarget });
+  return {
+    address: options.access.endpoint,
+    state: () => current,
+    started,
+    stop: async () => {
+      await tunnel.stop();
+    },
+  };
+}
+
+/** One line per state change, for a terminal or a journal. */
+export function describeTunnelState(state: ManagedTunnelState, address: string): string {
+  switch (state.status) {
+    case "starting":
+      return "tunnel: connecting…";
+    case "ready":
+      return `tunnel: live at ${address}`;
+    case "retrying":
+      return `tunnel: ${state.error ?? "not verified yet"} retrying in ${Math.max(1, Math.round((state.retryInMs ?? 0) / 1000))}s`;
+    case "stopped":
+      return "tunnel: stopped";
+    default:
+      return `tunnel: ${state.error ?? state.status}`;
+  }
+}


### PR DESCRIPTION
Rung three of the hosting ladder (after #804's `serve` / `serve --tailscale`):

```sh
npx openmausbot login          # once: an emailed code signs this machine in
npx openmausbot serve --tunnel # https://c-….openmausbot.com, no domain, no proxy, no open port
```

`login` reserves the machine's public address through the existing control plane (`accounts.openmausbot.com`); `serve --tunnel` connects the server there through a Cloudflare tunnel and prints the pairing link at that address; `logout` releases it; `status` shows it.

**How it is built.** Headless reuse of the desktop's managed-tunnel stack: `electron/control-plane-client.mjs`, `companion-account-service.mjs`, `managed-companion-tunnel.mjs`, the connector guardian and the pinned `cloudflared` download are used as-is (typed with `.d.mts` files), so a fix lands in both. The control plane needs no change: it already points every tunnel at `127.0.0.1:8812`, and the guardian's gateway listens there.

**Security shape.**
- The harness opens a second, IPC listener (`OMB_TUNNEL_SOCKET`) for the gateway. `request-auth` treats a request with no peer address as "through a proxy" by construction: public traffic needs a paired session whatever headers it carries or lacks. The loopback bind and its owner trust are untouched. (Test: a request with no headers at all through the gateway is a 403 stranger, where the loopback listener would have made it the owner.)
- `GET /api/health` answers strangers with `{app}` only; pid (the desktop boot probe) and the static flag stay behind the gate. The tunnel verifier and the phone's route race need this probe before they have a session.
- Credentials: a 0600 JSON file under the data dir (a server has no keychain; a key next to the ciphertext would be theatre). An unreadable file is "unavailable", never "empty", so a real account is never replaced by a fresh one.
- `--tunnel` without an account is a startup error, never a silent local-only server.
- cloudflared: `OMB_CLOUDFLARED_PATH`, then the pinned copy in the data dir, then PATH; otherwise downloaded once by `scripts/prepare-cloudflared.mjs --current --root <data dir>` as its own process (it runs itself when executed directly, so it is bundled as its own entry and never inlined).

**Tests** (52 across the touched files, plus the npm-package standalone proof): credentials semantics; login/logout/status against a stub control plane (`server/testing/control-plane-stub.ts`); guardian + gateway + connector chain verified through the gateway and torn down on stop; the CLI end to end including pairing through the gateway; the IPC rule in `request-auth`; parser cases.

**Not in this PR:** a real-network run (needs a sign-in code emailed to an account; `npx openmausbot login` on a machine of yours is the actual UX), the phone app speaking server pairing (next), `systemd`/`launchd` units, Windows named-pipe listener beyond compile (the e2e tests skip on win32).

Docs: `docs/self-hosting.md` gains the option; `docs/plans/remote-workspace.md` marks transports 2–3 shipped for the CLI; the older headless plan's "no second bind" constraint is marked superseded with the reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added account login and logout commands for managed tunnel access.
  * Added `serve --tunnel` to expose servers through a managed Cloudflare tunnel.
  * Added tunnel status reporting, pairing links, secure credential storage, and graceful cleanup.
  * Added an unauthenticated health endpoint and secure remote-request authentication.

* **Documentation**
  * Added self-hosting instructions for login, tunnel setup, pairing, and logout.
  * Documented command-line support for Tailscale and managed tunnels.

* **Bug Fixes**
  * Improved tunnel setup validation and prevented incompatible tunnel options from being used together.

* **Tests**
  * Expanded coverage for authentication, tunnel lifecycle, credential security, and CLI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->