### PR TITLE
feat(browser): show the bot's browser picture-in-picture in the chat

### DIFF
--- a/docs/computer-use-integration.md
+++ b/docs/computer-use-integration.md
@@ -150,7 +150,10 @@ behavior contract.
    (built-in CDP: `Input.*`, `Runtime.*`, `Page.*`,
    `Accessibility.getFullAXTree` for playwright-mcp-style snapshot refs) +
    `capturePage()` for vision. User can grab the mouse mid-task for logins /
-   CAPTCHAs, then hand back. Known limit: Google OAuth blocks embedded
+   CAPTCHAs, then hand back. In the chat the page floats picture-in-picture
+   above the composer (`BrowserDock`, bottom-right, 16:10) the moment the bot
+   opens one or asks for hands; the Computer panel's Browser tab and the
+   expanded workspace show the same native view. Known limit: Google OAuth blocks embedded
    webviews — route Google-account flows to tier 2/3.
 2. **Opt-in "use my real Chrome": extension bridge.** Chrome 136+ killed
    `--remote-debugging-port` on the default profile (do NOT build the old

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -268,7 +268,7 @@ function Shell() {
       ) : group ? (
         <GroupView key={group.id} group={group} />
       ) : bot ? (
-        <ChatView bot={bot} />
+        <ChatView bot={bot} onExpandBrowser={remoteClient ? undefined : () => openBrowserWorkspace(bot.id)} />
       ) : (
         <main className="flex h-full min-w-0 flex-1 flex-col items-center justify-center gap-3 bg-app text-ink-secondary">
           <Loader2 size={20} className="animate-spin" />

--- a/src/components/BrowserDock.tsx
+++ b/src/components/BrowserDock.tsx
@@ -1,0 +1,113 @@
+// The bot's browser in the chat column: a picture-in-picture card over the
+// transcript's bottom-right corner, sized to the page's own 16:10 so nothing
+// is letterboxed. The page itself is the same native view the Computer panel
+// shows; this component decides when the chat should host it (the bot
+// opened a page, or asked for hands) and draws the fold-down pill when the
+// person has collapsed it. Pure decisions live in lib/browser-dock.ts.
+import { useEffect, useState } from "react";
+import { ChevronUp, Globe, Hand } from "lucide-react";
+
+import { useStore, type Bot } from "@/state/store";
+import { builtInBrowserEnabled } from "@/lib/feature-flags";
+import { browserDockAvailable, browserDockLabel, nextBrowserDockState } from "@/lib/browser-dock";
+import { useBrowserControl } from "@/hooks/use-browser-control";
+import { BrowserPanel } from "./BrowserPanel";
+
+export function BrowserDock({ bot, onExpand }: { bot: Bot; onExpand?: () => void }) {
+  const { state, dispatch } = useStore();
+  const bridge = window.ogb?.browser;
+  const available = browserDockAvailable({
+    featureEnabled: builtInBrowserEnabled(state.config),
+    botBrowser: bot.browser,
+    bridge: Boolean(bridge),
+    composer: true,
+    remoteClient: window.ogb?.remoteClient?.active === true,
+  });
+  const dock = state.browserDock[bot.id];
+  const helpReason = state.computerControl[bot.id]?.helpReason ?? null;
+  const [surface, setSurface] = useState<BrowserSurfaceState | null>(null);
+
+  // Follow the bot's active view: the first real page opens the dock, a
+  // closed view removes it. Events for other bots are not ours.
+  useEffect(() => {
+    if (!available || !bridge) return;
+    let alive = true;
+    const accept = (next: BrowserSurfaceState) => {
+      if (!alive || next.botId !== bot.id) return;
+      setSurface(next);
+    };
+    bridge.state(bot.id).then(accept).catch(() => {});
+    const off = bridge.onState(accept);
+    return () => {
+      alive = false;
+      off();
+    };
+  }, [available, bridge, bot.id]);
+
+  useEffect(() => {
+    if (!available || !surface) return;
+    const next = nextBrowserDockState({ current: dock, surfaceOpen: surface.open, url: surface.url, helpReason });
+    if ((next ?? null) !== (dock ?? null)) dispatch({ type: "browserDock", botId: bot.id, state: next ?? null });
+  }, [available, surface, helpReason, dock, bot.id, dispatch]);
+
+  if (!available || !dock) return null;
+  if (dock === "collapsed") return <CollapsedBar bot={bot} label={browserDockLabel(surface)} />;
+  return <OpenDock bot={bot} onExpand={onExpand} />;
+}
+
+function OpenDock({ bot, onExpand }: { bot: Bot; onExpand?: () => void }) {
+  const { dispatch } = useStore();
+  const { control, controlPending, controlAction, error } = useBrowserControl(bot.id);
+  return (
+    <div
+      data-browser-dock="open"
+      className="pointer-events-auto mb-2 w-[clamp(320px,44%,600px)] max-w-full rounded-2xl border border-hairline/40 bg-panel p-2.5 shadow-xl shadow-black/40"
+    >
+      <BrowserPanel
+        bot={bot}
+        control={control}
+        controlPending={controlPending}
+        onControl={controlAction}
+        onDismissHelp={() => void controlAction("dismiss-help")}
+        size="docked"
+        onExpand={onExpand}
+        onCollapse={() => dispatch({ type: "browserDock", botId: bot.id, state: "collapsed" })}
+      />
+      {error && (
+        <div role="alert" className="mt-2 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-[12px] text-danger">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CollapsedBar({ bot, label }: { bot: Bot; label: string }) {
+  const { state, dispatch } = useStore();
+  const held = state.computerControl[bot.id]?.held === true;
+  return (
+    <div
+      data-browser-dock="collapsed"
+      className="pointer-events-auto mb-2 flex max-w-[420px] items-center gap-2 rounded-full border border-hairline/40 bg-panel px-3 py-1.5 text-[12.5px] text-ink-secondary shadow-md shadow-black/30"
+    >
+      <Globe size={13} className="shrink-0" aria-hidden="true" />
+      <span className="min-w-0 truncate">
+        <span className="text-ink">{bot.name}'s browser</span>
+        {label ? ` · ${label}` : ""}
+      </span>
+      {held && (
+        <span className="flex shrink-0 items-center gap-1 text-accent-text">
+          <Hand size={12} aria-hidden="true" /> you have control
+        </span>
+      )}
+      <button
+        type="button"
+        onClick={() => dispatch({ type: "browserDock", botId: bot.id, state: "open" })}
+        className="ml-auto flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[12px] text-ink outline-none hover:bg-control focus-visible:ring-2 focus-visible:ring-accent"
+        aria-label="Show the browser"
+      >
+        Show <ChevronUp size={13} aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/BrowserPanel.tsx
+++ b/src/components/BrowserPanel.tsx
@@ -9,6 +9,7 @@ import {
   AlertTriangle,
   ArrowLeft,
   ArrowRight,
+  ChevronDown,
   ExternalLink,
   Globe,
   Hand,
@@ -229,23 +230,34 @@ export function BrowserPanel({
   onControl,
   size = "compact",
   onExpand,
+  onCollapse,
+  onDismissHelp,
 }: {
   bot: Bot;
   control: ControlSnapshot;
   controlPending: boolean;
   onControl: (action: "take" | "release") => Promise<boolean>;
-  size?: "compact" | "expanded";
-  /** Compact only: hand the tab to the main column. */
+  /** compact: the Computer panel's small preview; expanded: the whole main
+   * column; docked: the chat column, above the composer. Docked and
+   * expanded both take control in place on a click; compact expands first. */
+  size?: "compact" | "expanded" | "docked";
+  /** Compact and docked: hand the tab to the main column. */
   onExpand?: () => void;
-  /** Expanded only: hand the tab back to the panel. */
+  /** Docked: fold the page down to a one-line bar. */
   onCollapse?: () => void;
+  /** Docked: clear the bot's plea without taking control. */
+  onDismissHelp?: () => void;
 }) {
   const { state, dispatch } = useStore();
   const bridge = window.ogb?.browser;
   const pageVisible = usePageVisible();
   const layoutOwner = useId();
+  // Electron knows two presentations. The dock is the expanded one placed
+  // elsewhere: same aspect-fit scaling, and clicks take control in place
+  // instead of being swallowed to expand a watch-only preview.
+  const nativeMode: "compact" | "expanded" = size === "compact" ? "compact" : "expanded";
   const hostRef = useRef<HTMLDivElement>(null);
-  const nativeViewObscured = useNativeViewObscured(hostRef, size === "expanded" ? 1.6 : null);
+  const nativeViewObscured = useNativeViewObscured(hostRef, nativeMode === "expanded" ? 1.6 : null);
   const operationPending = useBrowserPanelOperationPending(bot.id);
   const nativeTakePending = useRef(false);
   const botBusyRef = useRef(browserProfileChangesDisabled(bot));
@@ -323,10 +335,10 @@ export function BrowserPanel({
     const send = () => {
       if (!alive) return;
       const rawBounds = elementBounds(hostRef.current);
-      const bounds = rawBounds && size === "expanded" ? aspectFitBrowserBounds(rawBounds) : rawBounds;
+      const bounds = rawBounds && nativeMode === "expanded" ? aspectFitBrowserBounds(rawBounds) : rawBounds;
       const target = bounds && pageVisible && !nativeViewObscured && shouldPlaceNativeSurface ? bounds : null;
       bridge
-        .layout(botId, target, activePartition, size, layoutOwner)
+        .layout(botId, target, activePartition, nativeMode, layoutOwner)
         .then((next) => {
           if (!alive) return;
           acceptSurface(next);
@@ -363,7 +375,7 @@ export function BrowserPanel({
       // The tab is gone; the page stays alive (a bot mid-task keeps its tab)
       // but nothing may paint over the chat. Scope the hide to this profile:
       // cleanup from an old selection must not hide the newly selected one.
-      void bridge.layout(botId, null, activePartition, size, layoutOwner).catch(() => {});
+      void bridge.layout(botId, null, activePartition, nativeMode, layoutOwner).catch(() => {});
     };
   }, [
     bridge,
@@ -371,7 +383,7 @@ export function BrowserPanel({
     pageVisible,
     activePartition,
     layoutOwner,
-    size,
+    nativeMode,
     acceptSurface,
     nativeViewObscured,
     presentation,
@@ -601,10 +613,12 @@ export function BrowserPanel({
   }
 
   const expanded = size === "expanded";
+  const docked = size === "docked";
+  const compact = size === "compact";
 
   return (
-    <div className={cn("flex h-full min-h-0 flex-col", !expanded && "overflow-y-auto overscroll-contain pr-0.5")}>
-      {!expanded ? (
+    <div className={cn(docked ? "flex flex-col" : "flex h-full min-h-0 flex-col", compact && "overflow-y-auto overscroll-contain pr-0.5")}>
+      {compact ? (
         <div className="mb-2 mt-2 flex items-center justify-between text-[13px] text-ink-secondary">
           <span className="flex items-center gap-2" aria-live="polite">
             {bot.name}'s browser
@@ -677,6 +691,7 @@ export function BrowserPanel({
             aria-label="Web address"
           />
         </div>
+        {!docked && (
         <button
           type="submit"
           disabled={!address.trim() || busy || profileBusy || operationPending}
@@ -684,6 +699,7 @@ export function BrowserPanel({
         >
           Go
         </button>
+        )}
         {currentUrl && (
           <button
             type="button"
@@ -695,20 +711,44 @@ export function BrowserPanel({
             <ExternalLink size={15} aria-hidden="true" />
           </button>
         )}
+        {docked && onExpand && (
+          <button
+            type="button"
+            onClick={onExpand}
+            className="rounded-md p-1.5 text-ink-secondary outline-none hover:bg-control hover:text-ink focus-visible:ring-2 focus-visible:ring-accent"
+            title="Show the page large"
+            aria-label="Show the page large"
+          >
+            <Maximize2 size={15} aria-hidden="true" />
+          </button>
+        )}
+        {docked && onCollapse && (
+          <button
+            type="button"
+            onClick={onCollapse}
+            className="rounded-md p-1.5 text-ink-secondary outline-none hover:bg-control hover:text-ink focus-visible:ring-2 focus-visible:ring-accent"
+            title="Fold the page down to a bar"
+            aria-label="Collapse the browser"
+          >
+            <ChevronDown size={15} aria-hidden="true" />
+          </button>
+        )}
       </form>
 
       {/* Keep a visible renderer frame around the rectangular native view.
           Compact clicks are consumed by Electron: the first click expands and
           takes control without also activating whatever is underneath it. */}
       <div
-        onClick={!expanded && onExpand ? onExpand : undefined}
-        title={!expanded && onExpand ? "Click to expand" : undefined}
+        onClick={compact && onExpand ? onExpand : undefined}
+        title={compact && onExpand ? "Click to expand" : undefined}
         data-browser-presentation={presentation}
         className={cn(
           "relative overflow-hidden rounded-2xl border border-hairline/60 bg-card p-[3px] shadow-sm shadow-black/10",
           expanded
             ? "min-h-[320px] flex-1"
-            : "aspect-[16/10] w-full max-w-[720px] shrink-0 self-center cursor-zoom-in",
+            : docked
+              ? "aspect-[16/10] w-full shrink-0"
+              : "aspect-[16/10] w-full max-w-[720px] shrink-0 self-center cursor-zoom-in",
         )}
       >
         <div
@@ -729,6 +769,59 @@ export function BrowserPanel({
         </div>
       </div>
 
+      {docked ? (
+        /* Who is driving, in the chat: the bot's plea and the button that
+           answers it sit together under the page it is stuck on. */
+        <div
+          role={control.helpReason && !control.held ? "alert" : undefined}
+          className={cn(
+            "mt-2 flex items-center justify-between gap-2 rounded-xl border px-2.5 py-1.5",
+            control.held
+              ? "border-accent/30 bg-accent/10"
+              : control.helpReason
+                ? "border-warning/25 bg-warning/10"
+                : "border-hairline/30 bg-card",
+          )}
+        >
+          <div className="min-w-0 text-[12px] leading-snug text-ink-secondary">
+            {control.held ? (
+              <>
+                You have control. Click and type on the page; <span className="font-medium text-ink">{bot.name}</span> is paused until you hand back.
+              </>
+            ) : control.helpReason ? (
+              <span className="text-warning">
+                <b className="font-semibold">{bot.name} needs you.</b> {control.helpReason}
+              </span>
+            ) : (
+              <>{bot.name} is browsing. Click into the page to take over any time.</>
+            )}
+          </div>
+          <div className="flex shrink-0 items-center gap-1.5">
+            {control.helpReason && !control.held && onDismissHelp && (
+              <button
+                type="button"
+                onClick={onDismissHelp}
+                disabled={controlPending}
+                className="rounded-lg px-2.5 py-1.5 text-[12.5px] text-ink-secondary outline-none hover:bg-control hover:text-ink focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-60"
+              >
+                Dismiss
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => void changeControl(control.held ? "release" : "take")}
+              disabled={controlPending || busy || profileBusy || operationPending}
+              className={cn(
+                "flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-medium outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-60",
+                control.held ? "bg-accent text-accent-ink" : "bg-control text-ink hover:bg-raised-hover",
+              )}
+            >
+              <Hand size={14} aria-hidden="true" />
+              {control.held ? "Hand back" : "Take control"}
+            </button>
+          </div>
+        </div>
+      ) : (
       <div className="mt-3 flex items-center justify-between gap-3">
         <div className="min-w-0 text-[12px] leading-relaxed text-ink-secondary">
           {control.held
@@ -748,8 +841,11 @@ export function BrowserPanel({
           {control.held ? "Hand back" : "Take control"}
         </button>
       </div>
+      )}
 
-      {/* Profile: which session (cookies, logins) this bot's tab uses. */}
+      {/* Profile: which session (cookies, logins) this bot's tab uses. The
+          dock leaves this to the panel so the chat stays about the page. */}
+      {!docked && (
       <div className="mt-3 rounded-xl border border-hairline/30 bg-card p-3">
         <div className="flex items-center justify-between gap-3">
           <div className="flex min-w-0 items-center gap-2 text-[13px] text-ink">
@@ -828,6 +924,7 @@ export function BrowserPanel({
             : `Profiles keep logins separate. “${bot.name}'s own” is private to this bot; Guest is cleared when you switch away.`}
         </div>
       </div>
+      )}
       {error && (
         <div role="alert" className="mt-2 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-[12px] text-danger">
           {error}

--- a/src/components/BrowserWorkspace.tsx
+++ b/src/components/BrowserWorkspace.tsx
@@ -2,67 +2,13 @@
 // whole main column. Opened by clicking the small preview in the computer
 // panel; closing hands the tab back to the panel. Control (Take control /
 // Hand back) is the same lease the panel uses, so a hold survives the swap.
-import { useCallback, useEffect, useState } from "react";
 import { Globe, X } from "lucide-react";
-import { z } from "zod";
-import { api, useStore, type Bot } from "@/state/store";
+import type { Bot } from "@/state/store";
+import { useBrowserControl } from "@/hooks/use-browser-control";
 import { BrowserPanel } from "./BrowserPanel";
 
-const controlSnapshotSchema = z.looseObject({
-  held: z.boolean().optional().default(false),
-  helpReason: z.string().nullable().optional().default(null),
-});
-
 export function BrowserWorkspace({ bot, onClose }: { bot: Bot; onClose: () => void }) {
-  const { state, dispatch } = useStore();
-  const control = state.computerControl[bot.id] ?? { held: false, helpReason: null };
-  const [controlPending, setControlPending] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    let alive = true;
-    api(`/api/bots/${bot.id}/computer/control`)
-      .then((raw) => {
-        if (!alive) return;
-        const snap = controlSnapshotSchema.parse(raw);
-        dispatch({
-          type: "computerControl",
-          botId: bot.id,
-          held: snap.held === true,
-          helpReason: snap.helpReason,
-        });
-      })
-      .catch(() => {});
-    return () => {
-      alive = false;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [bot.id]);
-
-  const controlAction = useCallback(async (action: "take" | "release"): Promise<boolean> => {
-    setControlPending(true);
-    setError(null);
-    try {
-      const snap = controlSnapshotSchema.parse(await api(`/api/bots/${bot.id}/computer/control`, {
-        method: "POST",
-        body: JSON.stringify({ action }),
-      }));
-      dispatch({
-        type: "computerControl",
-        botId: bot.id,
-        held: snap.held === true,
-        helpReason: snap.helpReason,
-      });
-      // A successful HTTP response is not enough: only advance Electron's
-      // native input gate when the durable lease reached the requested state.
-      return snap.held === (action === "take");
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
-      return false;
-    } finally {
-      setControlPending(false);
-    }
-  }, [bot.id, dispatch]);
+  const { control, controlPending, controlAction, error } = useBrowserControl(bot.id);
 
   return (
     <main className="flex h-full min-w-0 flex-1 flex-col bg-app">

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -69,6 +69,7 @@ import { webhookMessageView } from "@/lib/webhook-message";
 import { splitTranscriptAttachments } from "@/lib/composer-attachments";
 import { BOTTOM_FOLLOW_THRESHOLD, shouldResumeBottomFollow } from "@/lib/bottom-follow";
 import { useComposerDockPad } from "@/lib/composer-dock";
+import { BrowserDock } from "./BrowserDock";
 import {
   TRANSCRIPT_WINDOW_SIZE,
   expandWindowStart,
@@ -865,7 +866,14 @@ function PinnedBanner({
   );
 }
 
-export function ChatView({ bot }: { bot: Bot }) {
+export function ChatView({
+  bot,
+  /** Desktop only: hand the docked browser the whole main column. */
+  onExpandBrowser,
+}: {
+  bot: Bot;
+  onExpandBrowser?: () => void;
+}) {
   const { state, dispatch } = useStore();
   const remoteClient = window.ogb?.remoteClient?.active === true;
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -1345,6 +1353,14 @@ export function ChatView({ bot }: { bot: Bot }) {
             since={busySince}
           />
         </div>
+      </div>
+
+      {/* The bot's live page, picture-in-picture over the transcript's
+          bottom-right corner, just above the composer. It is a native view
+          that paints above React anyway, so an overlay is the honest shape;
+          the transcript keeps its own padding and scrolls behind it. */}
+      <div className="pointer-events-none absolute inset-x-0 z-[3] flex justify-end px-5" style={{ bottom: composerDock.height }}>
+        <BrowserDock bot={bot} onExpand={onExpandBrowser} />
       </div>
 
       {/* Reading scrollback — one tap back to the end, streaming or not */}

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -39,6 +39,7 @@ import { useDesktopCapabilities } from "./DesktopCapabilities";
 import { RoutineEditor } from "./RoutinesPage";
 import { AndroidDevicePanel, useAndroidUsbDevices } from "./AndroidDevicePanel";
 import { BrowserPanel } from "./BrowserPanel";
+import { computerPanelHostsBrowser } from "@/lib/browser-dock";
 import { builtInBrowserEnabled } from "@/lib/feature-flags";
 import { transitionComputerControlLease, type ComputerControlAction } from "@/lib/computer-control";
 import { LocalScreenPreview } from "./LocalScreenPreview";
@@ -1084,6 +1085,7 @@ export function ComputerPanel({
 
       {panelView === "browser" && browserEnabled ? (
         <div className="flex min-h-0 flex-1 flex-col px-4 pb-4">
+          {computerPanelHostsBrowser(state.browserDock[bot.id]) ? (
           <BrowserPanel
             bot={bot}
             control={control}
@@ -1091,6 +1093,24 @@ export function ComputerPanel({
             onControl={controlAction}
             onExpand={onExpandBrowser ? expandBrowser : undefined}
           />
+          ) : (
+          /* One React host at a time: while the chat dock is open it owns
+             the native rectangle, so this tab points there instead. */
+          <div className="mt-2 rounded-xl border border-hairline/30 bg-card p-4 text-[13px] text-ink-secondary">
+            <div className="flex items-center gap-2 text-ink">
+              <Globe size={14} aria-hidden="true" />
+              Showing in the chat
+            </div>
+            <p className="mt-1 leading-relaxed">{bot.name}'s page is docked above the message box.</p>
+            <button
+              type="button"
+              onClick={() => dispatch({ type: "browserDock", botId: bot.id, state: "collapsed" })}
+              className="mt-3 rounded-lg bg-control px-3 py-1.5 text-[13px] font-medium text-ink hover:bg-raised-hover"
+            >
+              Move it here
+            </button>
+          </div>
+          )}
           {error && (
             <div role="alert" className="mt-2 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-[12px] text-danger">
               {error}

--- a/src/hooks/use-browser-control.ts
+++ b/src/hooks/use-browser-control.ts
@@ -1,0 +1,65 @@
+// The durable who-is-driving lease for one bot's browser, as the chat dock
+// and the expanded workspace both need it: read the snapshot on mount, then
+// take / release through the server. BrowserPanel layers the native Electron
+// gate on top (see transitionBrowserControlLease); this hook only owns the
+// server half and the store copy every panel reads.
+import { useCallback, useEffect, useState } from "react";
+import { z } from "zod";
+
+import { api, useStore } from "@/state/store";
+
+const controlSnapshotSchema = z.looseObject({
+  held: z.boolean().optional().default(false),
+  helpReason: z.string().nullable().optional().default(null),
+});
+
+export type BrowserControlAction = "take" | "release" | "dismiss-help";
+
+export function useBrowserControl(botId: string) {
+  const { state, dispatch } = useStore();
+  const control = state.computerControl[botId] ?? { held: false, helpReason: null };
+  const [controlPending, setControlPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    api(`/api/bots/${botId}/computer/control`)
+      .then((raw) => {
+        if (!alive) return;
+        const snap = controlSnapshotSchema.parse(raw);
+        dispatch({ type: "computerControl", botId, held: snap.held === true, helpReason: snap.helpReason });
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, [botId, dispatch]);
+
+  /** Resolves true only when the durable lease reached the requested state:
+   * a 200 that left the lease unchanged must not advance Electron's gate. */
+  const controlAction = useCallback(
+    async (action: BrowserControlAction): Promise<boolean> => {
+      setControlPending(true);
+      setError(null);
+      try {
+        const snap = controlSnapshotSchema.parse(
+          await api(`/api/bots/${botId}/computer/control`, {
+            method: "POST",
+            body: JSON.stringify({ action }),
+          }),
+        );
+        dispatch({ type: "computerControl", botId, held: snap.held === true, helpReason: snap.helpReason });
+        if (action === "dismiss-help") return snap.helpReason === null;
+        return snap.held === (action === "take");
+      } catch (cause) {
+        setError(cause instanceof Error ? cause.message : String(cause));
+        return false;
+      } finally {
+        setControlPending(false);
+      }
+    },
+    [botId, dispatch],
+  );
+
+  return { control, controlPending, controlAction, error, setError };
+}

--- a/src/lib/browser-dock.test.ts
+++ b/src/lib/browser-dock.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  browserDockAvailable,
+  browserDockHasPage,
+  browserDockLabel,
+  computerPanelHostsBrowser,
+  nextBrowserDockState,
+} from "./browser-dock";
+
+describe("browser dock state", () => {
+  it("stays hidden while the view sits on about:blank", () => {
+    expect(nextBrowserDockState({ current: undefined, surfaceOpen: true, url: "about:blank", helpReason: null })).toBeUndefined();
+    expect(nextBrowserDockState({ current: undefined, surfaceOpen: true, url: "", helpReason: null })).toBeUndefined();
+  });
+
+  it("opens on the first real page", () => {
+    expect(nextBrowserDockState({ current: undefined, surfaceOpen: true, url: "https://ledger.example.com/login", helpReason: null })).toBe("open");
+  });
+
+  it("keeps a person's collapse across later navigations", () => {
+    expect(nextBrowserDockState({ current: "collapsed", surfaceOpen: true, url: "https://ledger.example.com/invoices", helpReason: null })).toBe("collapsed");
+  });
+
+  it("reopens a collapsed dock when the bot asks for hands", () => {
+    expect(nextBrowserDockState({ current: "collapsed", surfaceOpen: true, url: "https://ledger.example.com/login", helpReason: "the sign-in wants a password" })).toBe("open");
+  });
+
+  it("removes the dock when the view closes", () => {
+    expect(nextBrowserDockState({ current: "open", surfaceOpen: false, url: "", helpReason: null })).toBeUndefined();
+    expect(nextBrowserDockState({ current: "open", surfaceOpen: false, url: "", helpReason: "still asking" })).toBeUndefined();
+  });
+
+  it("treats about:blank and empty as no page", () => {
+    expect(browserDockHasPage("about:blank")).toBe(false);
+    expect(browserDockHasPage(" ")).toBe(false);
+    expect(browserDockHasPage(undefined)).toBe(false);
+    expect(browserDockHasPage("https://example.com")).toBe(true);
+  });
+});
+
+describe("browser dock availability", () => {
+  const base = { featureEnabled: true, botBrowser: undefined, bridge: true, composer: true, remoteClient: false };
+
+  it("needs the workspace flag, the bridge, and a composer of its own", () => {
+    expect(browserDockAvailable(base)).toBe(true);
+    expect(browserDockAvailable({ ...base, featureEnabled: false })).toBe(false);
+    expect(browserDockAvailable({ ...base, bridge: false })).toBe(false);
+    expect(browserDockAvailable({ ...base, composer: false })).toBe(false);
+    expect(browserDockAvailable({ ...base, remoteClient: true })).toBe(false);
+  });
+
+  it("respects the bot's own browser switch", () => {
+    expect(browserDockAvailable({ ...base, botBrowser: false })).toBe(false);
+    expect(browserDockAvailable({ ...base, botBrowser: true })).toBe(true);
+  });
+});
+
+describe("browser dock label", () => {
+  it("prefers the page title, then the host", () => {
+    expect(browserDockLabel({ url: "https://ledger.example.com/login", title: "Sign in · Ledger" })).toBe("Sign in · Ledger");
+    expect(browserDockLabel({ url: "https://ledger.example.com/login", title: "" })).toBe("ledger.example.com");
+    expect(browserDockLabel({ url: "about:blank", title: "" })).toBe("");
+    expect(browserDockLabel(null)).toBe("");
+  });
+});
+
+describe("computer panel hosting", () => {
+  it("hands the rectangle to the dock only while it is open", () => {
+    expect(computerPanelHostsBrowser("open")).toBe(false);
+    expect(computerPanelHostsBrowser("collapsed")).toBe(true);
+    expect(computerPanelHostsBrowser(undefined)).toBe(true);
+  });
+});

--- a/src/lib/browser-dock.ts
+++ b/src/lib/browser-dock.ts
@@ -1,0 +1,82 @@
+// The browser dock: the bot's live page shown in the chat column, pinned
+// between the transcript and the composer. Pure decisions live here so the
+// component only wires them to the store and the Electron bridge.
+//
+// Why a dock and not a card in the message stream: the page is a native
+// Electron view that paints above React and takes only a window rectangle.
+// The transcript's scroll container cannot clip it, so a card that scrolled
+// past the header would draw over it. Pinned above the composer, the
+// transcript scrolls behind the page and the rectangle never needs clipping.
+
+/** "open" shows the live page; "collapsed" leaves a one-line bar the person
+ * can reopen from. Absent means the bot has not opened a page this session
+ * (or closed its browser), so nothing is shown. */
+export type BrowserDockState = "open" | "collapsed";
+
+/** Pages that carry no content worth surfacing. A fresh view sits on
+ * about:blank until the bot's first navigation. */
+export function browserDockHasPage(url: string | null | undefined): boolean {
+  const value = String(url ?? "").trim();
+  return value !== "" && value !== "about:blank";
+}
+
+/** What the dock should show after a surface or control change.
+ *
+ * - The view closing removes the dock.
+ * - A plea for help always opens it: the person must see what the bot is
+ *   stuck on and the button that answers it.
+ * - The first real page opens it. After that, a person who collapsed it
+ *   keeps it collapsed until the next plea or until they reopen it.
+ */
+export function nextBrowserDockState(input: {
+  current: BrowserDockState | undefined;
+  surfaceOpen: boolean;
+  url: string | null | undefined;
+  helpReason: string | null | undefined;
+}): BrowserDockState | undefined {
+  if (!input.surfaceOpen) return undefined;
+  if (input.helpReason) return "open";
+  if (input.current) return input.current;
+  return browserDockHasPage(input.url) ? "open" : undefined;
+}
+
+/** Whether the chat column may host the dock at all: the workspace flag,
+ * the bot's own browser switch, a desktop bridge, and a composer of its
+ * own (Spaces renders one floating composer for many chats, and a dock per
+ * card would fight over the same native view). */
+export function browserDockAvailable(input: {
+  featureEnabled: boolean;
+  botBrowser: boolean | undefined;
+  bridge: boolean;
+  composer: boolean;
+  remoteClient: boolean;
+}): boolean {
+  return (
+    input.featureEnabled &&
+    input.botBrowser !== false &&
+    input.bridge &&
+    input.composer &&
+    !input.remoteClient
+  );
+}
+
+/** Short label for the collapsed bar and the panel placeholder: the page
+ * title when there is one, else the host, else nothing. */
+export function browserDockLabel(surface: { url?: string; title?: string } | null | undefined): string {
+  const title = String(surface?.title ?? "").trim();
+  if (title) return title;
+  const url = String(surface?.url ?? "").trim();
+  if (!browserDockHasPage(url)) return "";
+  try {
+    return new URL(url).host || url;
+  } catch {
+    return url;
+  }
+}
+
+/** Only one React host may position the native view at a time. While the
+ * dock is open it owns the rectangle; the Computer panel's Browser tab shows
+ * a note instead of a second, competing host. */
+export function computerPanelHostsBrowser(dock: BrowserDockState | undefined): boolean {
+  return dock !== "open";
+}

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -1179,3 +1179,21 @@ describe("messageAdded leaf adoption", () => {
     expect(next.bots[0].messages.map((m) => m.id)).toContain("shot");
   });
 });
+
+describe("browser dock state", () => {
+  it("opens, collapses, and forgets a bot's dock without touching others", () => {
+    const opened = reducer(initialState, { type: "browserDock", botId: "bot-1", state: "open" });
+    expect(opened.browserDock).toEqual({ "bot-1": "open" });
+    const collapsed = reducer(opened, { type: "browserDock", botId: "bot-1", state: "collapsed" });
+    expect(collapsed.browserDock).toEqual({ "bot-1": "collapsed" });
+    const second = reducer(collapsed, { type: "browserDock", botId: "bot-2", state: "open" });
+    const forgotten = reducer(second, { type: "browserDock", botId: "bot-1", state: null });
+    expect(forgotten.browserDock).toEqual({ "bot-2": "open" });
+  });
+
+  it("returns the same state when nothing changes", () => {
+    const opened = reducer(initialState, { type: "browserDock", botId: "bot-1", state: "open" });
+    expect(reducer(opened, { type: "browserDock", botId: "bot-1", state: "open" })).toBe(opened);
+    expect(reducer(initialState, { type: "browserDock", botId: "bot-9", state: null })).toBe(initialState);
+  });
+});

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -33,6 +33,7 @@ import { showNotification, type NotificationTarget } from "@/lib/notify";
 import { speaker } from "@/lib/tts";
 import { createBotPatchQueue, type BotUpdatePatch } from "./bot-patch-queue";
 import { skillRecorderEnabled } from "@/lib/feature-flags";
+import type { BrowserDockState } from "@/lib/browser-dock";
 import { openLiveEvents } from "@/lib/live-events";
 
 const MAX_ROUTINE_RUNS = 2_000;
@@ -486,6 +487,8 @@ export interface AppState {
    * (the bot's hands are refused server-side); helpReason = the bot's open
    * plea for the person to take over */
   computerControl: Record<string, { held: boolean; helpReason: string | null }>;
+  /** The browser dock in each bot's chat: open, collapsed to a bar, or absent. */
+  browserDock: Record<string, BrowserDockState>;
   /** a search hit to scroll to once its thread is on screen; nonce lets the
    * same message be focused twice in a row */
   focusMessage: { threadId: string; messageId: string; nonce: number; consumed: boolean } | null;
@@ -658,6 +661,7 @@ export type Action =
   | { type: "screenFrame"; botId: string; png: string; mime: string }
   | { type: "provisioning"; botId: string; on: boolean }
   | { type: "computerControl"; botId: string; held: boolean; helpReason: string | null }
+  | { type: "browserDock"; botId: string; state: BrowserDockState | null }
   | { type: "setModel"; botId: string; selection: ModelSelection }
   | { type: "interrupt"; botId: string; threadId?: string; onError?: () => void }
   | { type: "connected"; value: boolean }
@@ -1176,6 +1180,13 @@ export function reducer(state: AppState, action: Action): AppState {
           [action.botId]: { held: action.held, helpReason: action.helpReason },
         },
       };
+    case "browserDock": {
+      if ((state.browserDock[action.botId] ?? null) === action.state) return state;
+      const browserDock = { ...state.browserDock };
+      if (action.state === null) delete browserDock[action.botId];
+      else browserDock[action.botId] = action.state;
+      return { ...state, browserDock };
+    }
     case "setModel":
       return updateBot(state, action.botId, (b) => ({ ...b, modelSelection: action.selection }));
     case "connected":
@@ -1477,6 +1488,7 @@ export const initialState: AppState = {
   provisioning: {},
   deletingBots: {},
   computerControl: {},
+  browserDock: {},
   focusMessage: null,
   connected: false,
   error: null,


### PR DESCRIPTION
## Summary

The built-in browser used to live only in the Computer panel's Browser tab: a quarter-size preview beside the chat, the bot's "I need your hands" plea in the panel, and the explanation in the transcript. Now the moment a bot opens a page, or calls `browser_request_takeover`, the same native view floats **picture-in-picture** over the transcript's bottom-right corner, just above the composer, at the page's own 16:10 so nothing is letterboxed.

- **`BrowserPanel` gains a third size, `docked`**: address bar with Expand and Collapse, the page, and a control strip that carries the plea (`<bot> needs you. <reason>` with Take control / Dismiss), the held state (`You have control … Hand back`), or the quiet hint. Electron sees it as the expanded presentation, so a click takes control in place instead of being swallowed to expand a watch-only preview.
- **`BrowserDock`** decides when the chat hosts the view (first real page or a plea opens it; a person's collapse sticks until the next plea) and draws the fold-down pill. Pure rules live in `lib/browser-dock.ts` with tests.
- **Store** tracks the dock per bot. The Computer panel's Browser tab yields to an open dock ("Showing in the chat · Move it here") so only one React host positions the native view at a time.
- **`useBrowserControl`** extracts the durable lease calls `BrowserWorkspace` already made; the dock shares it.
- Expand from the dock opens the existing full-column workspace. No server, API, or Electron main changes.

Why an overlay and not a card in the message stream: the page is a native Electron `WebContentsView` that paints above React and cannot be clipped by the transcript's scroll container, so a card that scrolled past the header would draw over it.

Design reference: the "In-Chat Browser Dock" artifact (before/after mock). The shipped shape is the picture-in-picture variant Omkar asked for during testing, not the full-width strip in the mock.

## Test plan

- [x] `tsc -b`, `oxlint`, and vitest for `src/components`, `src/lib`, `src/state` (714 tests) pass
- [x] Isolated dev Electron instance: a real Claude turn opened example.com and called `browser_request_takeover`; the card appeared bottom-right with "Pip needs you. I need you to sign in for me"; Take control held the server lease and flipped the strip; Hand back released it, cleared the plea, and the bot's waiting tool returned
- [x] Collapse → pill ("Pip's browser · Example Domain · Show") → Show reopens; native host unmounts while collapsed
- [x] Computer panel → Browser tab shows "Showing in the chat" with "Move it here" while the dock is open
- [ ] OMB2 side-by-side build on a real bot session (Omkar)
- [ ] Windows package via the "Package Windows" workflow (dock is invisible there today, see table)

## Platforms
| Platform | Applies? | Status |
|---|---|---|
| macOS     | yes | in this PR, tested in an isolated dev Electron instance |
| Windows   | yes | in this PR (same renderer code, no platform gate touched); NOT built on Windows yet. Note: `electron/preload.cjs` enables the built-in browser only on darwin/linux, so the dock renders nothing on Windows until that gate opens |
| iOS       | n/a | the native `WebContentsView` cannot exist on the phone; the plea still reaches the phone through the unchanged `computerControl` payload |
| Android   | n/a | same as iOS |
| Companion | n/a | no phone-called route added or changed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a floating browser preview above the chat composer.
  * Added controls to expand, collapse, reclaim, or move the browser view to the Computer panel.
  * Browser previews open automatically when a bot navigates to a page or requests assistance.
  * Added browser-control status and takeover actions directly within the docked view.

* **Documentation**
  * Documented browser picture-in-picture behavior and embedded-browser limitations.

* **Tests**
  * Added coverage for browser dock behavior, availability, labels, state transitions, and multi-bot isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->