### PR TITLE
fix(mcp): answer ping in the Cua stdio bridge

### DIFF
--- a/server/container-mcp.test.ts
+++ b/server/container-mcp.test.ts
@@ -56,4 +56,58 @@ posixOnly("Local VM Cua MCP bridge", () => {
         `${CUA_EXECUTABLE} mcp --socket ${CUA_SOCKET}`,
     );
   });
+
+  it("answers ping locally so the bundled cua-driver is not invoked", async () => {
+    const bin = await mkdtemp(join(tmpdir(), "openmausbot-container-mcp-ping-"));
+    temporary.push(bin);
+    const fakeDocker = join(bin, "docker");
+    await writeFile(
+      fakeDocker,
+      `#!/bin/sh\n` +
+        `printf 'ARGS:%s\\n' "$*" >&2\n` +
+        `while IFS= read -r line; do\n` +
+        `  case "$line" in\n` +
+        `    *'"method":"ping"'* ) printf 'PING-RECEIVED:%s\\n' "$line" >&2 ;;\n` +
+        `    *'"method":"tools/list"'* ) printf '{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}\\n' ;;\n` +
+        `  esac\n` +
+        `done\n`,
+      { mode: 0o700 },
+    );
+    await chmod(fakeDocker, 0o700);
+
+    const input =
+      '{"jsonrpc":"2.0","id":2,"method":"ping","params":{}}\n' +
+      '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}\n';
+
+    const result = await new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve, reject) => {
+      const child = spawn(
+        process.execPath,
+        [fileURLToPath(new URL("./container-mcp.ts", import.meta.url)), "docker", CONTAINER, CUA_SOCKET],
+        {
+          env: { ...process.env, OMB_EXTRA_PATH: bin, NODE_NO_WARNINGS: "1" },
+          stdio: ["pipe", "pipe", "pipe"],
+        },
+      );
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (chunk: Buffer) => (stdout += chunk.toString()));
+      child.stderr.on("data", (chunk: Buffer) => (stderr += chunk.toString()));
+      child.on("error", reject);
+      child.on("close", (code) => resolve({ code, stdout, stderr }));
+      child.stdin.end(input);
+    });
+
+    expect(result.code).toBe(0);
+    const lines = result.stdout.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+    expect(lines).toEqual([
+      { jsonrpc: "2.0", id: 2, result: {} },
+      { jsonrpc: "2.0", id: 1, result: { tools: [] } },
+    ]);
+    expect(result.stderr).not.toContain("PING-RECEIVED");
+    expect(result.stderr).toContain(
+      `ARGS:exec -i -u cua -e HOME=/home/cua -e DISPLAY=:1 -e CUA_DRIVER_INSTALL_CHANNEL=python_package ` +
+        `-e CUA_DRIVER_RS_TELEMETRY_ENABLED=0 ${CONTAINER} ` +
+        `${CUA_EXECUTABLE} mcp --socket ${CUA_SOCKET}`,
+    );
+  });
 });

--- a/server/mcp-bridge.test.ts
+++ b/server/mcp-bridge.test.ts
@@ -8,6 +8,7 @@ import {
   createGateInterceptor,
   createInactivityWatchdog,
   createLineSplitter,
+  createMcpBridgeInterceptor,
   runLivenessProbe,
 } from "./mcp-bridge.ts";
 
@@ -224,5 +225,80 @@ describe("createGateInterceptor", () => {
     await drain();
     expect(refused).toEqual([]);
     expect(forwarded).toHaveLength(1);
+  });
+});
+
+describe("createMcpBridgeInterceptor", () => {
+  const frame = (method: string, id?: number) => JSON.stringify({ jsonrpc: "2.0", id, method, params: {} });
+  const drain = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  it("answers ping locally and does not forward it", () => {
+    const forwarded: string[] = [];
+    const answered: string[] = [];
+    const intercept = createMcpBridgeInterceptor({
+      answer: (line) => answered.push(line),
+      forward: (line) => forwarded.push(line),
+    });
+    intercept(frame("ping", 1));
+    expect(answered).toEqual(['{"jsonrpc":"2.0","id":1,"result":{}}']);
+    expect(forwarded).toEqual([]);
+  });
+
+  it("treats a ping notification as a silent swallow", () => {
+    const forwarded: string[] = [];
+    const answered: string[] = [];
+    const intercept = createMcpBridgeInterceptor({
+      answer: (line) => answered.push(line),
+      forward: (line) => forwarded.push(line),
+    });
+    intercept(JSON.stringify({ jsonrpc: "2.0", method: "ping", params: {} }));
+    expect(answered).toEqual([]);
+    expect(forwarded).toEqual([]);
+  });
+
+  it("forwards non-ping frames untouched", () => {
+    const forwarded: string[] = [];
+    const answered: string[] = [];
+    const intercept = createMcpBridgeInterceptor({
+      answer: (line) => answered.push(line),
+      forward: (line) => forwarded.push(line),
+    });
+    for (const line of [frame("initialize", 1), frame("tools/list", 2), "not json"]) {
+      intercept(line);
+    }
+    expect(answered).toEqual([]);
+    expect(forwarded).toEqual([frame("initialize", 1), frame("tools/list", 2), "not json"]);
+  });
+
+  it("answers ping even when a gate would refuse tools/call", async () => {
+    const forwarded: string[] = [];
+    const answered: string[] = [];
+    const intercept = createMcpBridgeInterceptor({
+      answer: (line) => answered.push(line),
+      forward: (line) => forwarded.push(line),
+      gate: { isHeld: async () => true },
+    });
+    intercept(frame("ping", 1));
+    intercept(frame("tools/call", 2));
+    await drain();
+    expect(forwarded).toEqual([]);
+    expect(answered).toHaveLength(2);
+    expect(JSON.parse(answered[0]!)).toEqual({ jsonrpc: "2.0", id: 1, result: {} });
+    expect(JSON.parse(answered[1]!).result.isError).toBe(true);
+    expect(JSON.parse(answered[1]!).result.content[0].text).toMatch(/taken control/i);
+  });
+
+  it("forwards other frames through the gate", async () => {
+    const forwarded: string[] = [];
+    const answered: string[] = [];
+    const intercept = createMcpBridgeInterceptor({
+      answer: (line) => answered.push(line),
+      forward: (line) => forwarded.push(line),
+      gate: { isHeld: async () => true },
+    });
+    intercept(frame("tools/list", 1));
+    await drain();
+    expect(answered).toEqual([]);
+    expect(forwarded).toEqual([frame("tools/list", 1)]);
   });
 });

--- a/server/mcp-bridge.ts
+++ b/server/mcp-bridge.ts
@@ -1,17 +1,17 @@
-// The one transparent stdio bridge behind both MCP entry points
+// The one stdio bridge behind both MCP entry points
 // (container-mcp.ts for the Local VM, vps-container-mcp.ts for the BYO VPS).
-// It defines no tools and parses no MCP messages: bytes in, bytes out.
 //
-// The single exception to that transparency is the who-is-driving gate
-// (opt-in via `gate`). While the person holds control of this computer in
-// the app, a `tools/call` from the agent is answered with a refusal HERE,
-// on the near side, and never forwarded — Cua Driver on the far side has
-// no concept of a person holding the wheel, so the refusal cannot come
-// from anywhere else. Everything that is not a tools/call still passes
-// through untouched, and with no gate configured the bridge remains the
-// byte-for-byte pipe described above.
+// It is almost transparent — bytes in, bytes out — with two deliberate
+// near-side exceptions:
 //
-// Two behaviors live here so neither entry point can drift:
+//   1. `ping`. The bundled cua-driver (through at least v0.22.1) does not
+//      implement this MCP method and would answer with -32601. Answering it
+//      here keeps the handshake alive without reaching the driver.
+//   2. The who-is-driving `gate` (opt-in via `gate`). While the person holds
+//      control of this computer, a `tools/call` from the agent is answered
+//      with a refusal here and never forwarded.
+//
+// Both behaviors live here so neither entry point can drift:
 //   1. Exit without truncation. `process.exit()` in a close/error handler
 //      discards whatever is still buffered on stdout — a final MCP result
 //      would be cut mid-frame. The bridge sets exitCode and unpipes instead,
@@ -205,6 +205,50 @@ export function createGateInterceptor(options: {
   };
 }
 
+export interface McpBridgeInterceptorOptions {
+  /** Writes a JSON-RPC response line to the agent's stdout. */
+  answer: (line: string) => void;
+  /** Forwards a line to the far-end child. */
+  forward: (line: string) => void;
+  /** Optional who-is-driving gate; when set, `tools/call` may be refused. */
+  gate?: {
+    isHeld: () => Promise<boolean>;
+    refusalText?: string;
+  };
+}
+
+/** The near-side MCP method filter. `ping` is answered here so the bundled
+ * cua-driver is never invoked for it; everything else is delegated to the
+ * gate (if configured) or forwarded untouched. */
+export function createMcpBridgeInterceptor(
+  options: McpBridgeInterceptorOptions,
+): (line: string) => void {
+  const afterPing = options.gate
+    ? createGateInterceptor({
+        isHeld: options.gate.isHeld,
+        forward: options.forward,
+        refuse: options.answer,
+        refusalText: options.gate.refusalText,
+      })
+    : options.forward;
+  return (line: string) => {
+    let frame: any = null;
+    try {
+      frame = JSON.parse(line);
+    } catch {
+      // not a frame this bridge understands — forward untouched
+    }
+    if (frame && frame.method === "ping") {
+      // Notifications have no `id` and require no response.
+      if (frame.id !== undefined) {
+        options.answer(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: {} }));
+      }
+      return;
+    }
+    afterPing(line);
+  };
+}
+
 export function runMcpBridge(options: BridgeOptions): void {
   const child = spawn(options.command, options.args, {
     shell: false,
@@ -216,40 +260,44 @@ export function runMcpBridge(options: BridgeOptions): void {
   child.stdin.on("error", () => {});
   child.stderr.pipe(process.stderr);
 
-  let detach: () => void;
-  if (options.gate) {
-    const client = createControlClient({ url: options.gate.url, token: options.gate.token });
-    const inbound = createLineSplitter(
-      createGateInterceptor({
-        isHeld: async () => (await client.state(true)).held,
-        forward: (line) => child.stdin.write(line + "\n"),
-        refuse: (line) => process.stdout.write(line + "\n"),
-      }),
-    );
-    const onStdin = (chunk: Buffer) => inbound.push(chunk);
-    process.stdin.on("data", onStdin);
-    process.stdin.on("end", () => {
-      inbound.flush();
-      child.stdin.end();
-    });
-    // Injected refusals must never land inside one of the child's
-    // half-written frames, so the child's stdout is re-emitted at line
-    // granularity as well.
-    const outbound = createLineSplitter((line) => process.stdout.write(line + "\n"));
-    child.stdout.on("data", (chunk) => outbound.push(chunk));
-    child.stdout.on("end", () => outbound.flush());
-    detach = () => {
-      process.stdin.off("data", onStdin);
-      process.stdin.pause();
-    };
-  } else {
-    process.stdin.pipe(child.stdin);
-    child.stdout.pipe(process.stdout);
-    detach = () => {
-      process.stdin.unpipe(child.stdin);
-      process.stdin.pause();
-    };
-  }
+  const client = options.gate
+    ? createControlClient({ url: options.gate.url, token: options.gate.token })
+    : null;
+
+  const answer = (line: string) => process.stdout.write(line + "\n");
+  const forward = (line: string) => child.stdin.write(line + "\n");
+  const inbound = createLineSplitter(
+    createMcpBridgeInterceptor({
+      answer,
+      forward,
+      ...(options.gate
+        ? {
+            gate: {
+              isHeld: async () => (await client!.state(true)).held,
+            },
+          }
+        : {}),
+    }),
+  );
+
+  const onStdin = (chunk: Buffer) => inbound.push(chunk);
+  process.stdin.on("data", onStdin);
+  process.stdin.on("end", () => {
+    inbound.flush();
+    child.stdin.end();
+  });
+
+  // Injected responses and refusals must never land inside one of the
+  // child's half-written frames, so the child's stdout is re-emitted at
+  // line granularity as well.
+  const outbound = createLineSplitter((line) => process.stdout.write(line + "\n"));
+  child.stdout.on("data", (chunk) => outbound.push(chunk));
+  child.stdout.on("end", () => outbound.flush());
+
+  const detach = () => {
+    process.stdin.off("data", onStdin);
+    process.stdin.pause();
+  };
 
   let watchdog: WatchdogHandle | null = null;
   if (options.liveness) {


### PR DESCRIPTION
## Summary

- Intercept `ping` in `server/mcp-bridge.ts` and answer it on the near side, so the bundled cua-driver is never invoked for MCP `ping` probes.
- Keep the who-is-driving `tools/call` gate behavior unchanged.
- Add unit tests for `createMcpBridgeInterceptor` in `server/mcp-bridge.test.ts` and an integration test in `server/container-mcp.test.ts` that asserts the fake `cua-driver` process does not receive `ping`.

This addresses the "unknown method ping" failure reported in #659 without adding a ping handler to cua-driver itself, mirroring how the harness's `agents-proxy.ts` already handles ping locally.

## Test plan

- `pnpm typecheck` passes.
- `npx oxlint server/mcp-bridge.ts server/mcp-bridge.test.ts server/container-mcp.test.ts` passes.
- Manual integration tests against bundled `container-mcp` and `vps-container-mcp` show `ping` answered with `{"jsonrpc":"2.0","id":...,"result":{}}` and the fake upstream `docker`/cua-driver receives only `tools/list`.
- The `vitest` suite for these files requires Node >= 23.4 (for `node:sqlite`) and was not runnable in the Node 20 verification environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - MCP bridge `ping` requests are now answered locally, improving compatibility and avoiding unsupported responses from the bundled driver.
  - `ping` notifications are handled silently without unnecessary forwarding.
  - Non-`ping` messages continue to be forwarded correctly, including when access-control checks are enabled.
  - Bridge output is now consistently relayed line by line, improving response handling when no access-control gate is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->