### PR TITLE
feat(ios): pair with a server directly from its QR

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -237,15 +237,21 @@ is the reference implementation.
 
 ## Using it from your phone
 
-The iOS companion pairs with a running server. Start the companion process
-next to the harness and pair by QR:
+The iOS app pairs with a server the same way a laptop does: scan the QR
+code that `openmausbot serve` (or `openmausbot pair`) prints, or paste the
+whole `https://host/pair#code=…` link into the address field on the pairing
+screen. The phone gets a session of its own, listed and revocable with
+`openmausbot sessions`. It can chat, approve, and read; creating bots,
+changing models, connecting apps and cloud computers stay with the owner in
+the server's own UI, and the app hides those controls.
+
+Older way, still supported: run the companion sidecar next to the harness
+and pair by its own QR. It advertises on your private networks
+(Tailscale-aware) and issues per-device credentials on pairing.
 
 ```sh
 node --experimental-strip-types companion/src/index.ts
 ```
-
-It advertises on your private networks (Tailscale-aware) and issues
-per-device credentials on pairing — see the pairing screen in the iOS app.
 
 ## Updating
 

--- a/ios/App/ChatListView.swift
+++ b/ios/App/ChatListView.swift
@@ -387,6 +387,9 @@ struct ChatListView: View {
             updatesButton
                 .frame(minWidth: 148)
             searchButton
+            // Creating bots and sections is the owner's, on the server's own
+            // UI, when this phone is paired with a server directly.
+            if session.connection?.pairedWithServer != true {
             Menu {
                 Button("New section", systemImage: "folder.badge.plus", action: openNewSection)
                     .disabled(!hasVisibleBots)
@@ -401,6 +404,7 @@ struct ChatListView: View {
             .buttonStyle(.plain)
             .glassCapsule()
             .accessibilityLabel("Create")
+            }
         }
     }
 

--- a/ios/App/PairingView.swift
+++ b/ios/App/PairingView.swift
@@ -231,6 +231,13 @@ struct PairingView: View {
             Button("Continue") {
                 Haptics.selection()
                 failure = nil
+                // The whole link a server printed (https://host/pair#code=…) is
+                // fine here too: it names both the address and the code.
+                if let url = URL(string: manualAddress.trimmingCharacters(in: .whitespacesAndNewlines)),
+                   let invite = PairingInvite.parse(url) {
+                    accept(invite)
+                    return
+                }
                 guard let connection = Self.parse(manualAddress) else {
                     failure = "That address doesn't look right. Copy it from Phone settings and try again."
                     return
@@ -315,7 +322,9 @@ struct PairingView: View {
                         .foregroundStyle(.secondary)
 
                     TextField("000000", text: $code)
-                        .keyboardType(.numberPad)
+                        .keyboardType(.asciiCapable)
+                        .textInputAutocapitalization(.characters)
+                        .autocorrectionDisabled()
                         .textContentType(.oneTimeCode)
                         .font(.system(size: 28, weight: .bold, design: .rounded))
                         .multilineTextAlignment(.center)
@@ -323,7 +332,8 @@ struct PairingView: View {
                         .background(Color(uiColor: .tertiarySystemGroupedBackground))
                         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                         .onChange(of: code) { _, value in
-                            code = String(value.filter { $0.isASCII && $0.isNumber }.prefix(6))
+                            // six digits for a computer, ABCD-EFGH-JKLM for a server
+                            code = String(value.uppercased().filter { $0.isASCII && ($0.isNumber || $0.isLetter || $0 == "-") }.prefix(14))
                         }
 
                     Button {
@@ -338,7 +348,7 @@ struct PairingView: View {
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
-                    .disabled(code.count != 6 || pairing)
+                    .disabled(!Self.codeLooksComplete(code) || pairing)
                 }
             }
 
@@ -442,6 +452,11 @@ struct PairingView: View {
                 }
             }
         }
+    }
+
+    /// A companion's six digits, or a server's twelve characters.
+    static func codeLooksComplete(_ code: String) -> Bool {
+        (code.count == 6 && code.allSatisfy(\.isNumber)) || PairingInvite.normalizedServerCode(code) != nil
     }
 
     private func accept(_ invite: PairingInvite?) {

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -272,6 +272,25 @@ final class Session: ObservableObject {
         if invited.allowedRouteKinds == nil {
             invited.establishRoutePolicyFromInvite()
         }
+        // A 12-character code pairs with a server directly (its own sessions,
+        // a client-scope bearer); anything else is the companion sidecar's.
+        if let code = PairingInvite.normalizedServerCode(credential) {
+            let paired = try await CompanionClient.pairWithServer(
+                connection: invited,
+                code: code,
+                label: deviceName,
+                attemptId: pairRequestId
+            )
+            var stored = invited
+            if !paired.environment.label.isEmpty { stored.name = paired.environment.label }
+            stored.serverEnvironmentId = paired.environment.environmentId
+            stored.companionDeviceId = nil
+            if let existing = registry.matchingConnection(for: stored) {
+                stored.id = existing.id
+            }
+            try commitPairing(stored, token: paired.token)
+            return
+        }
         let outcome = try await CompanionClient.pairFirstReachable(
             connection: invited,
             credential: credential,
@@ -298,8 +317,15 @@ final class Session: ObservableObject {
         if let existing = registry.matchingConnection(for: stored) {
             stored.id = existing.id
         }
+        try commitPairing(stored, token: paired.token, winner: winner)
+    }
 
-        try Keychain.save(paired.token, for: stored.id)
+    /// The device token goes to the keychain and the connection to defaults —
+    /// deliberately apart, so the thing that gets backed up is never the
+    /// credential. Shared by companion and server pairing; `winner` is the
+    /// route that answered, which a server pairing (one route) has no use for.
+    private func commitPairing(_ stored: Connection, token: String, winner: CompanionEndpoint? = nil) throws {
+        try Keychain.save(token, for: stored.id)
         let firstPairing = registry.connections.isEmpty
         var updatedRegistry = registry
         updatedRegistry.upsert(stored)
@@ -329,14 +355,14 @@ final class Session: ObservableObject {
         registry = updatedRegistry
         connections = registry.connections
         self.connection = stored
-        self.token = paired.token
+        self.token = token
         let liveRoutes = winner.map { route in
             [route] + stored.orderedEndpoints.filter { $0.url != route.url }
         } ?? stored.orderedEndpoints
         self.rotation = CandidateRotation(endpoints: liveRoutes)
         self.client = CompanionClient(
             connection: winner.map(stored.dialing) ?? stored,
-            token: paired.token
+            token: token
         )
         self.state = CompanionState()
         // A fresh pairing settles any restore that was still waiting on the
@@ -404,8 +430,14 @@ final class Session: ObservableObject {
     }
 
     func forgetConnection(id: String) {
-        guard registry.connection(id: id) != nil else { return }
+        guard let forgotten = registry.connection(id: id) else { return }
         let wasActive = registry.activeConnectionID == id
+        // A server session is ended on the server too, best effort: the
+        // bearer is discarded locally either way.
+        if forgotten.pairedWithServer, let token = try? Keychain.token(for: id) {
+            let client = CompanionClient(connection: forgotten, token: token)
+            Task.detached { try? await client.logout() }
+        }
         if wasActive { stopActiveRuntime() }
         preparedPhoneCredentials = preparedPhoneCredentials.filter { $0.value.connectionID != id }
         Keychain.remove(id)

--- a/ios/App/SettingsView.swift
+++ b/ios/App/SettingsView.swift
@@ -115,13 +115,17 @@ struct SettingsView: View {
                         }
                     }
 
-                    NavigationLink {
-                        ConnectedAppsView()
-                    } label: {
-                        Label {
-                            Text("Connected Apps")
-                        } icon: {
-                            SettingsIcon(symbol: "link", color: .blue)
+                    // Connecting apps needs the admin scope; on a server the
+                    // owner does it in the server's own UI.
+                    if session.connection?.pairedWithServer != true {
+                        NavigationLink {
+                            ConnectedAppsView()
+                        } label: {
+                            Label {
+                                Text("Connected Apps")
+                            } icon: {
+                                SettingsIcon(symbol: "link", color: .blue)
+                            }
                         }
                     }
                 }

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -45,6 +45,12 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
     /// Sidecar device identity returned after redemption. Bound into every
     /// credential envelope and checked against the authenticated bearer.
     public var companionDeviceId: String?
+    /// Set when this connection was paired against the server's own sessions
+    /// (`openmausbot serve` / the Docker stack) rather than the desktop's
+    /// companion sidecar: the bearer is an `omb_sess_` token with the client
+    /// scope, so what the app may administer differs. Absent on connections
+    /// saved before servers could be paired directly.
+    public var serverEnvironmentId: String?
 
     public init(
         id: String = UUID().uuidString,
@@ -57,7 +63,8 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
         allowedRouteKinds: Set<CompanionEndpointKind>? = nil,
         allowedLocalRouteURLs: Set<String>? = nil,
         secretPublicKey: String? = nil,
-        companionDeviceId: String? = nil
+        companionDeviceId: String? = nil,
+        serverEnvironmentId: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -70,7 +77,13 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
         self.allowedLocalRouteURLs = allowedLocalRouteURLs
         self.secretPublicKey = secretPublicKey
         self.companionDeviceId = companionDeviceId
+        self.serverEnvironmentId = serverEnvironmentId
     }
+
+    /// Paired with a server directly (client scope): chat, approvals and
+    /// reading are in; creating bots, changing models, connected apps and
+    /// cloud computers are the owner's, done on the server's own UI.
+    public var pairedWithServer: Bool { serverEnvironmentId != nil }
 
     /// The representation `URLComponents.host` accepts for a literal IPv6
     /// address. It adds brackets exactly once and leaves DNS/IPv4 names alone.
@@ -207,6 +220,7 @@ public struct PairingInvite: Equatable, Sendable {
     }
 
     public static func parse(_ url: URL) -> PairingInvite? {
+        if let server = parseServerLink(url) { return server }
         guard url.scheme?.lowercased() == "openmausbot",
               url.host?.lowercased() == "pair",
               let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
@@ -283,6 +297,44 @@ public struct PairingInvite: Equatable, Sendable {
         var seen = Set<String>()
         let unique = stable.filter { seen.insert($0.url).inserted }
         return unique.isEmpty ? nil : unique
+    }
+
+    /// `https://host/pair#code=ABCD-EFGH-JKLM`: the link a server prints
+    /// (`openmausbot serve`, `openmausbot pair`, the Docker stack). It pairs
+    /// against the server's own sessions, not the companion sidecar. The code
+    /// rides in the fragment, which never reaches a server in a request, and
+    /// the server takes it with or without dashes.
+    static func parseServerLink(_ url: URL) -> PairingInvite? {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let scheme = components.scheme?.lowercased(),
+              scheme == "https" || scheme == "http",
+              let host = components.host, !host.isEmpty,
+              components.path == "/pair",
+              components.query == nil,
+              let fragment = components.fragment
+        else { return nil }
+        var values: [String: String] = [:]
+        for pair in fragment.split(separator: "&") {
+            let parts = pair.split(separator: "=", maxSplits: 1)
+            guard parts.count == 2, values[String(parts[0])] == nil else { return nil }
+            values[String(parts[0])] = String(parts[1]).removingPercentEncoding ?? String(parts[1])
+        }
+        guard let raw = values["code"], let code = normalizedServerCode(raw) else { return nil }
+        var origin = components
+        origin.path = ""
+        origin.fragment = nil
+        guard let originString = origin.string, let connection = Connection.parse(originString) else { return nil }
+        return PairingInvite(connection: connection, credential: code)
+    }
+
+    /// A server pairing code: 12 characters from a confusion-free alphabet,
+    /// shown as three dashed groups. Only the shape is checked here; a
+    /// mistyped code fails at the server with its own message. Six-digit
+    /// codes and `omb_pair_` tokens are the companion's and return nil.
+    public static func normalizedServerCode(_ raw: String) -> String? {
+        let cleaned = raw.uppercased().filter { $0.isASCII && ($0.isLetter || $0.isNumber) }
+        guard cleaned.count == 12, !cleaned.allSatisfy(\.isNumber) else { return nil }
+        return cleaned
     }
 
     private static func credential(from values: [String: String]) -> String? {
@@ -603,6 +655,38 @@ public struct CompanionClient: Sendable {
         // address must not consume the default twenty-second API deadline.
         pairRequest.timeoutInterval = 8
         return try await client.send(pairRequest, as: PairResponse.self)
+    }
+
+    /// Pair against the server's own sessions (`POST /api/auth/pair`). The
+    /// answer is a bearer for the client scope; no cookie is asked for, so
+    /// the token is the app's alone. `attemptId` makes a retry after a lost
+    /// response idempotent for a minute, like the companion's request id.
+    public static func pairWithServer(
+        connection: Connection,
+        code: String,
+        label: String,
+        attemptId: String = UUID().uuidString,
+        session: URLSession = .shared
+    ) async throws -> ServerPairResponse {
+        let client = CompanionClient(connection: connection, token: nil, session: session)
+        var request = try client.makeRequest(
+            "POST",
+            "/api/auth/pair",
+            body: ["code": code, "label": label, "attemptId": attemptId]
+        )
+        request.timeoutInterval = 8
+        return try await client.send(request, as: ServerPairResponse.self)
+    }
+
+    /// The server's public descriptor: reachable before pairing, and the way
+    /// to notice that the address now belongs to a different server.
+    public func environment() async throws -> ServerEnvironment {
+        try await send(makeRequest("GET", "/.well-known/openmausbot/environment"), as: ServerEnvironment.self)
+    }
+
+    /// End this session on the server (server-paired connections only).
+    public func logout() async throws {
+        try await send(makeRequest("POST", "/api/auth/logout"))
     }
 
     /// Resolve the multi-address invite before consuming its credential.

--- a/ios/Sources/CompanionCore/Models.swift
+++ b/ios/Sources/CompanionCore/Models.swift
@@ -1015,3 +1015,30 @@ struct RoutineRunResponse: Codable, Sendable { var run: RoutineRun }
 struct ConnectorAuthorizationResponse: Codable, Sendable {
     var url: String
 }
+
+// MARK: - Server sessions (pairing with a server directly)
+
+/// What `POST /api/auth/pair` returns on a server: the bearer, the session
+/// it opened, and the server's public descriptor.
+public struct ServerPairResponse: Codable, Sendable {
+    public var token: String
+    public var session: ServerSession
+    public var environment: ServerEnvironment
+}
+
+public struct ServerSession: Codable, Hashable, Sendable {
+    public var id: String
+    public var label: String
+    public var scopes: [String]
+    public var expiresAt: Double?
+
+    public var isAdmin: Bool { scopes.contains("admin") }
+}
+
+/// `GET /.well-known/openmausbot/environment`, served without a session.
+public struct ServerEnvironment: Codable, Hashable, Sendable {
+    public var environmentId: String
+    public var label: String
+    public var platform: String?
+    public var version: String?
+}

--- a/ios/Tests/CompanionCoreTests/Fixtures/auth-pair-response.json
+++ b/ios/Tests/CompanionCoreTests/Fixtures/auth-pair-response.json
@@ -1,0 +1,18 @@
+{
+  "token": "omb_sess_Zk3vJq8mN2xR7tL9wP4yH6bC1dF5gA0sE8uK2iO7",
+  "session": {
+    "id": "sess_01J9X",
+    "label": "Milind's iPhone",
+    "scopes": ["client"],
+    "createdAt": 1757059200000,
+    "lastSeenAt": 1757059200000,
+    "expiresAt": 1759651200000
+  },
+  "environment": {
+    "environmentId": "env_7f3a9c",
+    "label": "cab mini",
+    "platform": "linux",
+    "version": "0.1.55",
+    "capabilities": { "remoteSessions": true, "selfUpdate": false }
+  }
+}

--- a/ios/Tests/CompanionCoreTests/Fixtures/environment.json
+++ b/ios/Tests/CompanionCoreTests/Fixtures/environment.json
@@ -1,0 +1,7 @@
+{
+  "environmentId": "env_7f3a9c",
+  "label": "cab mini",
+  "platform": "linux",
+  "version": "0.1.55",
+  "capabilities": { "remoteSessions": true, "selfUpdate": false }
+}

--- a/ios/Tests/CompanionCoreTests/ServerPairingTests.swift
+++ b/ios/Tests/CompanionCoreTests/ServerPairingTests.swift
@@ -74,7 +74,11 @@ final class ServerPairingTests: XCTestCase {
     }
 
     private func fixture(_ name: String) throws -> Data {
-        let url = try XCTUnwrap(Bundle.module.url(forResource: name, withExtension: "json"))
+        // `.copy("Fixtures")` keeps the directory; a stale local build may flatten it
+        let url = try XCTUnwrap(
+            Bundle.module.url(forResource: name, withExtension: "json", subdirectory: "Fixtures")
+                ?? Bundle.module.url(forResource: name, withExtension: "json")
+        )
         return try Data(contentsOf: url)
     }
 

--- a/ios/Tests/CompanionCoreTests/ServerPairingTests.swift
+++ b/ios/Tests/CompanionCoreTests/ServerPairingTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+import XCTest
+@testable import CompanionCore
+
+/// Pairing with a server directly (`openmausbot serve`, the Docker stack):
+/// the `https://host/pair#code=…` link, `POST /api/auth/pair`, and the
+/// connection that comes out of it.
+private final class ServerRequestStub: URLProtocol {
+    static let lock = NSLock()
+    static var requests: [URLRequest] = []
+    static var action: (URLRequest) -> (Int, Data) = { _ in (500, Data()) }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lock.lock()
+        Self.requests.append(request)
+        let (status, body) = Self.action(request)
+        Self.lock.unlock()
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    static func reset(_ handler: @escaping (URLRequest) -> (Int, Data)) {
+        lock.lock()
+        requests = []
+        action = handler
+        lock.unlock()
+    }
+
+    static func captured() -> [URLRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return requests
+    }
+
+    static func body(of request: URLRequest) -> [String: Any]? {
+        var data = request.httpBody
+        if data == nil, let stream = request.httpBodyStream {
+            stream.open()
+            defer { stream.close() }
+            var result = Data()
+            var buffer = [UInt8](repeating: 0, count: 1_024)
+            while stream.hasBytesAvailable {
+                let count = stream.read(&buffer, maxLength: buffer.count)
+                if count <= 0 { break }
+                result.append(buffer, count: count)
+            }
+            data = result
+        }
+        guard let data else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+}
+
+final class ServerPairingTests: XCTestCase {
+    private var session: URLSession!
+
+    override func setUp() {
+        super.setUp()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ServerRequestStub.self]
+        session = URLSession(configuration: configuration)
+    }
+
+    private func fixture(_ name: String) throws -> Data {
+        let url = try XCTUnwrap(Bundle.module.url(forResource: name, withExtension: "json"))
+        return try Data(contentsOf: url)
+    }
+
+    func testTheServersLinkBecomesAHostedInviteWithTheNormalizedCode() throws {
+        let invite = try XCTUnwrap(PairingInvite.parse(XCTUnwrap(URL(string: "https://c-7f3a9c.openmausbot.com/pair#code=abcd-efgh-jklm"))))
+        XCTAssertEqual(invite.credential, "ABCDEFGHJKLM")
+        XCTAssertEqual(invite.connection.activeEndpoint?.kind, .hosted)
+        XCTAssertEqual(invite.connection.activeEndpoint?.url, "https://c-7f3a9c.openmausbot.com")
+        XCTAssertEqual(invite.connection.host, "c-7f3a9c.openmausbot.com")
+
+        // a port survives; a plain-http LAN link infers the local kind
+        let withPort = try XCTUnwrap(PairingInvite.parse(XCTUnwrap(URL(string: "https://mini.example:8443/pair#code=ABCDEFGHJKLM"))))
+        XCTAssertEqual(withPort.connection.activeEndpoint?.url, "https://mini.example:8443")
+        let lan = try XCTUnwrap(PairingInvite.parse(XCTUnwrap(URL(string: "http://192.168.1.20:8799/pair#code=ABCD-EFGH-JKLM"))))
+        XCTAssertEqual(lan.connection.activeEndpoint?.kind, .lan)
+    }
+
+    func testOnlyAWellFormedServerLinkIsAccepted() throws {
+        for bad in [
+            "https://mini.example/pair", // no code
+            "https://mini.example/pair#code=ABCD-EFGH", // too short
+            "https://mini.example/pair#code=123456789012", // digits only is not a server code
+            "https://mini.example/other#code=ABCDEFGHJKLM", // wrong path
+            "https://mini.example/pair?code=ABCDEFGHJKLM", // in the query, not the fragment
+            "https://mini.example/pair#code=ABCDEFGHJKLM&code=ABCDEFGHJKLM", // duplicated
+            "ftp://mini.example/pair#code=ABCDEFGHJKLM",
+        ] {
+            XCTAssertNil(PairingInvite.parse(try XCTUnwrap(URL(string: bad))), bad)
+        }
+        // the companion's own invites still parse
+        XCTAssertNotNil(PairingInvite.parse(try XCTUnwrap(URL(string: "openmausbot://pair?address=192.168.1.9:8810&code=123456"))))
+    }
+
+    func testServerCodesAreDistinguishedFromCompanionCredentialsByShape() {
+        XCTAssertEqual(PairingInvite.normalizedServerCode(" abcd-efgh-jklm "), "ABCDEFGHJKLM")
+        XCTAssertNil(PairingInvite.normalizedServerCode("123456"))
+        XCTAssertNil(PairingInvite.normalizedServerCode("omb_pair_" + String(repeating: "a", count: 43)))
+        XCTAssertNil(PairingInvite.normalizedServerCode("ABCDEFGHJKL"))
+    }
+
+    func testPairingPostsTheCodeWithoutACookieAndKeepsTheBearer() async throws {
+        let body = try fixture("auth-pair-response")
+        ServerRequestStub.reset { _ in (200, body) }
+        let connection = try XCTUnwrap(Connection.parse("https://c-7f3a9c.openmausbot.com"))
+        let paired = try await CompanionClient.pairWithServer(
+            connection: connection,
+            code: "ABCDEFGHJKLM",
+            label: "Milind's iPhone",
+            attemptId: "attempt-1",
+            session: session
+        )
+        XCTAssertEqual(paired.token, "omb_sess_Zk3vJq8mN2xR7tL9wP4yH6bC1dF5gA0sE8uK2iO7")
+        XCTAssertEqual(paired.session.scopes, ["client"])
+        XCTAssertFalse(paired.session.isAdmin)
+        XCTAssertEqual(paired.environment.environmentId, "env_7f3a9c")
+        XCTAssertEqual(paired.environment.label, "cab mini")
+
+        let request = try XCTUnwrap(ServerRequestStub.captured().first)
+        XCTAssertEqual(request.url?.absoluteString, "https://c-7f3a9c.openmausbot.com/api/auth/pair")
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+        let sent = try XCTUnwrap(ServerRequestStub.body(of: request))
+        XCTAssertEqual(sent["code"] as? String, "ABCDEFGHJKLM")
+        XCTAssertEqual(sent["label"] as? String, "Milind's iPhone")
+        XCTAssertEqual(sent["attemptId"] as? String, "attempt-1")
+        XCTAssertNil(sent["cookie"], "the token is the app's; never ask for a browser cookie")
+    }
+
+    func testARefusedCodeSurfacesTheServersOwnMessage() async throws {
+        ServerRequestStub.reset { _ in (401, Data(#"{"error":"that code is not valid or has expired"}"#.utf8)) }
+        let connection = try XCTUnwrap(Connection.parse("https://c-7f3a9c.openmausbot.com"))
+        do {
+            _ = try await CompanionClient.pairWithServer(connection: connection, code: "ABCDEFGHJKLM", label: "phone", session: session)
+            XCTFail("expected a refusal")
+        } catch let error as APIError {
+            guard case let .status(code, message) = error else { return XCTFail("\(error)") }
+            XCTAssertEqual(code, 401)
+            XCTAssertEqual(message, "that code is not valid or has expired")
+        }
+    }
+
+    func testTheDescriptorIsReadableWithoutASession() async throws {
+        let body = try fixture("environment")
+        ServerRequestStub.reset { _ in (200, body) }
+        let connection = try XCTUnwrap(Connection.parse("https://c-7f3a9c.openmausbot.com"))
+        let environment = try await CompanionClient(connection: connection, token: nil, session: session).environment()
+        XCTAssertEqual(environment, ServerEnvironment(environmentId: "env_7f3a9c", label: "cab mini", platform: "linux", version: "0.1.55"))
+        XCTAssertEqual(ServerRequestStub.captured().first?.url?.path, "/.well-known/openmausbot/environment")
+    }
+
+    func testConnectionsSavedBeforeServerPairingStillDecodeAsCompanionOnes() throws {
+        let legacy = Data(#"{"id":"c1","name":"Ada's computer","host":"192.168.1.9","port":8810}"#.utf8)
+        let decoded = try JSONDecoder().decode(Connection.self, from: legacy)
+        XCTAssertFalse(decoded.pairedWithServer)
+        var server = decoded
+        server.serverEnvironmentId = "env_7f3a9c"
+        XCTAssertTrue(server.pairedWithServer)
+        let round = try JSONDecoder().decode(Connection.self, from: JSONEncoder().encode(server))
+        XCTAssertEqual(round.serverEnvironmentId, "env_7f3a9c")
+    }
+}


### PR DESCRIPTION
The phone side of the hosting ladder. Scan the QR that `openmausbot serve` (or `pair`, or the Docker stack) prints, and the iOS app pairs with the **server's own sessions** rather than the companion sidecar. No sidecar needed on a VPS or a Mac mini running `openmausbot serve`.

**How it works**
- `PairingInvite.parse` now recognises `https://host/pair#code=ABCD-EFGH-JKLM` (scanned, or pasted whole into the address field). The code's *shape* tells the two worlds apart: 12 confusion-free characters is a server, six digits or an `omb_pair_` token is the companion. One code field serves both.
- `CompanionClient.pairWithServer` → `POST /api/auth/pair` with `{code, label, attemptId}` and no `cookie`, so the `omb_sess_…` bearer is the app's alone. It lands in the same keychain item; the existing `Authorization: Bearer` header works unchanged, and `GET /api/events` with a bearer needs no stream ticket.
- `Connection.serverEnvironmentId` marks a server-paired connection (records saved by older builds decode as companion ones). `environment()` reads the public descriptor; `logout()` ends the session on the server when the connection is forgotten.
- Client scope has no admin routes, so the app hides what it cannot do: New bot / New section, and Connected Apps. Other admin-only screens (model picker, avatar generation, cloud desktop) still show and surface the server's 403 message; hiding those is the follow-up.

**Verified**: 7 new CompanionCore tests (link parsing and refusals, code shapes, the pair request body/headers and a refused code's message, descriptor decode, legacy decode) alongside the existing suites; `xcodebuild` for the simulator with CI's flags succeeds. Not exercised here: a real phone against a real server — that is the first thing to try once this and #815 are in.

Docs: the phone section of `docs/self-hosting.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct phone pairing with servers using QR codes, pairing URLs, or server codes.
  * Added support for server session roles, environment discovery, and server-side logout.
  * Simplified server-paired views by hiding unavailable creation and connected-app options.
  * Added Cloudflare tunnel setup guidance, reserved addresses, and protected credentials.
  * Retained the companion sidecar as a supported legacy pairing method.

* **Tests**
  * Added coverage for server pairing, invite parsing, authentication responses, and environment discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->