### PR TITLE
ci(npm): upgrade npm before publishing so OIDC trusted publishing is attempted

### DIFF
--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -75,6 +75,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         working-directory: release/npm
         run: |
+          # Trusted publishing needs npm 11.5.1 or newer; the runner's bundled npm may lag.
+          npm install -g npm@latest
           npm --version
           npm publish --access public --provenance
       - name: Note the npm package on the GitHub release (release tags only)


### PR DESCRIPTION
0.1.56's tag job failed with `ENEEDAUTH`: no OIDC exchange was attempted. Trusted publishing needs npm ≥ 11.5.1; the runner's bundled npm may lag, so install the latest npm before `npm publish --provenance`. The trusted publisher itself still has to exist on npmjs.com (package → Settings → Publishing access → GitHub Actions, `milind-soni/OpenMausBot`, `npm-package.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package publishing process to use the latest npm CLI before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->