### PR TITLE
fix(computer): publish Local VM screen frames to stream-only clients

### DIFF
--- a/server/container-computer.test.ts
+++ b/server/container-computer.test.ts
@@ -19,6 +19,7 @@ import {
   WORKSPACE_LABEL,
   computerProxyEnv,
   containerComputerAction,
+  containerComputerFrame,
   containerComputerMcp,
   containerComputerScreenshot,
   containerComputerStatus,
@@ -651,6 +652,33 @@ describe("Cua integration", () => {
     expect(image).toBe(`data:image/png;base64,${png.toString("base64")}`);
     expect(fake.calls).toContain(screenshotCall);
     expect(fake.calls.some((call) => /xdotool|scrot|vnc/i.test(call))).toBe(false);
+  });
+
+  // The live screen poller broadcasts this shape verbatim to every SSE
+  // client, and the phone renders nothing but those events: a data URL here
+  // would reach it as base64 that decodes to garbage.
+  it("hands the screen poller raw base64 and a bare format, not a data URL", async () => {
+    const png = validPng;
+    const fake = runner({
+      "/usr/bin/which docker": "docker\n",
+      "/usr/bin/which podman": new Error("missing"),
+      "docker info --format {{.ServerVersion}}": "29\n",
+      [`docker image inspect ${IMAGE}`]: preparedImageInspect(),
+      [`docker inspect ${CONTAINER}`]: readyInspect(),
+      [versionProbe]: `cua-driver ${CUA_DRIVER_VERSION}\n`,
+      [statusProbe]: "running\n",
+      [healthProbe]: JSON.stringify({ schema_version: "1", overall: "degraded", checks: [] }),
+      [readinessProbe]: "{}\n",
+      [readinessRead]: png.toString("base64"),
+      [`${driverExec} call get_desktop_state {} --socket ${CUA_SOCKET} ` +
+        "--screenshot-out-file /tmp/openmausbot-preview.png"]: "{}\n",
+      [`docker exec ${CONTAINER} base64 -w0 /tmp/openmausbot-preview.png`]: png.toString("base64"),
+    });
+
+    const frame = await containerComputerFrame(fake.run, "linux");
+
+    expect(frame).toEqual({ png: png.toString("base64"), format: "png" });
+    expect(frame.png.startsWith("data:")).toBe(false);
   });
 });
 

--- a/server/container-computer.ts
+++ b/server/container-computer.ts
@@ -1028,11 +1028,14 @@ export function wholeScreenshot(bytes: Buffer): ScreenshotCheck {
   };
 }
 
-export async function containerComputerScreenshot(
+/** The raw frame, in the shape the live screen poller broadcasts to every
+ * client (server/index.ts). The web panel wants a data URL instead, so
+ * containerComputerScreenshot below wraps this one. */
+export async function containerComputerFrame(
   runner: CommandRunner = sh,
   platform: NodeJS.Platform = process.platform,
   target: LocalVmTarget = SHARED_LOCAL_VM_TARGET,
-): Promise<string> {
+): Promise<{ png: string; format: "png" | "jpeg" }> {
   const cacheable = runner === sh && platform === process.platform;
   const now = Date.now();
   const cached = screenshotStatusCache.get(target.key);
@@ -1070,11 +1073,20 @@ export async function containerComputerScreenshot(
     if (!checked.ok) {
       throw Object.assign(new Error("Cua Driver returned an incomplete screenshot"), { status: 502 });
     }
-    return `data:${checked.mime};base64,${data}`;
+    return { png: data, format: checked.mime === "image/jpeg" ? "jpeg" : "png" };
   } catch (error) {
     if (cacheable) screenshotStatusCache.delete(target.key);
     throw error;
   }
+}
+
+export async function containerComputerScreenshot(
+  runner: CommandRunner = sh,
+  platform: NodeJS.Platform = process.platform,
+  target: LocalVmTarget = SHARED_LOCAL_VM_TARGET,
+): Promise<string> {
+  const { png, format } = await containerComputerFrame(runner, platform, target);
+  return `data:image/${format};base64,${png}`;
 }
 
 const screenshotStatusCache = new Map<

--- a/server/index.ts
+++ b/server/index.ts
@@ -85,6 +85,7 @@ import { openMausStatusSystemPrompt } from "./openmaus-status-capsule.ts";
 import {
   containerComputerAction,
   containerComputerExists,
+  containerComputerFrame,
   containerComputerMcp,
   containerComputerScreenshot,
   containerComputerStatus,
@@ -4225,6 +4226,23 @@ async function startTurn(
           localVmTarget,
         );
         computerKind = "vm";
+        // Same contract as the Box and VPS branches below: without this the
+        // poller never starts, so the Local VM publishes no `screen` events
+        // and every client that only has the stream (the phone) waits
+        // forever. The web panel hid the gap by polling the screenshot
+        // route itself.
+        previewCapture = () => {
+          // The shared desktop outlives the turn. Once another thread owns
+          // it, a capture still in flight would picture ITS work under this
+          // bot's name — live and in the settled transcript frame, which is
+          // taken after the lease is already released. No owner means the
+          // desktop is simply idle: that final frame is ours to keep.
+          const owner = localVmLeaseFor(localVmTarget).current(localVmOwnerBusy);
+          if (owner && owner.threadId !== threadId) {
+            throw new Error("the Local VM moved on to another turn");
+          }
+          return containerComputerFrame(undefined, undefined, localVmTarget);
+        };
       } else if (wants === "local") {
         if (!shouldMountLocalComputer({
           requested: "local",

--- a/server/local-vm-lease.test.ts
+++ b/server/local-vm-lease.test.ts
@@ -36,6 +36,24 @@ describe("LocalVmLease", () => {
     expect(lease.current(busy, 1_151)).toBeNull();
   });
 
+  // The screen poller's Local VM capture reads current() to decide whether a
+  // frame still belongs to the turn that asked for it: the settled transcript
+  // frame is taken AFTER the turn released the desktop, so "nobody owns it"
+  // has to stay distinguishable from "somebody else does".
+  it("reads as unowned once the turn settles, and as the new thread after a handoff", () => {
+    const lease = new LocalVmLease(100);
+    let busyBot: string | null = "bot-a";
+    const busy = (botId: string) => botId === busyBot;
+
+    lease.claim("thread-a", "bot-a", busy, 1_000);
+    busyBot = null;
+    expect(lease.current(busy, 1_010)).toBeNull();
+
+    busyBot = "bot-b";
+    lease.claim("thread-b", "bot-b", busy, 1_020);
+    expect(lease.current(busy, 1_030)).toMatchObject({ threadId: "thread-b" });
+  });
+
   it("does not revive an expired owner from a delayed event", () => {
     const lease = new LocalVmLease(100);
     const busy = () => true;


### PR DESCRIPTION
Fixes #839.

## The bug

A Local VM turn never publishes screen frames. `previewCapture` starts as `null` in `startTurn`, and the `wants === "vm"` branch mounts the desktop's computer tools and sets `computerKind`, but never assigns a capture — the Box and VPS branches both do. With no capture, `startScreenPoller` is skipped, and the turn emits no `{kind:"screen"}` SSE events at all.

The web panel hides this: `ComputerPanel` polls `/api/bots/:id/local-computer/screenshot` itself every 3s, so the desktop preview looks correct. The iOS companion has nothing but the stream — `ComputerView` renders `state.screens[bot.id]` and nothing else — so it shows the busy state (`Idle` → `Preview`, which reads `bot.busy`) and then waits on "Waiting for a frame…" forever. That is exactly the report in #839: web and phone watching the same working bot at the same time, one showing Firefox driving in the VM, the other showing a spinner.

Same reason the transcript never got a settled screenshot for a Local VM turn: the fold at turn end needs the poller too.

## The change

- Assign `previewCapture` in the Local VM branch, against the same `localVmTarget` the agent is driving.
- Split `containerComputerScreenshot` into `containerComputerFrame`, which returns the raw base64 and a bare `"png" | "jpeg"` — the shape `startScreenPoller` → `captureOutsideHumanControl` → `broadcast({kind:"screen"})` expects — plus a thin data-URL wrapper for the existing HTTP route. The route's response is byte-identical, JPEG included (the format still comes from the magic-byte check in `wholeScreenshot`, not from a filename).
- The capture refuses a frame once another thread owns the desktop. A shared VM outlives the turn, and the settled transcript frame is captured *after* `releaseLocalVmThread` has already run, so an in-flight capture could otherwise picture the next bot's work under this one's name. No owner means the desktop is merely idle, and that final frame is still this turn's to keep.

The browser fallback below (`if (!previewCapture && browser)`) is now correctly outranked: a Local VM bot that also has the built-in browser used to stream frames of the headless browser instead of the desktop it was actually working on.

## Tests

- `containerComputerFrame` hands the poller raw base64 and a bare format, never a data URL (the conversion is the subtle half — a data URL would reach the phone as base64 that decodes to garbage). Verified by mutation: returning a data URL from the frame function fails this test and the existing data-URL test.
- `LocalVmLease` reads as unowned once the turn settles and as the new thread after a handoff — the two-branch contract the capture guard depends on.
- `server/index.test.ts` (199), plus `container-computer`, `container-mcp`, `computer-proxy`, `private-screen-capture`, `screen-frame-gate`, `cloud-backend`, `local-vm-lease` all pass. `tsc -p tsconfig.server.json` clean, `oxlint` adds no new warning.

## Deliberately not in this PR

- **`wants === "local"` (host CUA) has the same gap.** A bot driving the Mac directly also assigns no `previewCapture`, so the phone can never watch it either. Fixing it needs a different capture path — the web panel gets those frames from the Electron main process (`window.ogb.screenFrame()`), not from the harness — and it puts the user's own screen on the wire, which deserves its own discussion. Happy to open a separate issue.
- **The web panel keeps its own 3s poll during a VM turn.** Now that frames stream, that poll is redundant work on the same container; the cloud path already stands down while live frames are fresh (`latestLive`) and the VM path could do the same. Left out to keep this diff to the bug.
- **`/tmp/openmausbot-preview.png` is a fixed path**, so two concurrent captures (the panel's poll and the stream) can race on it. Pre-existing — two browser tabs already do this — and self-healing, since `wholeScreenshot` rejects a torn frame and the poller retries on the next tick. Say the word if you want it made per-capture here.

## Verification

Reviewed against the code paths end to end. I have not re-run the original EC2 + iPhone reproduction against a patched server yet; if you want that before merging, I can deploy this to the same self-hosted box from the issue and confirm frames land on the phone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Local virtual machine sessions now provide live screen previews through the screen-polling stream.
  - Screen captures can be processed as raw PNG or JPEG frames while preserving existing image-preview behavior.

- **Bug Fixes**
  - Improved virtual machine handoff handling after the previous session owner finishes, allowing leases to transfer reliably to a new session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->