### PR TITLE
fix(antigravity): Windows install no longer fails with EPERM unlink on agy_acp_server.exe

### DIFF
--- a/server/drivers/antigravity-acp.ts
+++ b/server/drivers/antigravity-acp.ts
@@ -159,6 +159,10 @@ export class AntigravityAcpClient {
   private diagnosticBuffer = "";
   private closed = false;
   private readonly onAuthorizationUrl?: (url: string) => void;
+  /** Settles once the runtime process is gone. On Windows a running
+   * executable pins its file and its directory, so an installer must not
+   * rename or delete either until this settles. */
+  readonly exited: Promise<void>;
 
   constructor(
     runtime: AntigravityRuntime,
@@ -180,8 +184,13 @@ export class AntigravityAcpClient {
     this.child.stderr!.setEncoding("utf8");
     this.child.stderr!.on("data", (chunk: string) => this.consumeDiagnostics(chunk));
     this.child.once("error", (error) => this.failAll(error));
-    this.child.once("close", (code) => {
-      if (!this.closed) this.failAll(new Error(`Antigravity ACP exited ${code ?? "unexpectedly"}.`));
+    this.exited = new Promise((resolve) => {
+      this.child.once("close", (code) => {
+        if (!this.closed) this.failAll(new Error(`Antigravity ACP exited ${code ?? "unexpectedly"}.`));
+        resolve();
+      });
+      // A spawn failure emits `error` and then `close`, but not always `exit`.
+      this.child.once("error", () => resolve());
     });
   }
 
@@ -273,6 +282,22 @@ export class AntigravityAcpClient {
     this.closed = true;
     this.failAll(new Error("Antigravity ACP was closed."));
     killCliTree(this.child);
+  }
+
+  /** Close, then wait (bounded) for the process to be gone. `killCliTree`
+   * on Windows asks taskkill and returns at once; the exit lands later. */
+  async closeAndWait(timeoutMs = 5_000): Promise<boolean> {
+    this.close();
+    let timer: NodeJS.Timeout | undefined;
+    const timedOut = new Promise<boolean>((resolve) => {
+      timer = setTimeout(() => resolve(false), timeoutMs);
+      timer.unref?.();
+    });
+    try {
+      return await Promise.race([this.exited.then(() => true), timedOut]);
+    } finally {
+      clearTimeout(timer);
+    }
   }
 }
 
@@ -472,7 +497,9 @@ export async function validateAntigravityRuntime(runtime: AntigravityRuntime, ex
         throw new Error("The download did not identify as the expected Google Antigravity ACP release.");
       }
     } finally {
-      client.close();
+      // The caller is about to rename the directory this executable runs
+      // from; on Windows that fails with EPERM while the process lives.
+      await client.closeAndWait();
     }
   } finally {
     await rm(profileDirectory, { recursive: true, force: true });

--- a/server/drivers/antigravity-acp.ts
+++ b/server/drivers/antigravity-acp.ts
@@ -189,8 +189,8 @@ export class AntigravityAcpClient {
         if (!this.closed) this.failAll(new Error(`Antigravity ACP exited ${code ?? "unexpectedly"}.`));
         resolve();
       });
-      // A spawn failure emits `error` and then `close`, but not always `exit`.
-      this.child.once("error", () => resolve());
+      // Failed spawns also emit `close`. An `error` alone can instead mean
+      // a failed kill, and is not evidence that the runtime stopped.
     });
   }
 
@@ -484,26 +484,45 @@ export function isValidAntigravityInitializeResult(
  */
 export async function validateAntigravityRuntime(runtime: AntigravityRuntime, expectedVersion: string): Promise<void> {
   const profileDirectory = await mkdtemp(join(tmpdir(), "openmaus-antigravity-verify-"));
+  let client: AntigravityAcpClient | undefined;
+  let failed = false;
+  let failure: unknown;
   try {
     const profile = await prepareAntigravityProfile({
       instanceId: `verify-${randomUUID()}`,
       runtime,
       profileDirectory,
     });
-    const client = new AntigravityAcpClient(runtime, profile, profileDirectory);
-    try {
-      const initialized = await client.initialize();
-      if (!isValidAntigravityInitializeResult(initialized, expectedVersion)) {
-        throw new Error("The download did not identify as the expected Google Antigravity ACP release.");
-      }
-    } finally {
-      // The caller is about to rename the directory this executable runs
-      // from; on Windows that fails with EPERM while the process lives.
-      await client.closeAndWait();
+    client = new AntigravityAcpClient(runtime, profile, profileDirectory);
+    const initialized = await client.initialize();
+    if (!isValidAntigravityInitializeResult(initialized, expectedVersion)) {
+      throw new Error("The download did not identify as the expected Google Antigravity ACP release.");
     }
-  } finally {
-    await rm(profileDirectory, { recursive: true, force: true });
+  } catch (error) {
+    failed = true;
+    failure = error;
   }
+  // The caller is about to rename the directory this executable runs from.
+  // Neither it nor the profile is safe to touch before confirmed close.
+  let stopped = !client;
+  try {
+    if (client) {
+      stopped = await client.closeAndWait();
+      if (!stopped) throw new Error("Antigravity did not shut down after runtime verification.");
+    }
+  } catch (error) {
+    if (!failed) {
+      failed = true;
+      failure = error;
+    }
+  }
+  if (stopped) {
+    await rm(profileDirectory, { recursive: true, force: true, maxRetries: 4, retryDelay: 250 })
+      .catch((error) => {
+        console.warn(`antigravity: could not remove verification profile ${profileDirectory}: ${error instanceof Error ? error.message : String(error)}`);
+      });
+  }
+  if (failed) throw failure;
 }
 
 export interface AntigravityAuthStart {

--- a/server/drivers/antigravity-lifecycle.test.ts
+++ b/server/drivers/antigravity-lifecycle.test.ts
@@ -1,0 +1,153 @@
+import { EventEmitter } from "node:events";
+import { existsSync, rmSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { killCliTree, spawnCli } from "../procs.ts";
+import { AntigravityAcpClient, validateAntigravityRuntime } from "./antigravity-acp.ts";
+import type { AntigravityRuntime } from "./antigravity-runtime.ts";
+
+const scratch = vi.hoisted(() => [] as string[]);
+vi.mock("../procs.ts", () => ({ spawnCli: vi.fn(), killCliTree: vi.fn() }));
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const fs = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...fs,
+    rm: vi.fn(fs.rm),
+    mkdtemp: async (...args: Parameters<typeof fs.mkdtemp>) => {
+      const directory = await fs.mkdtemp(...args);
+      scratch.push(String(directory));
+      return directory;
+    },
+  };
+});
+const realRm = (await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises")).rm;
+
+const runtime: AntigravityRuntime = {
+  executablePath: "/fixture/antigravity",
+  harnessPath: "/fixture/harness",
+  source: "managed",
+  version: "1.1.1",
+};
+const initialized = {
+  protocolVersion: 1,
+  agentInfo: { name: "antigravity-acp", version: "1.1.1" },
+  agentCapabilities: { loadSession: true, sessionCapabilities: { resume: {} }, auth: { logout: {} } },
+  authMethods: [{ id: "oauth-personal" }],
+};
+
+function fakeChild(reply: object | null = { result: initialized }) {
+  const child = Object.assign(new EventEmitter(), {
+    stdin: new PassThrough(), stdout: new PassThrough(), stderr: new PassThrough(),
+  });
+  child.stdin.on("data", (line) => {
+    if (reply === null) return;
+    const request = JSON.parse(String(line));
+    child.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, ...reply })}\n`);
+  });
+  vi.mocked(spawnCli).mockReturnValue(child as unknown as ReturnType<typeof spawnCli>);
+  return child;
+}
+
+function client() {
+  return new AntigravityAcpClient(runtime, { directory: "/fixture", tokenPath: "/fixture/token", environment: {} }, "/fixture");
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.mocked(spawnCli).mockReset();
+  vi.mocked(killCliTree).mockReset();
+  vi.mocked(rm).mockReset().mockImplementation(realRm);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  // Only mocked processes use these test profiles; no child is alive here.
+  for (const directory of scratch.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe("Antigravity validation shutdown", () => {
+  it.each(["kill EPERM", "spawn ENOENT"])("does not treat %s as close", async (message) => {
+    const child = fakeChild(null);
+    const acp = client();
+    let exited = false;
+    void acp.exited.then(() => { exited = true; });
+    const rejected = expect(acp.initialize()).rejects.toThrow(message);
+    child.emit("error", new Error(message));
+    await rejected;
+    expect(exited).toBe(false);
+
+    const stopping = acp.closeAndWait(100);
+    await vi.advanceTimersByTimeAsync(99);
+    expect(exited).toBe(false);
+    child.emit("close", message.startsWith("spawn") ? -2 : 0);
+    await expect(stopping).resolves.toBe(true);
+    expect(exited).toBe(true);
+    expect(killCliTree).toHaveBeenCalledWith(child);
+  });
+
+  it("times out without close and still observes a later close", async () => {
+    const child = fakeChild();
+    const acp = client();
+    const stopping = acp.closeAndWait(100);
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(stopping).resolves.toBe(false);
+    child.emit("close", 0);
+    await expect(acp.closeAndWait(100)).resolves.toBe(true);
+    expect(killCliTree).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a validated runtime that does not stop, leaving its profile intact", async () => {
+    fakeChild();
+    let killed!: () => void;
+    const stopping = new Promise<void>((resolve) => { killed = resolve; });
+    vi.mocked(killCliTree).mockImplementation(killed);
+    const validation = validateAntigravityRuntime(runtime, "1.1.1");
+    const rejected = expect(validation).rejects.toThrow("did not shut down");
+    await stopping;
+    await vi.advanceTimersByTimeAsync(5_000);
+    await rejected;
+    expect(rm).not.toHaveBeenCalled();
+    expect(existsSync(scratch[0])).toBe(true);
+  });
+
+  it.each([
+    { reply: { error: { message: "initialize failed" } }, error: "initialize failed" },
+    { reply: { result: {} }, error: "did not identify" },
+  ])("preserves $error when shutdown times out", async ({ reply, error }) => {
+    fakeChild(reply);
+    let killed!: () => void;
+    const stopping = new Promise<void>((resolve) => { killed = resolve; });
+    vi.mocked(killCliTree).mockImplementation(killed);
+    const rejected = expect(validateAntigravityRuntime(runtime, "1.1.1")).rejects.toThrow(error);
+    await stopping;
+    await vi.advanceTimersByTimeAsync(5_000);
+    await rejected;
+    expect(rm).not.toHaveBeenCalled();
+    expect(existsSync(scratch[0])).toBe(true);
+  });
+
+  it.each([
+    { reply: { error: { message: "initialize failed" } }, error: "initialize failed" },
+    { reply: { result: {} }, error: "did not identify" },
+  ])("preserves $error when profile cleanup fails after close", async ({ reply, error }) => {
+    const child = fakeChild(reply);
+    vi.mocked(killCliTree).mockImplementation(() => { child.emit("close", 0); });
+    vi.mocked(rm).mockRejectedValueOnce(Object.assign(new Error("cleanup EPERM"), { code: "EPERM" }));
+    await expect(validateAntigravityRuntime(runtime, "1.1.1")).rejects.toThrow(error);
+    expect(rm).toHaveBeenCalledWith(scratch[0], { recursive: true, force: true, maxRetries: 4, retryDelay: 250 });
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("cleanup EPERM"));
+  });
+
+  it("keeps successful validation when profile cleanup remains locked after close", async () => {
+    const child = fakeChild();
+    vi.mocked(killCliTree).mockImplementation(() => { child.emit("close", 0); });
+    vi.mocked(rm).mockRejectedValueOnce(Object.assign(new Error("cleanup EPERM"), { code: "EPERM" }));
+    await expect(validateAntigravityRuntime(runtime, "1.1.1")).resolves.toBeUndefined();
+    expect(rm).toHaveBeenCalledWith(scratch[0], { recursive: true, force: true, maxRetries: 4, retryDelay: 250 });
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining(`verification profile ${scratch[0]}: cleanup EPERM`));
+  });
+});

--- a/server/drivers/antigravity-runtime.test.ts
+++ b/server/drivers/antigravity-runtime.test.ts
@@ -1,0 +1,78 @@
+import { mkdirSync, mkdtempSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { removeTempDir } from "../testing/cleanup.ts";
+import { retryOnWindowsFileLock, sweepStaleStaging, transientWindowsFileError } from "./antigravity-runtime.ts";
+
+const withCode = (code: string) => Object.assign(new Error(code), { code });
+const scratch: string[] = [];
+afterEach(async () => {
+  for (const dir of scratch.splice(0)) await removeTempDir(dir);
+});
+
+describe("installing the Antigravity runtime on Windows", () => {
+  it("knows the refusals Windows gives for a file something still holds open", () => {
+    for (const code of ["EPERM", "EBUSY", "EACCES", "ENOTEMPTY"]) expect(transientWindowsFileError(withCode(code)), code).toBe(true);
+    expect(transientWindowsFileError(withCode("ENOENT"))).toBe(false);
+    expect(transientWindowsFileError(new Error("plain"))).toBe(false);
+    expect(transientWindowsFileError(null)).toBe(false);
+  });
+
+  it("retries a rename that Windows refuses while the runtime is still exiting, with growing delays", async () => {
+    const delays: number[] = [];
+    let calls = 0;
+    const result = await retryOnWindowsFileLock(
+      async () => {
+        calls += 1;
+        if (calls < 3) throw withCode("EPERM");
+        return "renamed";
+      },
+      { sleep: async (ms) => { delays.push(ms); } },
+    );
+    expect(result).toBe("renamed");
+    expect(calls).toBe(3);
+    expect(delays).toEqual([250, 500]);
+  });
+
+  it("gives up after the attempts with the original error, and never retries other errors", async () => {
+    let calls = 0;
+    await expect(retryOnWindowsFileLock(async () => {
+      calls += 1;
+      throw withCode("EBUSY");
+    }, { attempts: 4, sleep: async () => {} })).rejects.toMatchObject({ code: "EBUSY" });
+    expect(calls).toBe(4);
+
+    calls = 0;
+    await expect(retryOnWindowsFileLock(async () => {
+      calls += 1;
+      throw withCode("ENOENT");
+    }, { sleep: async () => {} })).rejects.toMatchObject({ code: "ENOENT" });
+    expect(calls).toBe(1);
+  });
+
+  it("caps the delay at two seconds so a long lock does not turn into a long wait per attempt", async () => {
+    const delays: number[] = [];
+    await expect(retryOnWindowsFileLock(async () => {
+      throw withCode("EPERM");
+    }, { attempts: 8, sleep: async (ms) => { delays.push(ms); } })).rejects.toMatchObject({ code: "EPERM" });
+    expect(delays).toEqual([250, 500, 1000, 2000, 2000, 2000, 2000]);
+  });
+
+  it("sweeps leftover .install- folders from earlier attempts and nothing else", async () => {
+    const versions = mkdtempSync(join(tmpdir(), "omb-antigravity-versions-"));
+    scratch.push(versions);
+    mkdirSync(join(versions, ".install-old-1", "runtime"), { recursive: true });
+    writeFileSync(join(versions, ".install-old-1", "runtime", "agy_acp_server.exe"), "x");
+    mkdirSync(join(versions, ".install-old-2"));
+    mkdirSync(join(versions, "abc123"));
+    writeFileSync(join(versions, "abc123", ".install-complete.json"), "{}");
+    const removed = await sweepStaleStaging(versions);
+    expect(removed).toBe(2);
+    expect(existsSync(join(versions, ".install-old-1"))).toBe(false);
+    expect(existsSync(join(versions, ".install-old-2"))).toBe(false);
+    expect(existsSync(join(versions, "abc123", ".install-complete.json"))).toBe(true);
+    expect(await sweepStaleStaging(join(versions, "does-not-exist"))).toBe(0);
+  });
+});

--- a/server/drivers/antigravity-runtime.test.ts
+++ b/server/drivers/antigravity-runtime.test.ts
@@ -1,16 +1,8 @@
-import { mkdirSync, mkdtempSync, writeFileSync, existsSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import { removeTempDir } from "../testing/cleanup.ts";
-import { retryOnWindowsFileLock, sweepStaleStaging, transientWindowsFileError } from "./antigravity-runtime.ts";
+import { retryOnWindowsFileLock, transientWindowsFileError } from "./antigravity-runtime.ts";
 
 const withCode = (code: string) => Object.assign(new Error(code), { code });
-const scratch: string[] = [];
-afterEach(async () => {
-  for (const dir of scratch.splice(0)) await removeTempDir(dir);
-});
 
 describe("installing the Antigravity runtime on Windows", () => {
   it("knows the refusals Windows gives for a file something still holds open", () => {
@@ -60,19 +52,4 @@ describe("installing the Antigravity runtime on Windows", () => {
     expect(delays).toEqual([250, 500, 1000, 2000, 2000, 2000, 2000]);
   });
 
-  it("sweeps leftover .install- folders from earlier attempts and nothing else", async () => {
-    const versions = mkdtempSync(join(tmpdir(), "omb-antigravity-versions-"));
-    scratch.push(versions);
-    mkdirSync(join(versions, ".install-old-1", "runtime"), { recursive: true });
-    writeFileSync(join(versions, ".install-old-1", "runtime", "agy_acp_server.exe"), "x");
-    mkdirSync(join(versions, ".install-old-2"));
-    mkdirSync(join(versions, "abc123"));
-    writeFileSync(join(versions, "abc123", ".install-complete.json"), "{}");
-    const removed = await sweepStaleStaging(versions);
-    expect(removed).toBe(2);
-    expect(existsSync(join(versions, ".install-old-1"))).toBe(false);
-    expect(existsSync(join(versions, ".install-old-2"))).toBe(false);
-    expect(existsSync(join(versions, "abc123", ".install-complete.json"))).toBe(true);
-    expect(await sweepStaleStaging(join(versions, "does-not-exist"))).toBe(0);
-  });
 });

--- a/server/drivers/antigravity-runtime.ts
+++ b/server/drivers/antigravity-runtime.ts
@@ -6,6 +6,7 @@ import {
   mkdir,
   mkdtemp,
   open,
+  readdir,
   readFile,
   rename,
   rm,
@@ -28,6 +29,62 @@ import {
 
 const FREE_SPACE_MARGIN = 256 * 1024 * 1024;
 const DOWNLOAD_TIMEOUT_MS = 45 * 60_000;
+const STAGING_PREFIX = ".install-";
+
+/** Windows refuses to rename or delete a file something still holds open,
+ * with EPERM/EBUSY/EACCES rather than a clear "in use": the runtime the
+ * validator just stopped (taskkill is asynchronous) or an antivirus scan of
+ * a brand-new executable. Both clear within seconds. */
+export function transientWindowsFileError(error: unknown): boolean {
+  const code = typeof error === "object" && error !== null ? Reflect.get(error, "code") : undefined;
+  return code === "EPERM" || code === "EBUSY" || code === "EACCES" || code === "ENOTEMPTY";
+}
+
+export interface RetryOptions {
+  attempts?: number;
+  delayMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/** Retry a filesystem step on the transient Windows refusals above, with
+ * growing delays (default: 8 tries, 0.25 s → 2 s, about 10 s in total).
+ * Anything else, and the final failure, surface unchanged. */
+export async function retryOnWindowsFileLock<T>(step: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
+  const attempts = options.attempts ?? 8;
+  const sleep = options.sleep ?? wait;
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await step();
+    } catch (error) {
+      if (attempt >= attempts || !transientWindowsFileError(error)) throw error;
+      await sleep(Math.min(2_000, (options.delayMs ?? 250) * 2 ** (attempt - 1)));
+    }
+  }
+}
+
+/** Best effort: leftovers of installs that died or lost their cleanup race
+ * (see the finally block below). Never fails the install that found them. */
+export async function sweepStaleStaging(versions: string, options: { log?: (line: string) => void } = {}): Promise<number> {
+  let removed = 0;
+  let entries: string[];
+  try {
+    entries = await readdir(versions);
+  } catch {
+    return 0;
+  }
+  for (const entry of entries) {
+    if (!entry.startsWith(STAGING_PREFIX)) continue;
+    try {
+      await rm(join(versions, entry), { recursive: true, force: true });
+      removed += 1;
+    } catch (error) {
+      options.log?.(`antigravity: could not remove stale install folder ${entry}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  return removed;
+}
 const INSTALL_RECORD = ".install-complete.json";
 
 export interface AntigravityRuntime {
@@ -355,7 +412,9 @@ async function installOnce(options: AntigravityInstallOptions): Promise<Antigrav
     // extraction checks still fail safely if the disk fills.
   }
 
-  const staging = await mkdtemp(join(versions, `.install-${randomUUID()}-`));
+  await sweepStaleStaging(versions, { log: (line) => console.warn(line) });
+  const staging = await mkdtemp(join(versions, `${STAGING_PREFIX}${randomUUID()}-`));
+  let failure: unknown = null;
   try {
     const archivePath = join(staging, "download.zip");
     const runtimeDirectory = join(staging, "runtime");
@@ -422,7 +481,7 @@ async function installOnce(options: AntigravityInstallOptions): Promise<Antigrav
     };
     await writeFile(join(runtimeDirectory, INSTALL_RECORD), `${JSON.stringify(record)}\n`, { flag: "wx", mode: 0o600 });
     try {
-      await rename(runtimeDirectory, destination);
+      await retryOnWindowsFileLock(() => rename(runtimeDirectory, destination));
     } catch (error) {
       const winner = await completedRelease(destination, asset);
       if (!winner) throw error;
@@ -430,8 +489,20 @@ async function installOnce(options: AntigravityInstallOptions): Promise<Antigrav
     const installed = await completedRelease(destination, asset);
     if (!installed) throw new Error("The installed Antigravity runtime is incomplete.");
     return installed;
+  } catch (error) {
+    failure = error;
+    throw error;
   } finally {
-    await rm(staging, { recursive: true, force: true });
+    // Cleanup must never replace the real error with its own: a user who
+    // saw "EPERM: unlink agy_acp_server.exe" was looking at this line, not
+    // at why the install failed. Retried, then logged and left for the
+    // sweep at the next install.
+    try {
+      await retryOnWindowsFileLock(() => rm(staging, { recursive: true, force: true }));
+    } catch (cleanupError) {
+      const detail = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+      console.warn(`antigravity: could not remove the install folder ${staging} (${detail})${failure ? "" : "; the install itself succeeded"}`);
+    }
   }
 }
 

--- a/server/drivers/antigravity-runtime.ts
+++ b/server/drivers/antigravity-runtime.ts
@@ -6,7 +6,6 @@ import {
   mkdir,
   mkdtemp,
   open,
-  readdir,
   readFile,
   rename,
   rm,
@@ -34,7 +33,7 @@ const STAGING_PREFIX = ".install-";
 /** Windows refuses to rename or delete a file something still holds open,
  * with EPERM/EBUSY/EACCES rather than a clear "in use": the runtime the
  * validator just stopped (taskkill is asynchronous) or an antivirus scan of
- * a brand-new executable. Both clear within seconds. */
+ * a brand-new executable. Retry briefly; persistent refusals still fail. */
 export function transientWindowsFileError(error: unknown): boolean {
   const code = typeof error === "object" && error !== null ? Reflect.get(error, "code") : undefined;
   return code === "EPERM" || code === "EBUSY" || code === "EACCES" || code === "ENOTEMPTY";
@@ -64,27 +63,6 @@ export async function retryOnWindowsFileLock<T>(step: () => Promise<T>, options:
   }
 }
 
-/** Best effort: leftovers of installs that died or lost their cleanup race
- * (see the finally block below). Never fails the install that found them. */
-export async function sweepStaleStaging(versions: string, options: { log?: (line: string) => void } = {}): Promise<number> {
-  let removed = 0;
-  let entries: string[];
-  try {
-    entries = await readdir(versions);
-  } catch {
-    return 0;
-  }
-  for (const entry of entries) {
-    if (!entry.startsWith(STAGING_PREFIX)) continue;
-    try {
-      await rm(join(versions, entry), { recursive: true, force: true });
-      removed += 1;
-    } catch (error) {
-      options.log?.(`antigravity: could not remove stale install folder ${entry}: ${error instanceof Error ? error.message : String(error)}`);
-    }
-  }
-  return removed;
-}
 const INSTALL_RECORD = ".install-complete.json";
 
 export interface AntigravityRuntime {
@@ -412,9 +390,10 @@ async function installOnce(options: AntigravityInstallOptions): Promise<Antigrav
     // extraction checks still fail safely if the disk fills.
   }
 
-  await sweepStaleStaging(versions, { log: (line) => console.warn(line) });
+  // Another app/server process may be installing into this versions folder.
+  // The in-memory coalescing map cannot protect its staging directory.
   const staging = await mkdtemp(join(versions, `${STAGING_PREFIX}${randomUUID()}-`));
-  let failure: unknown = null;
+  let failed = false;
   try {
     const archivePath = join(staging, "download.zip");
     const runtimeDirectory = join(staging, "runtime");
@@ -490,18 +469,18 @@ async function installOnce(options: AntigravityInstallOptions): Promise<Antigrav
     if (!installed) throw new Error("The installed Antigravity runtime is incomplete.");
     return installed;
   } catch (error) {
-    failure = error;
+    failed = true;
     throw error;
   } finally {
     // Cleanup must never replace the real error with its own: a user who
     // saw "EPERM: unlink agy_acp_server.exe" was looking at this line, not
-    // at why the install failed. Retried, then logged and left for the
-    // sweep at the next install.
+    // at why the install failed. Only clean up this attempt's directory;
+    // if it stays locked, log and leave it without touching other attempts.
     try {
       await retryOnWindowsFileLock(() => rm(staging, { recursive: true, force: true }));
     } catch (cleanupError) {
       const detail = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
-      console.warn(`antigravity: could not remove the install folder ${staging} (${detail})${failure ? "" : "; the install itself succeeded"}`);
+      console.warn(`antigravity: could not remove the install folder ${staging} (${detail})${failed ? "" : "; the install itself succeeded"}`);
     }
   }
 }

--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -10,10 +10,11 @@ import { recordEvents, type EventRecorder } from "../testing/events.ts";
 import { removeTempDir } from "../testing/cleanup.ts";
 import {
   ANTIGRAVITY_AUTH_PREFIX,
-  authorizationUrlFromLine,
+  AntigravityAcpClient,
   AntigravityAuthController,
-  antigravityProfileDirectory,
   antigravityProfileAuthenticated,
+  antigravityProfileDirectory,
+  authorizationUrlFromLine,
   catalogFromAntigravityConfigOptions,
   isValidAntigravityInitializeResult,
   parseAntigravityAuthorizationUrl,
@@ -132,6 +133,21 @@ createInterface({ input: process.stdin }).on('line', line => {
     } finally {
       controller.cancel();
     }
+  });
+});
+
+describe("stopping the runtime before touching its files", () => {
+  it("closeAndWait resolves only once the process is gone, so a rename on Windows cannot hit a running executable", async () => {
+    const fake = fakeRuntime();
+    const runtime = await resolveAntigravityRuntime(fake.executable);
+    const profile = await prepareAntigravityProfile({ instanceId: "close-and-wait", runtime, baseDir: fake.directory });
+    const client = new AntigravityAcpClient(runtime, profile, fake.directory);
+    await client.initialize();
+    expect(client.child.exitCode).toBeNull();
+    expect(await client.closeAndWait()).toBe(true);
+    expect(client.child.exitCode !== null || client.child.signalCode !== null).toBe(true);
+    // idempotent, and immediate the second time
+    expect(await client.closeAndWait(100)).toBe(true);
   });
 });
 

--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -2,12 +2,13 @@ import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, readdirS
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ensureDirs } from "../config.ts";
 import type { ProviderInstance } from "../contracts.ts";
 import { recordEvents, type EventRecorder } from "../testing/events.ts";
 import { removeTempDir } from "../testing/cleanup.ts";
+import * as procs from "../procs.ts";
 import {
   ANTIGRAVITY_AUTH_PREFIX,
   AntigravityAcpClient,
@@ -21,6 +22,7 @@ import {
   prepareAntigravityProfile,
   probeAntigravityModels,
   validateAntigravityCallbackUrl,
+  validateAntigravityRuntime,
 } from "./antigravity-acp.ts";
 import {
   ANTIGRAVITY_RELEASE_VERSION,
@@ -56,6 +58,8 @@ function fakeRuntime(startupDelayMs = 0): { directory: string; executable: strin
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
   delete process.env.FAKE_ACP_AUTH_METHOD;
   delete process.env.FAKE_ACP_MODELS;
   delete process.env.FAKE_ACP_MODES;
@@ -137,6 +141,26 @@ createInterface({ input: process.stdin }).on('line', line => {
 });
 
 describe("stopping the runtime before touching its files", () => {
+  it("validates a real fake runtime and waits for its process to close before returning", async () => {
+    const fake = fakeRuntime();
+    const runtime = await resolveAntigravityRuntime(fake.executable);
+    vi.stubEnv("FAKE_ACP_AGENT_NAME", "Google Antigravity");
+    vi.stubEnv("FAKE_ACP_AGENT_VERSION", "1.1.1");
+    vi.stubEnv("FAKE_ACP_AUTH_METHOD", "oauth-personal");
+    let sawClose = false;
+    const spawn = procs.spawnCli;
+    const spawned = vi.spyOn(procs, "spawnCli").mockImplementation((...args) => {
+      const child = spawn(...args);
+      child.once("close", () => { sawClose = true; });
+      return child;
+    });
+    await validateAntigravityRuntime(runtime, "agy_acp_server_1.1.1");
+    expect(spawned).toHaveBeenCalledTimes(1);
+    expect(sawClose).toBe(true);
+    const child = spawned.mock.results[0]!.value;
+    expect(child.exitCode !== null || child.signalCode !== null).toBe(true);
+  });
+
   it("closeAndWait resolves only once the process is gone, so a rename on Windows cannot hit a running executable", async () => {
     const fake = fakeRuntime();
     const runtime = await resolveAntigravityRuntime(fake.executable);
@@ -379,9 +403,14 @@ describe("official Antigravity runtime", () => {
     })).rejects.toThrow(/redirected outside/u);
   });
 
-  it("coalesces, verifies, extracts, and reuses a pinned managed download", async () => {
+  it("coalesces, verifies, extracts, and reuses a pinned download without touching another install", async () => {
     const baseDir = mkdtempSync(join(tmpdir(), "omb-antigravity-install-"));
     scratch.push(baseDir);
+    const versions = join(baseDir, "tools", "antigravity-acp", `${process.platform}-${process.arch}`, "versions");
+    const otherStaging = join(versions, ".install-other-active", "runtime");
+    mkdirSync(otherStaging, { recursive: true });
+    const otherFile = join(otherStaging, "agy_acp_server.exe");
+    writeFileSync(otherFile, "another app process is still installing");
     const archive = Buffer.from(
       "UEsDBBQAAAAIAMaAI13ihkXDEwAAABEAAAASAAAAYWd5X2FjcF9zZXJ2ZXIucGFyU1bUT8rM0y/O4EqtyCxRMOACAFBLAwQUAAAACADGgCNd4oZFwxMAAAARAAAAFQAAAGxvY2FsaGFybmVzc19leHRlcm5hbFNW1E/KzNMvzuBKrcgsUTDgAgBQSwECFAMUAAAACADGgCNd4oZFwxMAAAARAAAAEgAAAAAAAAAAAAAAgAEAAAAAYWd5X2FjcF9zZXJ2ZXIucGFyUEsBAhQDFAAAAAgAxoAjXeKGRcMTAAAAEQAAABUAAAAAAAAAAAAAAIABQwAAAGxvY2FsaGFybmVzc19leHRlcm5hbFBLBQYAAAAAAgACAIMAAACJAAAAAAA=",
       "base64",
@@ -413,6 +442,8 @@ describe("official Antigravity runtime", () => {
     await installAntigravityRuntime(options);
     expect(fetches).toBe(1);
     expect(validations).toBe(2);
+    expect(readFileSync(otherFile, "utf8")).toBe("another app process is still installing");
+    expect(readdirSync(versions).filter((name) => name.startsWith(".install-"))).toEqual([".install-other-active"]);
   });
 
   it("isolates profiles by instance and strips ambient Google credentials", async () => {


### PR DESCRIPTION
## Summary

Fix the Windows Antigravity installation failure reported as `EPERM: operation not permitted, unlink ...versions/.install-.../runtime/agy_acp_server.exe`.

The installer validates the extracted runtime by starting it. Windows process termination is asynchronous: moving/removing its staging folder before shutdown completes can hit a locked executable. A cleanup failure could then hide the original installation error.

## Changes

- Track actual child `close`, not arbitrary `error` events; failed spawn/kill errors do not prove shutdown.
- Wait up to five seconds for validation shutdown. An unconfirmed stop fails validation and cannot promote the candidate; its temporary profile is left untouched.
- Preserve the original initialization/identity failure if shutdown also fails.
- Retry transient filesystem refusals during rename and this attempt's staging cleanup. Retry temporary-profile cleanup only after confirmed shutdown; persistent cleanup failures are warned about without replacing the real outcome.
- Removed the proposed blanket `.install-*` sweep. Another app/server process may still own those files; cleanup only targets the unique directory this attempt created.
- Added regression coverage for timeout, failed-kill/spawn events, delayed close, cleanup error preservation, a foreign active staging folder, and actual fake-process close ordering.

## Verification

- 76 focused tests passed across Antigravity, process helpers, and the provider registry.
- Typecheck passed. Lint passed with existing unrelated warnings; no new warnings in the changed files.
- Isolated fake-engine app: doctor healthy, bot creation, send, settled turn, and transcript verified; fixture stopped and temporary data removed.
- Packaged-server smoke passed: starts without node_modules in reach, proxy paths resolve, and MCP stdio flushes final frames.
- Full local runtime suite passed: **3,941 tests**. The owner merged this PR while the final CI jobs were still running; this is not a claim that every CI job had completed at merge time.

## Scope and limits

This is a targeted installer/shutdown fix, not an Antigravity rewrite or a release/version bump. No user app data, accounts, or live processes were modified. Windows CI exercises the real taskkill path with a fake runtime; the customer's exact failure has not been reproduced on a physical Windows machine.

Original implementation by the PR author; maintainer hardening in `61c34b5b`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows runtime installation reliability when files are temporarily locked.
  * Prevented installation updates from failing while the previous runtime process is still exiting.
  * Preserved the original initialization error when shutdown or profile cleanup also encounters a failure.
  * Added retries for transient file-operation errors while preserving terminal failures.
  * Avoided deleting profiles when runtime shutdown cannot be confirmed.

* **Tests**
  * Added coverage for Windows file-lock retries, cleanup behavior, and process shutdown handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->