### PR TITLE
fix(companion): restore authenticated phone actions in desktop builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
           OMB_SKIP_REAL_ELECTRON_BROWSER_FIXTURE: "0"
         run: pnpm exec vitest run electron/browser-closed-shadow.electron.test.mjs
       - run: pnpm check:electron
+      - name: Verify paired phone authorization against packaged harness
+        if: matrix.os == 'macos-latest'
+        run: pnpm build:companion && pnpm exec electron scripts/smoke-phone-relay-auth.cjs
       - name: production UI build
         if: matrix.os == 'ubuntu-latest'
         run: pnpm exec vite build

--- a/companion/src/index.ts
+++ b/companion/src/index.ts
@@ -39,6 +39,21 @@ import { createProxyHandler } from "./proxy.ts";
 import { companionOriginSocket, listenCompanionOrigin } from "./origin.ts";
 import { normalizedPhoneSecretPublicKey } from "./phone-secret-key.ts";
 
+// Only Electron supplies this port. Standalone sidecars retain the existing
+// unguarded local-server path; Electron children fail closed until initialized.
+const parentPort = (process as NodeJS.Process & {
+  parentPort?: { on(event: "message", listener: (event: { data?: unknown }) => void): void };
+}).parentPort;
+let mutationToken: string | null = null;
+parentPort?.on("message", ({ data }) => {
+  if (!data || typeof data !== "object") return;
+  const message = data as Record<string, unknown>;
+  if (message.type !== "openmausbot:companion-mutation-token") return;
+  if (typeof message.token === "string" && /^[A-Za-z0-9_-]{43}$/.test(message.token)) {
+    mutationToken = message.token;
+  }
+});
+
 /** A port from the environment, or the default. Anything that is not a whole
  * number in range is the default — a typo'd port must not become port 0. */
 const num = (value: string | undefined, fallback: number): number => {
@@ -139,6 +154,7 @@ const service = (): ServiceInfo => ({
 const connectedDevices = createConnectedDeviceTracker();
 const proxy = createProxyHandler({
     harnessPort: HARNESS_PORT,
+    mutationToken: parentPort ? () => mutationToken : undefined,
     // `authenticate` also stamps lastSeenAt, which is what makes the control
     // page able to say when a phone was last heard from.
     authenticate: (token) => devices.authenticate(token),

--- a/companion/src/proxy.ts
+++ b/companion/src/proxy.ts
@@ -10,7 +10,8 @@
 // request this process makes to 127.0.0.1 satisfies that by construction. So
 // the sidecar does NOT forward the device's Host or Origin. It speaks to the
 // harness as itself, from the machine the harness is already willing to
-// serve. Nothing upstream has to change, or even know this exists.
+// serve. Packaged harnesses also require a private per-launch relay capability,
+// attached only after authenticating the phone and authorizing its route.
 import { request as httpRequest, type IncomingMessage, type ServerResponse } from "node:http";
 import type { Duplex } from "node:stream";
 
@@ -28,6 +29,9 @@ import { createSseScrubber, isJson, scrub } from "./wire.ts";
 export interface ProxyOptions {
   /** Where the harness is listening on loopback. */
   harnessPort: number;
+  /** Private Electron capability; null means bootstrap is not ready yet.
+   * Undefined keeps standalone sidecars compatible with a plain Node harness. */
+  mutationToken?: () => string | null;
   /** Does this bearer token belong to a paired device? */
   authenticate: (token: string | undefined) => { id?: string; cloudDesktopAccess: boolean } | null;
   /** Redeem a pairing code. Handled here and never forwarded: the harness
@@ -210,7 +214,7 @@ const endpointSnapshot = (options: ProxyOptions): CompanionEndpointSnapshot => {
  * blocklist: `host` and `origin` must not travel (see above), `authorization`
  * is the sidecar's credential and means nothing to the harness, and hop-by-hop
  * headers are by definition not ours to relay. */
-const forwardHeaders = (req: IncomingMessage, authenticatedDeviceId?: string): Record<string, string> => {
+const forwardHeaders = (req: IncomingMessage, authenticatedDeviceId?: string, mutationToken?: string): Record<string, string> => {
   const out: Record<string, string> = {
     accept: String(req.headers.accept ?? "*/*"),
     // Lets a response whose URL is intentionally loopback-only (the VPS SSH
@@ -223,6 +227,7 @@ const forwardHeaders = (req: IncomingMessage, authenticatedDeviceId?: string): R
   // the harness to bind an encrypted credential to the same paired phone.
   if (authenticatedDeviceId && /^[\w-]{1,128}$/.test(authenticatedDeviceId)) {
     out["x-openmausbot-companion-device"] = authenticatedDeviceId;
+    if (mutationToken) out["x-openmausbot-companion-auth"] = mutationToken;
   }
   const contentType = req.headers["content-type"];
   if (contentType) out["content-type"] = String(contentType);
@@ -334,13 +339,17 @@ export function createProxyHandler(options: ProxyOptions) {
       return sendJson(res, 200, endpointSnapshot(options));
     }
 
+    const mutationToken = device ? options.mutationToken?.() : undefined;
+    if (device && options.mutationToken && !mutationToken) {
+      return sendJson(res, 503, { error: "The desktop connection is starting. Please try again shortly." });
+    }
     const upstream = httpRequest(
       {
         hostname: "127.0.0.1",
         port: options.harnessPort,
         path: req.url,
         method,
-        headers: forwardHeaders(req, device?.id),
+        headers: forwardHeaders(req, device?.id, mutationToken ?? undefined),
       },
       (harness) => {
         clearTimeout(headersDeadline);

--- a/companion/test/relay-auth.test.ts
+++ b/companion/test/relay-auth.test.ts
@@ -1,0 +1,60 @@
+import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
+import { once } from "node:events";
+import { afterEach, expect, it } from "vitest";
+import { createProxyHandler } from "../src/proxy.ts";
+
+const servers: Server[] = [];
+async function listen(server: Server): Promise<number> {
+  servers.push(server);
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("no test port");
+  return address.port;
+}
+afterEach(async () => {
+  for (const server of servers.splice(0).reverse()) {
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
+it("adds the private capability only after authenticating and authorizing, never from client headers", async () => {
+  const received: IncomingHttpHeaders[] = [];
+  const harnessPort = await listen(createServer((req, res) => {
+    received.push(req.headers);
+    req.resume();
+    res.writeHead(200, { "content-type": "application/json" }).end("{}");
+  }));
+  let capability: string | null = null;
+  const port = await listen(createServer(createProxyHandler({
+    harnessPort, mutationToken: () => capability,
+    authenticate: (token) => token === "paired" ? { id: "real-phone", cloudDesktopAccess: false } : null,
+    redeem: () => ({ error: "not pairing" }), serverName: () => "Fixture",
+  })));
+  const call = async (path: string, token = "paired", method = "POST") => {
+    const res = await fetch(`http://127.0.0.1:${port}${path}`, { method, headers: {
+      authorization: `Bearer ${token}`,
+      "x-openmausbot-companion-auth": "forged",
+      "x-openmausbot-desktop-owner": "forged-owner",
+      "x-openmausbot-companion-device": "forged-phone",
+    } });
+    await res.text();
+    return res.status;
+  };
+  expect(await call("/api/bots/b/read")).toBe(503);
+  expect(received).toHaveLength(0);
+  capability = "private-relay-secret";
+  expect(await call("/api/bots/b/read", "unpaired")).toBe(401);
+  expect(await call("/api/config", "paired", "PUT")).toBe(403);
+  expect(await call("/api/bots/b/computer/join")).toBe(403);
+  expect(received).toHaveLength(0);
+  expect(await call("/api/bots/b/read")).toBe(200);
+  expect(received).toHaveLength(1);
+  expect(received[0]["x-openmausbot-companion-auth"]).toBe(capability);
+  expect(received[0]["x-openmausbot-companion-device"]).toBe("real-phone");
+  expect(received[0]["x-openmausbot-desktop-owner"]).toBeUndefined();
+  expect(received[0].authorization).toBeUndefined();
+  await call("/api/health", "unpaired", "GET");
+  expect(received[1]["x-openmausbot-companion-auth"]).toBeUndefined();
+});

--- a/electron/companion.mjs
+++ b/electron/companion.mjs
@@ -187,7 +187,7 @@ export function stopCompanion() {
 }
 
 /** startCompanion's body, run inside the transition queue. */
-async function start({ resourcesPath, harnessPort, hostedUrl = null, secretPublicKey = null, log }) {
+async function start({ resourcesPath, harnessPort, mutationToken, hostedUrl = null, secretPublicKey = null, log }) {
   if (proc) return companionState();
   lastError = null;
   const resolved = entryPoint(resourcesPath);
@@ -249,6 +249,15 @@ async function start({ resourcesPath, harnessPort, hostedUrl = null, secretPubli
     lastError = "the companion process could not be started";
     return companionState();
   }
+  child.once("spawn", () => {
+    // Never expose this capability in argv, environment, logs or the renderer.
+    try {
+      child.postMessage({ type: "openmausbot:companion-mutation-token", token: mutationToken });
+    } catch {
+      log?.("companion authorization could not be initialized");
+      child.kill();
+    }
+  });
   child.stdout?.on("data", (d) => log?.(`[companion] ${String(d).trimEnd()}`));
   child.stderr?.on("data", (d) => log?.(`[companion err] ${String(d).trimEnd()}`));
 

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -284,6 +284,7 @@ const utilityServerExits = new WeakMap();
 const UTILITY_SERVER_STOP_TIMEOUT_MS = 6_500;
 const trustedApprovalMode = createTrustedApprovalModeCoordinator({ randomId: randomUUID });
 const desktopMutationToken = randomBytes(32).toString("base64url");
+const companionMutationToken = randomBytes(32).toString("base64url");
 
 function desktopDataDir() {
   // Match the historical desktop fallback for an unset or empty override,
@@ -638,6 +639,7 @@ function companionLaunchOptions(hostedUrl = null) {
   return {
     resourcesPath: process.resourcesPath,
     harnessPort: SERVER_PORT,
+    mutationToken: companionMutationToken,
     hostedUrl,
     // Only an embedded server receives the private half over its utility
     // port. A dev server launched in another terminal cannot decrypt, so it
@@ -980,6 +982,7 @@ function syncDesktopMutationToken(proc) {
     proc.postMessage({
       type: "openmausbot:desktop-mutation-token",
       token: desktopMutationToken,
+      companionToken: companionMutationToken,
     });
   } catch (error) {
     slog(`desktop mutation capability sync failed: ${error?.message ?? error}`);

--- a/scripts/smoke-phone-relay-auth.cjs
+++ b/scripts/smoke-phone-relay-auth.cjs
@@ -1,0 +1,136 @@
+// pnpm build:server && pnpm build:companion
+// pnpm exec electron scripts/smoke-phone-relay-auth.cjs
+// Real Electron children and pairing registry, disposable home, fake engine.
+const { app, utilityProcess } = require("electron");
+const assert = require("node:assert/strict");
+const { randomBytes } = require("node:crypto");
+const { mkdtempSync, writeFileSync, rmSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const { join, resolve } = require("node:path");
+const { createServer } = require("node:net");
+const { once } = require("node:events");
+const { setTimeout: delay } = require("node:timers/promises");
+
+const root = resolve(__dirname, "..");
+const home = mkdtempSync(join(tmpdir(), "omb-phone-auth-smoke-"));
+app.setPath("userData", join(home, "electron"));
+const children = [];
+let logs = "";
+const owner = randomBytes(32).toString("base64url");
+const relay = randomBytes(32).toString("base64url");
+async function freePort() {
+  const listener = createServer();
+  listener.listen(0, "127.0.0.1");
+  await once(listener, "listening");
+  const port = listener.address().port;
+  await new Promise((done) => listener.close(done));
+  return port;
+}
+async function until(check) {
+  const deadline = Date.now() + 40_000;
+  do {
+    const result = await check();
+    if (result) return result;
+    await delay(100);
+  } while (Date.now() < deadline);
+  throw new Error("Fixture timed out");
+}
+async function api(port, path, method = "GET", body, headers = {}) {
+  const response = await fetch(`http://127.0.0.1:${port}${path}`, {
+    method, headers: { "content-type": "application/json", ...headers },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    signal: AbortSignal.timeout(5000),
+  });
+  return { status: response.status, body: await response.json() };
+}
+function fork(entry, env) {
+  const child = utilityProcess.fork(join(root, entry), [], {
+    cwd: root, env, stdio: "pipe",
+  });
+  children.push(child);
+  child.stdout.on("data", (chunk) => { logs += chunk; });
+  child.stderr.on("data", (chunk) => { logs += chunk; });
+  return child;
+}
+app.whenReady().then(async () => {
+  const ports = new Set();
+  while (ports.size < 4) ports.add(await freePort());
+  const [harnessPort, webhookPort, phonePort, controlPort] = [...ports];
+  writeFileSync(join(home, "config.json"), JSON.stringify({ instances: {
+    claude: { driver: "claudeAgent", config: { cli: join(root, "server/testing/fake-claude-cli.ts") } },
+  } }));
+  const env = {
+    HOME: home, USERPROFILE: home, OMB_DATA_DIR: home, PATH: "",
+    ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
+    OMB_PORT: String(harnessPort), OMB_WEBHOOK_PORT: String(webhookPort),
+    OMB_COMPANION_PORT: String(phonePort), OMB_CONTROL_PORT: String(controlPort),
+    FAKE_CLAUDE_MODE: "happy",
+  };
+  const harness = fork("dist-server/index.js", { ...env, OMB_DESKTOP_PARENT: "1" });
+  await until(() => api(harnessPort, "/api/health").catch(() => null));
+  assert.equal((await api(harnessPort, "/api/bots", "POST", {})).status, 403);
+  harness.postMessage({ type: "openmausbot:desktop-mutation-token", token: owner, companionToken: relay });
+  const sidecar = fork("dist-companion/index.js", env);
+  await until(() => api(controlPort, "/state").catch(() => null));
+  const pairing = await api(controlPort, "/pairing", "POST");
+  assert.equal(pairing.status, 201);
+  const paired = await api(phonePort, "/api/pair", "POST", { credential: pairing.body.token, deviceName: "Fixture phone" });
+  assert.equal(paired.status, 201);
+  const phoneHeaders = { authorization: `Bearer ${paired.body.token}` };
+  const phone = (path, method = "GET", body, extra = {}) => api(phonePort, path, method, body, { ...phoneHeaders, ...extra });
+  assert.equal((await phone("/api/bots", "POST", {})).status, 503, "bootstrap must fail closed");
+  // Reproduce the old relay: marker/device alone cannot authorize a mutation.
+  assert.equal((await api(harnessPort, "/api/bots", "POST", {}, {
+    "x-openmausbot-companion": "1", "x-openmausbot-companion-device": paired.body.device.id,
+  })).status, 403);
+  sidecar.postMessage({ type: "openmausbot:companion-mutation-token", token: relay });
+  await until(async () => (await phone("/api/bots")).status === 200);
+  const created = await phone("/api/bots", "POST", { modelSelection: { instanceId: "claude", model: "claude-sonnet-5" } }, {
+    "x-openmausbot-companion-auth": "forged", "x-openmausbot-desktop-owner": "forged",
+    "x-openmausbot-companion-device": "forged-device",
+  });
+  assert.equal(created.status, 201);
+  const id = created.body.bot.id;
+  assert.equal((await phone(`/api/bots/${id}/read`, "POST", {})).status, 200);
+  assert.equal((await phone(`/api/bots/${id}/messages`, "POST", { text: "Hello from the paired phone" })).status, 202);
+  const bot = await until(async () => {
+    const result = await phone("/api/bots");
+    const current = result.body.bots.find((b) => b.id === id);
+    return current && !current.busy && current.messages.some((m) => m.text?.includes("hello from fake claude")) && current;
+  });
+  assert.ok(bot.messages.some((m) => m.text?.includes("Hello from the paired phone")));
+  // An app restart must not make an existing phone pair again. The registry
+  // persists the phone identity while the private relay credential rotates.
+  const sidecarExited = once(sidecar, "exit");
+  sidecar.kill();
+  await sidecarExited;
+  const nextRelay = randomBytes(32).toString("base64url");
+  harness.postMessage({ type: "openmausbot:desktop-mutation-token", token: owner, companionToken: nextRelay });
+  const restarted = fork("dist-companion/index.js", env);
+  restarted.once("spawn", () => restarted.postMessage({ type: "openmausbot:companion-mutation-token", token: nextRelay }));
+  await until(() => phone("/api/bots").then((r) => r.status === 200).catch(() => false));
+  assert.equal((await phone(`/api/bots/${id}/read`, "POST", {})).status, 200);
+  assert.equal((await api(phonePort, `/api/bots/${id}/read`, "POST", {})).status, 401);
+  assert.equal((await phone("/api/config", "PUT", {})).status, 403);
+  assert.equal((await phone("/api/internal/anything", "POST", {})).status, 404);
+  assert.equal((await api(controlPort, `/devices/${paired.body.device.id}`, "DELETE")).status, 200);
+  assert.equal((await phone(`/api/bots/${id}/read`, "POST", {})).status, 401);
+  console.log(JSON.stringify({ passed: true, realPairing: true, old403Reproduced: true,
+    botCreated: true, readMarked: true, replyVerified: true, forgedHeadersIgnored: true,
+    unpairedAndRevokedDenied: true, bootstrapFailsClosed: true, existingPairingAfterRestart: true }));
+}).catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+}).finally(async () => {
+  const evidence = join(tmpdir(), `omb-phone-auth-${Date.now()}.log`);
+  writeFileSync(evidence, logs.replaceAll(owner, "[redacted]").replaceAll(relay, "[redacted]"));
+  console.log(`Fixture log: ${evidence}`);
+  for (const child of children.reverse()) {
+    if (!child.pid) continue;
+    const exited = once(child, "exit");
+    child.kill();
+    await Promise.race([exited, delay(5000)]);
+  }
+  rmSync(home, { recursive: true, force: true });
+  app.exit(process.exitCode || 0);
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -361,6 +361,7 @@ const DESKTOP_MANAGED = process.env.OMB_DESKTOP_PARENT === "1";
 // Empty is deliberately a deny-all bootstrap state. Only Electron's private
 // utility-process port can replace it with the per-launch owner capability.
 let desktopMutationToken: string | undefined = DESKTOP_MANAGED ? "" : undefined;
+let companionMutationToken: string | undefined = DESKTOP_MANAGED ? "" : undefined;
 // Where remote clients reach this server (a proxy's public address); pairing URLs use it.
 const PUBLIC_URL = process.env.OMB_PUBLIC_URL?.trim().replace(/\/+$/, "") || null;
 const cfg = loadConfig();
@@ -424,6 +425,9 @@ function applyDesktopMutationTokenMessage(raw: unknown): boolean {
     throw new Error("invalid desktop mutation capability");
   }
   desktopMutationToken = message.token;
+  if (typeof message.companionToken === "string" && /^[A-Za-z0-9_-]{43}$/.test(message.companionToken)) {
+    companionMutationToken = message.companionToken;
+  }
   return true;
 }
 const browserCleanup = new BrowserCleanupCoordinator({
@@ -7339,6 +7343,7 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
       streamPath: "/api/events",
       url,
       loopbackMutationToken: desktopMutationToken,
+      companionMutationToken,
     });
     // Reachability probe, public: the phone races it across a server's
     // addresses before it has a session, and the tunnel verifier polls it.

--- a/server/request-auth.test.ts
+++ b/server/request-auth.test.ts
@@ -136,6 +136,42 @@ describe("resolveRequestAuth", () => {
   });
   afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
+  it("accepts authenticated relay mutations without exposing the desktop owner capability", () => {
+    const headers = {
+      host: "127.0.0.1:8799",
+      "x-openmausbot-companion": "1",
+      "x-openmausbot-companion-device": "phone-1",
+      "x-openmausbot-companion-auth": "relay-secret",
+    };
+    const check = (method: string, path: string, overrides: Record<string, string> = {}, relay = "relay-secret") =>
+      resolveRequestAuth(request({ ...headers, ...overrides }, method), {
+        sessions, cookieName, streamPath: "/api/events", url: new URL(path, "http://localhost"),
+        loopbackMutationToken: "desktop-secret", companionMutationToken: relay,
+      });
+    for (const [method, path] of [
+      ["POST", "/api/bots"], ["POST", "/api/bots/b/messages"],
+      ["POST", "/api/bots/b/read"], ["POST", "/api/bots/b/respond"],
+      ["POST", "/api/bots/b/secret-cards/card/provide"],
+      ["GET", "/api/events"], ["PATCH", "/api/bots/b/profile"],
+    ]) expect(check(method, path).auth?.kind, path).toBe("loopback");
+    const forged: Record<string, string>[] = [
+      { "x-openmausbot-companion-auth": "" },
+      { "x-openmausbot-companion-auth": "desktop-secret" },
+      { "x-openmausbot-companion-device": "" },
+      { "x-openmausbot-companion": "0" },
+      { origin: "https://evil.example" },
+      { "x-forwarded-for": "203.0.113.1" },
+      { host: "remote.example" },
+    ];
+    for (const overrides of forged) expect(check("POST", "/api/bots/b/read", overrides).auth).toBeNull();
+    expect(check("POST", "/api/bots/b/read", {}, "").auth).toBeNull();
+    for (const [method, path] of [
+      ["PUT", "/api/config"], ["POST", "/api/auth/pairing"],
+      ["POST", "/api/internal/anything"], ["GET", "/api/auth/sessions"],
+      ["POST", "/api/not-yet-supported"],
+    ]) expect(check(method, path).auth, path).toBeNull();
+  });
+
   function pairedToken(scopes: Array<"admin" | "client"> = ["admin", "client"]): string {
     const { code } = sessions.openPairing({ scopes });
     const result = sessions.exchange({ code, label: "test", source: "1.2.3.4" });

--- a/server/request-auth.ts
+++ b/server/request-auth.ts
@@ -13,6 +13,7 @@ import { timingSafeEqual } from "node:crypto";
 import { isIP } from "node:net";
 
 import type { Scope, SessionRecord, SessionRegistry } from "./sessions.ts";
+import { denyReason as companionDenial } from "../companion/src/routes.ts";
 
 export type RequestAuth =
   | { kind: "loopback"; scopes: readonly Scope[] }
@@ -283,6 +284,8 @@ export interface ResolveOptions {
    * port. When present, originless loopback callers may still read but every
    * public mutation must prove it came through the desktop's web session. */
   loopbackMutationToken?: string;
+  /** Separate private capability held by the authenticated phone relay. */
+  companionMutationToken?: string;
 }
 
 const DESKTOP_OWNER_HEADER = "x-openmausbot-desktop-owner";
@@ -348,6 +351,16 @@ export function resolveRequestAuth(req: IncomingMessage, options: ResolveOptions
   const proxied = isProxied(req);
   const loopback = !proxied && isLoopbackHost(headerValue(req.headers.host)) && isAllowedOrigin(headerValue(req.headers.origin));
   if (loopback) {
+    const companionToken = headerValue(req.headers["x-openmausbot-companion-auth"]);
+    if (companionToken && options.loopbackMutationToken !== undefined) {
+      if (
+        !secureTokenMatch(companionToken, options.companionMutationToken ?? "") ||
+        req.headers["x-openmausbot-companion"] !== "1" ||
+        !/^[\w-]{1,128}$/.test(headerValue(req.headers["x-openmausbot-companion-device"]) ?? "") ||
+        companionDenial({ path, method, authenticated: true })
+      ) return deny(403, "forbidden: invalid companion request");
+      return { auth: { kind: "loopback", scopes: LOOPBACK_SCOPES }, status: 401, error: "" };
+    }
     if (
       options.loopbackMutationToken !== undefined &&
       mutatingPublicRoute(method, path) &&


### PR DESCRIPTION
## Problem
Paired phones can read chats but receive "this change must come from the desktop app or a paired device" when marking a chat read, sending messages, or performing other writes. The packaged desktop owner guard was added without an authenticated relay capability for the companion sidecar.

## Fix
- Give the relay a separate per-launch capability over private Electron child messaging, never argv, environment, renderer, or disk.
- Attach it only after authenticating the paired phone and checking its route and existing device permissions. Ignore caller-supplied internal headers.
- Validate it at the harness boundary, sharing the existing companion route policy. Standalone Node compatibility remains unchanged.
- Fail closed during initialization. Existing phone pairing tokens survive relay restart and capability rotation; no phone reinstall or re-pairing is required.

## Verification
- 270 related tests pass; server typecheck and Electron syntax checks pass.
- Built harness plus real Electron sidecar smoke reproduces the old 403, performs actual pairing, creates a bot, marks its chat read, sends a message, and verifies the fake-engine reply.
- Verified existing pairing after restart, forged header handling, initialization rejection, and unpaired/revoked device rejection.
- Add this packaged relay smoke to macOS CI.
- All mutations used a disposable fixture, not the live app or user data.

## Scope
This is the urgent authentication regression fix, not full desktop/iOS feature parity. Existing route restrictions, response redaction, and cloud-desktop consent remain unchanged. Desktop release/install is still required for affected users.