### PR TITLE
fix(composio): carry chat-initiated second-account alias through to auth link

### DIFF
--- a/server/connector-proxy.test.ts
+++ b/server/connector-proxy.test.ts
@@ -104,6 +104,8 @@ describe("connector MCP bridge", () => {
           toolkits: [
             { toolkit: "googledrive", alias: "work-devhouse" },
             { name: "LINEAR", account: "personal" },
+            { toolkit: "googledrive", alias: "personal" },
+            { toolkit: "GOOGLEDRIVE", alias: " Work-Devhouse " },
           ],
         },
       },
@@ -118,6 +120,7 @@ describe("connector MCP bridge", () => {
       items: [
         { slug: "googledrive", alias: "work-devhouse" },
         { slug: "linear", alias: "personal" },
+        { slug: "googledrive", alias: "personal" },
       ],
     });
   });

--- a/server/connector-proxy.test.ts
+++ b/server/connector-proxy.test.ts
@@ -73,8 +73,53 @@ describe("connector MCP bridge", () => {
     expect(reply.id).toBe(7);
     expect(reply.result.content[0].text).toMatch(/secure connection card/i);
     expect(received.authorization).toBe("Bearer bridge-secret");
-    expect(received.body).toMatchObject({ botId: "bot-1", threadId: "thread-1", slugs: ["gmail"] });
+    expect(received.body).toMatchObject({ botId: "bot-1", threadId: "thread-1", items: [{ slug: "gmail" }] });
     expect(received.body.resumeKey).toMatch(/^[\w-]{8,100}$/);
+  });
+
+  it("carries an account alias when the agent asks for a second account", async () => {
+    let received: any = null;
+    const harness = await listen((request, response) => {
+      let body = "";
+      request.on("data", (chunk) => { body += chunk; });
+      request.on("end", () => {
+        received = { authorization: request.headers.authorization, body: JSON.parse(body) };
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end("{}");
+      });
+    });
+    const lines = start({
+      OMB_HARNESS_URL: harness,
+      OMB_CONNECTOR_TOKEN: "bridge-secret",
+      OMB_BOT_ID: "bot-1",
+      OMB_THREAD_ID: "thread-1",
+    });
+    child!.stdin.write(`${JSON.stringify({
+      jsonrpc: "2.0",
+      id: 8,
+      method: "tools/call",
+      params: {
+        name: "COMPOSIO_MANAGE_CONNECTIONS",
+        arguments: {
+          toolkits: [
+            { toolkit: "googledrive", alias: "work-devhouse" },
+            { name: "LINEAR", account: "personal" },
+          ],
+        },
+      },
+    })}\n`);
+    const reply = await nextJson(lines);
+    expect(reply.id).toBe(8);
+    expect(reply.result.content[0].text).toMatch(/secure connection card for googledrive \(work-devhouse\), linear \(personal\)/i);
+    expect(received.authorization).toBe("Bearer bridge-secret");
+    expect(received.body).toMatchObject({
+      botId: "bot-1",
+      threadId: "thread-1",
+      items: [
+        { slug: "googledrive", alias: "work-devhouse" },
+        { slug: "linear", alias: "personal" },
+      ],
+    });
   });
 
   it("answers initialize locally so a missing or failing upstream cannot fail the MCP handshake", async () => {

--- a/server/connector-proxy.ts
+++ b/server/connector-proxy.ts
@@ -115,25 +115,46 @@ async function relay(message: Json, timeoutMs = RELAY_TIMEOUT_MS): Promise<Json 
   return parseUpstream(await readBounded(response), message.id);
 }
 
-function connectorAdds(args: unknown): string[] {
+interface ConnectorRequest {
+  slug: string;
+  alias?: string;
+}
+
+function connectorAdds(args: unknown): ConnectorRequest[] {
   if (!args || typeof args !== "object" || Array.isArray(args)) return [];
   const toolkits = (args as { toolkits?: unknown }).toolkits;
   if (!Array.isArray(toolkits)) return [];
-  return [...new Set(toolkits.flatMap((item) => {
-    if (typeof item === "string") return [item.toLowerCase()];
-    if (!item || typeof item !== "object" || Array.isArray(item)) return [];
-    const row = item as { name?: unknown; toolkit?: unknown; action?: unknown };
-    const slug = typeof row.toolkit === "string" ? row.toolkit : row.name;
+  const seen = new Set<string>();
+  const requests: ConnectorRequest[] = [];
+  for (const item of toolkits) {
+    if (typeof item === "string") {
+      const slug = item.toLowerCase();
+      if (!seen.has(slug)) {
+        seen.add(slug);
+        requests.push({ slug });
+      }
+      continue;
+    }
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const row = item as { name?: unknown; toolkit?: unknown; action?: unknown; alias?: unknown; account?: unknown };
     const action = String(row.action ?? "add").toLowerCase();
-    return typeof slug === "string" && ["add", "connect", "initiate"].includes(action) ? [slug.toLowerCase()] : [];
-  }))];
+    if (!["add", "connect", "initiate"].includes(action)) continue;
+    const slug = typeof row.toolkit === "string" ? row.toolkit : row.name;
+    if (typeof slug !== "string") continue;
+    const normalized = slug.toLowerCase();
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    const alias = typeof row.alias === "string" ? row.alias : typeof row.account === "string" ? row.account : undefined;
+    requests.push({ slug: normalized, ...(alias ? { alias: alias.trim() } : {}) });
+  }
+  return requests;
 }
 
-async function showConnectorCards(slugs: string[]): Promise<void> {
+async function showConnectorCards(items: ConnectorRequest[]): Promise<void> {
   const response = await fetch(`${HARNESS}/api/internal/connectors/request`, {
     method: "POST",
     headers: { "content-type": "application/json", authorization: `Bearer ${TOKEN}` },
-    body: JSON.stringify({ botId: BOT_ID, threadId: THREAD_ID, slugs, resumeKey: randomUUID() }),
+    body: JSON.stringify({ botId: BOT_ID, threadId: THREAD_ID, items, resumeKey: randomUUID() }),
     signal: AbortSignal.timeout(30_000),
   });
   if (!response.ok) {
@@ -175,12 +196,13 @@ async function handle(message: Json): Promise<void> {
   if (method === "tools/call") {
     const params = (message.params ?? {}) as Json;
     const name = String(params.name ?? "");
-    const slugs = /MANAGE_CONNECTIONS$/i.test(name) ? connectorAdds(params.arguments) : [];
-    if (slugs.length) {
-      await showConnectorCards(slugs);
+    const requests = /MANAGE_CONNECTIONS$/i.test(name) ? connectorAdds(params.arguments) : [];
+    if (requests.length) {
+      await showConnectorCards(requests);
+      const labels = requests.map((r) => (r.alias ? `${r.slug} (${r.alias})` : r.slug)).join(", ");
       send(textResult(
         id,
-        `OpenMausBot showed the user a secure connection card for ${slugs.join(", ")}. End this turn now. The app will continue the task automatically after the connection finishes.`,
+        `OpenMausBot showed the user a secure connection card for ${labels}. End this turn now. The app will continue the task automatically after the connection finishes.`,
       ));
       return;
     }

--- a/server/connector-proxy.ts
+++ b/server/connector-proxy.ts
@@ -128,9 +128,10 @@ function connectorAdds(args: unknown): ConnectorRequest[] {
   const requests: ConnectorRequest[] = [];
   for (const item of toolkits) {
     if (typeof item === "string") {
-      const slug = item.toLowerCase();
-      if (!seen.has(slug)) {
-        seen.add(slug);
+      const slug = item.trim().toLowerCase();
+      const key = JSON.stringify([slug, ""]);
+      if (!seen.has(key)) {
+        seen.add(key);
         requests.push({ slug });
       }
       continue;
@@ -141,11 +142,12 @@ function connectorAdds(args: unknown): ConnectorRequest[] {
     if (!["add", "connect", "initiate"].includes(action)) continue;
     const slug = typeof row.toolkit === "string" ? row.toolkit : row.name;
     if (typeof slug !== "string") continue;
-    const normalized = slug.toLowerCase();
-    if (seen.has(normalized)) continue;
-    seen.add(normalized);
-    const alias = typeof row.alias === "string" ? row.alias : typeof row.account === "string" ? row.account : undefined;
-    requests.push({ slug: normalized, ...(alias ? { alias: alias.trim() } : {}) });
+    const normalized = slug.trim().toLowerCase();
+    const alias = (typeof row.alias === "string" ? row.alias : typeof row.account === "string" ? row.account : "").trim();
+    const key = JSON.stringify([normalized, alias.toLowerCase()]);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    requests.push({ slug: normalized, ...(alias ? { alias } : {}) });
   }
   return requests;
 }

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -130,6 +130,8 @@ let fakeClaudeDump: string;
 let fakeDockerFixture: string;
 let fakeDockerLog: string;
 let stderr = "";
+let connectorAccounts: Array<{ id: string; alias: string; status: string; toolkit: { slug: string } }> = [];
+const connectorLinkRequests: Array<{ toolkit: string; alias?: string }> = [];
 const browserCapabilityCalls: Array<{ operation: string; authorization?: string; body: any }> = [];
 let browserRevokeFailuresRemaining = 0;
 let browserRegisterDelayMs = 0;
@@ -638,6 +640,10 @@ beforeAll(async () => {
       res.writeHead(200, { "content-type": "application/json" });
       return res.end(JSON.stringify(operation === "register" ? { ok: true, expiresAt: body.expiresAt } : { ok: true }));
     }
+    if (req.url?.startsWith("/api/v3.1/connected_accounts") || req.url?.startsWith("/api/v3/toolkits")) {
+      res.writeHead(200, { "content-type": "application/json" });
+      return res.end(JSON.stringify({ items: req.url.startsWith("/api/v3.1/connected_accounts") ? connectorAccounts : [] }));
+    }
     if (req.url?.startsWith("/api/v3.1/tool_router/session")) {
       if (req.headers["x-api-key"] !== "ak_good") {
         res.writeHead(401, { "content-type": "application/json" });
@@ -646,6 +652,15 @@ beforeAll(async () => {
       let raw = "";
       for await (const chunk of req) raw += chunk;
       const body = raw ? JSON.parse(raw) : {};
+      if (req.url.includes("/toolkits")) {
+        res.writeHead(200, { "content-type": "application/json" });
+        return res.end(JSON.stringify({ items: [{ slug: "gmail", connected_account: { id: "ca_personal", status: "ACTIVE" } }] }));
+      }
+      if (req.url.endsWith("/link")) {
+        connectorLinkRequests.push(body);
+        res.writeHead(200, { "content-type": "application/json" });
+        return res.end(JSON.stringify({ redirect_url: "https://connect.composio.dev/fixture-only" }));
+      }
       res.writeHead(201, { "content-type": "application/json" });
       return res.end(JSON.stringify({
         session_id: "trs_config_test",
@@ -794,6 +809,7 @@ beforeAll(async () => {
       OMB_EXTRA_PATH: fakeDockerDir,
       OMB_BOX_API: `http://127.0.0.1:${boxStubPort}`,
       OMB_COMPOSIO_API: `http://127.0.0.1:${boxStubPort}/api/v3.1`,
+      OMB_COMPOSIO_TOOLKITS_API: `http://127.0.0.1:${boxStubPort}/api/v3`,
       OMB_STATIC_DIR: staticDir,
       // Created only by the browser integration test. Keeping an explicit
       // path prevents that test from ever discovering a developer app's live
@@ -7189,6 +7205,51 @@ describe("harness HTTP API", () => {
     // override must keep Composio configured until the next app launch.
     expect((await api("PUT", "/api/config", { profile: { name: "Grace" } })).status).toBe(200);
     expect((await api("GET", "/api/config")).body.composio).toEqual({ configured: true, mode: "self-hosted" });
+  });
+
+  it("keeps second-account cards separate and waits for the requested alias, not an existing account", async () => {
+    expect((await api("PUT", "/api/config", { composio: { apiKey: "ak_good" } })).status).toBe(200);
+    const bot = (await api("POST", "/api/bots")).body.bot;
+    connectorAccounts = [{ id: "ca_personal", alias: "personal", status: "ACTIVE", toolkit: { slug: "gmail" } }];
+    try {
+      const token = await mintTestCapability(BASE, bot.id, bot.threadId, { kind: "connectors" });
+      const create = async (items: unknown[], resumeKey = "alias-fixture-123") => {
+        const response = await fetch(`${BASE}/api/internal/connectors/request`, {
+          method: "POST",
+          headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+          body: JSON.stringify({ botId: bot.id, threadId: bot.threadId, resumeKey, items }),
+        });
+        return { status: response.status, body: await response.json() as any };
+      };
+      expect((await create([{ slug: "gmail", alias: "x".repeat(65) }])).status).toBe(400);
+      const requested = await create([
+        { slug: "gmail", alias: "work" }, { slug: "gmail", alias: "other" }, { slug: "gmail", alias: "WORK" },
+      ]);
+      expect(requested.status).toBe(200);
+      const [work, other, duplicate] = requested.body.messageIds;
+      expect(work).toBe(duplicate);
+      expect(other).not.toBe(work);
+      expect((await create([{ slug: "gmail", alias: "work" }])).body.messageIds).toEqual([work]);
+      const card = (id: string, action: string) => `/api/bots/${bot.id}/connector-cards/${id}/${action}`;
+      expect((await api("POST", card(work, "authorize"), { threadId: bot.threadId })).body.url).toBe("https://connect.composio.dev/fixture-only");
+      expect(connectorLinkRequests.at(-1)).toEqual({ toolkit: "gmail", alias: "work" });
+      const poll = () => api("GET", `${card(work, "status")}?threadId=${bot.threadId}`);
+      expect((await poll()).body.connected).toBe(false);
+      expect((await api("POST", card(work, "resume"), { threadId: bot.threadId })).status).toBe(409);
+      const pending = { id: "ca_work", alias: "Work", status: "INITIATED", toolkit: { slug: "gmail" } };
+      connectorAccounts.push(pending);
+      expect((await poll()).body).toMatchObject({ connected: false, pending: true });
+      pending.status = "FAILED";
+      expect((await poll()).body).toMatchObject({ connected: false, status: "FAILED" });
+      pending.status = "ACTIVE";
+      expect((await poll()).body.connected).toBe(true);
+      // The other requested alias is still missing, so no continuation yet.
+      expect((await api("POST", card(work, "resume"), { threadId: bot.threadId })).status).toBe(409);
+      expect((await api("GET", `${card(other, "status")}?threadId=${bot.threadId}`)).body.connected).toBe(false);
+    } finally {
+      connectorAccounts = [];
+      await api("DELETE", `/api/bots/${bot.id}`);
+    }
   });
 
   it("does not relay a slow connector request after Connected Apps is disabled", async () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -8208,9 +8208,22 @@ const server = createServer(async (req, res) => {
         const botId = String(body.botId ?? "");
         const threadId = String(body.threadId ?? "");
         const resumeKey = String(body.resumeKey ?? "");
-        const slugs: string[] = Array.isArray(body.slugs)
-          ? [...new Set<string>(body.slugs.map((slug: unknown) => String(slug).toLowerCase()).filter((slug: string) => CONNECTOR_SLUG.test(slug)))]
-          : [];
+        const rawItems = Array.isArray(body.items) ? body.items : Array.isArray(body.slugs) ? body.slugs : [];
+        const items: { slug: string; alias?: string }[] = [];
+        for (const raw of rawItems as unknown[]) {
+          if (typeof raw === "string") {
+            const slug = raw.toLowerCase();
+            if (CONNECTOR_SLUG.test(slug)) items.push({ slug });
+            continue;
+          }
+          if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+          const row = raw as { slug?: unknown; toolkit?: unknown; alias?: unknown; account?: unknown };
+          const slug = typeof row.slug === "string" ? row.slug : typeof row.toolkit === "string" ? row.toolkit : undefined;
+          if (!slug || !CONNECTOR_SLUG.test(slug.toLowerCase())) continue;
+          const alias = typeof row.alias === "string" ? row.alias : typeof row.account === "string" ? row.account : undefined;
+          items.push({ slug: slug.toLowerCase(), ...(alias ? { alias: alias.trim() } : {}) });
+        }
+        const slugs = [...new Set(items.map((item) => item.slug))];
         const owner = connectorThread(botId, threadId);
         if (!owner) return json(res, 403, { error: "conversation does not belong to this bot" });
         if (!/^[\w-]{8,100}$/.test(resumeKey)) return json(res, 400, { error: "invalid resume key" });
@@ -8221,27 +8234,32 @@ const server = createServer(async (req, res) => {
         const connectionState: Record<string, { connected?: boolean }> = await composio.connectionStatus(cfg, slugs).catch(() => ({}));
         requireActiveInternalCapability();
         const messageIds: string[] = [];
-        for (const slug of slugs) {
+        for (const item of items) {
           const existing = store.messagesFor(threadId).find(
-            (message) => message.connector?.resumeKey === resumeKey && message.connector.slug === slug,
+            (message) => message.connector?.resumeKey === resumeKey && message.connector.slug === item.slug,
           );
           if (existing) {
             messageIds.push(existing.id);
             continue;
           }
-          const toolkit = await composio.toolkitCard(cfg, slug);
+          const toolkit = await composio.toolkitCard(cfg, item.slug);
           requireActiveInternalCapability();
-          const connected = connectionState[slug]?.connected === true;
+          const connected = connectionState[item.slug]?.connected === true;
+          const status = item.alias ? "required" : connected ? "connected" : "required";
+          const description = item.alias
+            ? `Connect ${toolkit.label} as “${item.alias}” so the bot can continue`
+            : toolkit.blurb || `Connect ${toolkit.label} so the bot can continue`;
           const message = store.appendMessage(threadId, {
             role: "bot",
             kind: "connector",
             ...(owner.group ? { from: { botId: owner.bot.id, name: owner.bot.name, color: owner.bot.color } } : {}),
             connector: {
-              slug,
+              slug: item.slug,
               label: toolkit.label,
-              description: toolkit.blurb || `Connect ${toolkit.label} so the bot can continue`,
-              status: connected ? "connected" : "required",
+              description,
+              status,
               resumeKey,
+              ...(item.alias ? { alias: item.alias } : {}),
             },
           });
           messageIds.push(message.id);
@@ -12032,7 +12050,7 @@ const server = createServer(async (req, res) => {
           connector: { ...connector, status: "authorizing", error: undefined, dismissed: false },
         });
         try {
-          return json(res, 200, await composio.authorizeService(cfg, connector.slug));
+          return json(res, 200, await composio.authorizeService(cfg, connector.slug, connector.alias));
         } catch (error) {
           const detail = error instanceof Error ? error.message : String(error);
           store.patchMessage(threadId, message.id, {

--- a/server/index.ts
+++ b/server/index.ts
@@ -8341,7 +8341,7 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
         const items: { slug: string; alias?: string }[] = [];
         for (const raw of rawItems as unknown[]) {
           if (typeof raw === "string") {
-            const slug = raw.toLowerCase();
+            const slug = raw.trim().toLowerCase();
             if (CONNECTOR_SLUG.test(slug)) items.push({ slug });
             continue;
           }
@@ -8349,14 +8349,14 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
           const row = raw as { slug?: unknown; toolkit?: unknown; alias?: unknown; account?: unknown };
           const slug = typeof row.slug === "string" ? row.slug : typeof row.toolkit === "string" ? row.toolkit : undefined;
           if (!slug || !CONNECTOR_SLUG.test(slug.toLowerCase())) continue;
-          const alias = typeof row.alias === "string" ? row.alias : typeof row.account === "string" ? row.account : undefined;
-          items.push({ slug: slug.toLowerCase(), ...(alias ? { alias: alias.trim() } : {}) });
+          const alias = composio.normalizeAccountAlias((row.alias ?? row.account) as string | undefined);
+          items.push({ slug: slug.toLowerCase(), ...(alias ? { alias } : {}) });
         }
         const slugs = [...new Set(items.map((item) => item.slug))];
         const owner = connectorThread(botId, threadId);
         if (!owner) return json(res, 403, { error: "conversation does not belong to this bot" });
         if (!/^[\w-]{8,100}$/.test(resumeKey)) return json(res, 400, { error: "invalid resume key" });
-        if (!slugs.length || slugs.length > 12) return json(res, 400, { error: "one to twelve valid apps are required" });
+        if (!items.length || items.length > 12) return json(res, 400, { error: "one to twelve valid connection requests are required" });
         if (!composio.configured(cfg) || owner.bot.composio === false) {
           return json(res, 409, { error: "connected apps are not enabled for this bot" });
         }
@@ -8365,7 +8365,8 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
         const messageIds: string[] = [];
         for (const item of items) {
           const existing = store.messagesFor(threadId).find(
-            (message) => message.connector?.resumeKey === resumeKey && message.connector.slug === item.slug,
+            (message) => message.connector?.resumeKey === resumeKey && message.connector.slug === item.slug
+              && (message.connector.alias ?? "").toLowerCase() === (item.alias ?? "").toLowerCase(),
           );
           if (existing) {
             messageIds.push(existing.id);
@@ -12251,7 +12252,18 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
         }
       }
       if (m[3] === "status" && method === "GET") {
-        const state = (await composio.connectionStatus(cfg, [connector.slug]))[connector.slug];
+        const service = (await composio.connectionStatus(cfg, [connector.slug]))[connector.slug];
+        // A different active account must never complete a second-account card.
+        // Missing alias metadata stays pending rather than guessing from the
+        // toolkit-wide status (including scoped keys without account reads).
+        const account = connector.alias
+          ? service?.accounts?.find((item) => item.alias?.trim().toLowerCase() === connector.alias!.toLowerCase())
+          : undefined;
+        const state = connector.alias ? {
+          connected: /^active$/i.test(account?.status ?? ""),
+          pending: /^(initiated|initializing|pending)$/i.test(account?.status ?? ""),
+          status: account?.status ?? "not_connected",
+        } : service;
         const failed = /failed|expired|revoked|error/i.test(state?.status ?? "");
         const next = {
           ...connector,

--- a/server/store.ts
+++ b/server/store.ts
@@ -74,6 +74,8 @@ export interface ConnectorCardData {
   status: "required" | "authorizing" | "connected" | "failed";
   /** Cards created by one agent request resume together after all connect. */
   resumeKey: string;
+  /** Account alias supplied by the agent when adding a second (or first) account. */
+  alias?: string;
   error?: string;
   dismissed?: boolean;
   resumed?: boolean;

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -84,6 +84,7 @@ export interface ConnectorCardData {
   description: string;
   status: "required" | "authorizing" | "connected" | "failed";
   resumeKey: string;
+  alias?: string;
   error?: string;
   dismissed?: boolean;
   resumed?: boolean;


### PR DESCRIPTION
## Summary

Fixes [milind-soni/OpenMausBot#688](https://github.com/milind-soni/OpenMausBot/issues/688).

When a user already has one connected account for a service and asks the bot in chat to add a second account (e.g. a second Google Drive alias), the chat connection card was being created without the new alias. Because `composio.authorizeService` received only the toolkit slug, it reused the existing connection state / OAuth link for the first account instead of minting a fresh auth link for the second.

## Changes

- `server/connector-proxy.ts`: `COMPOSIO_MANAGE_CONNECTIONS` `toolkits` items can now include an `alias` (or `account`) and the proxy forwards `{ slug, alias? }` objects to the harness.
- `server/index.ts`:
  - `/api/internal/connectors/request` accepts both the new `items` shape and the legacy `slugs` list.
  - When an alias is supplied, the connector card is always created with `status: required` and the description names the requested alias.
  - `/api/bots/{botId}/connector-cards/{messageId}/authorize` now passes `connector.alias` to `composio.authorizeService`.
- `server/store.ts` + `src/state/store.tsx`: added `alias?: string` to `ConnectorCardData`.
- `server/connector-proxy.test.ts`: added a regression test asserting aliases survive from the MCP tool call to the harness request.

## Test plan

- `pnpm typecheck` passes.
- `pnpm vitest run server/connector-proxy.test.ts server/composio.test.ts` passes (30/30).
- `pnpm broker:test` passes (7/7).
- `pnpm test:electron` passes (137/137).
- `pnpm test:packaged-server` passes (built and smoked the packaged server).
- `pnpm vitest run` passes except two pre-existing, unrelated failures:
  - `scripts/linux-after-install.test.mjs` (fixture temp path mismatch in this environment)
  - `server/drivers/codex-catalog.test.ts` (missing catalog option, environment-specific)
- Isolated fixture (`control:omb launch` + `doctor` + `new-bot` + `send` + `wait`) succeeded.

EST-3244


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Connector requests can include account aliases or account names.
  - Connection cards display aliases and use them for descriptions, authorization, and status updates.
  - Confirmation messages identify connected accounts by alias.
  - Added a public health check and support for an additional tunnel connection.
  - Room interactions now identify API-sent messages and surface missed mentions.
- **Bug Fixes**
  - Improved handling of duplicate or invalid connector entries.
  - Preserved compatibility with slug-only connector requests.
  - Improved account-specific connection matching and status tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->