### PR TITLE
feat(browser): agent-browser as the bots' browser engine (step 1: headless servers)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,6 +47,13 @@ jobs:
           # the renderer is served by the server itself (OMB_STATIC_DIR)
           docker exec omb curl -sf http://127.0.0.1:8799/ | grep -qi "<html" || { docker logs omb; echo "UI not served"; exit 1; }
           docker logs omb | tail -5
+      - name: Prove the non-root user can browse with the baked-in Chrome
+        run: |
+          set -euo pipefail
+          test "$(docker exec omb id -un)" = maus
+          timeout 45 docker exec omb agent-browser --session ci-browser open 'data:text/html,<title>OMB browser smoke</title><h1>Browser ready</h1>'
+          timeout 15 docker exec omb agent-browser --session ci-browser get title | grep -Fx 'OMB browser smoke'
+          timeout 15 docker exec omb agent-browser --session ci-browser close
       - name: Prove the server never binds a public interface
         # The loopback-trust model is the auth model, so the image must keep
         # the server unreachable from the container's own network. Probe from a

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,18 @@ COPY . .
 RUN pnpm build:server && pnpm exec vite build
 
 FROM node:24-bookworm-slim
+# Install Chrome's Bookworm libraries directly: agent-browser --with-deps
+# invokes sudo even as root, and this image deliberately does not ship sudo.
 # git + curl: agent CLIs shell out to git; curl backs the healthcheck
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl git \
+    libxcb-shm0 libx11-xcb1 libx11-6 libxcb1 libxext6 libxrandr2 \
+    libxcomposite1 libxcursor1 libxdamage1 libxfixes3 libxi6 libgtk-3-0 \
+    libpangocairo-1.0-0 libpango-1.0-0 libatk1.0-0 libcairo-gobject2 \
+    libcairo2 libgdk-pixbuf-2.0-0 libxrender1 libasound2 libfreetype6 \
+    libfontconfig1 libdbus-1-3 libnss3 libnss3-tools libnspr4 \
+    libatk-bridge2.0-0 libdrm2 libxkbcommon0 libatspi2.0-0 libcups2 \
+    libxshmfence1 libgbm1 fonts-noto-color-emoji fonts-noto-cjk fonts-freefont-ttf \
   && rm -rf /var/lib/apt/lists/* \
   && useradd --create-home --home-dir /data --shell /bin/bash maus
 WORKDIR /app
@@ -43,9 +52,13 @@ RUN if [ -n "$ENGINES" ]; then npm install -g $ENGINES; fi
 # Pin here and in server/browser-engine-release.ts together.
 ARG AGENT_BROWSER_VERSION=0.36.0
 RUN npm install -g agent-browser@${AGENT_BROWSER_VERSION} \
-  && agent-browser install --with-deps \
+  && HOME=/opt/openmausbot-browser agent-browser install \
+  && ln -s /opt/openmausbot-browser/.agent-browser/browsers/chrome-*/chrome /opt/openmausbot-browser/chrome \
   && agent-browser --version
+# Keep the baked-in browser outside both root's private home and /data,
+# which may be an existing mounted volume. Session state still lives in HOME.
 ENV HOME=/data \
+    AGENT_BROWSER_EXECUTABLE_PATH=/opt/openmausbot-browser/chrome \
     OMB_DATA_DIR=/data/.openmausbot \
     OMB_STATIC_DIR=/app/dist \
     OMB_PORT=8799 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,13 @@ COPY --from=build --chown=maus:maus /src/dist ./dist
 # Optional engine CLIs baked into the image (space-separated npm packages).
 ARG ENGINES=""
 RUN if [ -n "$ENGINES" ]; then npm install -g $ENGINES; fi
+# The bots' browser (docs/plans/browser-engine.md): the pinned agent-browser
+# and a Chrome for Testing with its libraries, so a server bot can browse.
+# Pin here and in server/browser-engine-release.ts together.
+ARG AGENT_BROWSER_VERSION=0.36.0
+RUN npm install -g agent-browser@${AGENT_BROWSER_VERSION} \
+  && agent-browser install --with-deps \
+  && agent-browser --version
 ENV HOME=/data \
     OMB_DATA_DIR=/data/.openmausbot \
     OMB_STATIC_DIR=/app/dist \

--- a/apps/docs/content/docs/self-hosting/deploy-vps.mdx
+++ b/apps/docs/content/docs/self-hosting/deploy-vps.mdx
@@ -106,6 +106,18 @@ npx openmausbot serve --tailscale
 
 Tailscale terminates HTTPS with its own certificate and the pairing link uses the server's MagicDNS name (`https://maus.tail1234.ts.net`). Only devices on your tailnet can reach it, which is a very good property for a server that can run tools.
 
+## Give the bots a browser (optional)
+
+Bots can browse on a server. Docker (path B) ships the engine and a Chrome in
+the image; for paths A and C run this once on the server:
+
+```sh
+sudo npx openmausbot browser install --with-deps   # Linux: also installs Chrome's system libraries
+```
+
+Then turn the browser on under Settings → Experimental, and per bot. Each bot
+gets its own isolated session whose logins persist across restarts.
+
 ## Sign the engines in
 
 Bots run on the engine CLIs installed on the server, using your accounts. Sign each one in once; the logins live under the server's data directory and survive restarts and updates.

--- a/docs/deploy-vps.md
+++ b/docs/deploy-vps.md
@@ -98,6 +98,18 @@ npx openmausbot serve --tailscale
 
 Tailscale terminates HTTPS with its own certificate and the pairing link uses the server's MagicDNS name (`https://maus.tail1234.ts.net`). Only devices on your tailnet can reach it, which is a very good property for a server that can run tools.
 
+## Give the bots a browser (optional)
+
+Bots can browse on a server. Docker (path B) ships the engine and a Chrome in
+the image; for paths A and C run this once on the server:
+
+```sh
+sudo npx openmausbot browser install --with-deps   # Linux: also installs Chrome's system libraries
+```
+
+Then turn the browser on under Settings → Experimental, and per bot. Each bot
+gets its own isolated session whose logins persist across restarts.
+
 ## Sign the engines in
 
 Bots run on the engine CLIs installed on the server, using your accounts. Sign each one in once; the logins live under the server's data directory and survive restarts and updates.

--- a/docs/plans/browser-engine.md
+++ b/docs/plans/browser-engine.md
@@ -1,0 +1,119 @@
+# One browser engine: agent-browser
+
+**Decision (Sep 6, 2026):** the bots' browser is [agent-browser](https://github.com/vercel-labs/agent-browser)
+(Vercel Labs, Apache-2.0), pinned, on every platform: macOS, Windows and Linux
+desktop, and headless servers. It replaces the Electron browser surface. The
+comparison behind the decision (Playwright MCP, Chrome DevTools MCP, Steel,
+Stagehand, browser-use, browserless, Lightpanda) is summarised at the end.
+
+## Why
+
+- **Windows has no browser today.** The Electron surface needs the renderer
+  sandbox, and Electron 43 exits before ready with it on Windows
+  (electron/electron#51761). A browser that is its own Chrome process, driven
+  over CDP, does not depend on that.
+- **Servers have no browser today.** `openmausbot serve` and the Docker stack
+  run without Electron, so `availableBrowserConnection()` is null and the
+  toggle is greyed.
+- **One engine, one contract.** A skill written on a Mac runs on a VPS.
+- **The login wall.** Every shipping agent product (ChatGPT agent, Browserbase
+  Live View, Cloudflare Browser Run) hands the browser to the human at a
+  sign-in or CAPTCHA and resumes. agent-browser's stream carries screencast
+  frames out and mouse/keyboard in, so we get watch-and-take-over on desktop
+  and server for the price of a canvas.
+
+## What agent-browser gives us
+
+- A Rust daemon over CDP; Chrome for Testing downloaded and verified by
+  `agent-browser install` (existing Chrome/Chromium/Brave detected).
+- Isolated, parallel **sessions** (`--session <id>`), with `--restore`
+  auto-saving cookies and localStorage under a stable key; persistent
+  profiles; reuse of the user's own Chrome profile on a desktop; auth state
+  import/export; an encrypted auth vault (`AGENT_BROWSER_ENCRYPTION_KEY`).
+- An MCP stdio server (`agent-browser mcp --tools core`) whose verbs match our
+  17 `browser_*` tools almost one to one.
+- A stream server: JPEG frames (latest-wins, configurable quality/fps), the
+  active URL, viewport metadata; `input_mouse` / keyboard messages back in
+  with per-client input priority.
+
+## Shape
+
+```
+bot turn ──MCP stdio──> agent-browser mcp (session = bot or shared profile) ──CDP──> Chrome
+web UI browser panel <──ws frames / input──> agent-browser stream server ────────────┘
+```
+
+Where it plugs in today: `browserIntegration()` in `server/index.ts` returns
+the MCP server spec mounted into a turn (`{command, args, env}`), guarded by
+the workspace flag (`features.browser`), the bot's own switch, and the
+engine's `capabilities.browserMcp`. With no desktop connection it returns
+null; the headless engine becomes the second source of a spec there.
+
+## Steps
+
+### 1. Headless engine (servers, and the fallback everywhere)
+
+- `server/browser-engine.ts`: resolve the pinned agent-browser binary
+  (`OMB_AGENT_BROWSER_PATH` → `$OMB_DATA_DIR/tools/agent-browser/<version>/` →
+  PATH); download from the GitHub release with per-platform SHA-256 pinned in
+  `server/browser-engine-release.ts` (same pattern as `antigravity-release.ts`
+  and `prepare-cloudflared.mjs`); ensure Chrome with `agent-browser install`;
+  report `unavailable` with the reason rather than degrading silently.
+- `browserIntegration()`: when no desktop connection exists and the engine is
+  available, return `{command: <binary>, args: ["mcp", "--tools", "core",
+  "--no-webmcp"], env: {AGENT_BROWSER_SESSION, AGENT_BROWSER_RESTORE: "1",
+  AGENT_BROWSER_ENCRYPTION_KEY, AGENT_BROWSER_HEADLESS: "1"}}`. Session id =
+  the bot's browser profile partition, or the bot id (own session).
+- Encryption key: generated once into `$OMB_DATA_DIR/browser-engine-key`
+  (0600), like the tunnel credentials.
+- Capability: the environment descriptor gains `capabilities.browser:
+  "desktop" | "headless" | "unavailable"` (+ reason), and the Settings toggle
+  and the per-bot switch key off it instead of `window.ogb.browser`.
+- Docker: `npm install -g agent-browser@<pinned>` and `agent-browser install
+  --with-deps` at build time, as root, before `USER maus`.
+- Tests: resolver and download pinning (stub server), the integration spec
+  (mutation-check the guards), an e2e turn against a fake `agent-browser`
+  binary that speaks MCP.
+
+### 2. Desktop, all three platforms
+
+- The same engine and spec on the desktop; `availableBrowserConnection()` and
+  the Electron surface (`electron/browser-surface.cjs`, `browser-platform.cjs`,
+  the Windows gate, preload `browser:*` IPC) are deleted.
+- Optional headed mode (`--headed`) so the bot's browser is a real window.
+- Browser profiles UI keeps its concepts (own session, shared named session)
+  and gains "use my Chrome profile" (`--profile <name>`).
+
+### 3. Watch and take over
+
+- The browser panel renders the session's stream on a canvas and forwards
+  mouse/keyboard as `input_mouse` / keyboard messages; the address bar shows
+  the streamed URL.
+- While a human is in control, the bot's `browser_screenshot`/`snapshot`
+  return "a person is using this browser" (the one protected-field rule we
+  keep, rebuilt as a check before screenshots).
+- Server: the stream is reached through the harness with the session cookie
+  (never a public port); desktop: loopback.
+
+### 4. Tool-name adapter
+
+A thin adapter presents our `browser_*` names over the `core` tools so
+existing skills keep working; then the desktop docs and skills are updated to
+the single vocabulary.
+
+## Not doing
+
+- Bundling Steel, browser-use or Playwright MCP. Power users can add any of
+  them as a custom MCP server today.
+- Anti-detection, proxies, CAPTCHA solving.
+
+## Comparison (Sep 6, 2026)
+
+| Candidate | Why not |
+|---|---|
+| Playwright MCP (Microsoft) | Runner-up; a config swap since both are MCP servers. 70+ tools to trim, one client per persistent profile, no stream. |
+| Chrome DevTools MCP (Google) | Debug/perf focus, usage statistics to Google by default, no per-bot sessions, no stream. |
+| Steel | Live view with takeover, but the self-hosted server runs one session at a time and needs an installed Chrome; a Node/Fastify service with nginx and a UI. |
+| Stagehand, browser-use, Skyvern | Agents or model-driven SDKs: a second model loop under our agents. |
+| browserless | SSPL / commercial licence. |
+| Lightpanda | Not Chrome (partial web compatibility), AGPL. |

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -31,10 +31,14 @@ Runs fully on a server:
   server-side anyway)
 - text-to-speech (with a key), the web UI (the server serves it itself)
 
+- a browser for bots, once the engine is installed on the server
+  (`npx openmausbot browser install`, or nothing to do in the Docker image,
+  which ships it): each bot gets its own isolated, persistent session.
+  Watching it live from the app is the next step (docs/plans/browser-engine.md).
+
 Desktop-only for now (needs the Mac/Linux app):
 
-- the built-in browser panel, the skill recorder, dictation/voice,
-  controlling the host desktop
+- the skill recorder, dictation/voice, controlling the host desktop
 
 ## Quickest: one command with Node
 

--- a/server/browser-engine-release.ts
+++ b/server/browser-engine-release.ts
@@ -1,0 +1,60 @@
+// The pinned agent-browser release the harness downloads for the bots'
+// browser (docs/plans/browser-engine.md). Digests were computed from the
+// GitHub release assets on 2026-09-06; bump the version and every digest
+// together, through a pull request whose end-to-end run exercises the binary.
+// The Dockerfile pins the same version.
+export const AGENT_BROWSER_VERSION = "0.36.0";
+
+export interface AgentBrowserReleaseAsset {
+  /** `<platform>-<arch>`; Linux adds `-musl` on Alpine-style systems. */
+  target: string;
+  /** File name on the GitHub release. */
+  asset: string;
+  sha256: string;
+  bytes: number;
+}
+
+const RELEASES = new Map<string, AgentBrowserReleaseAsset>([
+  [
+    "darwin-arm64",
+    { target: "darwin-arm64", asset: "agent-browser-darwin-arm64", sha256: "b2106ab39db0838e7b1772f7f26f760518de56d09053150c56f9dddf15af997d", bytes: 12363200 },
+  ],
+  [
+    "darwin-x64",
+    { target: "darwin-x64", asset: "agent-browser-darwin-x64", sha256: "45d9ac061a7d72e61eaff905326e2e19365f4dadb12142ea2f2d76d84689c708", bytes: 13510280 },
+  ],
+  [
+    "linux-arm64",
+    { target: "linux-arm64", asset: "agent-browser-linux-arm64", sha256: "aeb556addca3903601a433de1acad3ace1c9c61d170084bf58d875884599a990", bytes: 12442720 },
+  ],
+  [
+    "linux-musl-arm64",
+    { target: "linux-musl-arm64", asset: "agent-browser-linux-musl-arm64", sha256: "1ca7e003c9cb185f174fc81e51a609db27c77e3bfe00a0edff60688f8cd14f88", bytes: 12297000 },
+  ],
+  [
+    "linux-musl-x64",
+    { target: "linux-musl-x64", asset: "agent-browser-linux-musl-x64", sha256: "a20cc2a5202a48f5820372803dedbcd5f556dff7a89421f1b0f2612962b10718", bytes: 13995728 },
+  ],
+  [
+    "linux-x64",
+    { target: "linux-x64", asset: "agent-browser-linux-x64", sha256: "56d15181e51e00213f907fcf39707cfc76bfa804ff20f5a9373661c73f96de5e", bytes: 14156776 },
+  ],
+  [
+    "win32-x64",
+    { target: "win32-x64", asset: "agent-browser-win32-x64.exe", sha256: "412ff72737a109e93f5304b0ff76c988fb6f1f451d0fc7e010577922bcc20ff3", bytes: 13837312 },
+  ],
+]);
+
+export function agentBrowserReleaseUrl(asset: AgentBrowserReleaseAsset): string {
+  return `https://github.com/vercel-labs/agent-browser/releases/download/v${AGENT_BROWSER_VERSION}/${asset.asset}`;
+}
+
+/** The asset for this machine, or null where Vercel publishes none. */
+export function resolveAgentBrowserReleaseAsset(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+  musl = false,
+): AgentBrowserReleaseAsset | null {
+  const key = platform === "linux" && musl ? `linux-musl-${arch}` : `${platform}-${arch}`;
+  return RELEASES.get(key) ?? null;
+}

--- a/server/browser-engine.test.ts
+++ b/server/browser-engine.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
@@ -27,23 +27,27 @@ describe("finding the browser engine", () => {
   it("prefers the explicit path, then the pinned download, then PATH, and reports why when nothing is there", () => {
     const dataDir = mkdtempSync(join(tmpdir(), "omb-engine-"));
     scratch.push(dataDir);
-    const pinned = pinnedBinaryPath(dataDir, "linux");
+    const pinned = pinnedBinaryPath(dataDir);
+    const name = process.platform === "win32" ? "agent-browser.exe" : "agent-browser";
+    const pathDir = join(dataDir, "bin");
+    const pathBinary = join(pathDir, name);
+    const override = join(dataDir, "override", name);
     const files = new Set<string>();
     const exists = (p: string) => files.has(p);
-    const env = { PATH: "/usr/local/bin:/usr/bin" };
+    const env = { PATH: [join(dataDir, "empty"), pathDir].join(delimiter) };
 
-    expect(resolveAgentBrowserBinary({ dataDir, env, platform: "linux", exists })).toBeNull();
-    expect(browserEngineStatus({ dataDir, env, platform: "linux", exists })).toMatchObject({ kind: "unavailable", installable: true });
+    expect(resolveAgentBrowserBinary({ dataDir, env, exists })).toBeNull();
+    expect(browserEngineStatus({ dataDir, env, exists })).toMatchObject({ kind: "unavailable", installable: true });
 
-    files.add("/usr/bin/agent-browser");
-    expect(resolveAgentBrowserBinary({ dataDir, env, platform: "linux", exists })).toBe("/usr/bin/agent-browser");
+    files.add(pathBinary);
+    expect(resolveAgentBrowserBinary({ dataDir, env, exists })).toBe(pathBinary);
     files.add(pinned);
-    expect(resolveAgentBrowserBinary({ dataDir, env, platform: "linux", exists })).toBe(pinned);
-    files.add("/opt/ab/agent-browser");
-    expect(resolveAgentBrowserBinary({ dataDir, env: { ...env, OMB_AGENT_BROWSER_PATH: "/opt/ab/agent-browser" }, platform: "linux", exists })).toBe("/opt/ab/agent-browser");
+    expect(resolveAgentBrowserBinary({ dataDir, env, exists })).toBe(pinned);
+    files.add(override);
+    expect(resolveAgentBrowserBinary({ dataDir, env: { ...env, OMB_AGENT_BROWSER_PATH: override }, exists })).toBe(override);
     // an override that does not exist is an error, not a silent fallback
-    expect(resolveAgentBrowserBinary({ dataDir, env: { ...env, OMB_AGENT_BROWSER_PATH: "/nope/agent-browser" }, platform: "linux", exists })).toBeNull();
-    expect(browserEngineStatus({ dataDir, env, platform: "linux", exists })).toMatchObject({ kind: "ready", binaryPath: pinned, version: AGENT_BROWSER_VERSION });
+    expect(resolveAgentBrowserBinary({ dataDir, env: { ...env, OMB_AGENT_BROWSER_PATH: join(dataDir, "missing", name) }, exists })).toBeNull();
+    expect(browserEngineStatus({ dataDir, env, exists })).toMatchObject({ kind: "ready", binaryPath: pinned, version: AGENT_BROWSER_VERSION });
   });
 
   it("knows every target Vercel publishes, and picks the musl build on Alpine", () => {

--- a/server/browser-engine.test.ts
+++ b/server/browser-engine.test.ts
@@ -1,0 +1,126 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  agentBrowserIntegration,
+  browserEngineEncryptionKey,
+  browserEngineStatus,
+  browserSessionId,
+  installAgentBrowserBinary,
+  isMusl,
+  pinnedBinaryPath,
+  resolveAgentBrowserBinary,
+} from "./browser-engine.ts";
+import { AGENT_BROWSER_VERSION, agentBrowserReleaseUrl, resolveAgentBrowserReleaseAsset } from "./browser-engine-release.ts";
+import { removeTempDir } from "./testing/cleanup.ts";
+
+const posix = process.platform !== "win32";
+const scratch: string[] = [];
+afterEach(async () => {
+  for (const dir of scratch.splice(0)) await removeTempDir(dir);
+});
+
+describe("finding the browser engine", () => {
+  it("prefers the explicit path, then the pinned download, then PATH, and reports why when nothing is there", () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "omb-engine-"));
+    scratch.push(dataDir);
+    const pinned = pinnedBinaryPath(dataDir, "linux");
+    const files = new Set<string>();
+    const exists = (p: string) => files.has(p);
+    const env = { PATH: "/usr/local/bin:/usr/bin" };
+
+    expect(resolveAgentBrowserBinary({ dataDir, env, platform: "linux", exists })).toBeNull();
+    expect(browserEngineStatus({ dataDir, env, platform: "linux", exists })).toMatchObject({ kind: "unavailable", installable: true });
+
+    files.add("/usr/bin/agent-browser");
+    expect(resolveAgentBrowserBinary({ dataDir, env, platform: "linux", exists })).toBe("/usr/bin/agent-browser");
+    files.add(pinned);
+    expect(resolveAgentBrowserBinary({ dataDir, env, platform: "linux", exists })).toBe(pinned);
+    files.add("/opt/ab/agent-browser");
+    expect(resolveAgentBrowserBinary({ dataDir, env: { ...env, OMB_AGENT_BROWSER_PATH: "/opt/ab/agent-browser" }, platform: "linux", exists })).toBe("/opt/ab/agent-browser");
+    // an override that does not exist is an error, not a silent fallback
+    expect(resolveAgentBrowserBinary({ dataDir, env: { ...env, OMB_AGENT_BROWSER_PATH: "/nope/agent-browser" }, platform: "linux", exists })).toBeNull();
+    expect(browserEngineStatus({ dataDir, env, platform: "linux", exists })).toMatchObject({ kind: "ready", binaryPath: pinned, version: AGENT_BROWSER_VERSION });
+  });
+
+  it("knows every target Vercel publishes, and picks the musl build on Alpine", () => {
+    for (const [platform, arch] of [["darwin", "arm64"], ["darwin", "x64"], ["linux", "x64"], ["linux", "arm64"], ["win32", "x64"]] as const) {
+      const asset = resolveAgentBrowserReleaseAsset(platform, arch);
+      expect(asset, `${platform}-${arch}`).not.toBeNull();
+      expect(asset?.sha256).toMatch(/^[0-9a-f]{64}$/u);
+      expect(agentBrowserReleaseUrl(asset!)).toContain(`/v${AGENT_BROWSER_VERSION}/`);
+    }
+    expect(resolveAgentBrowserReleaseAsset("linux", "x64", true)?.target).toBe("linux-musl-x64");
+    expect(resolveAgentBrowserReleaseAsset("freebsd", "x64")).toBeNull();
+    expect(isMusl("linux", (p) => p === "/lib/ld-musl-x86_64.so.1")).toBe(true);
+    expect(isMusl("linux", () => false)).toBe(false);
+    expect(isMusl("darwin", () => true)).toBe(false);
+  });
+});
+
+describe("installing the browser engine", () => {
+  it("downloads the pinned asset, verifies size and digest, and only then names the file", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "omb-engine-install-"));
+    scratch.push(dataDir);
+    const body = Buffer.from("#!/bin/sh\necho agent-browser\n");
+    const asset = { target: "linux-x64", asset: "agent-browser-linux-x64", sha256: createHash("sha256").update(body).digest("hex"), bytes: body.length };
+    const fetched: string[] = [];
+    const installed = await installAgentBrowserBinary({
+      dataDir,
+      platform: "linux",
+      asset,
+      fetchImpl: async (input) => {
+        fetched.push(String(input));
+        return new Response(body);
+      },
+    });
+    expect(installed).toBe(pinnedBinaryPath(dataDir, "linux"));
+    expect(fetched[0]).toBe(agentBrowserReleaseUrl(asset));
+    expect(readFileSync(installed, "utf8")).toContain("agent-browser");
+    if (posix) expect(statSync(installed).mode & 0o111).not.toBe(0);
+  });
+
+  it("refuses a download whose bytes do not match the pin, and leaves nothing behind", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "omb-engine-bad-"));
+    scratch.push(dataDir);
+    const asset = { target: "linux-x64", asset: "agent-browser-linux-x64", sha256: "a".repeat(64), bytes: 5 };
+    await expect(installAgentBrowserBinary({ dataDir, platform: "linux", asset, fetchImpl: async () => new Response(Buffer.from("hello")) })).rejects.toThrow(/SHA-256/u);
+    await expect(installAgentBrowserBinary({ dataDir, platform: "linux", asset, fetchImpl: async () => new Response(Buffer.from("hi")) })).rejects.toThrow(/pinned size/u);
+    expect(() => statSync(pinnedBinaryPath(dataDir, "linux"))).toThrow();
+  });
+});
+
+describe("what a bot gets", () => {
+  it("mounts agent-browser's MCP server with the core tools, an isolated auto-restored session, and WebMCP off", () => {
+    const spec = agentBrowserIntegration({ binaryPath: "/x/agent-browser", session: "bot-1", encryptionKey: "k".repeat(64), env: { PATH: "/usr/bin" } });
+    expect(spec.command).toBe("/x/agent-browser");
+    expect(spec.args).toEqual(["mcp", "--tools", "core", "--no-webmcp"]);
+    expect(spec.env).toMatchObject({ AGENT_BROWSER_SESSION: "bot-1", AGENT_BROWSER_RESTORE: "1", AGENT_BROWSER_HEADLESS: "1", PATH: "/usr/bin" });
+    expect(spec.env.AGENT_BROWSER_ENCRYPTION_KEY).toBe("k".repeat(64));
+    expect(agentBrowserIntegration({ binaryPath: "/x", session: "s", encryptionKey: "k", headless: false }).env.AGENT_BROWSER_HEADLESS).toBeUndefined();
+  });
+
+  it("names sessions after the shared profile, else the bot, in shell-safe form", () => {
+    expect(browserSessionId("bot-a", "")).toBe("bot-bot-a");
+    expect(browserSessionId("bot-a", "work partition/1")).toBe("work_partition_1");
+    expect(browserSessionId("b", "x".repeat(200))).toHaveLength(96);
+  });
+
+  it("makes one encryption key per data dir, private, and reuses it", () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "omb-engine-key-"));
+    scratch.push(dataDir);
+    const key = browserEngineEncryptionKey(dataDir);
+    expect(key).toMatch(/^[0-9a-f]{64}$/u);
+    expect(browserEngineEncryptionKey(dataDir)).toBe(key);
+    if (posix) expect(statSync(join(dataDir, "browser-engine-key")).mode & 0o777).toBe(0o600);
+    // a corrupted key file is replaced, never reused
+    writeFileSync(join(dataDir, "browser-engine-key"), "garbage\n");
+    const fresh = browserEngineEncryptionKey(dataDir);
+    expect(fresh).toMatch(/^[0-9a-f]{64}$/u);
+    expect(fresh).not.toBe(key);
+    mkdirSync(join(dataDir, "unused"));
+  });
+});

--- a/server/browser-engine.test.ts
+++ b/server/browser-engine.test.ts
@@ -102,9 +102,19 @@ describe("what a bot gets", () => {
     const spec = agentBrowserIntegration({ binaryPath: "/x/agent-browser", session: "bot-1", encryptionKey: "k".repeat(64), env: { PATH: "/usr/bin" } });
     expect(spec.command).toBe("/x/agent-browser");
     expect(spec.args).toEqual(["mcp", "--tools", "core", "--no-webmcp"]);
-    expect(spec.env).toMatchObject({ AGENT_BROWSER_SESSION: "bot-1", AGENT_BROWSER_RESTORE: "1", AGENT_BROWSER_HEADLESS: "1", PATH: "/usr/bin" });
+    expect(spec.env).toMatchObject({ AGENT_BROWSER_SESSION: "bot-1", AGENT_BROWSER_RESTORE: "bot-1", AGENT_BROWSER_RESTORE_SAVE: "auto", AGENT_BROWSER_HEADLESS: "1", PATH: "/usr/bin" });
     expect(spec.env.AGENT_BROWSER_ENCRYPTION_KEY).toBe("k".repeat(64));
     expect(agentBrowserIntegration({ binaryPath: "/x", session: "s", encryptionKey: "k", headless: false }).env.AGENT_BROWSER_HEADLESS).toBeUndefined();
+  });
+
+  it("keeps saved state separate for different bots and never saves guest state", () => {
+    const spec = (session: string, persistent = true) => agentBrowserIntegration({ binaryPath: "/x", session, encryptionKey: "k", persistent });
+    expect(spec("bot-a").env.AGENT_BROWSER_RESTORE).not.toBe(spec("bot-b").env.AGENT_BROWSER_RESTORE);
+    const first = browserSessionId("bot-a", "guest");
+    const second = browserSessionId("bot-a", "guest");
+    expect(first).toMatch(/^guest-[a-f0-9-]+$/u);
+    expect(first).not.toBe(second);
+    expect(spec(first, false).env).toMatchObject({ AGENT_BROWSER_RESTORE: first, AGENT_BROWSER_RESTORE_SAVE: "never" });
   });
 
   it("names sessions after the shared profile, else the bot, in shell-safe form", () => {

--- a/server/browser-engine.ts
+++ b/server/browser-engine.ts
@@ -9,7 +9,7 @@
 // Fail closed, say why: a missing engine reports `unavailable` with a
 // reason a person can act on, never a silently browserless bot.
 import { spawn } from "node:child_process";
-import { createHash, randomBytes } from "node:crypto";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
 import { delimiter, join, resolve } from "node:path";
 
@@ -171,12 +171,17 @@ export function agentBrowserIntegration(input: {
   binaryPath: string;
   session: string;
   encryptionKey: string;
+  /** Guest sessions must never save cookies or localStorage to disk. */
+  persistent?: boolean;
   headless?: boolean;
   env?: NodeJS.ProcessEnv;
 }): { command: string; args: string[]; env: Record<string, string> } {
   const env: Record<string, string> = {
     AGENT_BROWSER_SESSION: input.session,
-    AGENT_BROWSER_RESTORE: "1",
+    // This is a restore *name*, not a boolean. "1" would give every bot
+    // the same saved cookies despite using different daemon sessions.
+    AGENT_BROWSER_RESTORE: input.session,
+    AGENT_BROWSER_RESTORE_SAVE: input.persistent === false ? "never" : "auto",
     AGENT_BROWSER_ENCRYPTION_KEY: input.encryptionKey,
   };
   if (input.headless !== false) env.AGENT_BROWSER_HEADLESS = "1";
@@ -187,6 +192,7 @@ export function agentBrowserIntegration(input: {
 
 /** Session ids are file-system and shell safe: a bot id or a profile partition. */
 export function browserSessionId(botId: string, partitionId: string): string {
+  if (partitionId === "guest") return `guest-${randomUUID()}`;
   const raw = partitionId || `bot-${botId}`;
   return raw.replace(/[^A-Za-z0-9_.-]/gu, "_").slice(0, 96);
 }

--- a/server/browser-engine.ts
+++ b/server/browser-engine.ts
@@ -1,0 +1,207 @@
+// The bots' browser engine: agent-browser (docs/plans/browser-engine.md).
+//
+// One engine on every platform. This module answers three questions for the
+// harness: is the engine here (and if not, why), how does a bot get it as an
+// MCP server for a turn, and where does the session state live. Everything
+// that runs Chrome is agent-browser's; we resolve a pinned binary (or fetch
+// it, verified), make sure it has a Chrome, and hand a turn the spec.
+//
+// Fail closed, say why: a missing engine reports `unavailable` with a
+// reason a person can act on, never a silently browserless bot.
+import { spawn } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { delimiter, join, resolve } from "node:path";
+
+import { writeFileAtomic } from "./atomic.ts";
+import { DATA_DIR } from "./config.ts";
+import {
+  AGENT_BROWSER_VERSION,
+  agentBrowserReleaseUrl,
+  resolveAgentBrowserReleaseAsset,
+  type AgentBrowserReleaseAsset,
+} from "./browser-engine-release.ts";
+
+const ENGINE_DIR = "tools/agent-browser";
+const KEY_FILE = "browser-engine-key";
+const DOWNLOAD_TIMEOUT_MS = 10 * 60_000;
+
+export type BrowserEngineStatus =
+  | { kind: "ready"; binaryPath: string; version: string }
+  | { kind: "unavailable"; reason: string; installable: boolean };
+
+function executableName(platform: NodeJS.Platform = process.platform): string {
+  return platform === "win32" ? "agent-browser.exe" : "agent-browser";
+}
+
+/** Alpine-style systems need the musl build. */
+export function isMusl(platform: NodeJS.Platform = process.platform, exists: (p: string) => boolean = existsSync): boolean {
+  return platform === "linux" && (exists("/lib/ld-musl-x86_64.so.1") || exists("/lib/ld-musl-aarch64.so.1"));
+}
+
+export function pinnedBinaryPath(dataDir = DATA_DIR, platform: NodeJS.Platform = process.platform): string {
+  return join(dataDir, ENGINE_DIR, AGENT_BROWSER_VERSION, executableName(platform));
+}
+
+function onPath(env: NodeJS.ProcessEnv, platform: NodeJS.Platform, exists: (p: string) => boolean): string | null {
+  const pathValue = platform === "win32"
+    ? Object.entries(env).findLast(([key]) => key.toUpperCase() === "PATH")?.[1]
+    : env.PATH;
+  for (const part of (pathValue ?? "").split(delimiter)) {
+    const dir = part.trim().replace(/^"|"$/gu, "");
+    if (!dir) continue;
+    const candidate = resolve(dir, executableName(platform));
+    if (exists(candidate)) return candidate;
+  }
+  return null;
+}
+
+/** OMB_AGENT_BROWSER_PATH, then the pinned download under the data dir, then
+ * PATH (a package or image that installed it globally). */
+export function resolveAgentBrowserBinary(options: {
+  dataDir?: string;
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  exists?: (p: string) => boolean;
+} = {}): string | null {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const exists = options.exists ?? existsSync;
+  const override = env.OMB_AGENT_BROWSER_PATH?.trim();
+  if (override) return resolve(override) && exists(resolve(override)) ? resolve(override) : null;
+  const pinned = pinnedBinaryPath(options.dataDir, platform);
+  if (exists(pinned)) return pinned;
+  return onPath(env, platform, exists);
+}
+
+/** Download the pinned release asset for this machine into the data dir,
+ * verifying size and SHA-256 before the file gets its final name. */
+export async function installAgentBrowserBinary(options: {
+  dataDir?: string;
+  platform?: NodeJS.Platform;
+  arch?: string;
+  musl?: boolean;
+  /** Tests pin their own asset; production always resolves the release table. */
+  asset?: AgentBrowserReleaseAsset;
+  fetchImpl?: typeof fetch;
+  log?: (line: string) => void;
+} = {}): Promise<string> {
+  const platform = options.platform ?? process.platform;
+  const asset = options.asset ?? resolveAgentBrowserReleaseAsset(platform, options.arch ?? process.arch, options.musl ?? isMusl(platform));
+  if (!asset) throw new Error(`agent-browser publishes no build for ${platform}-${options.arch ?? process.arch}.`);
+  const destination = pinnedBinaryPath(options.dataDir, platform);
+  const directory = join(destination, "..");
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const url = agentBrowserReleaseUrl(asset);
+  options.log?.(`downloading agent-browser ${AGENT_BROWSER_VERSION} (${Math.round(asset.bytes / 1024 / 1024)} MB, digest pinned)`);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
+  timer.unref?.();
+  let body: Buffer;
+  try {
+    const response = await (options.fetchImpl ?? fetch)(url, { redirect: "follow", signal: controller.signal });
+    if (!response.ok) throw new Error(`the agent-browser download failed (HTTP ${response.status})`);
+    body = Buffer.from(await response.arrayBuffer());
+  } finally {
+    clearTimeout(timer);
+  }
+  if (body.length !== asset.bytes) throw new Error("the agent-browser download did not match its pinned size; nothing was installed");
+  const digest = createHash("sha256").update(body).digest("hex");
+  if (digest !== asset.sha256) throw new Error("the agent-browser download failed its SHA-256 check; nothing was installed");
+  const staging = `${destination}.${randomBytes(6).toString("hex")}.part`;
+  writeFileSync(staging, body, { mode: 0o755 });
+  if (platform !== "win32") chmodSync(staging, 0o755);
+  renameSync(staging, destination);
+  return destination;
+}
+
+/** `agent-browser install` fetches Chrome for Testing when no Chrome, Chromium
+ * or Brave is found; `--with-deps` adds the Linux libraries (needs a package
+ * manager and privileges, so it is for images and root shells). */
+export function ensureChrome(binaryPath: string, options: { withDeps?: boolean; env?: NodeJS.ProcessEnv; log?: (line: string) => void } = {}): Promise<void> {
+  const args = ["install", ...(options.withDeps ? ["--with-deps"] : [])];
+  return new Promise((done, fail) => {
+    const child = spawn(binaryPath, args, { env: options.env ?? process.env, stdio: ["ignore", "pipe", "pipe"], windowsHide: true });
+    let output = "";
+    child.stdout?.on("data", (chunk) => { output += String(chunk); });
+    child.stderr?.on("data", (chunk) => { output += String(chunk); });
+    child.on("error", fail);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        options.log?.("agent-browser: Chrome is ready");
+        done();
+      } else {
+        fail(new Error(`agent-browser install exited ${code ?? "by signal"}: ${output.trim().split("\n").slice(-3).join(" ")}`));
+      }
+    });
+  });
+}
+
+/** The key agent-browser uses to encrypt saved session state at rest. Made
+ * once, 0600, beside the rest of the data dir's secrets. */
+export function browserEngineEncryptionKey(dataDir = DATA_DIR): string {
+  const file = join(dataDir, KEY_FILE);
+  try {
+    const existing = readFileSync(file, "utf8").trim();
+    if (/^[0-9a-f]{64}$/u.test(existing)) return existing;
+  } catch {
+    // first run
+  }
+  const key = randomBytes(32).toString("hex");
+  mkdirSync(dataDir, { recursive: true });
+  writeFileAtomic(file, `${key}\n`, { mode: 0o600 });
+  return key;
+}
+
+/** What the harness can offer bots right now, with the reason when nothing. */
+export function browserEngineStatus(options: { dataDir?: string; env?: NodeJS.ProcessEnv; platform?: NodeJS.Platform; exists?: (p: string) => boolean } = {}): BrowserEngineStatus {
+  const binaryPath = resolveAgentBrowserBinary(options);
+  if (binaryPath) return { kind: "ready", binaryPath, version: AGENT_BROWSER_VERSION };
+  const platform = options.platform ?? process.platform;
+  const asset = resolveAgentBrowserReleaseAsset(platform, process.arch, isMusl(platform));
+  return asset
+    ? { kind: "unavailable", reason: "agent-browser is not installed on this machine yet", installable: true }
+    : { kind: "unavailable", reason: `agent-browser publishes no build for ${platform}-${process.arch}`, installable: false };
+}
+
+/** The MCP server a turn mounts so the bot gets browser tools. One isolated,
+ * auto-restored session per browser profile (or per bot), page-provided
+ * WebMCP tools off, and only the core tool set. */
+export function agentBrowserIntegration(input: {
+  binaryPath: string;
+  session: string;
+  encryptionKey: string;
+  headless?: boolean;
+  env?: NodeJS.ProcessEnv;
+}): { command: string; args: string[]; env: Record<string, string> } {
+  const env: Record<string, string> = {
+    AGENT_BROWSER_SESSION: input.session,
+    AGENT_BROWSER_RESTORE: "1",
+    AGENT_BROWSER_ENCRYPTION_KEY: input.encryptionKey,
+  };
+  if (input.headless !== false) env.AGENT_BROWSER_HEADLESS = "1";
+  const path = (input.env ?? process.env).PATH;
+  if (path) env.PATH = path;
+  return { command: input.binaryPath, args: ["mcp", "--tools", "core", "--no-webmcp"], env };
+}
+
+/** Session ids are file-system and shell safe: a bot id or a profile partition. */
+export function browserSessionId(botId: string, partitionId: string): string {
+  const raw = partitionId || `bot-${botId}`;
+  return raw.replace(/[^A-Za-z0-9_.-]/gu, "_").slice(0, 96);
+}
+
+export function describeBrowserEngine(status: BrowserEngineStatus): string {
+  return status.kind === "ready"
+    ? `browser engine: agent-browser ${status.version} at ${status.binaryPath}`
+    : `browser engine: unavailable (${status.reason})`;
+}
+
+// Kept for callers that want a file check without a full status.
+export function agentBrowserBinaryExists(dataDir = DATA_DIR): boolean {
+  try {
+    return statSync(pinnedBinaryPath(dataDir)).isFile();
+  } catch {
+    return false;
+  }
+}

--- a/server/cli.test.ts
+++ b/server/cli.test.ts
@@ -27,6 +27,9 @@ describe("openmausbot command line", () => {
     expect(parseArgs(["serve", "--tunnel"], {})).toMatchObject({ command: "serve", tunnel: true });
     expect(parseArgs(["login", "--email", "a@b.test"], {})).toMatchObject({ command: "login", email: "a@b.test" });
     expect(parseArgs(["logout"], {})).toMatchObject({ command: "logout" });
+    expect(parseArgs(["browser", "install", "--with-deps"], {})).toMatchObject({ command: "browser", browserAction: "install", withDeps: true });
+    expect(parseArgs(["browser", "status"], {})).toMatchObject({ command: "browser", browserAction: "status" });
+    expect(parseArgs(["browser"], {})).toEqual({ error: "browser needs an action: install or status" });
     expect(parseArgs(["serve", "--tailscale", "--tunnel"], {})).toEqual({ error: "choose one of --tailscale (your tailnet) and --tunnel (a public address)" });
   });
 

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -30,6 +30,13 @@ import qrcode from "qrcode-terminal";
 
 import { explainTailscaleFailure, tailscaleServe, tailscaleServeOff, tailscaleStatus, type TailscaleStatus } from "./tailscale.ts";
 import {
+  browserEngineStatus,
+  describeBrowserEngine,
+  ensureChrome,
+  installAgentBrowserBinary,
+  resolveAgentBrowserBinary,
+} from "./browser-engine.ts";
+import {
   cleanupTunnelOrigin,
   createTunnelAccount,
   createTunnelOrigin,
@@ -47,7 +54,7 @@ import {
 const HERE = dirname(fileURLToPath(import.meta.url));
 
 export interface CliOptions {
-  command: "serve" | "pair" | "sessions" | "status" | "login" | "logout" | "help";
+  command: "serve" | "pair" | "sessions" | "status" | "login" | "logout" | "browser" | "help";
   port: number;
   dataDir: string;
   label?: string;
@@ -58,10 +65,13 @@ export interface CliOptions {
   pair: boolean;
   revoke?: string;
   email?: string;
+  /** `browser install [--with-deps]` */
+  browserAction?: "install" | "status";
+  withDeps?: boolean;
   json: boolean;
 }
 
-const COMMANDS = ["serve", "pair", "sessions", "status", "login", "logout", "help", "--help", "-h"];
+const COMMANDS = ["serve", "pair", "sessions", "status", "login", "logout", "browser", "help", "--help", "-h"];
 
 export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): CliOptions | { error: string } {
   const [command = "help", ...rest] = argv;
@@ -76,6 +86,7 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
     tunnel: false,
     client: false,
     pair: true,
+    withDeps: false,
     json: false,
   };
   for (let i = 0; i < rest.length; i += 1) {
@@ -98,6 +109,8 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
       else if (arg === "--json") options.json = true;
       else if (arg === "--email") options.email = value();
       else if (options.command === "sessions" && arg === "revoke") options.revoke = value();
+      else if (options.command === "browser" && (arg === "install" || arg === "status")) options.browserAction = arg;
+      else if (options.command === "browser" && arg === "--with-deps") options.withDeps = true;
       else return { error: `unknown argument "${arg}"` };
     } catch (error) {
       return { error: error instanceof Error ? error.message : String(error) };
@@ -106,6 +119,7 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
   if (!Number.isInteger(options.port) || options.port < 1 || options.port > 65_535) return { error: "--port must be 1-65535" };
   if (options.publicUrl && !/^https?:\/\//.test(options.publicUrl)) return { error: "--public-url must start with http:// or https://" };
   if (options.tailscale && options.tunnel) return { error: "choose one of --tailscale (your tailnet) and --tunnel (a public address)" };
+  if (options.command === "browser" && !options.browserAction) return { error: "browser needs an action: install or status" };
   return options;
 }
 
@@ -118,6 +132,7 @@ export const USAGE = `openmausbot — run the server anywhere, pair devices to i
   openmausbot status
   openmausbot login [--email you@example.com]
   openmausbot logout
+  openmausbot browser install [--with-deps] | status
 
 serve   starts the server and prints a pairing link + QR code
 pair    mints a pairing code against a running server (--client: chat only)
@@ -126,6 +141,10 @@ status  what the server says about itself
 login   signs this machine in to an OpenMausBot account (an emailed code)
         and reserves its public address for --tunnel
 logout  releases that address and signs out
+browser install: the bots' browser engine (agent-browser, pinned) and a
+        Chrome for Testing, into the data dir; --with-deps also installs
+        the Linux libraries Chrome needs (run as root once). status: what
+        this machine has.
 
 --tailscale  serve over your tailnet: Tailscale terminates HTTPS and the
              link uses this machine's MagicDNS name (needs Tailscale signed in
@@ -352,6 +371,40 @@ export async function runLogout(options: CliOptions, io: CliIo = defaultIo()): P
   return 0;
 }
 
+export async function runBrowser(options: CliOptions, io: CliIo = defaultIo()): Promise<number> {
+  const status = browserEngineStatus({ dataDir: options.dataDir });
+  if (options.browserAction === "status") {
+    io.log(describeBrowserEngine(status));
+    if (status.kind !== "ready" && status.installable) io.log("install it with:  openmausbot browser install");
+    return status.kind === "ready" ? 0 : 1;
+  }
+  let binary = resolveAgentBrowserBinary({ dataDir: options.dataDir });
+  if (binary) {
+    io.log(`agent-browser is already here: ${binary}`);
+  } else {
+    if (status.kind !== "ready" && !status.installable) {
+      io.error(status.reason);
+      return 1;
+    }
+    try {
+      binary = await installAgentBrowserBinary({ dataDir: options.dataDir, log: io.log });
+    } catch (error) {
+      io.error(`could not install agent-browser: ${message(error)}`);
+      return 1;
+    }
+    io.log(`installed ${binary}`);
+  }
+  try {
+    await ensureChrome(binary, { withDeps: options.withDeps === true, log: io.log });
+  } catch (error) {
+    io.error(`Chrome is not ready: ${message(error)}`);
+    if (process.platform === "linux" && !options.withDeps) io.error("on Linux, Chrome needs system libraries: run `sudo openmausbot browser install --with-deps` once");
+    return 1;
+  }
+  io.log("bots on this server can use a browser now: turn it on under Settings → Experimental, then per bot");
+  return 0;
+}
+
 /** Where the server bundle lives relative to this file: next to it in the
  * npm package and the image (dist-server/), or the TypeScript source in a
  * checkout. */
@@ -500,6 +553,7 @@ export async function runServe(options: CliOptions, log: (line: string) => void 
   log("");
   log(`OpenMausBot is running on http://127.0.0.1:${options.port}${publicUrl ? `, reachable at ${publicUrl}` : ""}`);
   log(`data: ${options.dataDir}`);
+  log(describeBrowserEngine(browserEngineStatus({ dataDir: options.dataDir })));
   if (options.pair) {
     log("");
     log(await mintPairing(options.port, { label: options.label ? `${options.label} owner` : undefined, publicUrl: publicUrl ?? undefined }));
@@ -533,6 +587,8 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
       return runLogin(options);
     case "logout":
       return runLogout(options);
+    case "browser":
+      return runBrowser(options);
     default:
       console.log(USAGE);
       return 0;

--- a/server/index.ts
+++ b/server/index.ts
@@ -914,7 +914,7 @@ function engineBrowserIntegration(botId: string, profile: string | undefined) {
     return null;
   }
   const profileTarget = profile && profile !== "guest" ? browserProfilePartitionTarget(cfg, profile) : null;
-  const partitionId = profile === "guest" ? `guest-${botId}` : (profileTarget?.partitionId ?? "");
+  const partitionId = profile === "guest" ? "guest" : (profileTarget?.partitionId ?? "");
   const session = browserSessionId(botId, partitionId);
   return {
     connection: null,
@@ -924,6 +924,7 @@ function engineBrowserIntegration(botId: string, profile: string | undefined) {
       binaryPath: status.binaryPath,
       session,
       encryptionKey: browserEngineEncryptionKey(),
+      persistent: profile !== "guest",
     }),
   };
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -278,6 +278,13 @@ import {
   type BrowserCapability,
   type BrowserConnection,
 } from "./browser-connection.ts";
+import {
+  agentBrowserIntegration,
+  browserEngineEncryptionKey,
+  browserEngineStatus,
+  browserSessionId,
+  describeBrowserEngine,
+} from "./browser-engine.ts";
 import { captureOutsideHumanControl } from "./private-screen-capture.ts";
 import { screenFrameHash, screenTouchingTool, settledFrameIsNews } from "./screen-frame-gate.ts";
 import { RoutineRequestService } from "./routine-requests.ts";
@@ -851,7 +858,7 @@ async function browserIntegration(
   ownerId = randomUUID(),
 ) {
   const connection = availableBrowserConnection();
-  if (!connection) return null;
+  if (!connection) return engineBrowserIntegration(botId, profile);
   const control = controlIntegration(botId, threadId, generation);
   // A profile that no longer exists falls back to the bot's own session.
   // Canonical ids belong to config/bot references; Electron must receive the
@@ -891,6 +898,43 @@ async function browserIntegration(
       },
     },
   };
+}
+
+/** No desktop surface (a server, or a Windows desktop): the bot's browser is
+ * agent-browser, one isolated session per profile or per bot
+ * (docs/plans/browser-engine.md). Returns null, with the reason logged once,
+ * when the engine is not on this machine. */
+function engineBrowserIntegration(botId: string, profile: string | undefined) {
+  const status = browserEngineStatus();
+  if (status.kind !== "ready") {
+    if (!engineUnavailableLogged) {
+      engineUnavailableLogged = true;
+      console.warn(`${describeBrowserEngine(status)}; bots get no browser tools until it is installed`);
+    }
+    return null;
+  }
+  const profileTarget = profile && profile !== "guest" ? browserProfilePartitionTarget(cfg, profile) : null;
+  const partitionId = profile === "guest" ? `guest-${botId}` : (profileTarget?.partitionId ?? "");
+  const session = browserSessionId(botId, partitionId);
+  return {
+    connection: null,
+    capability: null,
+    profile: partitionId,
+    integration: agentBrowserIntegration({
+      binaryPath: status.binaryPath,
+      session,
+      encryptionKey: browserEngineEncryptionKey(),
+    }),
+  };
+}
+let engineUnavailableLogged = false;
+
+export function browserEngineSummary(): { kind: "desktop" | "headless" | "unavailable"; reason?: string; installable?: boolean; version?: string } {
+  if (availableBrowserConnection()) return { kind: "desktop" };
+  const status = browserEngineStatus();
+  return status.kind === "ready"
+    ? { kind: "headless", version: status.version }
+    : { kind: "unavailable", reason: status.reason, installable: status.installable };
 }
 
 function phoneIntegration() {
@@ -4541,9 +4585,9 @@ async function startTurn(
       // after its own turn.completed would never be torn down — it would
       // keep polling the box forever, carrying dead per-turn state. busy
       // is flipped false in the fold, so it is the honest "still running".
-      if (!previewCapture && browser) {
-        const { connection } = browser;
-        previewCapture = () => browserScreenshot(connection, browser.capability, fetch);
+      if (!previewCapture && browser?.connection && browser.capability) {
+        const { connection, capability } = browser;
+        previewCapture = () => browserScreenshot(connection, capability, fetch);
       }
       if (previewCapture && store.bot(bot.id)?.busy) {
         startScreenPoller(bot.id, previewCapture, { screenIsTheWork: instance.driverKind === "boxAgent" });
@@ -7391,6 +7435,9 @@ function configStatus() {
       showToolCalls: showToolCallsEnabled(cfg),
       browser: builtInBrowserEnabled(cfg),
     },
+    // Which browser this server can give bots: the desktop app's surface,
+    // the agent-browser engine, or nothing yet (with the reason).
+    browserEngine: browserEngineSummary(),
     // partitionId is non-secret routing metadata. The renderer needs it to
     // show the same durable session as an agent, but config PATCH validation
     // keeps it read-only and rejects callers that try to choose it.

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -39,7 +39,7 @@ import { useDesktopCapabilities } from "./DesktopCapabilities";
 import { RoutineEditor } from "./RoutinesPage";
 import { AndroidDevicePanel, useAndroidUsbDevices } from "./AndroidDevicePanel";
 import { BrowserPanel } from "./BrowserPanel";
-import { builtInBrowserEnabled } from "@/lib/feature-flags";
+import { browserAvailable, browserUnavailableReason, builtInBrowserEnabled } from "@/lib/feature-flags";
 import { transitionComputerControlLease, type ComputerControlAction } from "@/lib/computer-control";
 import { LocalScreenPreview } from "./LocalScreenPreview";
 import { LinuxLocalControl } from "./LinuxLocalControl";
@@ -286,7 +286,8 @@ export function ComputerPanel({
   const androidStatus = useAndroidUsbDevices();
   const androidConnected = androidStatus.devices.length > 0;
   // the built-in browser: a per-bot switch in Settings, and only the desktop app has one
-  const browserEnabled = builtInBrowserEnabled(state.config) && bot.browser !== false && Boolean(window.ogb?.browser);
+  const browserAvailableHere = browserAvailable(state.config, Boolean(window.ogb?.browser));
+  const browserEnabled = builtInBrowserEnabled(state.config) && bot.browser !== false && browserAvailableHere;
   // bumped when a Box API key is saved inline, to re-run the spin-up flow
   const [retry, setRetry] = useState(0);
   const vmReadinessAttempts = useRef(0);
@@ -298,11 +299,11 @@ export function ComputerPanel({
   // Computer engine runs inside the box, so it has no browser-only mode.
   const browserSelectable =
     builtInBrowserEnabled(state.config) &&
-    Boolean(window.ogb?.browser) &&
+    browserAvailableHere &&
     selectedInstance?.capabilities?.browserMcp === true &&
     selectedInstance.driverKind !== "boxAgent";
-  const browserDisabledReason = !window.ogb?.browser
-    ? "The built-in browser needs the OpenMausBot desktop app"
+  const browserDisabledReason = !browserAvailableHere
+    ? browserUnavailableReason(state.config)
     : !builtInBrowserEnabled(state.config)
       ? "The built-in browser is switched off under App Settings → Experimental"
       : "This model engine cannot use the built-in browser";

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -6,7 +6,7 @@ import { useEffect, useRef, useState } from "react";
 import { Coins, FlaskConical, Globe, KeyRound, Monitor, Search, TabletSmartphone, Terminal, Trash2, User, X } from "lucide-react";
 import { api, useStore, type AppSettingsSection, type ConfigStatus } from "@/state/store";
 import { analyticsEnabled, setAnalyticsEnabled } from "@/lib/analytics";
-import { builtInBrowserEnabled, showToolCallsEnabled, skillRecorderEnabled } from "@/lib/feature-flags";
+import { browserAvailable, browserUnavailableReason, builtInBrowserEnabled, showToolCallsEnabled, skillRecorderEnabled } from "@/lib/feature-flags";
 import { localeChoices } from "@/locales";
 import { ApiKeyRow, VpsConnection } from "./ApiKeys";
 import { useUpdaterState } from "@/lib/updater";
@@ -243,7 +243,7 @@ function ExperimentalFeaturesRow() {
   const { state, dispatch } = useStore();
   const skillRecorder = skillRecorderEnabled(state.config);
   const browser = builtInBrowserEnabled(state.config);
-  const desktopBrowser = Boolean(window.ogb?.browser);
+  const desktopBrowser = browserAvailable(state.config, Boolean(window.ogb?.browser));
   const browserBlockedOnWindows = window.ogb?.platform === "win32" && !desktopBrowser;
   const [saving, setSaving] = useState<"skillRecorder" | "browser" | null>(null);
   const [error, setError] = useState("");
@@ -294,8 +294,8 @@ function ExperimentalFeaturesRow() {
                 ? "Enabled for this workspace. Each bot also has its own browser switch."
                 : "Off by default. Enable it to let supported bots use a browser tab you can watch and take over."
               : browserBlockedOnWindows
-                ? "Temporarily unavailable on Windows while Electron's production sandbox support is being verified."
-                : "Needs the OpenMausBot desktop app."}
+                ? "Not available on this Windows machine yet: install the browser engine with `openmausbot browser install`."
+                : browserUnavailableReason(state.config)}
           </div>
         </div>
         <Switch

--- a/src/components/bot-settings/AccessSection.tsx
+++ b/src/components/bot-settings/AccessSection.tsx
@@ -5,6 +5,7 @@
 // list, webhooks list, and always-allowed list (the first read-only view of
 // standing grants) are new.
 import { useEffect, useState } from "react";
+import { browserUnavailableReason } from "@/lib/feature-flags";
 import { FolderOpen } from "lucide-react";
 
 import { api, useStore, type Bot } from "@/state/store";
@@ -278,14 +279,14 @@ export function AccessSection({
           <div className="mt-0.5 text-[13px] text-ink-secondary">
             {!desktopBrowser
               ? browserBlockedOnWindows
-                ? "The built-in browser is temporarily unavailable on Windows while Electron's production sandbox support is being verified."
-                : "The built-in browser needs the OpenMausBot desktop app."
+                ? "Not available on this Windows machine yet: install the browser engine with `openmausbot browser install`."
+                : browserUnavailableReason(state.config)
               : !browserFeature
                 ? "The built-in browser is switched off under App Settings → Experimental."
                 : !canUseBrowser
                   ? "This bot's current engine cannot use the built-in browser."
                   : browserEnabled
-                    ? "This bot has its own browser tab in the computer panel — its own logins, watchable and takeable at any time."
+                    ? "This bot has its own browser with its own logins."
                     : "Keep the built-in browser unavailable to this bot."}
           </div>
         </div>

--- a/src/components/bot-settings/useBotSettingsDerived.ts
+++ b/src/components/bot-settings/useBotSettingsDerived.ts
@@ -4,7 +4,7 @@
 // stay pure prop-takers. This hook is the one place in the bot settings
 // dialog that still reaches into useStore.
 import { useDesktopCapabilities } from "../DesktopCapabilities";
-import { builtInBrowserEnabled } from "@/lib/feature-flags";
+import { browserAvailable, browserUnavailableReason, builtInBrowserEnabled } from "@/lib/feature-flags";
 import { instanceSupportsLocalComputer, localComputerDisabledReason, localComputerSelectable } from "@/lib/local-computer";
 import { stateForBot } from "@/lib/mascot";
 import { useStore, type Bot } from "@/state/store";
@@ -62,7 +62,7 @@ export function useBotSettingsDerived(bot: Bot) {
   const connectedAppsConfigured = state.config?.composio?.configured === true;
   const connectedAppsEnabled = bot.composio !== false;
   const canUseBrowser = engine?.capabilities?.browserMcp === true;
-  const desktopBrowser = Boolean(window.ogb?.browser);
+  const desktopBrowser = browserAvailable(state.config, Boolean(window.ogb?.browser));
   const browserBlockedOnWindows = window.ogb?.platform === "win32" && !desktopBrowser;
   const browserFeature = builtInBrowserEnabled(state.config);
   const browserAllowed = bot.browser !== false;
@@ -71,7 +71,7 @@ export function useBotSettingsDerived(bot: Bot) {
   // itself; the box-native Computer engine has no browser-only mode.
   const browserSelectable = desktopBrowser && browserFeature && canUseBrowser && engine?.driverKind !== "boxAgent";
   const browserDisabledReason = !desktopBrowser
-    ? "The built-in browser needs the OpenMausBot desktop app"
+    ? browserUnavailableReason(state.config)
     : !browserFeature
       ? "The built-in browser is switched off under App Settings → Experimental"
       : "This model engine cannot use the built-in browser";

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,5 +1,23 @@
 export interface FeatureFlagConfig {
   features?: { skillRecorder?: boolean; showToolCalls?: boolean; browser?: boolean };
+  browserEngine?: { kind: "desktop" | "headless" | "unavailable"; reason?: string; installable?: boolean };
+}
+
+/** Whether this server can give a bot a browser at all: the desktop app's
+ * own surface, or the agent-browser engine on a server or a Windows desktop.
+ * Older servers report nothing; treat that like the desktop bridge check. */
+export function browserAvailable(config: FeatureFlagConfig | null | undefined, desktopBridge: boolean): boolean {
+  const kind = config?.browserEngine?.kind;
+  if (kind === undefined) return desktopBridge;
+  return kind === "desktop" || kind === "headless";
+}
+
+/** Why a bot cannot have a browser right now, in the user's words. */
+export function browserUnavailableReason(config: FeatureFlagConfig | null | undefined): string {
+  const engine = config?.browserEngine;
+  if (engine?.kind === "unavailable" && engine.installable) return "The browser engine is not installed on this server yet: run `openmausbot browser install` there.";
+  if (engine?.kind === "unavailable" && engine.reason) return engine.reason;
+  return "The built-in browser needs the OpenMausBot desktop app.";
 }
 
 /** Experimental features are available only after an explicit opt-in. */

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -363,8 +363,18 @@ export interface ConfigStatus {
   language?: string;
   /** Opt-in flags. Absent means off. */
   features?: { skillRecorder: boolean; showToolCalls?: boolean; browser?: boolean };
+  /** Which browser this server can give bots: the desktop app's surface, the
+   * agent-browser engine, or nothing yet (with the reason). */
+  browserEngine?: BrowserEngineSummary;
   /** Named browser sessions any bot can be pointed at. */
   browserProfiles?: BrowserProfile[];
+}
+
+export interface BrowserEngineSummary {
+  kind: "desktop" | "headless" | "unavailable";
+  reason?: string;
+  installable?: boolean;
+  version?: string;
 }
 
 export interface BrowserProfile {
@@ -377,7 +387,7 @@ export interface BrowserProfile {
 
 export type ConfigStatusFrame = Pick<
   ConfigStatus,
-  "xai" | "composio" | "box" | "vps" | "rooms" | "localVm" | "opencodeGo" | "tts" | "imageGen" | "profile" | "language" | "features" | "browserProfiles"
+  "xai" | "composio" | "box" | "vps" | "rooms" | "localVm" | "opencodeGo" | "tts" | "imageGen" | "profile" | "language" | "features" | "browserEngine" | "browserProfiles"
 >;
 
 export function configStatusFromFrame(frame: ConfigStatusFrame): ConfigStatus {
@@ -394,6 +404,7 @@ export function configStatusFromFrame(frame: ConfigStatusFrame): ConfigStatus {
     profile: frame.profile,
     language: frame.language,
     features: frame.features,
+    browserEngine: frame.browserEngine,
     browserProfiles: frame.browserProfiles,
   };
 }


### PR DESCRIPTION
First step of [docs/plans/browser-engine.md](https://github.com/milind-soni/OpenMausBot/blob/feat/browser-engine/docs/plans/browser-engine.md): one browser engine for every platform, starting where there is no browser today.

**What lands here**
- `server/browser-engine.ts` + `browser-engine-release.ts`: agent-browser 0.36.0 pinned with per-platform SHA-256; resolved from `OMB_AGENT_BROWSER_PATH`, then the data dir, then PATH; downloaded and verified (size + digest) when missing; Chrome via `agent-browser install`.
- `browserIntegration()` falls back to the engine when no desktop surface exists: `agent-browser mcp --tools core --no-webmcp`, one isolated auto-restored session per browser profile or per bot, saved state encrypted with a 0600 key in the data dir.
- `GET /api/config` reports `browserEngine` (`desktop` | `headless` | `unavailable` + reason); Settings → Experimental, the per-bot switch and the computer panel key off it instead of `window.ogb.browser`, with an install hint. Windows desktop users see the install hint instead of the sandbox message.
- `openmausbot browser install [--with-deps] | status`; `serve` prints the engine status at boot.
- Dockerfile: agent-browser + Chrome for Testing with libraries baked in (bigger image; the stack e2e builds it).
- Docs: self-hosting, the VPS guide, the plan.

**Verified:** 770 tests across the touched suites incl. new ones for resolver precedence, the pinned table, download verification (bad size / bad digest leave nothing behind), the turn spec, session naming, and the key file; typecheck and lint clean; bundled CLI runs. A real install + MCP handshake on macOS is running now and gets posted as a comment.

**Not in this PR (steps 2–4 of the plan):** desktop switch-over and Electron surface removal, the live stream + takeover in the panel, the tool-name adapter. Live preview on servers is therefore not there yet; screenshots in transcripts come from the bot's `screenshot` tool.

No auto-merge; review and merge when you are happy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added headless browser support for bots with isolated, persistent sessions.
  * Added browser installation and status commands, including optional system dependencies.
  * Added automatic Chrome browser setup in Docker deployments.
  * Added browser availability and installation status throughout the app.
* **Documentation**
  * Added VPS setup guidance for enabling browser support.
  * Documented headless browser capabilities and session behavior.
* **Bug Fixes**
  * Improved browser availability messages and disabled-state guidance based on actual server status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->