### PR TITLE
feat(deploy): add configurable local Docker Compose setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ OMB_PUBLIC_URL=
 OMB_WEBHOOK_PUBLIC_URL=
 # For Tailscale Serve, set the HTTPS hostname (without scheme or path).
 # Set OMB_PUBLIC_URL to https:// followed by the same hostname.
+# Requires OMB_BIND_ADDRESS=127.0.0.1 and a trusted local HTTPS proxy.
 OMB_HTTPS_HOST=
 OMB_BASE_IMAGE=ghcr.io/milind-soni/openmausbot:latest
 OMB_LOCAL_IMAGE=openmausbot-local:latest

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Optional: Compose provides defaults when these settings are omitted.
+COMPOSE_PROJECT_NAME=openmausbot
+OMB_BIND_ADDRESS=127.0.0.1
+OMB_HTTP_PORT=8080
+# Leave empty to use http://localhost:${OMB_HTTP_PORT:-8080}.
+OMB_PUBLIC_URL=
+# Leave empty to inherit OMB_PUBLIC_URL.
+OMB_WEBHOOK_PUBLIC_URL=
+# For Tailscale Serve, set the HTTPS hostname (without scheme or path).
+# Set OMB_PUBLIC_URL to https:// followed by the same hostname.
+OMB_HTTPS_HOST=
+OMB_BASE_IMAGE=ghcr.io/milind-soni/openmausbot:latest
+OMB_LOCAL_IMAGE=openmausbot-local:latest
+CADDY_IMAGE=caddy:2
+# Explicitly empty ENGINES skips npm engine installation.
+ENGINES="@anthropic-ai/claude-code @openai/codex"
+# Leave empty for <COMPOSE_PROJECT_NAME>_data.
+OMB_DATA_VOLUME=
+# Use true only when reusing a volume that already exists.
+OMB_DATA_EXTERNAL=false

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ cloudflare/control-plane/worker-configuration.d.ts
 
 # per-tenant deploy settings (see deploy/.env.example)
 deploy/.env
+/.env

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,7 @@
 name: ${COMPOSE_PROJECT_NAME:-openmausbot}
 services:
   omb:
+    init: true
     build:
       context: ./deploy/local
       args:

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,7 +19,11 @@ services:
       OMB_PUBLIC_URL: ${OMB_PUBLIC_URL:-http://localhost:${OMB_HTTP_PORT:-8080}}
       OMB_WEBHOOK_PUBLIC_URL: ${OMB_WEBHOOK_PUBLIC_URL:-${OMB_PUBLIC_URL:-http://localhost:${OMB_HTTP_PORT:-8080}}}
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://127.0.0.1:8799/api/health | grep -q openmausbot"]
+      test:
+        - CMD
+        - node
+        - -e
+        - "fetch('http://127.0.0.1:8799/api/health', { signal: AbortSignal.timeout(4000) }).then(async r => { if (!r.ok || !(await r.text()).includes('openmausbot')) process.exit(1); }).catch(() => process.exit(1))"
       interval: 15s
       timeout: 5s
       start_period: 30s
@@ -29,7 +33,21 @@ services:
     restart: unless-stopped
     network_mode: service:omb
     environment:
-      OMB_HTTPS_HOST: ${OMB_HTTPS_HOST:-https-disabled.invalid}
+      OMB_HTTPS_HOST: ${OMB_HTTPS_HOST:-}
+      OMB_BIND_ADDRESS: ${OMB_BIND_ADDRESS:-127.0.0.1}
+    command:
+      - /bin/sh
+      - -ec
+      - |
+        export OMB_UPSTREAM_SCHEME=http
+        if [ -n "$$OMB_HTTPS_HOST" ] && [ "$$OMB_BIND_ADDRESS" != "127.0.0.1" ]; then
+          echo "OMB_HTTPS_HOST requires OMB_BIND_ADDRESS=127.0.0.1; forward HTTPS through a trusted local proxy." >&2
+          exit 1
+        fi
+        if [ -n "$$OMB_HTTPS_HOST" ]; then
+          export OMB_UPSTREAM_SCHEME=https
+        fi
+        exec caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
     depends_on:
       omb:
         condition: service_healthy

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,44 @@
+name: ${COMPOSE_PROJECT_NAME:-openmausbot}
+services:
+  omb:
+    build:
+      context: ./deploy/local
+      args:
+        BASE_IMAGE: ${OMB_BASE_IMAGE:-ghcr.io/milind-soni/openmausbot:latest}
+        ENGINES: ${ENGINES-@anthropic-ai/claude-code @openai/codex}
+    image: ${OMB_LOCAL_IMAGE:-openmausbot-local:latest}
+    restart: unless-stopped
+    volumes:
+      - data:/data
+    ports:
+      - "${OMB_BIND_ADDRESS:-127.0.0.1}:${OMB_HTTP_PORT:-8080}:80"
+    environment:
+      OMB_PORT: "8799"
+      OMB_WEBHOOK_PORT: "8800"
+      OMB_PUBLIC_URL: ${OMB_PUBLIC_URL:-http://localhost:${OMB_HTTP_PORT:-8080}}
+      OMB_WEBHOOK_PUBLIC_URL: ${OMB_WEBHOOK_PUBLIC_URL:-${OMB_PUBLIC_URL:-http://localhost:${OMB_HTTP_PORT:-8080}}}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://127.0.0.1:8799/api/health | grep -q openmausbot"]
+      interval: 15s
+      timeout: 5s
+      start_period: 30s
+      retries: 5
+  caddy:
+    image: ${CADDY_IMAGE:-caddy:2}
+    restart: unless-stopped
+    network_mode: service:omb
+    environment:
+      OMB_HTTPS_HOST: ${OMB_HTTPS_HOST:-https-disabled.invalid}
+    depends_on:
+      omb:
+        condition: service_healthy
+    volumes:
+      - ./deploy/local/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+volumes:
+  data:
+    external: ${OMB_DATA_EXTERNAL:-false}
+    name: ${OMB_DATA_VOLUME:-${COMPOSE_PROJECT_NAME:-openmausbot}_data}
+  caddy_data:
+  caddy_config:

--- a/deploy/local/.dockerignore
+++ b/deploy/local/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/deploy/local/Caddyfile
+++ b/deploy/local/Caddyfile
@@ -1,6 +1,6 @@
 :80 {
 	map {host} {upstream_scheme} {
-		{$OMB_HTTPS_HOST:https-disabled.invalid} https
+		{$OMB_HTTPS_HOST:https-disabled.invalid} {$OMB_UPSTREAM_SCHEME:http}
 		default http
 	}
 	encode zstd gzip

--- a/deploy/local/Caddyfile
+++ b/deploy/local/Caddyfile
@@ -1,0 +1,16 @@
+:80 {
+	map {host} {upstream_scheme} {
+		{$OMB_HTTPS_HOST:https-disabled.invalid} https
+		default http
+	}
+	encode zstd gzip
+	handle /hooks/* {
+		reverse_proxy 127.0.0.1:8800
+	}
+	handle {
+		reverse_proxy 127.0.0.1:8799 {
+			header_up X-Forwarded-Proto {upstream_scheme}
+			flush_interval -1
+		}
+	}
+}

--- a/deploy/local/Dockerfile
+++ b/deploy/local/Dockerfile
@@ -1,0 +1,6 @@
+ARG BASE_IMAGE=ghcr.io/milind-soni/openmausbot:latest
+FROM ${BASE_IMAGE}
+USER root
+ARG ENGINES="@anthropic-ai/claude-code @openai/codex"
+RUN if [ -n "$ENGINES" ]; then npm install -g $ENGINES; fi
+USER maus

--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -1,0 +1,35 @@
+# Local Docker Compose
+
+From the repository root, run `docker compose up -d --build`, then open
+http://localhost:8080. Docker with Linux containers is required.
+Compose supplies defaults; no `.env` file is required.
+
+To customize, copy `.env.example` to `.env` in the repository root.
+The `.env` file is ignored by Git. Shell environment variables take precedence.
+`OMB_HTTP_PORT` changes the host port and the default public URL.
+Internal service ports remain fixed inside the shared network namespace.
+`ENGINES` selects space-separated npm packages; an empty value skips installation.
+
+For Tailscale Serve, set `OMB_PUBLIC_URL` to your HTTPS URL and
+`OMB_HTTPS_HOST` to its hostname without scheme or path. Configure Tailscale
+Serve on the host to forward to the chosen localhost HTTP port.
+Keep the default loopback bind address. The hostname mapping preserves HTTPS
+semantics for that host while localhost access continues to use HTTP.
+Private tailnet webhook URLs are only reachable by callers on that tailnet.
+
+Sign in and pair a browser:
+
+```sh
+docker compose exec omb codex login --device-auth
+docker compose exec omb node dist-server/openmausbot.js pair
+```
+
+On Windows, `./maus.ps1` forwards arguments to Compose using the repository
+directory. It respects Docker's selected context and `DOCKER_CONTEXT`.
+
+Data and engine credentials persist in the named data volume. For an existing
+volume, set `OMB_DATA_VOLUME` to its name and `OMB_DATA_EXTERNAL=true`.
+Fresh installs create their volume automatically.
+
+Update with `docker compose build --pull` followed by `docker compose up -d`.
+Stop with `docker compose stop`. `docker compose down -v` deletes managed volumes.

--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -3,6 +3,8 @@
 From the repository root, run `docker compose up -d --build`, then open
 http://localhost:8080. Docker with Linux containers is required.
 Compose supplies defaults; no `.env` file is required.
+The application container uses Docker's init process to reap orphaned agent
+subprocesses.
 
 To customize, copy `.env.example` to `.env` in the repository root.
 The `.env` file is ignored by Git. Shell environment variables take precedence.

--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -15,9 +15,14 @@ Internal service ports remain fixed inside the shared network namespace.
 For Tailscale Serve, set `OMB_PUBLIC_URL` to your HTTPS URL and
 `OMB_HTTPS_HOST` to its hostname without scheme or path. Configure Tailscale
 Serve on the host to forward to the chosen localhost HTTP port.
-Keep the default loopback bind address. The hostname mapping preserves HTTPS
+Keep the default `OMB_BIND_ADDRESS=127.0.0.1`. Caddy refuses to start when
+`OMB_HTTPS_HOST` is set with any other bind address, so direct remote HTTP
+clients cannot claim HTTPS semantics by supplying that hostname.
+The hostname mapping preserves HTTPS
 semantics for that host while localhost access continues to use HTTP.
 Private tailnet webhook URLs are only reachable by callers on that tailnet.
+Without `OMB_HTTPS_HOST`, the bind address can be changed for HTTP access.
+Only use HTTPS hostname mapping with a trusted local TLS-terminating proxy.
 
 Sign in and pair a browser:
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -81,6 +81,10 @@ pm2 to keep it up; `openmausbot serve` is a plain foreground process.
 
 ## Docker (with HTTPS on your own domain)
 
+For local Docker Desktop or private Tailscale access without a public domain,
+use the [local Compose setup](../deploy/local/README.md). It defaults to
+`http://localhost:8080` and supports optional `.env` overrides.
+
 One tenant = one container for the server plus Caddy for HTTPS.
 Requirements: Docker with Compose, a DNS name pointing at the machine, and
 ports 80/443 open.

--- a/maus.ps1
+++ b/maus.ps1
@@ -1,0 +1,12 @@
+[string[]]$ComposeArgs = @(if ($args.Count) { $args } else { 'ps' })
+$ErrorActionPreference = 'Stop'
+$dockerCommand = Get-Command docker.exe -ErrorAction SilentlyContinue
+$dockerPath = if ($dockerCommand) { $dockerCommand.Source } else { Join-Path $env:LOCALAPPDATA 'Programs\DockerDesktop\resources\bin\docker.exe' }
+if (-not (Test-Path -LiteralPath $dockerPath)) {
+    $dockerPath = 'C:\Program Files\Docker\Docker\resources\bin\docker.exe'
+}
+if (-not (Test-Path -LiteralPath $dockerPath)) {
+    throw 'Docker CLI was not found. Install Docker Desktop and add docker to PATH.'
+}
+& $dockerPath compose --project-directory $PSScriptRoot -f (Join-Path $PSScriptRoot 'compose.yaml') @ComposeArgs
+exit $LASTEXITCODE


### PR DESCRIPTION
## What changed

Add an optional root-level Docker Compose setup for localhost and private Tailscale access. Without `.env`, it binds `127.0.0.1:8080`, creates persistent volumes, and installs the default Claude/Codex CLIs in a small derived image. Enable Docker init for the application service so orphaned agent subprocesses are reaped.

Use Compose defaults (`${VAR:-default}`) for URLs, bind address, port, images, and volume settings. `ENGINES` deliberately uses `${VAR-default}` so an explicitly empty value disables engine installation. Include `.env.example`, a Windows Compose wrapper, and setup documentation. The existing public-domain deployment remains available.

## Why

The existing Docker recipe requires a public domain and ports 80/443. This adds a documented local/private deployment path, including configurable HTTPS hostname handling behind Tailscale Serve, without machine-specific values in the repository.

## How it was verified

### Complete application test suite: passed

On isolated Linux with Node 24.20.0, pnpm 10.33.0, a non-root user, and an init/subreaper, ran all stages of `pnpm test` (using verbose output for the main Vitest stage):

```sh
pnpm typecheck && pnpm exec vitest run --reporter=verbose && pnpm broker:test && pnpm test:electron && pnpm test:packaged-server
```

- Typecheck passed.
- Main Vitest: **340 files passed; 3,929 tests passed, 9 existing skips, 1 todo; zero failures or worker errors** (401.02 seconds).
- Broker: **7 passed**.
- Electron Node tests: **137 passed**.
- Packaged server: standalone startup, all 10 proxy paths, and MCP stdio smoke checks passed.

The application source tested is unchanged by the follow-up commit `60b78bb1`, which only adds Compose `init: true` and its documentation. No test skips or application changes were added to obtain these results.

### Compose verification

- Validated defaults with no `.env`, custom URLs/ports, empty `ENGINES`, and external-volume configuration.
- Built the derived image and checked Codex/Claude CLI versions.
- With the final Compose configuration, an isolated project reached healthy state, PID 1 was `docker-init`, and HTTP returned 200. Its containers and volumes were removed afterward.
- The process-tree test reproduces a zombie-process failure without a reaper and passes with init. This motivated the `init: true` follow-up.
- `git diff --check` passed; no personal `.env`, credentials, or backups are included.

### Earlier Windows failures investigated

The failures also reproduced on the unchanged base (`5d69ece9`):

- Symlink tests: Windows `CreateSymbolicLinkW` returned error 1314 (missing privilege), before the application assertions.
- AppImage test: `mv` was absent from the executable PATH; adding Git for Windows' `usr/bin` only to the test process made all 8 tests in that file pass.
- Real Electron fixture: the temporary `USERPROFILE` lacks `AppData/Roaming`, causing Electron path lookup to fail before ready. A minimal reproduction succeeds when that directory exists or user/session data paths are explicit. After fixing the test data path experimentally, CDP screenshot capture could hang; using the existing native capture path made all 3 fixture tests pass. These diagnostic changes are not included in this deployment PR. Existing Windows CI already treats the real Electron fixture as a non-blocking probe and references electron/electron#51761; the same exit code alone does not establish an ACL/GPU cause on this host.
- One Windows worker exit did not reproduce in 24 isolated repeats across Node 24.15 and 24.19 (72 test executions passed), or in the final Linux run. Its native cause is not claimed established.

Live Tailscale end-to-end access and macOS were not re-tested for this PR.

## Checklist

- [x] Typecheck and all `pnpm test` stages pass locally on isolated Linux
- [x] No application/server source changes or test skips
- [x] No `dist-server/` edits
- [x] No `shell: true` / cmd.exe string-building
- [x] No secrets in submitted files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Docker Compose setup for running OpenMausBot locally with persistent storage, health checks, and optional HTTPS through Tailscale Serve or a trusted proxy.
  - Added configurable environment settings for ports, URLs, image tags, volumes, and optional tooling.
  - Added a Windows PowerShell wrapper for common Docker Compose commands.

- **Documentation**
  - Added local deployment instructions, including browser pairing, Windows usage, updates, and stopping the service.
  - Expanded self-hosting guidance for Docker Desktop and private Tailscale access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->