### PR TITLE
docs: deploy on a VPS, step by step (repo + docs site)

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,16 @@ OpenMausBot is free and open source. If it does real work for you, you can
 one-time any amount, or monthly. Payments are handled by [Polar](https://polar.sh/supamaus),
 which takes care of receipts and taxes; nothing about the app ever sits behind a paywall.
 
+## Run it on a server
+
+Bots keep working with every laptop closed when the server runs on a VPS or
+a Mac mini. One command with Node 24: `npx openmausbot serve` (add
+`--tunnel` for a public address with no domain or open port, or
+`--tailscale` for your tailnet), or the Docker stack for your own domain.
+Devices pair once with a short code. The step-by-step guide is
+[docs/deploy-vps.md](docs/deploy-vps.md); the reference is
+[docs/self-hosting.md](docs/self-hosting.md).
+
 ## License
 
 [Apache License 2.0](LICENSE) © 2026 Milind Soni and OpenMausBot contributors.

--- a/apps/docs/content/docs/self-hosting/deploy-vps.mdx
+++ b/apps/docs/content/docs/self-hosting/deploy-vps.mdx
@@ -1,0 +1,221 @@
+---
+title: Deploy on a VPS
+description: From a blank Linux server to OpenMausBot running around the clock, reachable from your laptop, the desktop app and your phone.
+icon: Cloud
+---
+
+<Callout title="Three ways in, one login">
+  A public address with one command, your own domain with Docker, or your Tailscale network. Whichever you pick, devices pair once with a short code and stay signed in for 30 days. No password.
+</Callout>
+
+From a blank Linux server to OpenMausBot running on it around the clock, reachable from your laptop, the desktop app and your phone, with your bots working while every laptop is closed. It assumes nothing beyond being able to open a terminal and paste commands. About twenty minutes, most of it waiting.
+
+Three ways to make the server reachable are covered. Pick one; the rest of the guide is the same.
+
+| | You need | Who can reach it | Best for |
+|---|---|---|---|
+| **A. Public address, no domain** (`serve --tunnel`) | an OpenMausBot account (email code) | anyone with a pairing code, over HTTPS | the fastest path; a phone on cellular |
+| **B. Your own domain** (Docker + Caddy) | a domain name, ports 80/443 | anyone with a pairing code, over HTTPS | a permanent address you own |
+| **C. Your Tailscale network** (`serve --tailscale`) | Tailscale on the server and your devices | only your tailnet | the most private; nothing public at all |
+
+Whichever you pick, the login is the same: you **pair** each device once with a short code and it stays signed in for 30 days. There is no password.
+
+## What runs on a server, and what does not
+
+Runs fully on the server: every engine CLI (Claude Code, Codex, Grok, custom ACP engines), chats, rooms, bot-to-bot coordination, routines, connected apps and custom MCP servers, webhooks, Company Brain, computer use on cloud or container computers, text-to-speech, and the web UI (the server serves it itself).
+
+Needs the desktop app instead: the built-in browser panel, the skill recorder, dictation, and controlling the server's own desktop.
+
+## Before you start
+
+1. **A server.** Any Linux VPS: Ubuntu 22.04 or 24.04, 2 CPUs and 4 GB of RAM is plenty. You need `sudo` or root. Hetzner, DigitalOcean, Lightsail, a Mac mini in a cupboard: all fine.
+2. **Node 24 or newer** for paths A and C (`node --version`). On Ubuntu:
+
+   ```sh
+   curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash - && sudo apt-get install -y nodejs
+   ```
+
+   Path B uses Docker instead and needs no Node on the host.
+3. **Your engine accounts.** Bots run on the same engine CLIs you use on your laptop, with your subscriptions. You sign them in on the server once, the same way.
+
+Connect to the server for everything below:
+
+```sh
+ssh root@YOUR_SERVER_IP
+```
+
+## Path A: a public address with one command
+
+No domain, no proxy, no open port. The server gets an address like `https://c-7f3a9c.openmausbot.com` through a Cloudflare tunnel; only traffic through the tunnel reaches it, and that traffic still has to pair.
+
+```sh
+npx openmausbot login          # once: an emailed code signs this machine in and reserves its address
+npx openmausbot serve --tunnel # runs the server there and prints the pairing link with a QR code
+```
+
+`login` asks for your email, sends an 8-digit code, and prints the address it reserved for this machine. `serve --tunnel` downloads `cloudflared` on the first run (a pinned version with a verified digest, into `~/.openmausbot`), starts the server, connects the tunnel, and after a few seconds prints `tunnel: live at https://…`. Leave it running; see "Keep it running" for a service.
+
+The account credentials live in `~/.openmausbot/tunnel-account.json`, readable only by your user. `npx openmausbot logout` releases the address.
+
+Skip to "Sign the engines in".
+
+## Path B: your own domain, with Docker
+
+One container for the server plus Caddy for HTTPS at `https://maus.example.com`.
+
+1. **Point a name at the server.** In your DNS provider add an **A record** (name `maus`, value the server's public IP). After a few minutes `ping maus.example.com` should answer with that IP. Ports 80 and 443 must be open; most providers open them by default.
+2. **Install Docker:**
+
+   ```sh
+   curl -fsSL https://get.docker.com | sh
+   docker compose version   # prints a version; if "command not found", log out and back in
+   ```
+
+3. **Get the deploy files and set the name:**
+
+   ```sh
+   git clone https://github.com/milind-soni/OpenMausBot && cd OpenMausBot/deploy
+   cp .env.example .env
+   nano .env                # DOMAIN=maus.example.com ; ENGINES=@anthropic-ai/claude-code @openai/codex
+   ```
+
+   `ENGINES` lists the engine CLIs baked into your image, separated by spaces. Change it later and rebuild if you add one.
+
+4. **Start it:**
+
+   ```sh
+   docker compose pull omb && docker compose up -d
+   docker compose ps        # omb "healthy", caddy "running"
+   ```
+
+   Caddy requests the certificate on its own; give it a minute. Then `https://maus.example.com` shows a page asking for a pairing code. That is correct: nothing works until you pair.
+
+In this path, every `npx openmausbot …` command below is run inside the container instead:
+
+```sh
+docker compose exec omb node dist-server/openmausbot.js pair --label "My MacBook"
+```
+
+## Path C: only your Tailscale network
+
+Install Tailscale on the server and sign in (`curl -fsSL https://tailscale.com/install.sh | sh && sudo tailscale up`), enable HTTPS certificates for your tailnet once in the admin console (DNS → HTTPS Certificates), then:
+
+```sh
+npx openmausbot serve --tailscale
+```
+
+Tailscale terminates HTTPS with its own certificate and the pairing link uses the server's MagicDNS name (`https://maus.tail1234.ts.net`). Only devices on your tailnet can reach it, which is a very good property for a server that can run tools.
+
+## Sign the engines in
+
+Bots run on the engine CLIs installed on the server, using your accounts. Sign each one in once; the logins live under the server's data directory and survive restarts and updates.
+
+```sh
+claude                       # path A/C: on the server; path B: docker compose exec omb claude
+```
+
+Claude Code prints a link to open in your laptop's browser; approve it and the sign-in finishes. `/exit` to leave. Repeat for each engine you use (`codex`, …).
+
+## Pair your first device
+
+`serve` already printed a pairing link and QR code when it started. For another device later:
+
+```sh
+npx openmausbot pair --label "Kitchen iPad"
+```
+
+```
+pairing code:  RR8Y-BLR6-H939
+expires:       10:59:45 AM (single use)
+open or scan:  https://c-7f3a9c.openmausbot.com/pair#code=RR8Y-BLR6-H939
+```
+
+- **A browser:** open the link. The code is filled in; press **Connect**. That browser is paired for 30 days.
+- **The desktop app:** copy the link, then in the app's **Server** menu choose **Add Server from Copied Pairing Link…**. The menu switches between your own machine and every server you added.
+- **The phone:** scan the QR code from the iOS app's pairing screen, or paste the whole link into its address field. The phone can chat, approve, and read; creating bots, changing models, and connecting apps stay with you in the server's UI.
+
+Worth knowing: a code works **once** and expires after **five minutes**; the link only works on that address (typing the code by hand: open `…/pair` and enter it); ten wrong codes in a minute from one address pause pairing for that address for a minute; `--client` mints a code for a device that may chat and approve but not change settings or pair others.
+
+## Manage devices
+
+Every paired device is a session:
+
+```sh
+npx openmausbot sessions              # id, device, scope, last seen, expires
+npx openmausbot sessions revoke ID    # signs that device out and closes its stream at once
+npx openmausbot status                # what the server says about itself
+```
+
+## Keep it running
+
+`npx openmausbot serve` is a plain foreground process. Under systemd (paths A and C):
+
+```ini
+# /etc/systemd/system/openmausbot.service
+[Unit]
+Description=OpenMausBot server
+After=network-online.target
+
+[Service]
+User=maus                    # an unprivileged user that owns ~/.openmausbot and the engine logins
+WorkingDirectory=/home/maus
+ExecStart=/usr/bin/npx openmausbot serve --tunnel --no-pair
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```sh
+sudo systemctl daemon-reload && sudo systemctl enable --now openmausbot
+journalctl -u openmausbot -f            # the server's log, including "tunnel: live at …"
+```
+
+Use `--tailscale` instead of `--tunnel` for path C. `--no-pair` skips printing a code at every restart; mint one with `npx openmausbot pair` when you need it. Docker (path B) restarts on its own (`restart: unless-stopped`).
+
+## Update
+
+- **Paths A and C:** `npx openmausbot@latest serve …` always runs the newest published version; with the service above, `sudo systemctl restart openmausbot` picks it up.
+- **Path B:** `cd OpenMausBot/deploy && docker compose pull omb && docker compose up -d`.
+
+Routines and queued work survive a restart; a turn running at that moment does not, so update between runs.
+
+## Back up
+
+Everything that matters (bots, chats, routines, engine logins, paired sessions) is in one place: `~/.openmausbot` for paths A and C, the `deploy_data` Docker volume for path B.
+
+```sh
+tar czf openmausbot-data.tgz -C ~ .openmausbot                                  # A, C
+docker run --rm -v deploy_data:/data -v "$PWD":/b alpine tar czf /b/openmausbot-data.tgz -C /data .   # B
+```
+
+Keep the file somewhere else. Restore by stopping the server and untarring into the same place.
+
+## The rules the setup relies on
+
+Read this before putting anything else in front of the server.
+
+- The server only ever listens on loopback (`127.0.0.1:8799`). Never publish that port yourself. The tunnel, Caddy and Tailscale each reach it from the same machine.
+- A request that arrives through a proxy or the tunnel is treated as remote and needs a session, whatever headers it carries. A proxy of your own (nginx, Traefik, Cloudflare Tunnel) must forward the real `Host` and add `X-Forwarded-For` and `X-Forwarded-Proto`, must not buffer the event stream, and must **not** rewrite `Host` to `127.0.0.1`.
+- Pairing is the login. Want a second wall in front of it? Path B's `Caddyfile` has a commented `basic_auth` block for a shared password.
+- The session cookie is marked `Secure`; do not serve this over plain HTTP on the public internet.
+- The one thing a stranger can read is `/.well-known/openmausbot/environment` (the server's id, label, version, capabilities) and `/api/health` (only the app name). Everything else answers "pair this device".
+
+## Troubleshooting
+
+**`serve --tunnel` says "no account on this machine yet".** Run `npx openmausbot login` on this machine first; the credentials are per machine.
+
+**The tunnel stays on "retrying".** The server is running and usable locally; the public hop is not verified yet. Wait a minute (Cloudflare needs a moment on a fresh address), then check `journalctl`/the terminal for the reason. If it never comes up, `npx openmausbot logout && npx openmausbot login` issues a fresh address.
+
+**Path B: the page never loads or shows a certificate error.** Caddy could not get a certificate. Check that the name resolves to the server and that ports 80 and 443 are open; `docker compose logs caddy` shows the reason.
+
+**"forbidden: pair this device to use the server remotely" / "this request came through a proxy".** Expected before pairing, and for tools that call the API without a session. Pair the device. Scripts send `Authorization: Bearer <token>` with the token from the pairing response instead of a cookie.
+
+**Pairing code refused.** It expired (five minutes) or was used. Mint a new one. "Too many failed pairing attempts" means wait a minute.
+
+**A bot says the engine is not signed in.** Sign that engine in again on the server.
+
+**What does the server think it is?** `https://<address>/.well-known/openmausbot/environment` is public and shows its id, label, version and capabilities; `npx openmausbot status` prints the same on the server.
+
+**Something else.** `journalctl -u openmausbot --since -10m` (or `docker compose logs omb --tail 100`) shows the server's startup lines. Paste them with your question in the community channel.

--- a/apps/docs/content/docs/self-hosting/index.mdx
+++ b/apps/docs/content/docs/self-hosting/index.mdx
@@ -12,7 +12,7 @@ OpenMausBot is local-first by default: the harness listens on loopback, agent CL
 2. Install and authenticate the agent CLIs you want to use.
 3. Add optional third-party keys only for the services you need.
 4. Keep the harness on loopback.
-5. Use the paired companion sidecar or Tailscale when another device needs access.
+5. Use it from other devices by pairing them: a browser, the desktop app or the phone, over a public address, your own domain or your tailnet. See [Deploy on a VPS](/docs/self-hosting/deploy-vps).
 
 ## What is still third party
 

--- a/apps/docs/content/docs/self-hosting/meta.json
+++ b/apps/docs/content/docs/self-hosting/meta.json
@@ -1,5 +1,10 @@
 {
   "title": "Self-hosting",
   "icon": "Server",
-  "pages": ["index", "networking", "data-and-backups"]
+  "pages": [
+    "index",
+    "deploy-vps",
+    "networking",
+    "data-and-backups"
+  ]
 }

--- a/docs/deploy-vps.md
+++ b/docs/deploy-vps.md
@@ -1,0 +1,213 @@
+# Deploy OpenMausBot on a VPS
+
+From a blank Linux server to OpenMausBot running on it around the clock, reachable from your laptop, the desktop app and your phone, with your bots working while every laptop is closed. It assumes nothing beyond being able to open a terminal and paste commands. About twenty minutes, most of it waiting.
+
+Three ways to make the server reachable are covered. Pick one; the rest of the guide is the same.
+
+| | You need | Who can reach it | Best for |
+|---|---|---|---|
+| **A. Public address, no domain** (`serve --tunnel`) | an OpenMausBot account (email code) | anyone with a pairing code, over HTTPS | the fastest path; a phone on cellular |
+| **B. Your own domain** (Docker + Caddy) | a domain name, ports 80/443 | anyone with a pairing code, over HTTPS | a permanent address you own |
+| **C. Your Tailscale network** (`serve --tailscale`) | Tailscale on the server and your devices | only your tailnet | the most private; nothing public at all |
+
+Whichever you pick, the login is the same: you **pair** each device once with a short code and it stays signed in for 30 days. There is no password.
+
+## What runs on a server, and what does not
+
+Runs fully on the server: every engine CLI (Claude Code, Codex, Grok, custom ACP engines), chats, rooms, bot-to-bot coordination, routines, connected apps and custom MCP servers, webhooks, Company Brain, computer use on cloud or container computers, text-to-speech, and the web UI (the server serves it itself).
+
+Needs the desktop app instead: the built-in browser panel, the skill recorder, dictation, and controlling the server's own desktop.
+
+## Before you start
+
+1. **A server.** Any Linux VPS: Ubuntu 22.04 or 24.04, 2 CPUs and 4 GB of RAM is plenty. You need `sudo` or root. Hetzner, DigitalOcean, Lightsail, a Mac mini in a cupboard: all fine.
+2. **Node 24 or newer** for paths A and C (`node --version`). On Ubuntu:
+
+   ```sh
+   curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash - && sudo apt-get install -y nodejs
+   ```
+
+   Path B uses Docker instead and needs no Node on the host.
+3. **Your engine accounts.** Bots run on the same engine CLIs you use on your laptop, with your subscriptions. You sign them in on the server once, the same way.
+
+Connect to the server for everything below:
+
+```sh
+ssh root@YOUR_SERVER_IP
+```
+
+## Path A: a public address with one command
+
+No domain, no proxy, no open port. The server gets an address like `https://c-7f3a9c.openmausbot.com` through a Cloudflare tunnel; only traffic through the tunnel reaches it, and that traffic still has to pair.
+
+```sh
+npx openmausbot login          # once: an emailed code signs this machine in and reserves its address
+npx openmausbot serve --tunnel # runs the server there and prints the pairing link with a QR code
+```
+
+`login` asks for your email, sends an 8-digit code, and prints the address it reserved for this machine. `serve --tunnel` downloads `cloudflared` on the first run (a pinned version with a verified digest, into `~/.openmausbot`), starts the server, connects the tunnel, and after a few seconds prints `tunnel: live at https://…`. Leave it running; see "Keep it running" for a service.
+
+The account credentials live in `~/.openmausbot/tunnel-account.json`, readable only by your user. `npx openmausbot logout` releases the address.
+
+Skip to "Sign the engines in".
+
+## Path B: your own domain, with Docker
+
+One container for the server plus Caddy for HTTPS at `https://maus.example.com`.
+
+1. **Point a name at the server.** In your DNS provider add an **A record** (name `maus`, value the server's public IP). After a few minutes `ping maus.example.com` should answer with that IP. Ports 80 and 443 must be open; most providers open them by default.
+2. **Install Docker:**
+
+   ```sh
+   curl -fsSL https://get.docker.com | sh
+   docker compose version   # prints a version; if "command not found", log out and back in
+   ```
+
+3. **Get the deploy files and set the name:**
+
+   ```sh
+   git clone https://github.com/milind-soni/OpenMausBot && cd OpenMausBot/deploy
+   cp .env.example .env
+   nano .env                # DOMAIN=maus.example.com ; ENGINES=@anthropic-ai/claude-code @openai/codex
+   ```
+
+   `ENGINES` lists the engine CLIs baked into your image, separated by spaces. Change it later and rebuild if you add one.
+
+4. **Start it:**
+
+   ```sh
+   docker compose pull omb && docker compose up -d
+   docker compose ps        # omb "healthy", caddy "running"
+   ```
+
+   Caddy requests the certificate on its own; give it a minute. Then `https://maus.example.com` shows a page asking for a pairing code. That is correct: nothing works until you pair.
+
+In this path, every `npx openmausbot …` command below is run inside the container instead:
+
+```sh
+docker compose exec omb node dist-server/openmausbot.js pair --label "My MacBook"
+```
+
+## Path C: only your Tailscale network
+
+Install Tailscale on the server and sign in (`curl -fsSL https://tailscale.com/install.sh | sh && sudo tailscale up`), enable HTTPS certificates for your tailnet once in the admin console (DNS → HTTPS Certificates), then:
+
+```sh
+npx openmausbot serve --tailscale
+```
+
+Tailscale terminates HTTPS with its own certificate and the pairing link uses the server's MagicDNS name (`https://maus.tail1234.ts.net`). Only devices on your tailnet can reach it, which is a very good property for a server that can run tools.
+
+## Sign the engines in
+
+Bots run on the engine CLIs installed on the server, using your accounts. Sign each one in once; the logins live under the server's data directory and survive restarts and updates.
+
+```sh
+claude                       # path A/C: on the server; path B: docker compose exec omb claude
+```
+
+Claude Code prints a link to open in your laptop's browser; approve it and the sign-in finishes. `/exit` to leave. Repeat for each engine you use (`codex`, …).
+
+## Pair your first device
+
+`serve` already printed a pairing link and QR code when it started. For another device later:
+
+```sh
+npx openmausbot pair --label "Kitchen iPad"
+```
+
+```
+pairing code:  RR8Y-BLR6-H939
+expires:       10:59:45 AM (single use)
+open or scan:  https://c-7f3a9c.openmausbot.com/pair#code=RR8Y-BLR6-H939
+```
+
+- **A browser:** open the link. The code is filled in; press **Connect**. That browser is paired for 30 days.
+- **The desktop app:** copy the link, then in the app's **Server** menu choose **Add Server from Copied Pairing Link…**. The menu switches between your own machine and every server you added.
+- **The phone:** scan the QR code from the iOS app's pairing screen, or paste the whole link into its address field. The phone can chat, approve, and read; creating bots, changing models, and connecting apps stay with you in the server's UI.
+
+Worth knowing: a code works **once** and expires after **five minutes**; the link only works on that address (typing the code by hand: open `…/pair` and enter it); ten wrong codes in a minute from one address pause pairing for that address for a minute; `--client` mints a code for a device that may chat and approve but not change settings or pair others.
+
+## Manage devices
+
+Every paired device is a session:
+
+```sh
+npx openmausbot sessions              # id, device, scope, last seen, expires
+npx openmausbot sessions revoke ID    # signs that device out and closes its stream at once
+npx openmausbot status                # what the server says about itself
+```
+
+## Keep it running
+
+`npx openmausbot serve` is a plain foreground process. Under systemd (paths A and C):
+
+```ini
+# /etc/systemd/system/openmausbot.service
+[Unit]
+Description=OpenMausBot server
+After=network-online.target
+
+[Service]
+User=maus                    # an unprivileged user that owns ~/.openmausbot and the engine logins
+WorkingDirectory=/home/maus
+ExecStart=/usr/bin/npx openmausbot serve --tunnel --no-pair
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```sh
+sudo systemctl daemon-reload && sudo systemctl enable --now openmausbot
+journalctl -u openmausbot -f            # the server's log, including "tunnel: live at …"
+```
+
+Use `--tailscale` instead of `--tunnel` for path C. `--no-pair` skips printing a code at every restart; mint one with `npx openmausbot pair` when you need it. Docker (path B) restarts on its own (`restart: unless-stopped`).
+
+## Update
+
+- **Paths A and C:** `npx openmausbot@latest serve …` always runs the newest published version; with the service above, `sudo systemctl restart openmausbot` picks it up.
+- **Path B:** `cd OpenMausBot/deploy && docker compose pull omb && docker compose up -d`.
+
+Routines and queued work survive a restart; a turn running at that moment does not, so update between runs.
+
+## Back up
+
+Everything that matters (bots, chats, routines, engine logins, paired sessions) is in one place: `~/.openmausbot` for paths A and C, the `deploy_data` Docker volume for path B.
+
+```sh
+tar czf openmausbot-data.tgz -C ~ .openmausbot                                  # A, C
+docker run --rm -v deploy_data:/data -v "$PWD":/b alpine tar czf /b/openmausbot-data.tgz -C /data .   # B
+```
+
+Keep the file somewhere else. Restore by stopping the server and untarring into the same place.
+
+## The rules the setup relies on
+
+Read this before putting anything else in front of the server.
+
+- The server only ever listens on loopback (`127.0.0.1:8799`). Never publish that port yourself. The tunnel, Caddy and Tailscale each reach it from the same machine.
+- A request that arrives through a proxy or the tunnel is treated as remote and needs a session, whatever headers it carries. A proxy of your own (nginx, Traefik, Cloudflare Tunnel) must forward the real `Host` and add `X-Forwarded-For` and `X-Forwarded-Proto`, must not buffer the event stream, and must **not** rewrite `Host` to `127.0.0.1`.
+- Pairing is the login. Want a second wall in front of it? Path B's `Caddyfile` has a commented `basic_auth` block for a shared password.
+- The session cookie is marked `Secure`; do not serve this over plain HTTP on the public internet.
+- The one thing a stranger can read is `/.well-known/openmausbot/environment` (the server's id, label, version, capabilities) and `/api/health` (only the app name). Everything else answers "pair this device".
+
+## Troubleshooting
+
+**`serve --tunnel` says "no account on this machine yet".** Run `npx openmausbot login` on this machine first; the credentials are per machine.
+
+**The tunnel stays on "retrying".** The server is running and usable locally; the public hop is not verified yet. Wait a minute (Cloudflare needs a moment on a fresh address), then check `journalctl`/the terminal for the reason. If it never comes up, `npx openmausbot logout && npx openmausbot login` issues a fresh address.
+
+**Path B: the page never loads or shows a certificate error.** Caddy could not get a certificate. Check that the name resolves to the server and that ports 80 and 443 are open; `docker compose logs caddy` shows the reason.
+
+**"forbidden: pair this device to use the server remotely" / "this request came through a proxy".** Expected before pairing, and for tools that call the API without a session. Pair the device. Scripts send `Authorization: Bearer <token>` with the token from the pairing response instead of a cookie.
+
+**Pairing code refused.** It expired (five minutes) or was used. Mint a new one. "Too many failed pairing attempts" means wait a minute.
+
+**A bot says the engine is not signed in.** Sign that engine in again on the server.
+
+**What does the server think it is?** `https://<address>/.well-known/openmausbot/environment` is public and shows its id, label, version and capabilities; `npx openmausbot status` prints the same on the server.
+
+**Something else.** `journalctl -u openmausbot --since -10m` (or `docker compose logs omb --tail 100`) shows the server's startup lines. Paste them with your question in the community channel.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -13,6 +13,11 @@ path **today**; first-class remote access is coming — see
 > (Caddy) in front. Proper token-based remote auth is exactly what the
 > Remote Workspace plan adds.
 
+Step by step, for a server you do not have yet: [Deploy OpenMausBot on a
+VPS](deploy-vps.md) walks through the three ways in (public address, own
+domain, Tailscale), signing engines in, pairing, keeping it running,
+updating and backups. This page is the reference behind it.
+
 ## What works headless (and what doesn't)
 
 Runs fully on a server:


### PR DESCRIPTION
A detailed, plain-language guide from a blank Linux server to OpenMausBot running around the clock: three ways in (`serve --tunnel` public address, own domain with Docker + Caddy, Tailscale), engine sign-in, pairing a browser / the desktop app / the phone, `openmausbot sessions`, a systemd unit, updating, backups, the rules a proxy must follow, and troubleshooting. Lives at `docs/deploy-vps.md` and, with the same content, on the docs site under Self-hosting → Deploy on a VPS. `docs/self-hosting.md` and the README link to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added step-by-step Linux VPS deployment guidance covering Cloudflare tunnels, custom domains with Docker and Caddy, and private Tailscale networks.
  * Documented prerequisites, engine sign-in, device pairing, session management, systemd setup, updates, backups, security, and troubleshooting.
  * Added deployment guidance for running the service on a server or Mac mini, including available tunnel options.
  * Updated self-hosting navigation and introductory content with links to the new deployment guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->