### PR TITLE
feat(spaces): opt-in multi-bot canvas with split screen and trackpad pan/zoom

### DIFF
--- a/docs/superpowers/specs/2026-09-03-spaces-canvas-design.md
+++ b/docs/superpowers/specs/2026-09-03-spaces-canvas-design.md
@@ -1,0 +1,251 @@
+# Spaces: a multi-bot canvas for the desktop app
+
+Status: approved design, not yet implemented
+Date: 2026-09-03
+
+## Summary
+
+Spaces is an opt-in second view of the bots you already have. Instead of one
+chat beside a sidebar, every bot gets a card on a single zoomable canvas. Zoom
+out and you see the whole workspace at once, like Mission Control; zoom in and
+one card fills the screen with its neighbours peeking past the edges, and you
+slide between bots the way you slide between desktops.
+
+Nothing about the existing shell changes. Spaces is a rendering of state the
+client already holds, reachable only after the user turns it on.
+
+## Goals
+
+- One canvas holding a live card per bot and per room.
+- Two states — grid and focus — that are the same layout at two zoom levels.
+- A floating composer that always addresses the focused bot, with `@` to
+  redirect anywhere.
+- Ambient awareness: status chips on every card, toasts when a bot you are not
+  watching finishes something.
+- Off by default. Available only after an explicit opt-in in Settings.
+
+## Non-goals
+
+- Real per-bot `BrowserWindow`s. A later phase may add a "detach this bot"
+  action; v1 is one window.
+- Free-form card positioning. Spaces is a grid, not a desk.
+- Replacing the sidebar shell. Spaces is a place you visit.
+
+## Decisions and their rationale
+
+**Simulated canvas, not real OS windows.** The reference interface has no
+traffic lights, no title bars, and one global input; it is a canvas that
+resembles a window manager. Real windows would cost N renderers, cross-window
+store sync, and per-window state persistence, and the grid view would have to be
+simulated anyway because macOS does not let an app tile its own Mission Control.
+A "detach this bot into its own window" action is deliberately deferred to a
+later phase.
+
+**A mode you enter and leave.** The Settings toggle unlocks Spaces; it does not
+replace the shell. The sidebar view stays the default and stays mounted
+underneath, so leaving is instant and every existing surface — Settings,
+Routines, Browser workspace, Team Map — keeps its current home.
+
+**Grid and focus are one layout at two zoom levels.** All cards sit at fixed
+positions in an R x C grid. Both states are a single transform on the stage that
+contains them:
+
+    grid   ->  scale(fitAll)  translate3d(0, 0, 0)
+    focus  ->  scale(1)       translate3d(-col * W, -row * H, 0)
+
+The cell is sized so that a focused card occupies 65% of the viewport width and
+75% of its height, matching the reference interface: at `scale(1)` the adjacent
+columns land just past the edges, which is what produces the peeking neighbours
+without any separate treatment. Columns are `clamp(2, floor(viewportWidth /
+minCellWidth), 4)` and rows are `ceil(count / columns)`, so a narrow window
+tiles two across and a wide one four. The grid scale is whatever fits all rows
+and columns inside the viewport with a 48px margin, floored at 0.22 so cards
+never become unreadable — past that floor the grid scrolls vertically instead of
+shrinking further.
+
+Sliding walks the grid in reading order: right along a row, wrapping down to the
+start of the next. This is why the focused state shows neighbours to the left
+and right only. Because one element transitions rather than N, the cost of a
+transition is the same for six bots as for forty, and a card's position never
+changes between the two views, so spatial memory holds.
+
+**Every card is live.** Cards are real `ChatView` / `GroupView` instances:
+scrollable, typeable, with working suggestion chips and inline artifacts. Cards
+are always mounted and interactive; they are only *painted* when near the
+viewport. See Performance.
+
+**All visible bots, virtualized.** Population is `state.bots` filtered by
+`!hidden`, concatenated with `state.groups`, in the sidebar's existing order.
+No curation step, no cap, no silent reordering between visits.
+
+**No new animation dependency.** The repo has deliberately avoided one
+(`react`, `react-dom`, `react-markdown`, `lucide-react`, `qrcode.react`,
+`tailwind-merge`). A single transformed stage needs only CSS transitions; toasts
+and the artifact zoom use the Web Animations API.
+
+## Architecture
+
+### New modules, under `src/components/spaces/`
+
+| Module | Responsibility |
+|---|---|
+| `SpacesShell.tsx` | Owns `mode` (`grid` \| `focus`) and the stage transform. The only stateful piece. |
+| `SpacesStage.tsx` | Positions cards on the grid. Pure layout, no state. |
+| `SpaceCard.tsx` | One card: chrome, status chip, and a live `ChatView`/`GroupView` or a snapshot. |
+| `SpacesComposer.tsx` | The floating pill. Wraps the existing `Composer` with an identity chip and `@` picker. |
+| `SpacesToasts.tsx` | Top-right background-activity stack. |
+| `spaces-layout.ts` | Pure: grid dimensions from viewport and count, index <-> (row, col), transform for a state. |
+| `spaces-nav.ts` | Pure reducer for navigation intents: next, prev, up, down, focus, grid, wrap and clamp rules. |
+| `spaces-flip.ts` | `flipTo(fromEl, toEl)` — the one shared-element transition. |
+
+The pure modules exist as separate files specifically so the real logic is
+testable under `environment: "node"`, which is what the suite runs.
+
+### Changes to existing files
+
+- `src/lib/feature-flags.ts` — add `spacesEnabled(config)`, mirroring
+  `builtInBrowserEnabled`.
+- `src/state/store.tsx` (line ~348) — add `spaces?: boolean` to the `features`
+  type.
+- `src/components/SettingsModal.tsx` — the toggle, in the existing
+  `experimental` section beside the browser and skill-recorder switches. No new
+  settings surface.
+- `src/App.tsx` — render `<SpacesShell>` as an overlay above the normal shell
+  when open, leaving the sidebar shell mounted beneath it.
+- `src/components/ChatView.tsx` — **the one real refactor.** Add
+  `active?: boolean`, defaulting to `true` so every existing call site is
+  unchanged. When `false`, skip global `window` keydown registration (line
+  ~867), autofocus, and scroll-into-view. Twenty mounted ChatViews must not mean
+  twenty Cmd-F handlers.
+
+No new server fields, no new IPC channels, no protocol change.
+
+## Interaction
+
+### The focused card is `state.selectedId`
+
+Spaces adds exactly one piece of local state: `mode`. The focused card is the
+selected bot. Focusing dispatches the existing select action, so leaving Spaces
+lands in that bot's normal chat with no reconciliation, and the sidebar
+underneath was already correct.
+
+### Navigation
+
+| Input | Action |
+|---|---|
+| `Ctrl-Up` / pinch out | Focus -> grid |
+| `Ctrl-Down` / pinch in / click a card / `Esc` | Grid -> focus |
+| `Ctrl-Left` / `Ctrl-Right` | Previous / next in reading order |
+| Two-finger horizontal swipe | Slide, tracking the finger, snapping on release |
+| `Cmd-1`..`Cmd-9` | Jump to that card, extending the existing binding in `App.tsx` |
+| `Esc` from focus | Leave Spaces |
+
+macOS reserves genuine three-finger Spaces swipes for the OS; Electron never
+receives them. Two-finger horizontal scroll arrives as `wheel` events with
+`deltaX` and is what we bind. On a trackpad it feels near-identical. It is not
+literally the same gesture, and the docs should not claim it is.
+
+### Composer
+
+`SpacesComposer` wraps the existing `Composer` rather than reimplementing it, so
+attachments, queued messages, and voice work unchanged. It adds the bot identity
+chip and the `@` picker. Typing `@` opens a bot list; choosing one sends through
+that bot's normal path and slides the stage to it as the message lands — the
+motion is the receipt. Each live card keeps its own inline composer; the pill is
+the fast path, not the only path.
+
+### Toasts
+
+A subscriber watches `bot.activity` transitions and terminal assistant messages.
+When a bot that is not focused settles, it pushes a toast. Rules that keep it
+from becoming noise:
+
+- At most three stacked.
+- Four-second dismiss.
+- Coalesced per bot: a second event replaces that bot's toast rather than
+  stacking a new one.
+- Suppressed entirely in grid mode, where the card itself is already visible.
+
+Clicking a toast focuses that card.
+
+### Status chips
+
+Derived entirely from fields that already exist on `Bot`: `activity`
+(`working` | `waiting-on-you` | `idle` | `no-signal` | `dead`), `unread`, and
+`busy`. Rooms use the equivalent fields on `Group`.
+
+### Artifact zoom-out
+
+A FLIP transition via the Web Animations API: measure the artifact's rect inside
+its card, mount the existing `BrowserWorkspace` at full size, animate a transform
+from first rect to last, hand over. Reversed on dismiss. Confined to
+`spaces-flip.ts`.
+
+## Performance
+
+The budget is the load-bearing constraint, because every card is live. The rule
+is: **mounted and interactive always; painted only when near the viewport.**
+
+- Off-screen cards get `content-visibility: auto` with `contain-intrinsic-size`
+  matching the cell. The browser skips their layout, style, and paint while the
+  DOM stays mounted, so clicking one is instant with no re-hydration, and forty
+  cards cost roughly what six do to render.
+- The stage gets `will-change: transform` during a transition, removed on
+  settle. Leaving it on permanently pins every card into its own compositor
+  layer.
+- **Degradation is measured, not guessed.** `SpacesShell` samples frame timing
+  over the first few transitions. If p95 frame time stays above 20ms, cards
+  beyond the nearest nine swap to static snapshots, and a quiet line in Settings
+  explains why. Everything-live stays the promise; it degrades on a machine that
+  cannot hold it rather than stuttering for everyone.
+
+## Failure modes
+
+| Situation | Behaviour |
+|---|---|
+| Zero visible bots | Empty state on the canvas with a "New bot" action. Never a blank wallpaper. |
+| One bot | Focus mode only. `Ctrl-Up` is a no-op; a one-cell grid is a worse view of one card. |
+| A card throws | Per-card error boundary, reusing the `Component`-based boundary already in `ChatView`. One broken bot shows a failed tile, not a dead canvas. |
+| Focused bot deleted while open | Focus moves to the next card in reading order; if none remain, back to grid, then to the empty state. |
+| Flag turned off while open | The reducer closes the view on config change, exactly as `skill-recorder` does in `store.tsx` (~line 866). |
+| Window resized or display changed | Grid dimensions recompute from the pure layout function. The focused bot stays focused; its cell moves. |
+| `prefers-reduced-motion` | Transitions become instant cuts. The spatial model survives without the animation. |
+
+## Testing
+
+The suite runs `environment: "node"` with `renderToStaticMarkup`; there is no
+jsdom and no testing-library. The test plan is shaped to that.
+
+- `spaces-layout.test.ts`, `spaces-nav.test.ts` — the real coverage. Grid
+  dimensions across viewport sizes and bot counts, index <-> cell round-tripping,
+  transform math, wrap at row end, clamp at the ends, deletion while focused,
+  the zero-bot and one-bot cases.
+- `SpaceCard.test.ts` — `renderToStaticMarkup`, following the existing
+  `ApprovalCard.test.ts` pattern: correct chip per `activity` value, unread
+  state, group versus bot cards, live versus snapshot.
+- `feature-flags` — `spacesEnabled` gating, beside the existing flag tests.
+- `ChatView` — assert that `active: false` registers no global key handler,
+  which is the regression that would otherwise appear only at twenty cards.
+
+**What tests cannot cover:** transform smoothness, gesture feel, and the FLIP
+zoom. `environment: "node"` cannot assert on animation. These are verified by
+hand via `pnpm dev:desktop` before the work is called done. Green tests are not
+evidence that the motion is right.
+
+## Risks
+
+- **The artifact zoom-out is the least predictable item**, because it couples
+  Spaces to `BrowserWorkspace`. If scope must be shed to land sooner, cut this
+  first; everything else is load-bearing for the feel.
+- **The `ChatView` `active` refactor touches a 1400-line file** that every user
+  sees. The default-`true` signature keeps existing call sites untouched, which
+  is the mitigation, but the change deserves careful review.
+- **v1 is large** — canvas, live cards, toasts, chips, rooms, FLIP zoom, and the
+  ChatView refactor. It is buildable as specified. It is not small.
+
+## Deferred
+
+- Detaching a card into a real `BrowserWindow`.
+- Broadcasting one instruction to several bots at once (overlaps rooms; needs
+  its own confirmation and cost guard).
+- Free-form card positioning.

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -18,6 +18,7 @@ import { customMcpServers,
   saveConfig,
   skillRecorderEnabled,
   builtInBrowserEnabled,
+  spacesEnabled,
   browserProfilePartitionId,
   browserProfilePartitionTarget,
   browserProfileReplacementConflict,
@@ -799,5 +800,22 @@ describe("customMcpServers", () => {
       }),
     );
     expect(Object.keys(out)).toEqual(["keeper"]);
+  });
+});
+
+describe("spaces feature flag", () => {
+  it("is off unless the config says otherwise", () => {
+    expect(spacesEnabled({})).toBe(false);
+    expect(spacesEnabled({ features: {} })).toBe(false);
+    expect(spacesEnabled({ features: { spaces: false } })).toBe(false);
+    expect(spacesEnabled({ features: { spaces: true } })).toBe(true);
+  });
+
+  it("survives a config PATCH", () => {
+    expect(parseConfigPatch({ features: { spaces: true } })).toEqual({ features: { spaces: true } });
+  });
+
+  it("does not ride on another experiment being enabled", () => {
+    expect(spacesEnabled({ features: { browser: true, skillRecorder: true } })).toBe(false);
   });
 });

--- a/server/config.ts
+++ b/server/config.ts
@@ -220,6 +220,8 @@ const featureConfigSchema = z.object({
   /** Experimental built-in browser. Off until explicitly enabled; each bot
    * also has its own switch. */
   browser: z.boolean().optional(),
+  /** The Spaces canvas: every bot as a card on one zoomable surface. */
+  spaces: z.boolean().optional(),
 });
 const instanceConfigSchema = z.object({
   driver: z.string().min(1),
@@ -290,7 +292,7 @@ export interface AppConfig {
    * separate container, durable workspace, viewer and lease. */
   localVm?: { mode?: "shared" | "per-bot"; maxInstances?: number };
   /** Opt-in product experiments. Every flag defaults to disabled. */
-  features?: { skillRecorder?: boolean; showToolCalls?: boolean; browser?: boolean };
+  features?: { skillRecorder?: boolean; showToolCalls?: boolean; browser?: boolean; spaces?: boolean };
   /** Named browser sessions any bot can be pointed at. */
   browserProfiles?: BrowserProfile[];
   instances?: InstanceConfigMap;
@@ -428,6 +430,11 @@ export function showToolCallsEnabled(cfg: AppConfig): boolean {
  * switch sits under it, so either can withhold the browser. */
 export function builtInBrowserEnabled(cfg: AppConfig): boolean {
   return cfg.features?.browser === true;
+}
+
+/** Workspace-level gate for the Spaces canvas. */
+export function spacesEnabled(cfg: AppConfig): boolean {
+  return cfg.features?.spaces === true;
 }
 
 // OMB_DATA_DIR isolates test/soak rigs from the user's real fleet.

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -5129,20 +5129,20 @@ describe("harness HTTP API", () => {
   it("keeps Teach a skill off by default and persists an explicit opt-in", async () => {
     const before = await api("GET", "/api/config");
     expect(before.status).toBe(200);
-    expect(before.body.features).toEqual({ browser: false, skillRecorder: false, showToolCalls: false });
+    expect(before.body.features).toEqual({ browser: false, skillRecorder: false, showToolCalls: false, spaces: false });
 
     const saved = await api("PATCH", "/api/config", {
       features: { skillRecorder: true },
     });
     expect(saved.status).toBe(200);
-    expect(saved.body.features).toEqual({ browser: false, skillRecorder: true, showToolCalls: false });
+    expect(saved.body.features).toEqual({ browser: false, skillRecorder: true, showToolCalls: false, spaces: false });
 
     const disk = JSON.parse(readFileSync(join(home, ".openmausbot", "config.json"), "utf8"));
     expect(disk.features).toEqual({ skillRecorder: true });
 
     const tools = await api("PATCH", "/api/config", { features: { showToolCalls: true } });
     expect(tools.status).toBe(200);
-    expect(tools.body.features).toEqual({ browser: false, skillRecorder: true, showToolCalls: true });
+    expect(tools.body.features).toEqual({ browser: false, skillRecorder: true, showToolCalls: true, spaces: false });
 
     await api("PATCH", "/api/config", { features: { skillRecorder: false, showToolCalls: false } });
   });

--- a/server/index.ts
+++ b/server/index.ts
@@ -106,6 +106,7 @@ import {
   saveConfig,
   showToolCallsEnabled,
   skillRecorderEnabled,
+  spacesEnabled,
   builtInBrowserEnabled,
   browserProfileReplacementConflict,
   browserProfilePartitionTarget,
@@ -7148,6 +7149,7 @@ function configStatus() {
       skillRecorder: skillRecorderEnabled(cfg),
       showToolCalls: showToolCallsEnabled(cfg),
       browser: builtInBrowserEnabled(cfg),
+      spaces: spacesEnabled(cfg),
     },
     // partitionId is non-secret routing metadata. The renderer needs it to
     // show the same durable session as an agent, but config PATCH validation

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,8 @@ import { BrowserWorkspace } from "@/components/BrowserWorkspace";
 import { SkillRecorderPage } from "@/components/SkillRecorderPage";
 import { TeamMapPage } from "@/components/TeamMapPage";
 import { heldComputerControlBotIds } from "@/lib/computer-control";
-import { skillRecorderEnabled } from "@/lib/feature-flags";
+import { skillRecorderEnabled, spacesEnabled } from "@/lib/feature-flags";
+import { SpacesShell } from "@/components/spaces/SpacesShell";
 import { setLocale } from "@/lib/i18n";
 
 function Shell() {
@@ -74,6 +75,8 @@ function Shell() {
     const onKey = (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
       if (!mod) return;
+      // Cmd-Opt-<n> belongs to the Spaces layout switcher, not to jump-to-bot.
+      if (e.altKey) return;
       const bots = state.bots.filter((b) => !b.hidden);
       if (e.key === "n" && !e.shiftKey) {
         e.preventDefault();
@@ -96,6 +99,21 @@ function Shell() {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [state.bots, state.selectedId, dispatch]);
+
+  // Cmd-Opt-Up zooms out into Spaces. NOT Control-Up: macOS reserves every
+  // Control+Arrow for Mission Control and never delivers them to the app.
+  // Only bound once the feature is switched on; the shell closes it itself.
+  const canvasUnlocked = spacesEnabled(state.config);
+  useEffect(() => {
+    if (!canvasUnlocked || state.spacesOpen) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (!event.metaKey || !event.altKey || event.ctrlKey || event.key !== "ArrowUp") return;
+      event.preventDefault();
+      dispatch({ type: "toggleSpaces", open: true });
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [canvasUnlocked, dispatch, state.spacesOpen]);
 
   useEffect(() => {
     window.ogb?.setUnreadCount?.(unreadCount);
@@ -306,6 +324,9 @@ function Shell() {
           palette on top when one of them is open underneath */}
       <CommandPalette onOpenChange={setPaletteOpen} />
       </div>
+      {canvasUnlocked && state.spacesOpen && (
+        <SpacesShell onClose={() => dispatch({ type: "toggleSpaces", open: false })} />
+      )}
     </div>
   );
 }

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -40,6 +40,7 @@ import { EngineSetup } from "./EngineSetup";
 import { BotAvatar, MausAvatar } from "./Avatar";
 import { TurnPresence } from "./TurnPresence";
 import { showToolCallsEnabled } from "@/lib/feature-flags";
+import { installChatHotkeys } from "@/lib/chat-hotkeys";
 import { stateForBot } from "@/lib/mascot";
 import { showWorkingDots } from "@/lib/turn-tail";
 import { liveActivityLabel } from "@/lib/live-activity";
@@ -865,7 +866,20 @@ function PinnedBanner({
   );
 }
 
-export function ChatView({ bot }: { bot: Bot }) {
+export function ChatView({
+  bot,
+  /** Spaces mounts one ChatView per bot. Only the focused one answers the
+   * keyboard; the rest stay live and scrollable but silent. */
+  active = true,
+  /** Spaces supplies one floating composer for the whole canvas, so the
+   * per-card one would be a second input for the same bot, stacked directly
+   * under it. */
+  composer = true,
+}: {
+  bot: Bot;
+  active?: boolean;
+  composer?: boolean;
+}) {
   const { state, dispatch } = useStore();
   const remoteClient = window.ogb?.remoteClient?.active === true;
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -884,16 +898,6 @@ export function ChatView({ bot }: { bot: Bot }) {
     bot.messages,
   );
   useEffect(() => setFindOpen(false), [bot.threadId]);
-  useEffect(() => {
-    const onFind = (event: KeyboardEvent) => {
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "f") {
-        event.preventDefault();
-        setFindOpen(true);
-      }
-    };
-    window.addEventListener("keydown", onFind);
-    return () => window.removeEventListener("keydown", onFind);
-  }, []);
 
   // only the active branch is rendered; forks stay reachable via ‹ › nav
   const messages = useMemo(() => visibleMessages(bot), [bot]);
@@ -1083,16 +1087,15 @@ export function ChatView({ bot }: { bot: Bot }) {
   // keyboard is a scroll gesture too (upstream lesson): PageUp/Home/ArrowUp
   // break follow like an upward wheel; the at-end onScroll check re-arms it.
   // ArrowUp only counts outside inputs — in the composer it edits, not scrolls.
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      const typing = e.target instanceof HTMLTextAreaElement || e.target instanceof HTMLInputElement;
-      if (e.key === "PageUp" || ((e.key === "Home" || e.key === "ArrowUp") && !typing)) {
-        setBottomFollow(false);
-      }
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [setBottomFollow]);
+  useEffect(
+    () =>
+      installChatHotkeys(window, {
+        active,
+        onFind: () => setFindOpen(true),
+        onScrollAway: () => setBottomFollow(false),
+      }),
+    [active, setBottomFollow],
+  );
 
   const atEnd = () => {
     const el = scrollRef.current;
@@ -1363,6 +1366,7 @@ export function ChatView({ bot }: { bot: Bot }) {
           request can restore the old task without spilling into the newly
           selected one. ArrowUp-to-edit stays gated on busy because editing
           rewinds the thread, which a live turn forbids (the server 409s it). */}
+      {composer && (
       <div ref={composerDockRef} className="absolute inset-x-0 bottom-0 z-[2]">
       <Composer
         key={bot.threadId}
@@ -1376,6 +1380,7 @@ export function ChatView({ bot }: { bot: Bot }) {
           : undefined}
       />
       </div>
+      )}
       </div>
 
     </main>

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/state/store";
 import { BotAvatar, MausAvatar } from "./Avatar";
 import { TurnPresence } from "./TurnPresence";
+import { installChatHotkeys } from "@/lib/chat-hotkeys";
 import { showToolCallsEnabled } from "@/lib/feature-flags";
 import { roomActivityVisible } from "@/lib/room-activity";
 import { normalizeState } from "@/lib/mascot";
@@ -873,7 +874,17 @@ function RoomSetup({ group, members }: { group: Group; members: Bot[] }) {
     </section>
   );
 }
-export function GroupView({ group }: { group: Group }) {
+export function GroupView({
+  group,
+  /** See ChatView: only the focused card answers the keyboard. */
+  active = true,
+  /** See ChatView: Spaces supplies one composer for the whole canvas. */
+  composer = true,
+}: {
+  group: Group;
+  active?: boolean;
+  composer?: boolean;
+}) {
   const { state, dispatch } = useStore();
   const remoteClient = window.ogb?.remoteClient?.active === true;
   const stream = useStreaming();
@@ -898,16 +909,10 @@ export function GroupView({ group }: { group: Group }) {
   const membersTriggerRef = useRef<HTMLButtonElement>(null);
   const closeMembers = useCallback(() => setMembersOpen(false), []);
   useEffect(() => setFindOpen(false), [group.threadId]);
-  useEffect(() => {
-    const onFind = (event: KeyboardEvent) => {
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "f") {
-        event.preventDefault();
-        setFindOpen(true);
-      }
-    };
-    window.addEventListener("keydown", onFind);
-    return () => window.removeEventListener("keydown", onFind);
-  }, []);
+  useEffect(
+    () => installChatHotkeys(window, { active, onFind: () => setFindOpen(true), onScrollAway: () => {} }),
+    [active],
+  );
 
   const members = useMemo(
     () => group.memberIds.map((id) => state.bots.find((b) => b.id === id)).filter((b): b is Bot => Boolean(b)),
@@ -1347,6 +1352,7 @@ export function GroupView({ group }: { group: Group }) {
         </button>
       )}
 
+      {composer && (
       <div ref={composerDockRef} className="absolute inset-x-0 bottom-0 z-[2]">
       <Composer
         key={group.threadId}
@@ -1359,6 +1365,7 @@ export function GroupView({ group }: { group: Group }) {
         onRestoreReply={restoreReply}
       />
       </div>
+      )}
       </div>
     </main>
   );

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -6,7 +6,7 @@ import { useEffect, useRef, useState } from "react";
 import { Coins, FlaskConical, Globe, KeyRound, Monitor, Search, TabletSmartphone, Terminal, Trash2, User, X } from "lucide-react";
 import { api, useStore, type AppSettingsSection, type ConfigStatus } from "@/state/store";
 import { analyticsEnabled, setAnalyticsEnabled } from "@/lib/analytics";
-import { builtInBrowserEnabled, showToolCallsEnabled, skillRecorderEnabled } from "@/lib/feature-flags";
+import { builtInBrowserEnabled, showToolCallsEnabled, skillRecorderEnabled, spacesEnabled } from "@/lib/feature-flags";
 import { localeChoices } from "@/locales";
 import { ApiKeyRow, VpsConnection } from "./ApiKeys";
 import { useUpdaterState } from "@/lib/updater";
@@ -32,7 +32,7 @@ const SECTIONS: Array<{
   keywords: string[];
 }> = [
   { id: "general", label: "General", icon: User, keywords: ["profile", "name", "email", "skin", "theme", "appearance", "analytics", "updates", "tools", "tool calls"] },
-  { id: "experimental", label: "Experimental", icon: FlaskConical, keywords: ["early", "preview", "teach", "skill", "browser", "profiles"] },
+  { id: "experimental", label: "Experimental", icon: FlaskConical, keywords: ["early", "preview", "teach", "skill", "browser", "profiles", "spaces", "canvas", "windows", "grid"] },
   { id: "connections", label: "Connections", icon: KeyRound, keywords: ["keys", "api", "composio", "box", "xai", "vps"] },
   { id: "engines", label: "Engines", icon: Terminal, keywords: ["models", "claude", "grok", "providers", "cli"] },
   { id: "companion", label: "Remote access", icon: TabletSmartphone, keywords: ["companion", "device", "phone", "desktop", "client", "host", "pair", "pairing", "mobile", "https", "secure", "tailscale", "wifi", "remote", "advanced"] },
@@ -245,10 +245,11 @@ function ExperimentalFeaturesRow() {
   const browser = builtInBrowserEnabled(state.config);
   const desktopBrowser = Boolean(window.ogb?.browser);
   const browserBlockedOnWindows = window.ogb?.platform === "win32" && !desktopBrowser;
-  const [saving, setSaving] = useState<"skillRecorder" | "browser" | null>(null);
+  const spaces = spacesEnabled(state.config);
+  const [saving, setSaving] = useState<"skillRecorder" | "browser" | "spaces" | null>(null);
   const [error, setError] = useState("");
 
-  const toggle = async (feature: "skillRecorder" | "browser", next: boolean) => {
+  const toggle = async (feature: "skillRecorder" | "browser" | "spaces", next: boolean) => {
     if (saving) return;
     setSaving(feature);
     setError("");
@@ -282,6 +283,21 @@ function ExperimentalFeaturesRow() {
           aria-label="Show Teach a skill"
           disabled={saving !== null}
           onClick={() => void toggle("skillRecorder", !skillRecorder)}
+          className="disabled:cursor-wait disabled:opacity-50"
+        />
+      </div>
+      <div className="mt-4 flex items-center justify-between gap-4 border-t border-hairline/30 pt-4">
+        <div className="min-w-0">
+          <div className="text-[14px] font-medium text-ink">Spaces</div>
+          <div className="mt-0.5 text-[12px] leading-relaxed text-ink-secondary">
+            Every bot as a card on one canvas. ⌘⌥↑ opens it, ⌘⌥1/2/3 puts one, two or three bots on screen, ⌘⌥← and ⌘⌥→ slide between them, Esc comes back. You can also pan and pinch with the trackpad. Your usual sidebar stays exactly as it is.
+          </div>
+        </div>
+        <Switch
+          checked={spaces}
+          aria-label="Show Spaces"
+          disabled={saving !== null}
+          onClick={() => void toggle("spaces", !spaces)}
           className="disabled:cursor-wait disabled:opacity-50"
         />
       </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -25,6 +25,7 @@ import {
   Search,
   Sparkles,
   Puzzle,
+  LayoutGrid,
   Trash2,
   Users,
   X,
@@ -36,7 +37,7 @@ import { stateForBot } from "@/lib/mascot";
 import { cn } from "@/lib/cn";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { WorkingDots } from "./WorkingIndicator";
-import { skillRecorderEnabled } from "@/lib/feature-flags";
+import { skillRecorderEnabled, spacesEnabled } from "@/lib/feature-flags";
 import { nextRename } from "@/lib/rename";
 import { downloadAllBots } from "@/lib/team-files";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
@@ -1678,6 +1679,21 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
             <Network size={20} className={state.activeView === "team-map" ? "text-accent" : "text-ink-secondary"} />
             <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Team map</span>
           </button>
+          {spacesEnabled(state.config) && (
+            <button
+              onClick={() => dispatch({ type: "toggleSpaces", open: true })}
+              aria-label={density === "icons" ? "Spaces" : undefined}
+              title={density === "icons" ? "Spaces" : undefined}
+              className={cn(
+                "flex min-h-10 w-full items-center rounded-xl py-2 text-left transition-colors",
+                density === "icons" ? "justify-center px-2" : "gap-3 px-3",
+                "text-ink hover:bg-raised/50",
+              )}
+            >
+              <LayoutGrid size={20} className="text-ink-secondary" />
+              <span className={cn("flex-1 text-[14px]", density === "icons" && "hidden")}>Spaces</span>
+            </button>
+          )}
           {!remoteClient && skillRecorderEnabled(state.config) && (
             <button
               onClick={() => dispatch({ type: "showSkillRecorder" })}
@@ -1736,6 +1752,17 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
                 active: state.activeView === "team-map",
                 onSelect: () => dispatch({ type: "showTeamMap" }),
               },
+              ...(spacesEnabled(state.config)
+                ? [
+                    {
+                      key: "spaces",
+                      label: "Spaces",
+                      icon: <LayoutGrid size={18} />,
+                      active: state.spacesOpen,
+                      onSelect: () => dispatch({ type: "toggleSpaces", open: true }),
+                    },
+                  ]
+                : []),
               ...(!remoteClient && skillRecorderEnabled(state.config)
                 ? [
                     {

--- a/src/components/spaces/SpaceCard.test.ts
+++ b/src/components/spaces/SpaceCard.test.ts
@@ -1,0 +1,78 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { SpaceCard } from "./SpaceCard";
+import type { Bot, Group } from "@/state/store";
+
+const bot = (over: Partial<Bot> = {}) =>
+  ({
+    id: "bot-1",
+    threadId: "t1",
+    name: "Gmail",
+    title: "Inbox",
+    description: "",
+    notifications: true,
+    color: "blue",
+    unread: false,
+    modelSelection: {},
+    messages: [],
+    ...over,
+  }) as Bot;
+
+const group = (over: Partial<Group> = {}) =>
+  ({
+    id: "room-1",
+    threadId: "t2",
+    name: "Design",
+    memberIds: ["bot-1"],
+    defaultResponder: "auto",
+    bulletin: "",
+    unread: false,
+    createdAt: 0,
+    messages: [],
+    ...over,
+  }) as unknown as Group;
+
+const render = (props: Record<string, unknown>) =>
+  renderToStaticMarkup(
+    createElement(SpaceCard as never, {
+      focused: false,
+      onFocus: () => {},
+      children: createElement("div", null, "body"),
+      ...props,
+    }),
+  );
+
+describe("SpaceCard", () => {
+  it("names the bot and shows its status chip", () => {
+    const html = render({ subject: bot({ activity: "waiting-on-you" }) });
+    expect(html).toContain("Gmail");
+    expect(html).toContain("Waiting on you");
+  });
+
+  it("labels a room as a room, not a bot", () => {
+    const html = render({ subject: group({ memberIds: ["a", "b", "c"] }) });
+    expect(html).toContain("Design");
+    expect(html).toContain("3 members");
+  });
+
+  it("marks the focused card for assistive tech and leaves the rest unmarked", () => {
+    expect(render({ subject: bot(), focused: true })).toContain('aria-current="true"');
+    expect(render({ subject: bot(), focused: false })).not.toContain('aria-current="true"');
+  });
+
+  it("renders the body it is given", () => {
+    expect(render({ subject: bot() })).toContain("body");
+  });
+
+  it("shows a snapshot placeholder instead of the body when parked", () => {
+    const html = render({ subject: bot(), parked: true });
+    expect(html).not.toContain("body");
+    expect(html).toContain("Gmail");
+  });
+
+  it("stays keyboard reachable", () => {
+    expect(render({ subject: bot() })).toContain("<button");
+  });
+});

--- a/src/components/spaces/SpaceCard.tsx
+++ b/src/components/spaces/SpaceCard.tsx
@@ -1,0 +1,109 @@
+import { Component, type ReactNode } from "react";
+import { Maximize2 } from "lucide-react";
+
+import type { Bot, Group } from "@/state/store";
+import { BotAvatar } from "@/components/Avatar";
+import { cn } from "@/lib/cn";
+import { statusChip, TONE_CLASS } from "./spaces-status";
+
+/** One broken bot shows a failed tile, not a dead canvas. */
+class CardBoundary extends Component<{ children: ReactNode; name: string }, { failed: boolean }> {
+  state = { failed: false };
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+  render() {
+    if (this.state.failed) {
+      return (
+        <div className="flex h-full items-center justify-center px-6 text-center text-[13px] text-ink-secondary">
+          {this.props.name} could not be shown here. Open it from the sidebar to see what happened.
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+function isGroup(subject: Bot | Group): subject is Group {
+  return Array.isArray((subject as Group).memberIds);
+}
+
+export interface SpaceCardProps {
+  subject: Bot | Group;
+  focused: boolean;
+  onFocus: () => void;
+  /** Beyond the performance budget: keep the card in place, drop its body. */
+  parked?: boolean;
+  /** Lift this card's browser out into a full-screen surface. Focused-only. */
+  onExpand?: () => void;
+  children: ReactNode;
+}
+
+export function SpaceCard({ subject, focused, onFocus, parked = false, onExpand, children }: SpaceCardProps) {
+  const chip = statusChip(subject);
+  const room = isGroup(subject);
+  const subtitle = room
+    ? `${subject.memberIds.length} member${subject.memberIds.length === 1 ? "" : "s"}`
+    : subject.title || subject.description || "";
+
+  return (
+    <section
+      aria-label={subject.name}
+      {...(focused ? { "aria-current": "true" as const } : {})}
+      className={cn(
+        "relative flex h-full w-full flex-col overflow-hidden rounded-2xl border bg-panel shadow-2xl transition-[border-color,opacity] duration-200",
+        focused ? "border-accent/40 opacity-100" : "border-hairline/40 opacity-80",
+      )}
+    >
+      {/* The whole header is the hit target: clicking a card focuses it,
+          which is also how the grid behaves. */}
+      <button
+        type="button"
+        onClick={onFocus}
+        className="flex shrink-0 items-center gap-2.5 border-b border-hairline/30 px-3 py-2.5 text-left"
+      >
+        {room ? (
+          <span className="grid size-7 shrink-0 place-items-center rounded-full bg-raised text-[11px] font-medium text-ink-secondary">
+            {subject.memberIds.length}
+          </span>
+        ) : (
+          <BotAvatar bot={subject} size={28} />
+        )}
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-[13px] font-medium text-ink">{subject.name}</span>
+          {subtitle ? (
+            <span className="block truncate text-[11px] text-ink-secondary">{subtitle}</span>
+          ) : null}
+        </span>
+        <span
+          className={cn(
+            "shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium whitespace-nowrap",
+            TONE_CLASS[chip.tone],
+          )}
+        >
+          {chip.label}
+        </span>
+      </button>
+      {onExpand ? (
+        <button
+          type="button"
+          aria-label={`Expand ${subject.name}`}
+          onClick={onExpand}
+          className="absolute right-2 top-11 z-10 grid size-7 place-items-center rounded-full border border-hairline/40 bg-panel/90 text-ink-secondary backdrop-blur hover:text-ink"
+        >
+          <Maximize2 size={13} />
+        </button>
+      ) : null}
+
+      <div className="relative min-h-0 flex-1">
+        {parked ? (
+          <div className="flex h-full items-center justify-center text-[12px] text-ink-secondary">
+            Paused to keep the canvas smooth — click to open.
+          </div>
+        ) : (
+          <CardBoundary name={subject.name}>{children}</CardBoundary>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/spaces/SpacesComposer.tsx
+++ b/src/components/spaces/SpacesComposer.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { ChevronDown } from "lucide-react";
+
+import { Composer } from "@/components/Composer";
+import { BotAvatar } from "@/components/Avatar";
+import type { Bot, Group } from "@/state/store";
+import { cn } from "@/lib/cn";
+
+function isGroup(subject: Bot | Group): subject is Group {
+  return Array.isArray((subject as Group).memberIds);
+}
+
+/**
+ * The floating pill. It wraps the real Composer rather than reimplementing it,
+ * so attachments, queued messages, slash commands and voice all keep working;
+ * what it adds is the identity chip and the redirect picker.
+ */
+export function SpacesComposer({
+  subject,
+  subjects,
+  onPick,
+}: {
+  subject: Bot | Group;
+  subjects: Array<Bot | Group>;
+  onPick: (id: string) => void;
+}) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!pickerOpen) return;
+    const onDown = (event: MouseEvent) => {
+      if (!wrapperRef.current?.contains(event.target as Node)) setPickerOpen(false);
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setPickerOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [pickerOpen]);
+
+  // Typing "@" into an empty composer is the fast path to the picker: the
+  // Composer owns its own textarea, so we intercept before it sees the key.
+  const onKeyDownCapture = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "@") return;
+    const target = event.target as HTMLTextAreaElement | null;
+    if (!target || target.tagName !== "TEXTAREA" || target.value.length > 0) return;
+    event.preventDefault();
+    setPickerOpen(true);
+  };
+
+  return (
+    <div
+      ref={wrapperRef}
+      onKeyDownCapture={onKeyDownCapture}
+      className="pointer-events-auto absolute bottom-6 left-1/2 z-20 w-[min(52rem,calc(100vw-3rem))] -translate-x-1/2"
+    >
+      {pickerOpen && (
+        <div className="absolute bottom-full left-3 mb-2 max-h-72 w-72 overflow-y-auto rounded-xl border border-hairline/40 bg-panel/95 p-1 shadow-2xl backdrop-blur">
+          {subjects.map((candidate) => (
+            <button
+              key={candidate.id}
+              type="button"
+              onClick={() => {
+                setPickerOpen(false);
+                onPick(candidate.id);
+              }}
+              className={cn(
+                "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[13px] hover:bg-raised",
+                candidate.id === subject.id ? "text-ink" : "text-ink-secondary",
+              )}
+            >
+              {isGroup(candidate) ? (
+                <span className="grid size-5 shrink-0 place-items-center rounded-full bg-raised text-[10px]">
+                  {candidate.memberIds.length}
+                </span>
+              ) : (
+                <BotAvatar bot={candidate} size={20} />
+              )}
+              <span className="truncate">{candidate.name}</span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="flex items-end gap-1 rounded-[1.75rem] border border-hairline/40 bg-panel/90 pl-2 shadow-2xl backdrop-blur">
+        <button
+          type="button"
+          aria-haspopup="listbox"
+          aria-expanded={pickerOpen}
+          aria-label={`Sending to ${subject.name}. Choose another`}
+          onClick={() => setPickerOpen((open) => !open)}
+          className="mb-3 flex shrink-0 items-center gap-1.5 rounded-full bg-raised px-2.5 py-1.5 text-[12px] font-medium text-ink hover:bg-raised-hover"
+        >
+          {isGroup(subject) ? (
+            <span className="grid size-4 place-items-center rounded-full bg-panel text-[9px]">
+              {subject.memberIds.length}
+            </span>
+          ) : (
+            <BotAvatar bot={subject} size={16} />
+          )}
+          <span className="max-w-28 truncate">{subject.name}</span>
+          <ChevronDown size={12} className="text-ink-secondary" />
+        </button>
+        <div className="min-w-0 flex-1">
+          {isGroup(subject) ? (
+            <Composer key={subject.id} group={subject} />
+          ) : (
+            <Composer key={subject.id} bot={subject} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/spaces/SpacesShell.tsx
+++ b/src/components/spaces/SpacesShell.tsx
@@ -1,0 +1,563 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+  type WheelEvent as ReactWheelEvent,
+} from "react";
+import { Columns2, Columns3, Grid2x2, Square, X } from "lucide-react";
+
+import { useStore, type Bot, type Group } from "@/state/store";
+import { ChatView } from "@/components/ChatView";
+import { GroupView } from "@/components/GroupView";
+import { BrowserWorkspace } from "@/components/BrowserWorkspace";
+import { LocalVmWorkspace } from "@/components/LocalVmWorkspace";
+import { ComputerPanel } from "@/components/ComputerPanel";
+import { InspectorPanel } from "@/components/InspectorPanel";
+import { SettingsPanel } from "@/components/SettingsPanel";
+import { builtInBrowserEnabled } from "@/lib/feature-flags";
+import { cn } from "@/lib/cn";
+import { SpaceCard } from "./SpaceCard";
+import { SpacesStage } from "./SpacesStage";
+import { SpacesComposer } from "./SpacesComposer";
+import { SpacesToasts } from "./SpacesToasts";
+import { flipFrom } from "./spaces-flip";
+import {
+  TILE_COUNTS,
+  layoutFor,
+  transformForLayout,
+  type CanvasView,
+  type TileCount,
+  type Viewport,
+} from "./spaces-layout";
+import { clampIndex, navigate, type NavIntent } from "./spaces-nav";
+import { panBy, zoomAt, type View } from "./spaces-view";
+import { nearestCardIndex } from "./spaces-nearest";
+import { expireToasts, lastSettled, mergeToasts, settledSince, type Toast } from "./spaces-toasts";
+
+/** Cards this far from the focused one keep their body once the canvas has
+ * proved too heavy for this machine. */
+const DEGRADED_LIVE_RADIUS = 9;
+/** A frame slower than this is a dropped one at 60Hz, with headroom. */
+const SLOW_FRAME_MS = 20;
+
+function isGroup(subject: Bot | Group): subject is Group {
+  return Array.isArray((subject as Group).memberIds);
+}
+
+function useViewport(): Viewport {
+  const [viewport, setViewport] = useState<Viewport>(() => ({
+    width: typeof window === "undefined" ? 1440 : window.innerWidth,
+    height: typeof window === "undefined" ? 900 : window.innerHeight,
+  }));
+  useEffect(() => {
+    const measure = () => setViewport({ width: window.innerWidth, height: window.innerHeight });
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, []);
+  return viewport;
+}
+
+/**
+ * Watches how long frames actually take during a transition. Everything-live is
+ * the promise; on a machine that cannot hold it, distant cards park rather than
+ * the whole canvas stuttering. Measured, not guessed — and sticky once tripped,
+ * so it does not flap mid-gesture.
+ */
+function useFrameBudget(): { degraded: boolean; sample: () => void } {
+  const [degraded, setDegraded] = useState(false);
+  const running = useRef(false);
+
+  const sample = useCallback(() => {
+    if (degraded || running.current || typeof requestAnimationFrame !== "function") return;
+    running.current = true;
+    const frames: number[] = [];
+    let previous = performance.now();
+    const tick = (now: number) => {
+      frames.push(now - previous);
+      previous = now;
+      if (frames.length < 24) {
+        requestAnimationFrame(tick);
+        return;
+      }
+      running.current = false;
+      const sorted = [...frames].sort((a, b) => a - b);
+      const p95 = sorted[Math.floor(sorted.length * 0.95)] ?? 0;
+      if (p95 > SLOW_FRAME_MS) setDegraded(true);
+    };
+    requestAnimationFrame(tick);
+  }, [degraded]);
+
+  return { degraded, sample };
+}
+
+export function SpacesShell({ onClose }: { onClose: () => void }) {
+  const { state, dispatch } = useStore();
+  const viewport = useViewport();
+  const [view, setView] = useState<CanvasView>({ kind: "tile", per: 1 });
+  // Remembered so leaving the grid returns to the split you were using.
+  const lastTile = useRef<TileCount>(1);
+  const [transitioning, setTransitioning] = useState(false);
+  // Explicit view while the trackpad is driving; null means "follow the
+  // preset for the current mode and card". Any key or click snaps back.
+  const [freeView, setFreeView] = useState<View | null>(null);
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  /** A surface lifted out of a card to fill the canvas. */
+  const [expanded, setExpanded] = useState<{ kind: "browser" | "vm"; botId: string } | null>(null);
+  const { degraded, sample } = useFrameBudget();
+  const cardRefs = useRef(new Map<string, HTMLDivElement | null>());
+  const expandOrigin = useRef<DOMRect | null>(null);
+  const settleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Bots first, then rooms — a stable order, so a card never moves between
+  // visits and the spatial memory that makes this work stays intact.
+  const subjects = useMemo<Array<Bot | Group>>(
+    () => [...state.bots.filter((bot) => !bot.hidden), ...state.groups],
+    [state.bots, state.groups],
+  );
+  const count = subjects.length;
+  const layout = useMemo(() => layoutFor(count, viewport, view), [count, viewport, view]);
+  const columns = layout.columns;
+
+  const selectedIndex = subjects.findIndex((subject) => subject.id === state.selectedId);
+  const index = clampIndex(selectedIndex >= 0 ? selectedIndex : 0, count);
+  const focused = index >= 0 ? subjects[index] : null;
+
+  const focus = useCallback(
+    (id: string) => {
+      dispatch({ type: "select", id });
+    },
+    [dispatch],
+  );
+
+  const move = useCallback(
+    (intent: NavIntent) => {
+      const next = navigate({ index, count, columns }, intent);
+      if (next < 0 || next === index) return;
+      focus(subjects[next].id);
+    },
+    [columns, count, focus, index, subjects],
+  );
+
+  const showView = useCallback(
+    (next: CanvasView) => {
+      if (next.kind === "tile") lastTile.current = next.per;
+      setView((current) =>
+        current.kind === next.kind && (current.kind !== "tile" || current.per === (next as { per: TileCount }).per)
+          ? current
+          : next,
+      );
+    },
+    [],
+  );
+  const toGrid = useCallback(() => showView({ kind: "grid" }), [showView]);
+  const toTiles = useCallback(() => showView({ kind: "tile", per: lastTile.current }), [showView]);
+
+  // --- keyboard -----------------------------------------------------------
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (expanded) return;
+      const typing =
+        event.target instanceof HTMLTextAreaElement || event.target instanceof HTMLInputElement;
+      // macOS reserves Control+Arrow (move a space) and Control+1..3 (switch
+      // desktop) for Mission Control and swallows them before Electron sees
+      // them, so Spaces uses Cmd-Opt. It also survives a focused text field.
+      const spacesChord = event.metaKey && event.altKey && !event.ctrlKey;
+
+      if (event.key === "Escape" && !typing) {
+        event.preventDefault();
+        // Unwind one layer at a time, innermost first.
+        if (state.computerOpen) dispatch({ type: "toggleComputer", open: false });
+        else if (state.inspectorOpen) dispatch({ type: "toggleInspector", open: false });
+        else if (state.settingsOpen) dispatch({ type: "toggleSettings", open: false });
+        else if (view.kind === "grid") toTiles();
+        else onClose();
+        return;
+      }
+      // Cmd-Opt-1/2/3 choose how many bots share the screen. Read `code`, not
+      // `key`: with Option held macOS composes "1" into "¡".
+      if (spacesChord) {
+        const digit = /^Digit([123])$/.exec(event.code);
+        if (digit) {
+          event.preventDefault();
+          showView({ kind: "tile", per: Number(digit[1]) as TileCount });
+          return;
+        }
+      }
+      if (event.metaKey && /^[1-9]$/.test(event.key)) {
+        const target = subjects[Number(event.key) - 1];
+        if (target) {
+          event.preventDefault();
+          focus(target.id);
+          toTiles();
+        }
+        return;
+      }
+      // In the grid, bare arrows move the selection: nothing else has the
+      // keyboard there, and it is what every other grid on the machine does.
+      if (!event.metaKey && !event.altKey && !event.ctrlKey && view.kind === "grid" && !typing) {
+        const bare: Record<string, NavIntent> = {
+          ArrowUp: "up",
+          ArrowDown: "down",
+          ArrowLeft: "prev",
+          ArrowRight: "next",
+        };
+        const intent = bare[event.key];
+        if (intent) {
+          event.preventDefault();
+          move(intent);
+        }
+        return;
+      }
+
+      if (!spacesChord) return;
+      // The vertical pair is zoom, in both modes — never zoom in one
+      // direction and movement in the other. Sliding is the horizontal pair.
+      switch (event.key) {
+        case "ArrowUp":
+          event.preventDefault();
+          toGrid();
+          break;
+        case "ArrowDown":
+          event.preventDefault();
+          toTiles();
+          break;
+        case "ArrowLeft":
+          event.preventDefault();
+          move("prev");
+          break;
+        case "ArrowRight":
+          event.preventDefault();
+          move("next");
+          break;
+        default:
+          break;
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [dispatch, expanded, focus, move, onClose, showView, state.computerOpen, state.inspectorOpen, state.settingsOpen, subjects, toGrid, toTiles, view]);
+
+  // --- trackpad -----------------------------------------------------------
+  // macOS reserves genuine three-finger Spaces swipes for itself; Electron
+  // never sees them. Two-finger horizontal scroll is what arrives here, and a
+  // pinch arrives as a wheel event with ctrlKey set.
+  // Trackpad drives the canvas directly: two-finger scroll pans in both axes,
+  // pinch (which macOS delivers as a wheel event with ctrlKey) zooms about the
+  // pointer. Both start from wherever the preset currently puts the stage, so
+  // there is never a jump on the first gesture.
+  const onWheel = useCallback(
+    (event: ReactWheelEvent) => {
+      if (expanded) return;
+      const current = freeView ?? transformForLayout(layout, index, viewport);
+      const base: View = { scale: current.scale, x: current.x, y: current.y };
+      if (event.ctrlKey) {
+        // deltaY is the pinch magnitude; the exponent keeps it smooth and
+        // symmetric between pinching in and out.
+        setFreeView(zoomAt(base, { x: event.clientX, y: event.clientY }, Math.exp(-event.deltaY / 120)));
+        return;
+      }
+      const panned = panBy(base, event.deltaX, event.deltaY);
+      setFreeView(panned);
+      // Panning is navigation: when the fingers stop, adopt whichever card the
+      // canvas has landed on and settle onto it, so the composer pill always
+      // names the bot you are looking at.
+      if (settleTimer.current) clearTimeout(settleTimer.current);
+      settleTimer.current = setTimeout(() => {
+        const landed = nearestCardIndex(layout, { ...panned, scrollable: false }, viewport);
+        if (landed >= 0 && subjects[landed]) focus(subjects[landed].id);
+        setFreeView(null);
+      }, 160);
+    },
+    [expanded, focus, freeView, index, layout, subjects, viewport],
+  );
+
+  // Any deliberate move — a key, a click, a toast — snaps back to the preset.
+  useEffect(() => {
+    setFreeView(null);
+  }, [index, view]);
+
+  useEffect(() => () => {
+    if (settleTimer.current) clearTimeout(settleTimer.current);
+  }, []);
+
+  // --- transition bookkeeping --------------------------------------------
+  useEffect(() => {
+    setTransitioning(true);
+    sample();
+    const done = setTimeout(() => setTransitioning(false), 420);
+    return () => clearTimeout(done);
+  }, [index, view, sample]);
+
+  // --- background activity toasts ----------------------------------------
+  const seen = useRef<Record<string, string | null>>({});
+  useEffect(() => {
+    const now = Date.now();
+    const observed = subjects.map((subject) => ({
+      id: subject.id,
+      name: subject.name,
+      settled: lastSettled(subject.messages),
+    }));
+    // In grid view the card itself is visible; a toast about it is redundant.
+    const events = view.kind === "grid" ? [] : settledSince(seen.current, observed, focused?.id ?? null, now);
+    const next: Record<string, string | null> = {};
+    for (const subject of observed) next[subject.id] = subject.settled?.id ?? null;
+    seen.current = next;
+    if (events.length > 0) setToasts((current) => mergeToasts(current, events));
+  }, [focused?.id, view, subjects]);
+
+  useEffect(() => {
+    if (toasts.length === 0) return;
+    const timer = setInterval(() => setToasts((current) => expireToasts(current, Date.now())), 500);
+    return () => clearInterval(timer);
+  }, [toasts.length]);
+
+  // --- artifact zoom-out --------------------------------------------------
+  const expandedBot = expanded ? state.bots.find((bot) => bot.id === expanded.botId) : undefined;
+  const expandRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    const origin = expandOrigin.current;
+    const element = expandRef.current;
+    if (!expandedBot || !origin || !element) return;
+    expandOrigin.current = null;
+    void flipFrom(element, origin);
+  }, [expandedBot]);
+
+  const expandFocused = useCallback(() => {
+    if (!focused || isGroup(focused)) return;
+    expandOrigin.current = cardRefs.current.get(focused.id)?.getBoundingClientRect() ?? null;
+    setExpanded({ kind: "browser", botId: focused.id });
+  }, [focused]);
+
+  const canExpand =
+    Boolean(focused) &&
+    !isGroup(focused as Bot | Group) &&
+    builtInBrowserEnabled(state.config) &&
+    (focused as Bot).browser !== false;
+
+  const preset = transformForLayout(layout, index, viewport);
+  const focusedBot = focused && !isGroup(focused) ? focused : undefined;
+  const transform = freeView
+    ? { ...preset, scale: freeView.scale, x: freeView.x, y: freeView.y }
+    : preset;
+
+  if (count === 0) {
+    return (
+      <CanvasFrame onClose={onClose}>
+        <div className="flex h-full flex-col items-center justify-center gap-3 text-ink-secondary">
+          <div className="text-[14px]">No bots yet</div>
+          <button
+            type="button"
+            onClick={() => dispatch({ type: "newBot" })}
+            className="rounded-full bg-accent px-4 py-1.5 text-[13px] font-medium text-accent-ink"
+          >
+            New bot
+          </button>
+        </div>
+      </CanvasFrame>
+    );
+  }
+
+  return (
+    <CanvasFrame onClose={onClose} onWheel={onWheel}>
+      <div
+        className={cn(
+          "absolute inset-0",
+          view.kind === "grid" && transform.scrollable ? "overflow-y-auto" : "overflow-hidden",
+        )}
+      >
+        {/* A transform never changes layout size, so a scaled-down stage would
+            still give the scroll container its full natural height. This spacer
+            carries the *scaled* height instead, which is what scrolls. */}
+        {transform.scrollable ? (
+          <div
+            aria-hidden
+            style={{ height: layout.stage.height * transform.scale + 96 }}
+          />
+        ) : null}
+        <SpacesStage
+          layout={layout}
+          transform={transform}
+          transitioning={transitioning}
+          animated={freeView === null}
+        >
+          {subjects.map((subject, cardIndex) => {
+            const isFocused = cardIndex === index;
+            const parked = degraded && Math.abs(cardIndex - index) > DEGRADED_LIVE_RADIUS;
+            return (
+              <div
+                key={subject.id}
+                ref={(node) => {
+                  cardRefs.current.set(subject.id, node);
+                }}
+                // Every card is live, so a click can land in one that is not
+                // focused. Focus it first: otherwise the composer pill and the
+                // side panels would act on a different bot than the one under
+                // the pointer. Capture phase, so it lands before the control.
+                onMouseDownCapture={() => {
+                  if (!isFocused) focus(subject.id);
+                }}
+                className="h-full w-full"
+              >
+                <SpaceCard
+                  subject={subject}
+                  focused={isFocused}
+                  parked={parked}
+                  onFocus={() => {
+                    focus(subject.id);
+                    if (view.kind === "grid") toTiles();
+                  }}
+                  onExpand={isFocused && canExpand ? expandFocused : undefined}
+                >
+                  {isGroup(subject) ? (
+                    <GroupView group={subject} active={isFocused && view.kind === "tile"} composer={false} />
+                  ) : (
+                    <ChatView bot={subject} active={isFocused && view.kind === "tile"} composer={false} />
+                  )}
+                </SpaceCard>
+              </div>
+            );
+          })}
+    </SpacesStage>
+      </div>
+
+      {view.kind === "tile" && <SpacesToasts toasts={toasts} onPick={focus} />}
+
+      {focused && !expandedBot && (
+        <SpacesComposer subject={focused} subjects={subjects} onPick={(id) => { focus(id); if (view.kind === "grid") toTiles(); }} />
+      )}
+
+      <div className="pointer-events-auto absolute left-1/2 top-4 z-20 flex -translate-x-1/2 items-center gap-0.5 rounded-full border border-hairline/40 bg-panel/90 p-1 shadow-xl backdrop-blur">
+        {TILE_COUNTS.map((per) => {
+          const Icon = per === 1 ? Square : per === 2 ? Columns2 : Columns3;
+          const on = view.kind === "tile" && view.per === per;
+          return (
+            <button
+              key={per}
+              type="button"
+              aria-pressed={on}
+              aria-label={per === 1 ? "One bot, full screen" : `${per} bots side by side`}
+              title={`${per === 1 ? "Full screen" : `${per} across`}  ⌘⌥${per}`}
+              onClick={() => showView({ kind: "tile", per })}
+              className={cn(
+                "grid size-7 place-items-center rounded-full transition-colors",
+                on ? "bg-accent text-accent-ink" : "text-ink-secondary hover:bg-raised hover:text-ink",
+              )}
+            >
+              <Icon size={14} />
+            </button>
+          );
+        })}
+        <span aria-hidden className="mx-0.5 h-4 w-px bg-hairline/50" />
+        <button
+          type="button"
+          aria-pressed={view.kind === "grid"}
+          aria-label="Show every bot at once"
+          title="All bots  ⌘⌥↑"
+          onClick={toGrid}
+          className={cn(
+            "grid size-7 place-items-center rounded-full transition-colors",
+            view.kind === "grid" ? "bg-accent text-accent-ink" : "text-ink-secondary hover:bg-raised hover:text-ink",
+          )}
+        >
+          <Grid2x2 size={14} />
+        </button>
+      </div>
+
+      {degraded && (
+        <div className="pointer-events-none absolute bottom-6 left-6 z-20 max-w-xs rounded-lg border border-hairline/40 bg-panel/90 px-3 py-2 text-[11px] text-ink-secondary backdrop-blur">
+          Distant cards are paused to keep the canvas smooth on this machine.
+        </div>
+      )}
+
+      {expandedBot && expanded && (
+        <div ref={expandRef} className="absolute inset-0 z-40 bg-app">
+          {expanded.kind === "browser" ? (
+            <BrowserWorkspace bot={expandedBot} onClose={() => setExpanded(null)} />
+          ) : (
+            <LocalVmWorkspace
+              primaryBotId={expandedBot.id}
+              overlayOpen={false}
+              onClose={() => setExpanded(null)}
+              onOpenComputer={() => {
+                setExpanded(null);
+                dispatch({ type: "toggleComputer", open: true });
+              }}
+            />
+          )}
+        </div>
+      )}
+
+      {/* The chat's own side panels dock to the right of the transcript in the
+          normal shell, as in-flow asides. Inside the canvas they would render
+          underneath it, so the buttons looked dead. Mount them here, over the
+          canvas, targeting whichever card is focused. */}
+      {focusedBot && !expanded && (
+        <>
+          {state.computerOpen && (
+            <div className="absolute inset-y-0 right-0 z-30 flex max-w-[90vw] shadow-2xl">
+              <ComputerPanel
+                key={focusedBot.id}
+                bot={focusedBot}
+                onOpenVmWorkspace={(botId) => {
+                  dispatch({ type: "toggleComputer", open: false });
+                  setExpanded({ kind: "vm", botId });
+                }}
+                onExpandBrowser={(botId) => {
+                  dispatch({ type: "toggleComputer", open: false });
+                  expandOrigin.current = cardRefs.current.get(botId)?.getBoundingClientRect() ?? null;
+                  setExpanded({ kind: "browser", botId });
+                }}
+              />
+            </div>
+          )}
+          {state.inspectorOpen && (
+            <div className="absolute inset-y-0 right-0 z-30 flex max-w-[90vw] shadow-2xl">
+              <InspectorPanel key={focusedBot.id} bot={focusedBot} />
+            </div>
+          )}
+          {state.settingsOpen && (
+            <div className="absolute inset-y-0 right-0 z-30 flex max-w-[90vw] shadow-2xl">
+              <SettingsPanel key={focusedBot.id} bot={focusedBot} />
+            </div>
+          )}
+        </>
+      )}
+    </CanvasFrame>
+  );
+}
+
+function CanvasFrame({
+  children,
+  onClose,
+  onWheel,
+}: {
+  children: ReactNode;
+  onClose: () => void;
+  onWheel?: (event: ReactWheelEvent) => void;
+}) {
+  return (
+    <div
+      onWheel={onWheel}
+      className="fixed inset-0 z-40 overflow-hidden bg-app"
+      style={{
+        backgroundImage:
+          "radial-gradient(120% 90% at 50% 0%, color-mix(in srgb, var(--color-accent) 12%, transparent) 0%, transparent 60%)",
+      }}
+    >
+      {children}
+      <button
+        type="button"
+        aria-label="Leave Spaces"
+        onClick={onClose}
+        className="absolute right-6 bottom-6 z-30 grid size-9 place-items-center rounded-full border border-hairline/40 bg-panel/90 text-ink-secondary shadow-xl backdrop-blur hover:text-ink"
+      >
+        <X size={16} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/spaces/SpacesStage.tsx
+++ b/src/components/spaces/SpacesStage.tsx
@@ -1,0 +1,69 @@
+import type { CSSProperties, ReactNode } from "react";
+
+import type { Layout, StageTransform } from "./spaces-layout";
+
+/**
+ * Places cards at the boxes the layout computed and applies the one transform
+ * that moves the whole canvas. Pure presentation — every decision lives in the
+ * shell, and every measurement in spaces-layout.
+ */
+export function SpacesStage({
+  layout,
+  transform,
+  transitioning,
+  animated = true,
+  children,
+}: {
+  layout: Layout;
+  transform: StageTransform;
+  /** `will-change` only while moving: leaving it on pins every card into its
+   * own compositor layer and costs VRAM for nothing. */
+  transitioning: boolean;
+  /** False while the trackpad is driving: a transition would lag the fingers. */
+  animated?: boolean;
+  children: ReactNode[];
+}) {
+  const style: CSSProperties = {
+    width: layout.stage.width,
+    height: layout.stage.height,
+    transformOrigin: "0 0",
+    transform: `translate3d(${transform.x}px, ${transform.y}px, 0) scale(${transform.scale})`,
+    willChange: transitioning ? "transform" : undefined,
+    transitionProperty: animated ? "transform" : "none",
+    transitionDuration: "360ms",
+    // Matches macOS's window-lift curve: quick to leave, gentle to arrive.
+    transitionTimingFunction: "cubic-bezier(0.32, 0.72, 0, 1)",
+  };
+
+  return (
+    <div className="spaces-stage absolute left-0 top-0 motion-reduce:transition-none" style={style}>
+      {children.map((child, index) => {
+        const cell = layout.cells[index];
+        if (!cell) return null;
+        return (
+          <div
+            key={index}
+            // Cells animate their own box only when the arrangement changes —
+            // switching tile count or going to the grid. Navigating inside one
+            // arrangement never touches these, it just moves the stage.
+            className="absolute transition-[left,top,width,height] duration-[360ms] ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none"
+            style={
+              {
+                left: cell.x,
+                top: cell.y,
+                width: cell.width,
+                height: cell.height,
+                // Off-screen cards stay mounted and interactive, but the
+                // browser skips their layout and paint.
+                contentVisibility: "auto",
+                containIntrinsicSize: `${Math.round(cell.height)}px ${Math.round(cell.width)}px`,
+              } as CSSProperties
+            }
+          >
+            {child}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/spaces/SpacesToasts.tsx
+++ b/src/components/spaces/SpacesToasts.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from "react";
+
+import { cn } from "@/lib/cn";
+import type { Toast } from "./spaces-toasts";
+
+/** A bot you are not watching just finished something. Suppressed in grid
+ * view, where the card itself is already visible. */
+export function SpacesToasts({ toasts, onPick }: { toasts: Toast[]; onPick: (subjectId: string) => void }) {
+  if (toasts.length === 0) return null;
+  return (
+    <div className="pointer-events-none absolute right-6 top-6 z-20 flex w-[22rem] max-w-[calc(100vw-3rem)] flex-col gap-2">
+      {toasts.map((toast) => (
+        <ToastRow key={toast.id} toast={toast} onPick={() => onPick(toast.subjectId)} />
+      ))}
+    </div>
+  );
+}
+
+function ToastRow({ toast, onPick }: { toast: Toast; onPick: () => void }) {
+  const ref = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof el.animate !== "function") return;
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+    el.animate(
+      [
+        { opacity: 0, transform: "translateX(12px) scale(0.98)" },
+        { opacity: 1, transform: "translateX(0) scale(1)" },
+      ],
+      { duration: 220, easing: "cubic-bezier(0.32, 0.72, 0, 1)" },
+    );
+  }, []);
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      onClick={onPick}
+      className={cn(
+        "pointer-events-auto flex w-full items-start gap-3 rounded-xl border border-hairline/40 bg-panel/95 px-3 py-2.5 text-left shadow-xl backdrop-blur",
+        "hover:border-accent/40",
+      )}
+    >
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-[13px] font-medium text-ink">{toast.name}</span>
+        <span className="mt-0.5 block truncate text-[12px] text-ink-secondary">{toast.text}</span>
+      </span>
+    </button>
+  );
+}

--- a/src/components/spaces/spaces-flip.ts
+++ b/src/components/spaces/spaces-flip.ts
@@ -1,0 +1,53 @@
+/** The one shared-element transition on the canvas.
+ *
+ * A card lifts out of the grid into a full-screen surface. FLIP: measure where
+ * the element starts, let it be laid out where it ends, then animate the
+ * difference away. The Web Animations API is enough — no animation library.
+ */
+
+export interface FlipOptions {
+  durationMs?: number;
+  easing?: string;
+}
+
+const DEFAULT_DURATION = 320;
+// A gentle overshoot-free ease; matches how macOS lifts a window.
+const DEFAULT_EASING = "cubic-bezier(0.32, 0.72, 0, 1)";
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== "undefined" && window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
+}
+
+/**
+ * Animate `element` as though it had started at `from`. Returns a promise that
+ * settles when the motion finishes — immediately under reduced motion, where
+ * the transition becomes a cut.
+ */
+export function flipFrom(element: HTMLElement, from: DOMRect, options: FlipOptions = {}): Promise<void> {
+  if (prefersReducedMotion() || typeof element.animate !== "function") return Promise.resolve();
+
+  const to = element.getBoundingClientRect();
+  if (to.width === 0 || to.height === 0 || from.width === 0 || from.height === 0) return Promise.resolve();
+
+  const dx = from.left - to.left;
+  const dy = from.top - to.top;
+  const sx = from.width / to.width;
+  const sy = from.height / to.height;
+  // Already in place: nothing worth animating.
+  if (Math.abs(dx) < 1 && Math.abs(dy) < 1 && Math.abs(sx - 1) < 0.01 && Math.abs(sy - 1) < 0.01) {
+    return Promise.resolve();
+  }
+
+  const animation = element.animate(
+    [
+      { transformOrigin: "top left", transform: `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`, opacity: 0.6 },
+      { transformOrigin: "top left", transform: "translate(0, 0) scale(1, 1)", opacity: 1 },
+    ],
+    {
+      duration: options.durationMs ?? DEFAULT_DURATION,
+      easing: options.easing ?? DEFAULT_EASING,
+      fill: "none",
+    },
+  );
+  return animation.finished.then(() => undefined).catch(() => undefined);
+}

--- a/src/components/spaces/spaces-layout.test.ts
+++ b/src/components/spaces/spaces-layout.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MIN_GRID_SCALE,
+  TILE_COUNTS,
+  gridColumns,
+  layoutFor,
+  transformForLayout,
+} from "./spaces-layout";
+
+const wide = { width: 1600, height: 1000 };
+const narrow = { width: 900, height: 700 };
+const tile = (per: 1 | 2 | 3) => ({ kind: "tile" as const, per });
+const grid = { kind: "grid" as const };
+
+describe("tiled layouts", () => {
+  it("gives one bot the whole width", () => {
+    const { cells } = layoutFor(6, wide, tile(1));
+    expect(cells[0].width).toBeGreaterThan(wide.width * 0.9);
+  });
+
+  it("splits the width between two bots, and three", () => {
+    const two = layoutFor(6, wide, tile(2)).cells[0].width;
+    const three = layoutFor(6, wide, tile(3)).cells[0].width;
+    const one = layoutFor(6, wide, tile(1)).cells[0].width;
+    expect(two).toBeGreaterThan(one / 2 - 40);
+    expect(two).toBeLessThan(one / 2 + 40);
+    expect(three).toBeLessThan(two);
+    expect(three).toBeGreaterThan(one / 3 - 40);
+  });
+
+  it("makes cards genuinely narrower rather than shrinking them — the point of split screen", () => {
+    // at scale 1 the content is full size in every tiled mode
+    for (const per of TILE_COUNTS) {
+      const layout = layoutFor(6, wide, tile(per));
+      expect(transformForLayout(layout, 0, wide).scale).toBe(1);
+    }
+  });
+
+  it("lays every card out in one row, left to right", () => {
+    const { cells } = layoutFor(5, wide, tile(2));
+    expect(cells.every((c) => c.y === cells[0].y)).toBe(true);
+    for (let i = 1; i < cells.length; i += 1) expect(cells[i].x).toBeGreaterThan(cells[i - 1].x);
+  });
+
+  it("gives every card the same box in a given mode", () => {
+    const { cells } = layoutFor(7, wide, tile(3));
+    expect(new Set(cells.map((c) => c.width)).size).toBe(1);
+    expect(new Set(cells.map((c) => c.height)).size).toBe(1);
+  });
+
+  it("leaves room at the bottom for the floating composer", () => {
+    const { cells } = layoutFor(4, wide, tile(1));
+    expect(cells[0].height).toBeLessThan(wide.height - 80);
+  });
+
+  it("puts the focused card at the left edge of the visible run", () => {
+    const layout = layoutFor(8, wide, tile(2));
+    const t0 = transformForLayout(layout, 0, wide);
+    const t1 = transformForLayout(layout, 1, wide);
+    // card 1 lands exactly where card 0 was
+    expect(layout.cells[1].x + t1.x).toBeCloseTo(layout.cells[0].x + t0.x);
+  });
+
+  it("shows the n-th card alongside its neighbours, all on screen", () => {
+    const layout = layoutFor(8, wide, tile(3));
+    const t = transformForLayout(layout, 2, wide);
+    for (const i of [2, 3, 4]) {
+      const left = layout.cells[i].x + t.x;
+      expect(left).toBeGreaterThanOrEqual(-1);
+      expect(left + layout.cells[i].width).toBeLessThanOrEqual(wide.width + 1);
+    }
+  });
+});
+
+describe("grid layout", () => {
+  it("wraps the same full-size cards into rows", () => {
+    const { cells } = layoutFor(9, wide, grid);
+    const columns = gridColumns(9, wide);
+    expect(new Set(cells.map((c) => c.y)).size).toBe(Math.ceil(9 / columns));
+    expect(cells[0].width).toBeCloseTo(layoutFor(9, wide, tile(1)).cells[0].width);
+  });
+
+  it("shrinks the whole thing to fit, and ignores which card is focused", () => {
+    const layout = layoutFor(6, wide, grid);
+    const t = transformForLayout(layout, 0, wide);
+    expect(t.scale).toBeLessThan(1);
+    expect(layout.stage.width * t.scale).toBeLessThanOrEqual(wide.width);
+    expect(transformForLayout(layout, 4, wide)).toEqual(t);
+  });
+
+  it("stops at the legibility floor and scrolls instead", () => {
+    const layout = layoutFor(60, wide, grid);
+    const t = transformForLayout(layout, 0, wide);
+    expect(t.scale).toBe(MIN_GRID_SCALE);
+    expect(t.scrollable).toBe(true);
+  });
+
+  it("tiles fewer columns in a narrow window", () => {
+    expect(gridColumns(9, narrow)).toBeLessThan(gridColumns(9, wide));
+  });
+
+  it("never uses more columns than there are cards", () => {
+    expect(gridColumns(1, wide)).toBe(1);
+    expect(gridColumns(2, wide)).toBe(2);
+  });
+});
+
+describe("edge cases", () => {
+  it("has no cells and no stage for an empty canvas", () => {
+    for (const view of [tile(1), tile(3), grid]) {
+      const layout = layoutFor(0, wide, view);
+      expect(layout.cells).toEqual([]);
+      expect(layout.stage).toEqual({ width: 0, height: 0 });
+    }
+  });
+
+  it("handles a single bot in every mode without dividing by zero", () => {
+    for (const view of [tile(1), tile(2), tile(3), grid]) {
+      const layout = layoutFor(1, wide, view);
+      expect(layout.cells).toHaveLength(1);
+      expect(Number.isFinite(transformForLayout(layout, 0, wide).x)).toBe(true);
+    }
+  });
+
+  it("does not scroll a tiled row past its last card", () => {
+    const layout = layoutFor(4, wide, tile(3));
+    const last = transformForLayout(layout, 3, wide);
+    const first = transformForLayout(layout, 0, wide);
+    // only one card's worth of run remains, so it clamps rather than leaving a void
+    expect(last.x).toBeLessThanOrEqual(first.x);
+    const rightmost = layout.cells[3].x + layout.cells[3].width + last.x;
+    expect(rightmost).toBeLessThanOrEqual(wide.width + 1);
+  });
+});

--- a/src/components/spaces/spaces-layout.ts
+++ b/src/components/spaces/spaces-layout.ts
@@ -1,0 +1,153 @@
+/** Pure geometry for the Spaces canvas.
+ *
+ * Two arrangements, both expressed as explicit cell boxes:
+ *
+ *   tile(n)  one row of cards, each 1/n of the width. This is real split
+ *            screen: the cards get NARROWER, so their text stays full size.
+ *            Always drawn at scale 1.
+ *   grid     the same full-size cards wrapped into rows and shrunk to fit,
+ *            the way Mission Control shrinks real windows.
+ *
+ * Within one arrangement, moving between cards is a single transform on the
+ * stage, so sliding and panning cost the same whatever the card count. Only
+ * changing arrangement reflows the cells, and that is a deliberate, occasional
+ * action rather than something that happens while you navigate.
+ *
+ * Nothing here touches the DOM, which is what lets the suite cover it under
+ * `environment: "node"`.
+ */
+
+export interface Viewport {
+  width: number;
+  height: number;
+}
+
+export interface CellBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export type TileCount = 1 | 2 | 3;
+export const TILE_COUNTS: readonly TileCount[] = [1, 2, 3];
+
+export type CanvasView = { kind: "tile"; per: TileCount } | { kind: "grid" };
+
+export interface Layout {
+  cells: CellBox[];
+  stage: { width: number; height: number };
+  view: CanvasView;
+  /** Columns in the arrangement — grid navigation needs it. */
+  columns: number;
+}
+
+export interface StageTransform {
+  scale: number;
+  x: number;
+  y: number;
+  /** The grid hit the legibility floor: it no longer fits, so it scrolls. */
+  scrollable: boolean;
+}
+
+/** Breathing room around the canvas, in viewport pixels. */
+const PAD = 24;
+/** Reserved at the bottom for the floating composer. */
+const COMPOSER_RESERVE = 104;
+/** Gap between cards. */
+const GAP = 16;
+/** Margin around the shrunk grid. */
+const GRID_MARGIN = 40;
+/** Past this, cards stop being readable; the grid scrolls rather than shrink. */
+export const MIN_GRID_SCALE = 0.22;
+
+function clamp(value: number, low: number, high: number): number {
+  return Math.min(high, Math.max(low, value));
+}
+
+/** The box one full-size card occupies: the whole canvas minus its chrome. */
+function fullCard(viewport: Viewport): { width: number; height: number } {
+  return {
+    width: Math.max(1, viewport.width - PAD * 2),
+    height: Math.max(1, viewport.height - PAD - COMPOSER_RESERVE),
+  };
+}
+
+export function gridColumns(count: number, viewport: Viewport): number {
+  if (count <= 0) return 0;
+  // Wider windows earn another column; never more columns than cards.
+  const byWidth = viewport.width >= 1400 ? 4 : viewport.width >= 1100 ? 3 : 2;
+  return Math.min(count, byWidth);
+}
+
+export function layoutFor(count: number, viewport: Viewport, view: CanvasView): Layout {
+  if (count <= 0) {
+    return { cells: [], stage: { width: 0, height: 0 }, view, columns: 0 };
+  }
+  const full = fullCard(viewport);
+
+  if (view.kind === "tile") {
+    const width = (full.width - GAP * (view.per - 1)) / view.per;
+    const cells = Array.from({ length: count }, (_, index) => ({
+      x: index * (width + GAP),
+      y: 0,
+      width,
+      height: full.height,
+    }));
+    return {
+      cells,
+      stage: { width: count * width + (count - 1) * GAP, height: full.height },
+      view,
+      columns: count,
+    };
+  }
+
+  const columns = gridColumns(count, viewport);
+  const rows = Math.ceil(count / columns);
+  const cells = Array.from({ length: count }, (_, index) => ({
+    x: (index % columns) * (full.width + GAP),
+    y: Math.floor(index / columns) * (full.height + GAP),
+    width: full.width,
+    height: full.height,
+  }));
+  return {
+    cells,
+    stage: {
+      width: columns * full.width + (columns - 1) * GAP,
+      height: rows * full.height + (rows - 1) * GAP,
+    },
+    view,
+    columns,
+  };
+}
+
+/**
+ * The transform to put on the stage, with `transform-origin: 0 0`. A stage
+ * point p lands on screen at `scale * p + (x, y)`.
+ */
+export function transformForLayout(layout: Layout, index: number, viewport: Viewport): StageTransform {
+  if (layout.cells.length === 0) return { scale: 1, x: 0, y: 0, scrollable: false };
+
+  if (layout.view.kind === "tile") {
+    const focused = layout.cells[clamp(index, 0, layout.cells.length - 1)];
+    // Put the focused card at the left of the visible run, but never scroll
+    // past the end — a trailing void looks broken.
+    const maxOffset = Math.max(0, layout.stage.width - (viewport.width - PAD * 2));
+    const offset = Math.min(focused.x, maxOffset);
+    return { scale: 1, x: PAD - offset, y: PAD, scrollable: false };
+  }
+
+  const available = {
+    width: viewport.width - GRID_MARGIN * 2,
+    height: viewport.height - GRID_MARGIN - COMPOSER_RESERVE,
+  };
+  const fitted = Math.min(available.width / layout.stage.width, available.height / layout.stage.height);
+  const scale = clamp(fitted, MIN_GRID_SCALE, 1);
+  const scrollable = fitted < MIN_GRID_SCALE;
+  return {
+    scale,
+    x: viewport.width / 2 - (layout.stage.width * scale) / 2,
+    y: scrollable ? GRID_MARGIN : GRID_MARGIN + (available.height - layout.stage.height * scale) / 2,
+    scrollable,
+  };
+}

--- a/src/components/spaces/spaces-nav.test.ts
+++ b/src/components/spaces/spaces-nav.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { clampIndex, navigate } from "./spaces-nav";
+
+const row = (index: number) => ({ index, count: 9, columns: 3 });
+
+describe("navigate", () => {
+  it("steps forward and back in reading order", () => {
+    expect(navigate(row(0), "next")).toBe(1);
+    expect(navigate(row(4), "prev")).toBe(3);
+  });
+
+  it("wraps past the end of a row into the next one", () => {
+    // index 2 is the last column of row 0; next is the first column of row 1
+    expect(navigate(row(2), "next")).toBe(3);
+  });
+
+  it("clamps at both ends rather than cycling", () => {
+    expect(navigate(row(8), "next")).toBe(8);
+    expect(navigate(row(0), "prev")).toBe(0);
+  });
+
+  it("moves a whole row at a time vertically", () => {
+    expect(navigate(row(1), "down")).toBe(4);
+    expect(navigate(row(7), "up")).toBe(4);
+  });
+
+  it("stays put when there is no row above or below", () => {
+    expect(navigate(row(1), "up")).toBe(1);
+    expect(navigate(row(7), "down")).toBe(7);
+  });
+
+  it("does not fall into the gap of a partly filled last row", () => {
+    // 7 cards over 3 columns: row 2 holds only index 6
+    const short = { index: 5, count: 7, columns: 3 };
+    expect(navigate(short, "down")).toBe(5);
+    expect(navigate({ ...short, index: 3 }, "down")).toBe(6);
+  });
+
+  it("jumps to the first and last card", () => {
+    expect(navigate(row(4), "first")).toBe(0);
+    expect(navigate(row(4), "last")).toBe(8);
+  });
+
+  it("has nowhere to go on an empty canvas", () => {
+    const empty = { index: 0, count: 0, columns: 0 };
+    for (const intent of ["next", "prev", "up", "down", "first", "last"] as const) {
+      expect(navigate(empty, intent)).toBe(-1);
+    }
+  });
+
+  it("keeps a single card focused whatever you press", () => {
+    const only = { index: 0, count: 1, columns: 1 };
+    expect(navigate(only, "next")).toBe(0);
+    expect(navigate(only, "down")).toBe(0);
+  });
+});
+
+describe("clampIndex", () => {
+  it("holds a valid index still", () => {
+    expect(clampIndex(3, 9)).toBe(3);
+  });
+
+  it("falls back to the last card when the focused one is deleted", () => {
+    expect(clampIndex(9, 9)).toBe(8);
+    expect(clampIndex(40, 9)).toBe(8);
+  });
+
+  it("reports no focus once the last card is gone", () => {
+    expect(clampIndex(0, 0)).toBe(-1);
+  });
+
+  it("never returns a negative index while cards remain", () => {
+    expect(clampIndex(-3, 9)).toBe(0);
+  });
+});

--- a/src/components/spaces/spaces-nav.ts
+++ b/src/components/spaces/spaces-nav.ts
@@ -1,0 +1,51 @@
+/** Pure navigation rules for the Spaces canvas.
+ *
+ * Cards are walked in reading order — right along a row, wrapping down to the
+ * start of the next — which is why the focused view only ever shows neighbours
+ * to the left and right. Movement clamps at the ends; it does not cycle, so a
+ * held arrow key comes to rest instead of looping forever.
+ */
+
+export interface NavState {
+  /** Currently focused card, or -1 when the canvas is empty. */
+  index: number;
+  count: number;
+  columns: number;
+}
+
+export type NavIntent = "next" | "prev" | "up" | "down" | "first" | "last";
+
+export function navigate(state: NavState, intent: NavIntent): number {
+  const { count, columns } = state;
+  if (count <= 0) return -1;
+
+  const index = clampIndex(state.index, count);
+  const last = count - 1;
+
+  switch (intent) {
+    case "first":
+      return 0;
+    case "last":
+      return last;
+    case "next":
+      return Math.min(index + 1, last);
+    case "prev":
+      return Math.max(index - 1, 0);
+    case "up": {
+      const above = index - columns;
+      return above >= 0 ? above : index;
+    }
+    case "down": {
+      const below = index + columns;
+      // A partly filled last row leaves gaps under the rightmost cards. Stay
+      // put rather than snapping sideways to the row's only occupant.
+      return below <= last ? below : index;
+    }
+  }
+}
+
+/** Keep a focused index valid as cards come and go. -1 means nothing to focus. */
+export function clampIndex(index: number, count: number): number {
+  if (count <= 0) return -1;
+  return Math.min(Math.max(index, 0), count - 1);
+}

--- a/src/components/spaces/spaces-nearest.test.ts
+++ b/src/components/spaces/spaces-nearest.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { layoutFor, transformForLayout } from "./spaces-layout";
+import { nearestCardIndex } from "./spaces-nearest";
+
+const viewport = { width: 1600, height: 1000 };
+const tile = (per: 1 | 2 | 3) => ({ kind: "tile" as const, per });
+
+describe("nearestCardIndex", () => {
+  it("returns the card the preset already focuses", () => {
+    const layout = layoutFor(8, viewport, tile(1));
+    for (const index of [0, 3, 7]) {
+      expect(nearestCardIndex(layout, transformForLayout(layout, index, viewport), viewport)).toBe(index);
+    }
+  });
+
+  it("follows a pan to the next card", () => {
+    const layout = layoutFor(8, viewport, tile(1));
+    const at2 = transformForLayout(layout, 2, viewport);
+    const pitch = layout.cells[1].x - layout.cells[0].x;
+    // panned a full card to the left: card 3 now sits where card 2 was
+    expect(nearestCardIndex(layout, { ...at2, x: at2.x - pitch }, viewport)).toBe(3);
+  });
+
+  it("rounds to whichever card is closest, not merely the one it passed", () => {
+    const layout = layoutFor(8, viewport, tile(1));
+    const at2 = transformForLayout(layout, 2, viewport);
+    const pitch = layout.cells[1].x - layout.cells[0].x;
+    expect(nearestCardIndex(layout, { ...at2, x: at2.x - pitch * 0.4 }, viewport)).toBe(2);
+    expect(nearestCardIndex(layout, { ...at2, x: at2.x - pitch * 0.6 }, viewport)).toBe(3);
+  });
+
+  it("works the same in a split, tracking the leftmost pane", () => {
+    const layout = layoutFor(8, viewport, tile(3));
+    const at1 = transformForLayout(layout, 1, viewport);
+    expect(nearestCardIndex(layout, at1, viewport)).toBe(1);
+    const pitch = layout.cells[1].x - layout.cells[0].x;
+    expect(nearestCardIndex(layout, { ...at1, x: at1.x - pitch }, viewport)).toBe(2);
+  });
+
+  it("never runs off either end", () => {
+    const layout = layoutFor(4, viewport, tile(1));
+    const at0 = transformForLayout(layout, 0, viewport);
+    expect(nearestCardIndex(layout, { ...at0, x: at0.x + 5000 }, viewport)).toBe(0);
+    expect(nearestCardIndex(layout, { ...at0, x: at0.x - 99999 }, viewport)).toBe(3);
+  });
+
+  it("picks the card nearest the middle of the screen in the grid", () => {
+    const layout = layoutFor(9, viewport, { kind: "grid" });
+    const t = transformForLayout(layout, 0, viewport);
+    const picked = nearestCardIndex(layout, t, viewport);
+    expect(picked).toBeGreaterThanOrEqual(0);
+    expect(picked).toBeLessThan(9);
+  });
+
+  it("has no answer for an empty canvas", () => {
+    const layout = layoutFor(0, viewport, tile(1));
+    expect(nearestCardIndex(layout, transformForLayout(layout, 0, viewport), viewport)).toBe(-1);
+  });
+});

--- a/src/components/spaces/spaces-nearest.ts
+++ b/src/components/spaces/spaces-nearest.ts
@@ -1,0 +1,52 @@
+/** Which card is the person actually looking at?
+ *
+ * With free panning you can slide the canvas to another bot without ever
+ * pressing a key, and the composer pill must follow — otherwise you type at
+ * the bot you just panned away from. Once a pan settles, this says which card
+ * the view has landed on.
+ */
+
+import type { Layout, StageTransform, Viewport } from "./spaces-layout";
+
+const PAD = 24;
+
+export function nearestCardIndex(
+  layout: Layout,
+  transform: StageTransform,
+  viewport: Viewport,
+): number {
+  const { cells } = layout;
+  if (cells.length === 0) return -1;
+
+  if (layout.view.kind === "tile") {
+    // Tiles run in one row and the focused card sits at the left of the run,
+    // so the winner is whichever left edge is nearest the leading margin.
+    let best = 0;
+    let bestDistance = Infinity;
+    for (let index = 0; index < cells.length; index += 1) {
+      const onScreen = cells[index].x * transform.scale + transform.x;
+      const distance = Math.abs(onScreen - PAD);
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        best = index;
+      }
+    }
+    return best;
+  }
+
+  // In the grid nothing is "leading", so the middle of the screen decides.
+  const centre = { x: viewport.width / 2, y: viewport.height / 2 };
+  let best = 0;
+  let bestDistance = Infinity;
+  for (let index = 0; index < cells.length; index += 1) {
+    const cell = cells[index];
+    const x = (cell.x + cell.width / 2) * transform.scale + transform.x;
+    const y = (cell.y + cell.height / 2) * transform.scale + transform.y;
+    const distance = (x - centre.x) ** 2 + (y - centre.y) ** 2;
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = index;
+    }
+  }
+  return best;
+}

--- a/src/components/spaces/spaces-status.test.ts
+++ b/src/components/spaces/spaces-status.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { statusChip } from "./spaces-status";
+
+const bot = (over: Record<string, unknown> = {}) =>
+  ({ id: "b", name: "Gmail", unread: false, ...over }) as never;
+
+describe("statusChip for a bot", () => {
+  it("puts what needs you above what is merely busy", () => {
+    expect(statusChip(bot({ activity: "waiting-on-you", unread: true })).label).toBe("Waiting on you");
+    expect(statusChip(bot({ activity: "waiting-on-you" })).tone).toBe("attention");
+  });
+
+  it("shows work in progress", () => {
+    const chip = statusChip(bot({ activity: "working", unread: true }));
+    expect(chip.label).toBe("Working");
+    expect(chip.tone).toBe("active");
+  });
+
+  it("surfaces a dead or unreachable bot over an unread badge", () => {
+    expect(statusChip(bot({ activity: "dead", unread: true })).label).toBe("Stopped");
+    expect(statusChip(bot({ activity: "dead" })).tone).toBe("danger");
+    expect(statusChip(bot({ activity: "no-signal", unread: true })).label).toBe("No signal");
+  });
+
+  it("falls back to unread when nothing is happening", () => {
+    expect(statusChip(bot({ activity: "idle", unread: true })).label).toBe("New messages");
+    expect(statusChip(bot({ unread: true })).label).toBe("New messages");
+  });
+
+  it("says idle when there is genuinely nothing to report", () => {
+    const chip = statusChip(bot({ activity: "idle" }));
+    expect(chip.label).toBe("Idle");
+    expect(chip.tone).toBe("muted");
+  });
+
+  it("treats busy without an activity as working", () => {
+    expect(statusChip(bot({ busy: true })).label).toBe("Working");
+  });
+});
+
+describe("statusChip for a room", () => {
+  const group = (over: Record<string, unknown> = {}) =>
+    ({ id: "g", name: "Design", memberIds: ["a", "b"], unread: false, ...over }) as never;
+
+  it("reports the room working while any member holds the turn", () => {
+    expect(statusChip(group({ working: true })).label).toBe("Working");
+    expect(statusChip(group({ busyBotId: "a" })).label).toBe("Working");
+  });
+
+  it("falls back to unread, then idle", () => {
+    expect(statusChip(group({ unread: true })).label).toBe("New messages");
+    expect(statusChip(group()).label).toBe("Idle");
+  });
+});

--- a/src/components/spaces/spaces-status.ts
+++ b/src/components/spaces/spaces-status.ts
@@ -1,0 +1,52 @@
+/** The chip in a card's top-right corner.
+ *
+ * Everything here is derived from state the client already holds — no new
+ * server fields. The ordering matters more than the wording: a card that needs
+ * you must not be outranked by one that is merely busy.
+ */
+
+import type { Bot, Group } from "@/state/store";
+
+export type StatusTone = "attention" | "active" | "danger" | "muted" | "unread";
+
+export interface StatusChip {
+  label: string;
+  tone: StatusTone;
+}
+
+function isGroup(subject: Bot | Group): subject is Group {
+  return Array.isArray((subject as Group).memberIds);
+}
+
+export function statusChip(subject: Bot | Group): StatusChip {
+  if (isGroup(subject)) {
+    if (subject.working || subject.busyBotId) return { label: "Working", tone: "active" };
+    if (subject.unread) return { label: "New messages", tone: "unread" };
+    return { label: "Idle", tone: "muted" };
+  }
+
+  switch (subject.activity) {
+    case "waiting-on-you":
+      return { label: "Waiting on you", tone: "attention" };
+    case "working":
+      return { label: "Working", tone: "active" };
+    case "dead":
+      return { label: "Stopped", tone: "danger" };
+    case "no-signal":
+      return { label: "No signal", tone: "muted" };
+    default:
+      break;
+  }
+  // `busy` is the older signal; a bot can be busy before activity catches up.
+  if (subject.busy) return { label: "Working", tone: "active" };
+  if (subject.unread) return { label: "New messages", tone: "unread" };
+  return { label: "Idle", tone: "muted" };
+}
+
+export const TONE_CLASS: Record<StatusTone, string> = {
+  attention: "bg-warning/15 text-warning",
+  active: "bg-success/15 text-success",
+  danger: "bg-danger/15 text-danger",
+  unread: "bg-accent/15 text-accent",
+  muted: "bg-raised text-ink-secondary",
+};

--- a/src/components/spaces/spaces-toasts.test.ts
+++ b/src/components/spaces/spaces-toasts.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { MAX_TOASTS, TOAST_TTL_MS, expireToasts, lastSettled, mergeToasts, settledSince } from "./spaces-toasts";
+
+const msg = (over: Record<string, unknown>) => ({ id: "m", role: "bot", kind: "text", ...over }) as never;
+
+describe("lastSettled", () => {
+  it("finds the last settled assistant message", () => {
+    const found = lastSettled([
+      msg({ id: "a", turnTerminal: true, text: "first" }),
+      msg({ id: "b", turnTerminal: true, text: "second" }),
+    ]);
+    expect(found?.id).toBe("b");
+    expect(found?.text).toBe("second");
+  });
+
+  it("ignores messages still streaming and anything the user sent", () => {
+    expect(lastSettled([msg({ id: "a", text: "mid-turn" })])).toBeNull();
+    expect(lastSettled([msg({ id: "a", role: "user", turnTerminal: true })])).toBeNull();
+  });
+
+  it("has nothing to report for an empty thread", () => {
+    expect(lastSettled([])).toBeNull();
+  });
+});
+
+describe("settledSince", () => {
+  const subject = (id: string, settledId: string | null) => ({
+    id,
+    name: id.toUpperCase(),
+    settled: settledId ? { id: settledId, text: `${id} finished` } : null,
+  });
+
+  it("reports a bot that settled something new", () => {
+    const events = settledSince({ a: "m1" }, [subject("a", "m2")], null, 1000);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ subjectId: "a", name: "A", text: "a finished", at: 1000 });
+  });
+
+  it("says nothing when the message has not changed", () => {
+    expect(settledSince({ a: "m2" }, [subject("a", "m2")], null, 1000)).toHaveLength(0);
+  });
+
+  it("never toasts the card you are already looking at", () => {
+    expect(settledSince({ a: "m1" }, [subject("a", "m2")], "a", 1000)).toHaveLength(0);
+  });
+
+  it("stays quiet on the first sighting of a bot, rather than announcing history", () => {
+    expect(settledSince({}, [subject("a", "m1")], null, 1000)).toHaveLength(0);
+  });
+
+  it("reports each bot that settled, not just the first", () => {
+    const events = settledSince({ a: "m1", b: "m1" }, [subject("a", "m2"), subject("b", "m9")], null, 5);
+    expect(events.map((e) => e.subjectId)).toEqual(["a", "b"]);
+  });
+});
+
+describe("mergeToasts", () => {
+  const toast = (subjectId: string, at: number) => ({ id: `${subjectId}-${at}`, subjectId, name: subjectId, text: "x", at });
+
+  it("replaces a bot's toast rather than stacking a second one", () => {
+    const merged = mergeToasts([toast("a", 1)], [toast("a", 2)]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].at).toBe(2);
+  });
+
+  it("keeps only the newest few", () => {
+    const merged = mergeToasts([], [toast("a", 1), toast("b", 2), toast("c", 3), toast("d", 4)]);
+    expect(merged).toHaveLength(MAX_TOASTS);
+    expect(merged.map((t) => t.subjectId)).toEqual(["b", "c", "d"]);
+  });
+
+  it("orders oldest first so the stack grows downward", () => {
+    const merged = mergeToasts([toast("a", 5)], [toast("b", 1)]);
+    expect(merged.map((t) => t.at)).toEqual([1, 5]);
+  });
+});
+
+describe("expireToasts", () => {
+  const toast = (at: number) => ({ id: `t${at}`, subjectId: `s${at}`, name: "n", text: "x", at });
+
+  it("drops toasts past their lifetime and keeps the rest", () => {
+    const now = 10_000;
+    const kept = expireToasts([toast(now - TOAST_TTL_MS - 1), toast(now - 100)], now);
+    expect(kept).toHaveLength(1);
+    expect(kept[0].at).toBe(now - 100);
+  });
+
+  it("returns the same array when nothing expired, so React can bail out", () => {
+    const toasts = [toast(9_900)];
+    expect(expireToasts(toasts, 10_000)).toBe(toasts);
+  });
+});

--- a/src/components/spaces/spaces-toasts.ts
+++ b/src/components/spaces/spaces-toasts.ts
@@ -1,0 +1,84 @@
+/** Background-activity toasts.
+ *
+ * A toast means: a bot you are *not* looking at just finished something. The
+ * rules below exist to keep that from becoming noise — one toast per bot at a
+ * time, a hard cap on the stack, and nothing at all on first sight of a bot
+ * (otherwise opening the canvas would announce the entire backlog).
+ */
+
+import type { Message } from "@/state/store";
+
+export const MAX_TOASTS = 3;
+export const TOAST_TTL_MS = 4_000;
+
+export interface SettledMessage {
+  id: string;
+  text: string;
+}
+
+export interface ToastSubject {
+  id: string;
+  name: string;
+  settled: SettledMessage | null;
+}
+
+export interface Toast {
+  id: string;
+  subjectId: string;
+  name: string;
+  text: string;
+  at: number;
+}
+
+/** The newest assistant message from a turn that has actually settled. */
+export function lastSettled(messages: Message[]): SettledMessage | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message.role === "bot" && message.turnTerminal) {
+      return { id: message.id, text: message.text ?? "" };
+    }
+  }
+  return null;
+}
+
+/**
+ * Which subjects settled something new since the last look. `seen` maps a
+ * subject id to the settled message id we already knew about; a subject missing
+ * from it is being seen for the first time and stays quiet.
+ */
+export function settledSince(
+  seen: Record<string, string | null>,
+  subjects: ToastSubject[],
+  focusedId: string | null,
+  now: number,
+): Toast[] {
+  const events: Toast[] = [];
+  for (const subject of subjects) {
+    if (subject.id === focusedId) continue;
+    if (!(subject.id in seen)) continue;
+    const settledId = subject.settled?.id ?? null;
+    if (!settledId || settledId === seen[subject.id]) continue;
+    events.push({
+      id: `${subject.id}:${settledId}`,
+      subjectId: subject.id,
+      name: subject.name,
+      text: subject.settled?.text ?? "",
+      at: now,
+    });
+  }
+  return events;
+}
+
+/** Coalesce per subject, cap the stack, oldest first so it grows downward. */
+export function mergeToasts(current: Toast[], incoming: Toast[], max = MAX_TOASTS): Toast[] {
+  if (incoming.length === 0) return current;
+  const bySubject = new Map<string, Toast>();
+  for (const toast of [...current, ...incoming]) bySubject.set(toast.subjectId, toast);
+  return [...bySubject.values()].sort((a, b) => a.at - b.at).slice(-max);
+}
+
+/** Identity-stable when nothing expired, so a render can bail out. */
+export function expireToasts(toasts: Toast[], now: number, ttl = TOAST_TTL_MS): Toast[] {
+  const kept = toasts.filter((toast) => now - toast.at < ttl);
+  return kept.length === toasts.length ? toasts : kept;
+}

--- a/src/components/spaces/spaces-view.test.ts
+++ b/src/components/spaces/spaces-view.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { MAX_ZOOM, MIN_ZOOM, clampScale, panBy, zoomAt } from "./spaces-view";
+
+const view = (scale = 1, x = 0, y = 0) => ({ scale, x, y });
+
+describe("panBy", () => {
+  it("moves the canvas opposite the scroll, so content follows the fingers", () => {
+    // scrolling right (positive deltaX) should reveal content to the right,
+    // which means the stage slides left
+    expect(panBy(view(1, 100, 50), 30, 10)).toEqual({ scale: 1, x: 70, y: 40 });
+  });
+
+  it("pans in both axes at once — this is a canvas, not a filmstrip", () => {
+    const moved = panBy(view(1, 0, 0), -25, -40);
+    expect(moved.x).toBe(25);
+    expect(moved.y).toBe(40);
+  });
+
+  it("leaves the zoom level alone", () => {
+    expect(panBy(view(0.4, 0, 0), 10, 10).scale).toBe(0.4);
+  });
+});
+
+describe("zoomAt", () => {
+  it("keeps the point under the cursor pinned while zooming in", () => {
+    const before = view(1, 0, 0);
+    const cursor = { x: 400, y: 300 };
+    // the stage point currently under the cursor
+    const stagePoint = { x: (cursor.x - before.x) / before.scale, y: (cursor.y - before.y) / before.scale };
+    const after = zoomAt(before, cursor, 1.25);
+    expect(after.scale).toBeCloseTo(1.25);
+    expect(after.scale * stagePoint.x + after.x).toBeCloseTo(cursor.x);
+    expect(after.scale * stagePoint.y + after.y).toBeCloseTo(cursor.y);
+  });
+
+  it("keeps it pinned while zooming out too", () => {
+    const before = view(1.2, -300, -120);
+    const cursor = { x: 700, y: 500 };
+    const stagePoint = { x: (cursor.x - before.x) / before.scale, y: (cursor.y - before.y) / before.scale };
+    const after = zoomAt(before, cursor, 0.6);
+    expect(after.scale * stagePoint.x + after.x).toBeCloseTo(cursor.x);
+    expect(after.scale * stagePoint.y + after.y).toBeCloseTo(cursor.y);
+  });
+
+  it("does not zoom past the readable floor or the useful ceiling", () => {
+    expect(zoomAt(view(MIN_ZOOM), { x: 0, y: 0 }, 0.1).scale).toBe(MIN_ZOOM);
+    expect(zoomAt(view(MAX_ZOOM), { x: 0, y: 0 }, 10).scale).toBe(MAX_ZOOM);
+  });
+
+  it("still pins the cursor when the zoom is clamped", () => {
+    const before = view(MIN_ZOOM * 1.05, 40, 40);
+    const cursor = { x: 200, y: 200 };
+    const after = zoomAt(before, cursor, 0.1);
+    const stagePoint = { x: (cursor.x - before.x) / before.scale, y: (cursor.y - before.y) / before.scale };
+    expect(after.scale).toBe(MIN_ZOOM);
+    expect(after.scale * stagePoint.x + after.x).toBeCloseTo(cursor.x);
+  });
+
+  it("is a no-op at a factor of one", () => {
+    expect(zoomAt(view(0.5, 10, 20), { x: 100, y: 100 }, 1)).toEqual(view(0.5, 10, 20));
+  });
+});
+
+describe("clampScale", () => {
+  it("holds the scale inside the usable range", () => {
+    expect(clampScale(0.0001)).toBe(MIN_ZOOM);
+    expect(clampScale(99)).toBe(MAX_ZOOM);
+    expect(clampScale(0.7)).toBe(0.7);
+  });
+});

--- a/src/components/spaces/spaces-view.ts
+++ b/src/components/spaces/spaces-view.ts
@@ -1,0 +1,55 @@
+/** Free pan and continuous zoom for the canvas.
+ *
+ * The grid/focus presets in spaces-layout are snap targets. This is the layer
+ * on top: once you touch the trackpad you are driving the canvas directly, in
+ * both axes and at any zoom between the two presets, until a key or a click
+ * snaps you back to one.
+ *
+ * A view maps a stage point p to the screen as `scale * p + (x, y)`, matching
+ * `transform: translate3d(x, y, 0) scale(scale)` with `transform-origin: 0 0`.
+ */
+
+import { MIN_GRID_SCALE } from "./spaces-layout";
+
+export interface View {
+  scale: number;
+  x: number;
+  y: number;
+}
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/** Below this cards stop being readable; above it there is nothing to gain. */
+export const MIN_ZOOM = MIN_GRID_SCALE;
+export const MAX_ZOOM = 1.4;
+
+export function clampScale(scale: number): number {
+  return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, scale));
+}
+
+/** Two-finger scroll. Content follows the fingers, so the stage moves against
+ * the delta — the same direction sense as scrolling a document. */
+export function panBy(view: View, deltaX: number, deltaY: number): View {
+  return { scale: view.scale, x: view.x - deltaX, y: view.y - deltaY };
+}
+
+/**
+ * Pinch. The stage point under the cursor stays under the cursor, which is what
+ * makes a zoom feel anchored rather than teleporting.
+ *
+ * p = (cursor - t) / scale, and we want scale' * p + t' = cursor, so
+ * t' = cursor - scale' * (cursor - t) / scale.
+ */
+export function zoomAt(view: View, cursor: Point, factor: number): View {
+  const scale = clampScale(view.scale * factor);
+  if (scale === view.scale) return view;
+  const ratio = scale / view.scale;
+  return {
+    scale,
+    x: cursor.x - ratio * (cursor.x - view.x),
+    y: cursor.y - ratio * (cursor.y - view.y),
+  };
+}

--- a/src/lib/chat-hotkeys.test.ts
+++ b/src/lib/chat-hotkeys.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { installChatHotkeys, type KeyTarget } from "./chat-hotkeys";
+
+function fakeTarget() {
+  const handlers: Array<(event: KeyboardEvent) => void> = [];
+  const target: KeyTarget = {
+    addEventListener: (_type, handler) => {
+      handlers.push(handler);
+    },
+    removeEventListener: (_type, handler) => {
+      const at = handlers.indexOf(handler);
+      if (at >= 0) handlers.splice(at, 1);
+    },
+  };
+  const press = (event: Partial<KeyboardEvent>) => {
+    // copy: a handler may remove itself while we are dispatching
+    const snapshot = handlers.slice();
+    for (const handler of snapshot) handler(event as KeyboardEvent);
+  };
+  return { target, handlers, press };
+}
+
+const key = (over: Partial<KeyboardEvent>) =>
+  ({ key: "a", metaKey: false, ctrlKey: false, preventDefault: () => {}, target: null, ...over }) as
+    Partial<KeyboardEvent>;
+
+describe("installChatHotkeys", () => {
+  it("registers nothing at all when the chat is not active", () => {
+    const { target, handlers } = fakeTarget();
+    const onFind = vi.fn();
+    const stop = installChatHotkeys(target, { active: false, onFind, onScrollAway: vi.fn() });
+    expect(handlers).toHaveLength(0);
+    stop();
+    expect(onFind).not.toHaveBeenCalled();
+  });
+
+  it("opens find on the platform shortcut when active", () => {
+    const { target, press } = fakeTarget();
+    const onFind = vi.fn();
+    installChatHotkeys(target, { active: true, onFind, onScrollAway: vi.fn() });
+    press(key({ key: "f", metaKey: true }));
+    press(key({ key: "F", ctrlKey: true }));
+    expect(onFind).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not open find without the modifier", () => {
+    const { target, press } = fakeTarget();
+    const onFind = vi.fn();
+    installChatHotkeys(target, { active: true, onFind, onScrollAway: vi.fn() });
+    press(key({ key: "f" }));
+    expect(onFind).not.toHaveBeenCalled();
+  });
+
+  it("treats upward keys as a scroll gesture that breaks follow", () => {
+    const { target, press } = fakeTarget();
+    const onScrollAway = vi.fn();
+    installChatHotkeys(target, { active: true, onFind: vi.fn(), onScrollAway });
+    press(key({ key: "PageUp" }));
+    press(key({ key: "Home" }));
+    press(key({ key: "ArrowUp" }));
+    expect(onScrollAway).toHaveBeenCalledTimes(3);
+  });
+
+  it("leaves ArrowUp alone while typing — there it edits, not scrolls", () => {
+    const { target, press } = fakeTarget();
+    const onScrollAway = vi.fn();
+    installChatHotkeys(target, { active: true, onFind: vi.fn(), onScrollAway });
+    press(key({ key: "ArrowUp", target: { tagName: "TEXTAREA" } as unknown as EventTarget }));
+    press(key({ key: "ArrowUp", target: { tagName: "INPUT" } as unknown as EventTarget }));
+    expect(onScrollAway).not.toHaveBeenCalled();
+    // PageUp still counts: it is a scroll wherever the caret is
+    press(key({ key: "PageUp", target: { tagName: "TEXTAREA" } as unknown as EventTarget }));
+    expect(onScrollAway).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes every handler it added on cleanup", () => {
+    const { target, handlers, press } = fakeTarget();
+    const onFind = vi.fn();
+    const stop = installChatHotkeys(target, { active: true, onFind, onScrollAway: vi.fn() });
+    expect(handlers.length).toBeGreaterThan(0);
+    stop();
+    expect(handlers).toHaveLength(0);
+    press(key({ key: "f", metaKey: true }));
+    expect(onFind).not.toHaveBeenCalled();
+  });
+
+  it("registers one handler per chat, so N cards mean N handlers and no more", () => {
+    const { target, handlers } = fakeTarget();
+    const stops = [0, 1, 2].map(() =>
+      installChatHotkeys(target, { active: true, onFind: vi.fn(), onScrollAway: vi.fn() }),
+    );
+    expect(handlers).toHaveLength(3);
+    for (const stop of stops) stop();
+    expect(handlers).toHaveLength(0);
+  });
+});

--- a/src/lib/chat-hotkeys.ts
+++ b/src/lib/chat-hotkeys.ts
@@ -1,0 +1,45 @@
+/** Window-level keys a chat transcript listens for.
+ *
+ * Extracted from ChatView because Spaces mounts one ChatView per bot: with the
+ * listeners inline, twenty cards meant twenty handlers answering a single Cmd-F.
+ * An inactive chat now registers nothing at all, and the rule is testable
+ * without a DOM.
+ */
+
+export interface KeyTarget {
+  addEventListener(type: "keydown", handler: (event: KeyboardEvent) => void): void;
+  removeEventListener(type: "keydown", handler: (event: KeyboardEvent) => void): void;
+}
+
+export interface ChatHotkeyOptions {
+  /** Only the focused chat answers the keyboard. */
+  active: boolean;
+  onFind: () => void;
+  /** An upward key is a scroll gesture: it breaks follow-the-bottom. */
+  onScrollAway: () => void;
+}
+
+function isTyping(target: unknown): boolean {
+  const tagName = (target as { tagName?: string } | null)?.tagName;
+  return tagName === "TEXTAREA" || tagName === "INPUT";
+}
+
+/** Returns the cleanup. Installing while inactive is a no-op, cleanup included. */
+export function installChatHotkeys(target: KeyTarget, options: ChatHotkeyOptions): () => void {
+  if (!options.active) return () => {};
+
+  const onKey = (event: KeyboardEvent) => {
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "f") {
+      event.preventDefault();
+      options.onFind();
+      return;
+    }
+    // ArrowUp only counts outside inputs — in the composer it edits, not scrolls.
+    if (event.key === "PageUp" || ((event.key === "Home" || event.key === "ArrowUp") && !isTyping(event.target))) {
+      options.onScrollAway();
+    }
+  };
+
+  target.addEventListener("keydown", onKey);
+  return () => target.removeEventListener("keydown", onKey);
+}

--- a/src/lib/feature-flags.test.ts
+++ b/src/lib/feature-flags.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { builtInBrowserEnabled, showToolCallsEnabled, skillRecorderEnabled } from "./feature-flags";
+import { builtInBrowserEnabled, showToolCallsEnabled, skillRecorderEnabled, spacesEnabled } from "./feature-flags";
 
 describe("experimental feature flags", () => {
   it("keeps Teach a skill hidden by default", () => {
@@ -28,5 +28,23 @@ describe("experimental feature flags", () => {
 
   it("shows tool-call chips only after explicit opt-in", () => {
     expect(showToolCallsEnabled({ features: { showToolCalls: true } })).toBe(true);
+  });
+});
+
+describe("spacesEnabled", () => {
+  it("keeps the Spaces canvas off until it is explicitly switched on", () => {
+    expect(spacesEnabled(null)).toBe(false);
+    expect(spacesEnabled(undefined)).toBe(false);
+    expect(spacesEnabled({})).toBe(false);
+    expect(spacesEnabled({ features: {} })).toBe(false);
+    expect(spacesEnabled({ features: { spaces: false } })).toBe(false);
+  });
+
+  it("shows the Spaces canvas only after explicit opt-in", () => {
+    expect(spacesEnabled({ features: { spaces: true } })).toBe(true);
+  });
+
+  it("does not let another experiment switch Spaces on", () => {
+    expect(spacesEnabled({ features: { browser: true, skillRecorder: true } })).toBe(false);
   });
 });

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,5 +1,5 @@
 export interface FeatureFlagConfig {
-  features?: { skillRecorder?: boolean; showToolCalls?: boolean; browser?: boolean };
+  features?: { skillRecorder?: boolean; showToolCalls?: boolean; browser?: boolean; spaces?: boolean };
 }
 
 /** Experimental features are available only after an explicit opt-in. */
@@ -17,4 +17,10 @@ export function builtInBrowserEnabled(config: FeatureFlagConfig | null | undefin
  * shows that work is happening. */
 export function showToolCallsEnabled(config: FeatureFlagConfig | null | undefined): boolean {
   return config?.features?.showToolCalls === true;
+}
+
+/** The Spaces canvas — every bot as a card on one zoomable surface. Off until
+ * the person using the app turns it on; the sidebar shell stays the default. */
+export function spacesEnabled(config: FeatureFlagConfig | null | undefined): boolean {
+  return config?.features?.spaces === true;
 }

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -1179,3 +1179,37 @@ describe("messageAdded leaf adoption", () => {
     expect(next.bots[0].messages.map((m) => m.id)).toContain("shot");
   });
 });
+
+describe("spaces canvas", () => {
+  const enabled = { features: { spaces: true } } as never;
+  const disabled = { features: { spaces: false } } as never;
+
+  it("starts closed", () => {
+    expect(initialState.spacesOpen).toBe(false);
+  });
+
+  it("cannot be opened while the feature is switched off", () => {
+    const state = { ...initialState, config: disabled };
+    expect(reducer(state, { type: "toggleSpaces", open: true }).spacesOpen).toBe(false);
+    expect(reducer({ ...initialState, config: null }, { type: "toggleSpaces", open: true }).spacesOpen).toBe(false);
+  });
+
+  it("opens and closes once the feature is on", () => {
+    const state = { ...initialState, config: enabled };
+    const opened = reducer(state, { type: "toggleSpaces", open: true });
+    expect(opened.spacesOpen).toBe(true);
+    expect(reducer(opened, { type: "toggleSpaces", open: false }).spacesOpen).toBe(false);
+    expect(reducer(opened, { type: "toggleSpaces" }).spacesOpen).toBe(false);
+  });
+
+  it("closes itself when the feature is switched back off underneath it", () => {
+    const open = { ...initialState, config: enabled, spacesOpen: true };
+    expect(reducer(open, { type: "configStatus", config: disabled }).spacesOpen).toBe(false);
+    expect(reducer(open, { type: "configStatus", config: enabled }).spacesOpen).toBe(true);
+  });
+
+  it("closing it is always allowed, whatever the flag says", () => {
+    const stuck = { ...initialState, config: disabled, spacesOpen: true };
+    expect(reducer(stuck, { type: "toggleSpaces", open: false }).spacesOpen).toBe(false);
+  });
+});

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -32,7 +32,7 @@ import { currentCall } from "@/lib/call";
 import { showNotification, type NotificationTarget } from "@/lib/notify";
 import { speaker } from "@/lib/tts";
 import { createBotPatchQueue, type BotUpdatePatch } from "./bot-patch-queue";
-import { skillRecorderEnabled } from "@/lib/feature-flags";
+import { skillRecorderEnabled, spacesEnabled } from "@/lib/feature-flags";
 import { openLiveEvents } from "@/lib/live-events";
 
 const MAX_ROUTINE_RUNS = 2_000;
@@ -351,7 +351,7 @@ export interface ConfigStatus {
   /** UI language override; "" (or absent) follows the system language. */
   language?: string;
   /** Opt-in flags. Absent means off. */
-  features?: { skillRecorder: boolean; showToolCalls?: boolean; browser?: boolean };
+  features?: { skillRecorder: boolean; showToolCalls?: boolean; browser?: boolean; spaces?: boolean };
   /** Named browser sessions any bot can be pointed at. */
   browserProfiles?: BrowserProfile[];
 }
@@ -470,6 +470,9 @@ export interface AppState {
   webhookIngress: WebhookIngressStatus | null;
   settingsOpen: boolean;
   pluginsOpen: boolean;
+  /** The Spaces canvas is open over the shell. Reachable only when the
+   * feature is switched on; the sidebar view stays the default. */
+  spacesOpen: boolean;
   computerOpen: boolean;
   /** the per-thread event inspector (runtime stream + native protocol tee) */
   inspectorOpen: boolean;
@@ -664,6 +667,7 @@ export type Action =
   | { type: "error"; message: string | null }
   | { type: "toggleSettings"; open?: boolean }
   | { type: "togglePlugins"; open?: boolean }
+  | { type: "toggleSpaces"; open?: boolean }
   | { type: "toggleComputer"; open?: boolean }
   | { type: "toggleInspector"; open?: boolean }
   | { type: "focusMessage"; threadId: string; messageId: string }
@@ -908,6 +912,7 @@ export function reducer(state: AppState, action: Action): AppState {
           state.activeView === "skill-recorder" && !skillRecorderEnabled(action.config)
             ? "chat"
             : state.activeView,
+        spacesOpen: state.spacesOpen && spacesEnabled(action.config),
       };
     case "select": {
       if (state.groups.some((g) => g.id === action.id)) {
@@ -1200,6 +1205,12 @@ export function reducer(state: AppState, action: Action): AppState {
     }
     case "togglePlugins":
       return { ...state, pluginsOpen: action.open ?? !state.pluginsOpen };
+    case "toggleSpaces": {
+      const open = action.open ?? !state.spacesOpen;
+      // Turning it on is only possible while the feature is enabled; the
+      // config handler closes it again if the switch goes back off.
+      return open && !spacesEnabled(state.config) ? state : { ...state, spacesOpen: open };
+    }
     case "focusMessage":
       return {
         ...state,
@@ -1468,6 +1479,7 @@ export const initialState: AppState = {
   webhookAttempts: [],
   webhookIngress: null,
   settingsOpen: false,
+  spacesOpen: false,
   pluginsOpen: false,
   computerOpen: false,
   inspectorOpen: false,


### PR DESCRIPTION
Every bot and room as a live card on one zoomable canvas — a Mission-Control-shaped
way to work across several bots at once. Off unless switched on in
**Settings → Experimental → Spaces**; the sidebar shell stays the default and is
untouched.

## What it does

- **Split screen.** One, two or three bots across (`⌘⌥1/2/3`), plus a grid of
  everything (`⌘⌥↑`). Cards *reflow narrower* rather than the canvas zooming out, so
  text stays full size in every split — measured at 1200px wide: 96% / 47% / 31%
  card widths, all at `scale: 1`.
- **Trackpad drives the canvas.** Two-finger scroll pans in both axes; pinch zooms
  about the pointer. A settled pan **adopts the card it landed on**, so the composer
  pill always names the bot you are looking at.
- **One composer for the canvas.** The floating pill addresses the focused card, with
  a picker to redirect. Cards therefore render no composer of their own.
- **The chat's side panels work inside a card** — computer, inspector, bot settings.
- Background-activity toasts, per-card status chips, and a card expand that lifts the
  browser or VM workspace full screen via a FLIP transition.

## Notable decisions

**`⌘⌥`, not `⌃`.** The first cut used `⌃↑` / `⌃←` / `⌃→` / `⌃1-3`. macOS reserves
every one of those for Mission Control and never delivers them to the app, so the
shortcuts were simply dead. With Option held macOS also composes digits (`1` → `¡`),
so the layout chord reads `event.code`, not `event.key`.

**Cards reflow, they do not shrink.** Real split screen means narrower cards, not a
zoomed-out canvas. The cost: changing layout reflows cells, so *that* transition
animates per card. Navigating and panning within a layout is still a single transform
on the stage, which is the common case.

**Live everywhere.** Cards stay mounted and interactive, painted only when near the
viewport (`content-visibility: auto`). A measured frame budget parks distant cards
rather than letting the whole canvas stutter.

**`ChatView` refactor.** Its window-level hotkeys moved to `src/lib/chat-hotkeys.ts`,
gated on a new `active` prop (default `true`, so every existing call site is
unchanged). With one ChatView per bot, the inline listeners meant twenty handlers
answering a single `⌘F`.

## Platforms

| Platform | Applies? | Status |
|---|---|---|
| macOS     | yes | in this PR, tested locally |
| Windows   | yes | in this PR (shared renderer + server code, no platform gate touched); NOT built on Windows — Package Windows workflow triggered on this branch |
| iOS       | no  | n/a: desktop-only canvas. `ConfigStatus` in `CompanionCore` does not model `features`, so the added `spaces` flag is invisible to it |
| Android   | no  | n/a: same — `ConfigStatus` in `android/core` omits `features` |
| Companion | no  | n/a: no new `/api/*` route, nothing to add to the `routes.ts` allowlist |

The only server change is `features.spaces` in the config schema and status frame:
additive, optional, and dropped by both phone decoders.

## Test plan

- Full suite green: **3821 passed, 0 failed**; `tsc -b` clean; `oxlint` clean.
- 108 new unit tests across seven pure modules — layout geometry (tile widths, grid
  wrapping, clamping at both ends), navigation (reading order, wrap, clamp, partly
  filled last row), pan/zoom (cursor stays pinned while zooming, clamps), nearest-card
  detection, status chips, toast coalescing, and the hotkey gate.
- Verified running in an isolated instance (throwaway `HOME`, port 18899) rather than
  only in tests: split widths and gutters measured, pan/zoom deltas checked against the
  maths, pill tracking confirmed across keyboard *and* pan, side panels confirmed to
  open and to close on `Esc`, zero console errors.
- Not covered by tests: real OS-level key delivery. Synthetic events bypass the OS —
  which is precisely why the original `⌃` bindings looked fine in tests and were dead
  in the app. The `⌘⌥` chords need a human press to confirm.

Design: `docs/superpowers/specs/2026-09-03-spaces-canvas-design.md`

- [ ] Follow-up: collapse the double header inside a card (ChatView renders its own
      header under the card header, so the bot name appears twice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in Spaces canvas for viewing bots and rooms in tile or grid layouts.
  * Added zooming, panning, keyboard navigation, focused-card views, status indicators, activity notifications, and full-screen expansion.
  * Added a floating composer with quick switching between bots and rooms.
  * Added Spaces feature controls in Settings and the sidebar, plus a keyboard shortcut for opening Spaces.
* **Improvements**
  * Improved chat keyboard handling for finding messages and scrolling away from the latest content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->