### PR TITLE
ci(release): dispatch the npm and Docker publishes on the new tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,9 @@
 name: Docker image
 
 on:
+  # release.yml dispatches this on the tag it just published: a tag created
+  # with the workflow token never fires push events on its own.
+  workflow_dispatch:
   push:
     branches: [main]
     tags: ["v*"]

--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -1,6 +1,9 @@
 name: npm package
 
 on:
+  # release.yml dispatches this on the tag it just published: a tag created
+  # with the workflow token never fires push events on its own.
+  workflow_dispatch:
   push:
     tags: ["v*"]
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -411,6 +411,8 @@ jobs:
       cancel-in-progress: false
     permissions:
       contents: write
+      # to dispatch the npm and Docker publishes on the new tag
+      actions: write
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -577,3 +579,10 @@ jobs:
           GH_TOKEN="$LEGACY_TOKEN" gh release view "v$VERSION" \
             --repo milind-soni/openmausbot-releases --json isDraft --jq .isDraft | grep -q false
           echo "v$VERSION is live on the canonical feed and its legacy updater bridge"
+          # Publishing created the tag with this workflow's token, and GitHub
+          # starts no workflow from events that token creates. Start the two
+          # tag-driven publishes by hand, on the tag, so they see refs/tags/v*.
+          for workflow in npm-package.yml docker.yml; do
+            GH_TOKEN="$CANONICAL_TOKEN" gh workflow run "$workflow" --repo "$GITHUB_REPOSITORY" --ref "v$VERSION"
+          done
+          echo "dispatched the npm package and Docker image publishes on v$VERSION"


### PR DESCRIPTION
When `release.yml` publishes with `publish=true`, the tag it creates comes from the workflow token, and GitHub starts no workflow from events that token creates: 0.1.55's npm and Docker runs only happened after the tag was recreated by hand. `npm-package.yml` and `docker.yml` gain `workflow_dispatch`, and the publish step dispatches both on `v<version>` (the job gets `actions: write`), so they run with `refs/tags/v*` exactly as a pushed tag would.

🤖 Generated with [Claude Code](https://claude.com/claude-code)