### PR TITLE
ci(npm): attach the package tarball to the GitHub release

### DIFF
--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -14,7 +14,9 @@ on:
       - .github/workflows/npm-package.yml
 
 permissions:
-  contents: read
+  # write: the release-tag run attaches the tarball to the GitHub release.
+  # Pull-request runs from forks get a read-only token regardless.
+  contents: write
   id-token: write
 
 jobs:
@@ -58,3 +60,17 @@ jobs:
         run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # The same tarball beside the desktop installers on the GitHub release,
+      # for people who install from a download rather than the registry. The
+      # release exists by the time the tag does (publishing it is what creates
+      # the tag); a tag pushed without one is left alone.
+      - name: Attach the tarball to the GitHub release (release tags only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" release/npm/openmausbot-*.tgz --repo "$GITHUB_REPOSITORY" --clobber
+          else
+            echo "no GitHub release named $GITHUB_REF_NAME; tarball not attached"
+          fi


### PR DESCRIPTION
On `v*` tags, after `npm publish`, upload `openmausbot-<version>.tgz` to the GitHub release for that tag (`--clobber`), beside the desktop installers. Only when the release exists; a bare tag is left alone. The workflow's token gains `contents: write` for that upload; fork pull requests still get a read-only token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Release builds now automatically attach the packaged npm archive to the corresponding GitHub release.
  - If no matching release exists, the upload is skipped with a notice rather than failing the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->