### PR TITLE
fix(cli): bundles run by path again (guardian split); docker e2e follows the public health probe

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,8 +85,9 @@ jobs:
           body() { curl -sk --max-time 10 "$@"; }
           H=https://localhost
           grep -q '"environmentId"' <<<"$(body $H/.well-known/openmausbot/environment)"   # descriptor is public
-          test "$(code $H/api/health)" = 403                                      # nothing else before pairing
-          grep -q 'pair this device' <<<"$(body $H/api/health)"
+          grep -q '^{"app":"openmausbot"}$' <<<"$(body $H/api/health)"             # the probe is public, and says only the app name
+          test "$(code $H/api/bots)" = 403                                        # nothing else before pairing
+          grep -q 'pair this device' <<<"$(body $H/api/bots)"
           grep -qi '<html' <<<"$(body $H/pair)"                                    # the UI shell is served so /pair can load
           test "$(code http://localhost/)" = 308                                   # HTTP redirects to HTTPS
           pairing=$(docker compose -f deploy/docker-compose.yml exec -T omb node dist-server/pair-cli.js --label ci)
@@ -110,7 +111,7 @@ jobs:
           sse=$( (curl -sk -b "$jar" -N --max-time 4 $H/api/events || true) | head -c 64 )
           test -n "$sse"                                                           # SSE streams, not buffered
           grep -q '"baseUrl":"https://localhost"' <<<"$(body -b "$jar" $H/api/webhooks)"   # OMB_WEBHOOK_PUBLIC_URL is advertised
-          test "$(code $H/api/health)" = 403                                      # and without the cookie it is still closed
+          test "$(code $H/api/bots)" = 403                                        # and without the cookie it is still closed
           docker compose -f deploy/docker-compose.yml down -v
 
   publish:

--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -41,6 +41,9 @@ jobs:
           cd release/npm && npm pack --silent && cd ../..
           rm -rf /tmp/omb-pack && mkdir -p /tmp/omb-pack && tar -xzf release/npm/openmausbot-*.tgz -C /tmp/omb-pack
           cd /tmp/omb-pack/package
+          # Every check below is a silent grep/test; say which one failed, and what the server said.
+          set -x
+          trap 'echo "--- serve.log"; cat serve.log 2>/dev/null; echo "--- tunnel.log"; cat tunnel.log 2>/dev/null' ERR
           test ! -d node_modules
           node cli.js --help | grep -q "openmausbot serve"
           HOME=/tmp/omb-pack/home node cli.js serve --no-pair --port 18799 --data-dir /tmp/omb-pack/data --label ci --public-url https://ci.example > serve.log 2>&1 &

--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -55,7 +55,9 @@ jobs:
           # the bundles also run directly by path (the image and docs do that), not only through cli.js:
           # a bundled module with a "run when executed directly" block would fire here
           node dist-server/openmausbot.js --help | grep -q "openmausbot serve"
-          OMB_PORT=1 node dist-server/pair-cli.js 2>&1 | grep -q "no OpenMausBot server"
+          OMB_PORT=1 node dist-server/pair-cli.js > pair.out 2>&1 || true
+          cat pair.out
+          grep -q "no OpenMausBot server" pair.out
           # --tunnel ships its own processes and fails closed without an account
           test -f dist-server/tunnel-guardian.js && test -f dist-server/prepare-cloudflared.js
           if HOME=/tmp/omb-pack/home node cli.js serve --tunnel --port 18798 --data-dir /tmp/omb-pack/data2 > tunnel.log 2>&1; then echo "serve --tunnel should refuse without login"; exit 1; fi

--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -49,6 +49,10 @@ jobs:
           OMB_PORT=18799 node cli.js status | grep -q "ci ·"
           OMB_PORT=18799 node cli.js pair --label "CI phone" | grep -q "open or scan:  https://ci.example/pair#code="
           OMB_PORT=18799 node cli.js sessions | grep -q "no paired devices yet"
+          # the bundles also run directly by path (the image and docs do that), not only through cli.js:
+          # a bundled module with a "run when executed directly" block would fire here
+          node dist-server/openmausbot.js --help | grep -q "openmausbot serve"
+          OMB_PORT=1 node dist-server/pair-cli.js 2>&1 | grep -q "no OpenMausBot server"
           # --tunnel ships its own processes and fails closed without an account
           test -f dist-server/tunnel-guardian.js && test -f dist-server/prepare-cloudflared.js
           if HOME=/tmp/omb-pack/home node cli.js serve --tunnel --port 18798 --data-dir /tmp/omb-pack/data2 > tunnel.log 2>&1; then echo "serve --tunnel should refuse without login"; exit 1; fi

--- a/electron/managed-companion-guardian-main.mjs
+++ b/electron/managed-companion-guardian-main.mjs
@@ -1,0 +1,12 @@
+// The connector guardian as a process: `node managed-companion-guardian-main.mjs
+// <cloudflared> <tokenFile> <socketPath> <pid> <originPort>`. Spawned by
+// managed-companion-tunnel.mjs (desktop) and, bundled as
+// dist-server/tunnel-guardian.js, by `openmausbot serve --tunnel`. Runs
+// unconditionally: nothing imports this file, and the library it wraps has
+// no side effects, so a bundle that inlines the library stays inert.
+import { guardianArguments, runManagedCompanionGuardian } from "./managed-companion-guardian.mjs";
+
+runManagedCompanionGuardian(guardianArguments(process.argv.slice(2))).then(
+  (code) => process.exit(code),
+  () => process.exit(1),
+);

--- a/electron/managed-companion-guardian.mjs
+++ b/electron/managed-companion-guardian.mjs
@@ -7,7 +7,6 @@
 // expose whatever process happens to bind a reusable local port later.
 import { spawn } from "node:child_process";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 
 import {
   createCompanionOriginGateway,
@@ -187,7 +186,7 @@ export async function runManagedCompanionGuardian({
   return outcome.kind === "connector" ? outcome.code : 0;
 }
 
-function guardianArguments(argv) {
+export function guardianArguments(argv) {
   if (argv.length !== 5) throw new Error("The managed companion guardian arguments are invalid");
   const [cloudflaredBinary, tokenFile, socketPath, rawPid, rawPort] = argv;
   const pid = Number(rawPid);
@@ -199,12 +198,8 @@ function guardianArguments(argv) {
   return { cloudflaredBinary, tokenFile, target, originPort };
 }
 
-const isDirectExecution =
-  process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
-
-if (isDirectExecution) {
-  runManagedCompanionGuardian(guardianArguments(process.argv.slice(2))).then(
-    (code) => process.exit(code),
-    () => process.exit(1),
-  );
-}
+// Executed as a process through managed-companion-guardian-main.mjs. This file
+// is a library on purpose: managed-companion-tunnel.mjs imports an environment
+// helper from it, and anything that bundles that module (the headless CLI's
+// entries) would otherwise inline a "run when executed directly" check that
+// is true for the bundle itself.

--- a/electron/managed-companion-tunnel.mjs
+++ b/electron/managed-companion-tunnel.mjs
@@ -142,7 +142,7 @@ export function resolveCloudflaredBinary({
 }
 
 export function resolveManagedCompanionGuardian({ appPath, exists = fs.existsSync } = {}) {
-  const entry = path.join(String(appPath ?? ""), "electron", "managed-companion-guardian.mjs");
+  const entry = path.join(String(appPath ?? ""), "electron", "managed-companion-guardian-main.mjs");
   return exists(entry) ? entry : null;
 }
 

--- a/scripts/bundle-server.mjs
+++ b/scripts/bundle-server.mjs
@@ -95,10 +95,10 @@ await build({
 // `openmausbot serve --tunnel` (server/tunnel.ts) spawns the connector guardian
 // as its own process, so it has to exist as a file beside the server, not only
 // as code inlined into the bundle that imports its neighbours. Bundled under
-// its own name: the same file the desktop app ships as
-// electron/managed-companion-guardian.mjs, so a fix lands in both.
+// its own name: the same code the desktop app runs from
+// electron/managed-companion-guardian-main.mjs, so a fix lands in both.
 await build({
-  entryPoints: [join(root, "electron", "managed-companion-guardian.mjs")],
+  entryPoints: [join(root, "electron", "managed-companion-guardian-main.mjs")],
   bundle: true,
   platform: "node",
   target: "node20",

--- a/server/exit.ts
+++ b/server/exit.ts
@@ -1,0 +1,9 @@
+// End the process with a code once stdout and stderr have flushed. On Linux a
+// pipe (CI's `| grep`, a journal) takes writes asynchronously, so
+// `process.exit` right after `console.error` can drop the very line that
+// says what went wrong. A write callback fires only once its data is out.
+export function exitAfterFlush(code: number): void {
+  process.exitCode = code;
+  const flushed = (stream: NodeJS.WriteStream) => new Promise<void>((done) => stream.write("", () => done()));
+  void Promise.all([flushed(process.stdout), flushed(process.stderr)]).then(() => process.exit(code));
+}

--- a/server/openmausbot.ts
+++ b/server/openmausbot.ts
@@ -1,10 +1,8 @@
 // Entry point for the `openmausbot` command (see cli.ts).
 import { main } from "./cli.ts";
+import { exitAfterFlush } from "./exit.ts";
 
-main().then(
-  (code) => process.exit(code),
-  (error) => {
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exit(1);
-  },
-);
+main().then(exitAfterFlush, (error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  exitAfterFlush(1);
+});

--- a/server/pair-cli.ts
+++ b/server/pair-cli.ts
@@ -1,11 +1,9 @@
 // Compatibility alias: `openmausbot pair` lives in cli.ts now. Kept because
 // docs and images reference dist-server/pair-cli.js.
 import { main } from "./cli.ts";
+import { exitAfterFlush } from "./exit.ts";
 
-main(["pair", ...process.argv.slice(2)]).then(
-  (code) => process.exit(code),
-  (error) => {
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exit(1);
-  },
-);
+main(["pair", ...process.argv.slice(2)]).then(exitAfterFlush, (error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  exitAfterFlush(1);
+});

--- a/server/tunnel.test.ts
+++ b/server/tunnel.test.ts
@@ -134,7 +134,7 @@ describe("where the pieces are", () => {
       void removeTempDir(bundled);
     }
     // a checkout: the source files
-    expect(guardianEntry()).toMatch(/managed-companion-guardian\.mjs$/);
+    expect(guardianEntry()).toMatch(/managed-companion-guardian-main\.mjs$/);
   });
 
   it("describes tunnel states in one line each", () => {

--- a/server/tunnel.ts
+++ b/server/tunnel.ts
@@ -186,7 +186,7 @@ export function prepareEntry(here = HERE): string {
 export function guardianEntry(here = HERE): string | null {
   const bundled = join(here, "tunnel-guardian.js");
   if (existsSync(bundled)) return bundled;
-  const source = resolve(here, "..", "electron", "managed-companion-guardian.mjs");
+  const source = resolve(here, "..", "electron", "managed-companion-guardian-main.mjs");
   return existsSync(source) ? source : null;
 }
 


### PR DESCRIPTION
Two things the Docker stack e2e caught, both from #815:

1. **Real bug.** `managed-companion-tunnel.mjs` imports an environment helper from the guardian file, so bundling `server/tunnel.ts` inlined the guardian's "run when executed directly" check into `openmausbot.js` and `pair-cli.js`, and that check is true for a bundle run by path: `node dist-server/pair-cli.js` died with *The managed companion guardian arguments are invalid*. The npm proof only went through `cli.js` and missed it. The guardian is now a side-effect-free library and `managed-companion-guardian-main.mjs` is the process entry (desktop spawn + `dist-server/tunnel-guardian.js`). The npm proof now runs both bundles directly by path.
2. The e2e asserted `GET /api/health` is 403 before pairing; since #815 the probe is public. It now asserts the probe says exactly `{"app":"openmausbot"}` to a stranger and checks closedness on `/api/bots`.

The 0.1.55 npm tarball carries bug 1 for direct `node dist-server/…` use only; `npx openmausbot` is unaffected. Neither this workflow nor the packaged smoke is a required check, which is how main stayed red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated companion guardian entry point for desktop and tunnel-based operation.
  * Improved pairing command verification and error reporting.

* **Bug Fixes**
  * Health checks now distinguish public health status from protected bot endpoints.
  * Improved command shutdown handling so final output is reliably displayed.
  * Updated tunnel guardian resolution for more reliable startup.

* **Tests**
  * Updated smoke tests to verify endpoint access, server startup, and pairing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->