### PR TITLE
fix(antigravity): recover setup errors and align Google sign-in discovery

### DIFF
--- a/server/drivers/antigravity-acp.ts
+++ b/server/drivers/antigravity-acp.ts
@@ -65,6 +65,25 @@ function takeLines(buffer: string): { lines: string[]; rest: string } {
   return { lines: parts.map((line) => line.replace(/\r$/u, "")), rest };
 }
 
+/** Only fixed, allowlisted startup hints leave stderr. Native output can
+ * contain OAuth codes and credentials in arbitrary formats, so generic
+ * text redaction is not enough to safely echo a diagnostic tail. */
+function startupHint(line: string): string | undefined {
+  if (/no space left|not enough (?:space|disk)|disk (?:is )?full|winerror\s*112/iu.test(line)) {
+    return "The runtime reported insufficient disk space while starting.";
+  }
+  if (/failed to (?:extract|load (?:python|embedded python))|could not load python/iu.test(line)) {
+    return "The runtime reported a problem unpacking or loading its bundled Python runtime.";
+  }
+  if (/permission denied|access is denied|winerror\s*5\b/iu.test(line)) {
+    return "The runtime reported a file or process permission failure.";
+  }
+  if (/address family not supported|failed to create.*(?:socket|listener)|failed to bind/iu.test(line)) {
+    return "The runtime reported a local network listener failure.";
+  }
+  return undefined;
+}
+
 /** The sign-in link in a server output line, or null for anything else.
  * Google announces it two ways and both land on stderr: it hands the link to
  * $BROWSER — our helper re-emits it JSON-encoded behind a private marker — and
@@ -157,6 +176,10 @@ export class AntigravityAcpClient {
   private pending = new Map<number, PendingRpc>();
   private buffer = "";
   private diagnosticBuffer = "";
+  private initializationComplete = false;
+  private startupOutputBytes = 0;
+  private startupDiagnosticBytes = 0;
+  private nativeStartupHint?: string;
   private closed = false;
   private readonly onAuthorizationUrl?: (url: string) => void;
   /** Settles once the runtime process is gone. On Windows a running
@@ -178,15 +201,18 @@ export class AntigravityAcpClient {
     );
     this.child.stdout!.setEncoding("utf8");
     this.child.stdout!.on("data", (chunk: string) => this.consume(chunk));
-    // Google announces the sign-in link on stderr, not stdout. Scan for that
-    // one line and drop every other byte: stderr also carries authorization
-    // codes, so nothing else is retained or surfaced.
+    // Keep only sign-in announcements and fixed startup failure categories;
+    // never surface raw stderr, which can contain authorization codes.
     this.child.stderr!.setEncoding("utf8");
     this.child.stderr!.on("data", (chunk: string) => this.consumeDiagnostics(chunk));
     this.child.once("error", (error) => this.failAll(error));
     this.exited = new Promise((resolve) => {
-      this.child.once("close", (code) => {
-        if (!this.closed) this.failAll(new Error(`Antigravity ACP exited ${code ?? "unexpectedly"}.`));
+      this.child.once("close", (code, signal) => {
+        this.noteStartupDiagnostic(this.diagnosticBuffer);
+        this.diagnosticBuffer = "";
+        if (!this.closed) this.failAll(new Error(
+          `Antigravity ACP exited ${code ?? signal ?? "unexpectedly"}.${this.nativeStartupHint ? ` ${this.nativeStartupHint}` : ""}`,
+        ));
         resolve();
       });
       // Failed spawns also emit `close`. An `error` alone can instead mean
@@ -195,6 +221,7 @@ export class AntigravityAcpClient {
   }
 
   private consume(chunk: string) {
+    if (!this.initializationComplete) this.startupOutputBytes += Buffer.byteLength(chunk);
     this.buffer += chunk;
     if (Buffer.byteLength(this.buffer) > MAX_PROTOCOL_LINE_BYTES) {
       this.failAll(new Error("Antigravity sent a protocol line that is too large."));
@@ -241,10 +268,17 @@ export class AntigravityAcpClient {
    * and released immediately and the tail is capped, so no authorization code
    * is ever held. Draining also keeps the pipe from stalling the server. */
   private consumeDiagnostics(chunk: string) {
+    if (!this.initializationComplete) this.startupDiagnosticBytes += Buffer.byteLength(chunk);
     const { lines, rest } = takeLines(this.diagnosticBuffer + chunk);
     // A partial line already longer than any legal link cannot become one.
     this.diagnosticBuffer = rest.length > MAX_DIAGNOSTIC_LINE_CHARS ? "" : rest;
-    for (const line of lines) this.announceAuthorizationUrl(line);
+    for (const line of lines) {
+      if (!this.announceAuthorizationUrl(line)) this.noteStartupDiagnostic(line);
+    }
+  }
+
+  private noteStartupDiagnostic(line: string) {
+    if (!this.initializationComplete) this.nativeStartupHint ??= startupHint(line);
   }
 
   private failAll(error: Error) {
@@ -261,7 +295,16 @@ export class AntigravityAcpClient {
     return new Promise((resolveRequest, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id);
-        reject(new Error(`${method} timed out.`));
+        if (method === "initialize") {
+          this.noteStartupDiagnostic(this.diagnosticBuffer);
+          reject(new Error(
+            `Antigravity initialization timed out after ${Math.ceil(timeoutMs / 1_000)} seconds (${process.platform}-${process.arch}). ` +
+            "The executable was found, but did not finish starting. " +
+            (this.nativeStartupHint ? `${this.nativeStartupHint} ` : "") +
+            `Startup output: ${this.startupOutputBytes} bytes; diagnostic output: ${this.startupDiagnosticBytes} bytes. ` +
+            "Retry setup. If it still fails, share this error and your OpenMausBot version; do not paste Google sign-in links or tokens.",
+          ));
+        } else reject(new Error(`${method} timed out.`));
       }, timeoutMs);
       timer.unref?.();
       this.pending.set(id, { resolve: resolveRequest, reject, timer });
@@ -270,11 +313,14 @@ export class AntigravityAcpClient {
   }
 
   async initialize(timeoutMs = STARTUP_TIMEOUT_MS): Promise<any> {
-    return this.request("initialize", {
+    const initialized = await this.request("initialize", {
       protocolVersion: 1,
       clientInfo: { name: "openmausbot", version: "0.0.0" },
       clientCapabilities: { fs: { readTextFile: false, writeTextFile: false }, terminal: false },
     }, timeoutMs);
+    this.initializationComplete = true;
+    this.nativeStartupHint = undefined;
+    return initialized;
   }
 
   close() {
@@ -492,6 +538,12 @@ export async function validateAntigravityRuntime(runtime: AntigravityRuntime, ex
       instanceId: `verify-${randomUUID()}`,
       runtime,
       profileDirectory,
+      // Google's Windows one-file executable expands a large Python runtime
+      // into TEMP. Forced shutdown skips its own cleanup. Keep verification's
+      // extraction inside the profile we already remove after confirmed close.
+      baseEnv: process.platform === "win32"
+        ? { ...process.env, TEMP: profileDirectory, TMP: profileDirectory }
+        : undefined,
     });
     client = new AntigravityAcpClient(runtime, profile, profileDirectory);
     const initialized = await client.initialize();

--- a/server/drivers/antigravity-lifecycle.test.ts
+++ b/server/drivers/antigravity-lifecycle.test.ts
@@ -69,7 +69,79 @@ afterEach(() => {
   for (const directory of scratch.splice(0)) rmSync(directory, { recursive: true, force: true });
 });
 
+describe("Antigravity initialization diagnostics", () => {
+  it("reports a timeout separately from a missing executable without exposing stderr", async () => {
+    const child = fakeChild(null);
+    const acp = client();
+    const result = acp.initialize(100).catch((error: Error) => error);
+    child.stderr.write("private auth code: do-not-disclose\n");
+    child.stderr.write("https://accounts.google.com/o/oauth2/v2/auth?state=private-state&code=secret-code\n");
+    child.stderr.write("Failed to extract Python bundle into a private path");
+    await vi.advanceTimersByTimeAsync(100);
+    const error = await result;
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toContain("executable was found");
+    expect(error.message).toContain(`${process.platform}-${process.arch}`);
+    expect(error.message).toContain("unpacking or loading its bundled Python runtime");
+    expect(error.message).toContain("Startup output: 0 bytes");
+    for (const secret of ["do-not-disclose", "accounts.google.com", "private-state", "secret-code", "private path"]) {
+      expect(error.message).not.toContain(secret);
+    }
+    acp.close();
+  });
+
+  it("keeps the existing 90-second cold-start allowance", async () => {
+    const child = fakeChild(null);
+    const acp = client();
+    const result = acp.initialize();
+    let settled = false;
+    void result.then(() => { settled = true; });
+    await vi.advanceTimersByTimeAsync(89_000);
+    expect(settled).toBe(false);
+    child.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, result: initialized })}\n`);
+    await expect(result).resolves.toEqual(initialized);
+    acp.close();
+  });
+
+  it("retains a fixed disk-space hint when the native process exits without a newline", async () => {
+    const child = fakeChild(null);
+    const acp = client();
+    const rejected = expect(acp.initialize()).rejects.toThrow("insufficient disk space");
+    child.stderr.write("No space left on device: user-private-directory");
+    child.emit("close", 1);
+    await rejected;
+    acp.close();
+  });
+
+  it("does not reuse a startup warning after initialization succeeds", async () => {
+    const child = fakeChild(null);
+    const acp = client();
+    child.stderr.write("permission denied during optional startup check\n");
+    const result = acp.initialize();
+    child.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, result: initialized })}\n`);
+    await result;
+    const pending = acp.request("authenticate", {});
+    const rejected = expect(pending).rejects.toThrow(/^Antigravity ACP exited 1\.$/u);
+    child.emit("close", 1);
+    await rejected;
+    acp.close();
+  });
+});
+
 describe("Antigravity validation shutdown", () => {
+  it("contains Windows one-file extraction in the owned verification profile", async () => {
+    const child = fakeChild();
+    vi.mocked(killCliTree).mockImplementation(() => { child.emit("close", 0); });
+    await validateAntigravityRuntime(runtime, "1.1.1");
+    const environment = vi.mocked(spawnCli).mock.calls[0][2].env!;
+    if (process.platform === "win32") {
+      expect(environment.TEMP).toBe(scratch[0]);
+      expect(environment.TMP).toBe(scratch[0]);
+    }
+    expect(environment.GEMINI_HOME).toBe(scratch[0]);
+    expect(existsSync(scratch[0])).toBe(false);
+  });
+
   it.each(["kill EPERM", "spawn ENOENT"])("does not treat %s as close", async (message) => {
     const child = fakeChild(null);
     const acp = client();

--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -9,6 +9,8 @@ import type { ProviderInstance } from "../contracts.ts";
 import { recordEvents, type EventRecorder } from "../testing/events.ts";
 import { removeTempDir } from "../testing/cleanup.ts";
 import * as procs from "../procs.ts";
+import * as envPath from "../env-path.ts";
+import * as managedRuntime from "./antigravity-runtime.ts";
 import {
   ANTIGRAVITY_AUTH_PREFIX,
   AntigravityAcpClient,
@@ -108,6 +110,70 @@ describe("official Antigravity catalog", () => {
 });
 
 describe("Antigravity sign-in lifecycle", () => {
+  it("preserves failed setup errors until retry or external recovery, without reviving stale errors", async () => {
+    if (!resolveAntigravityReleaseAsset()) return;
+    const fake = fakeRuntime();
+    const custom = join(fake.directory, "not-installed");
+    const install = vi.spyOn(managedRuntime, "installAntigravityRuntime")
+      .mockRejectedValueOnce(new Error("Antigravity initialization timed out: fixture failure"));
+    const instance = await AntigravityDriver.create({
+      instanceId: "failed-antigravity-install",
+      displayName: "Antigravity fixture", enabled: true,
+      config: { cli: custom, fullAuto: false },
+      environment: {},
+    });
+    try {
+      await expect(instance.installRuntime!()).rejects.toThrow("fixture failure");
+      expect(await instance.snapshot()).toEqual({ state: "unavailable", reason: "Antigravity initialization timed out: fixture failure" });
+      // Independent refreshes (including reopening the card) keep the cause.
+      expect((await instance.snapshot()).reason).toContain("fixture failure");
+      // A manual/shared install can recover without this instance retrying.
+      copyFileSync(fake.executable, custom);
+      if (process.platform !== "win32") chmodSync(custom, 0o755);
+      expect((await instance.snapshot()).state).toBe("available");
+      unlinkSync(custom);
+      const unavailable = await instance.snapshot();
+      expect(unavailable.state).toBe("unavailable");
+      expect(unavailable.reason).not.toContain("fixture failure");
+      install.mockRejectedValueOnce(new Error("Antigravity initialization timed out: fixture failure"));
+      await expect(instance.installRuntime!()).rejects.toThrow("fixture failure");
+      install.mockResolvedValueOnce({ executablePath: fake.executable, harnessPath: fake.harness, source: "managed", version: "1.1.1" });
+      await instance.installRuntime!();
+      expect((await instance.snapshot()).reason).not.toContain("fixture failure");
+    } finally {
+      await instance.dispose();
+    }
+  });
+
+  it("uses the same discovered PATH for readiness and Google sign-in", async () => {
+    const fake = fakeRuntime();
+    const executable = join(fake.directory, process.platform === "win32" ? "agy_acp_server.exe" : "agy_acp_server.par");
+    copyFileSync(fake.executable, executable);
+    if (process.platform !== "win32") chmodSync(executable, 0o755);
+    vi.stubEnv("PATH", "");
+    vi.spyOn(envPath, "augmentedPath").mockReturnValue(fake.directory);
+    const authenticate = vi.spyOn(AntigravityAuthController.prototype, "start").mockResolvedValue({
+      phase: "succeeded", flowId: null, authorizationUrl: null, expiresAt: null,
+    });
+    const instance = await AntigravityDriver.create({
+      instanceId: "path-only-antigravity",
+      displayName: "Antigravity fixture",
+      enabled: true,
+      config: { cli: "agy_acp_server" + (process.platform === "win32" ? ".exe" : ".par"), fullAuto: false },
+      environment: { PATH: "" },
+    });
+    try {
+      expect((await instance.snapshot()).state).toBe("available");
+      await expect(instance.startAuthentication!()).resolves.toMatchObject({ phase: "succeeded" });
+      expect(authenticate).toHaveBeenCalledWith(
+        expect.objectContaining({ executablePath: executable }),
+        expect.objectContaining({ environment: expect.objectContaining({ PATH: fake.directory }) }),
+      );
+    } finally {
+      await instance.dispose();
+    }
+  });
+
   // Google's server announces the link on stderr, never stdout — a fake that
   // prints to stdout passes against code that cannot sign in at all.
   it.each(["cancel", "provider failure"])("contains %s after handing the browser a sign-in URL", async (ending) => {

--- a/server/drivers/antigravity.ts
+++ b/server/drivers/antigravity.ts
@@ -28,6 +28,7 @@ import {
   resolveAntigravityRuntime,
 } from "./antigravity-runtime.ts";
 import { resolveAntigravityReleaseAsset } from "./antigravity-release.ts";
+import { augmentedPath } from "../env-path.ts";
 
 export const STATIC_ANTIGRAVITY_MODELS: ModelCatalog = {
   default: "gemini-3.8-flash-high",
@@ -140,8 +141,11 @@ export const AntigravityDriver: ProviderDriver<AcpConfig> = {
   async create(input: DriverCreateInput<AcpConfig>): Promise<ProviderInstance> {
     const base = await AcpAntigravityDriver.create(input);
     const auth = new AntigravityAuthController();
+    let installFailure: string | undefined;
     const runtimeAndProfile = async () => {
-      const environment = { ...process.env, ...input.environment };
+      // Match the ACP driver's discovery/chat environment. A GUI launch's
+      // raw PATH may omit an official runtime that the model picker found.
+      const environment = { ...process.env, ...input.environment, PATH: augmentedPath() };
       const runtime = await resolveAntigravityRuntime(input.config.cli, environment);
       const profile = await prepareAntigravityProfile({
         instanceId: input.instanceId,
@@ -155,10 +159,25 @@ export const AntigravityDriver: ProviderDriver<AcpConfig> = {
       get models() {
         return base.models;
       },
+      snapshot: async () => {
+        const snapshot = await base.snapshot();
+        if (snapshot.state === "available") installFailure = undefined;
+        // A failed first install has no promoted executable yet. Preserve
+        // why it failed across closing/reopening setup in this app session.
+        return snapshot.state === "unavailable" && installFailure
+          ? { ...snapshot, reason: installFailure }
+          : snapshot;
+      },
       ...(antigravityManagedInstallAvailable()
         ? {
             installRuntime: async () => {
-              await installAntigravityRuntime({ validate: validateAntigravityRuntime });
+              installFailure = undefined;
+              try {
+                await installAntigravityRuntime({ validate: validateAntigravityRuntime });
+              } catch (error) {
+                installFailure = error instanceof Error ? error.message : String(error);
+                throw error;
+              }
             },
           }
         : {}),

--- a/src/components/EngineSetup.test.ts
+++ b/src/components/EngineSetup.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { needsCli, needsSignIn } from "./EngineSetup";
-import type { InstanceInfo } from "@/state/store";
+import { EngineSetup, needsCli, needsSignIn } from "./EngineSetup";
+import { engineStatus } from "./ModelPicker";
+import { StoreProvider, type InstanceInfo } from "@/state/store";
+
+afterEach(() => vi.unstubAllGlobals());
 
 function instance(snapshot: InstanceInfo["snapshot"]): InstanceInfo {
   return {
@@ -30,5 +35,47 @@ describe("needsCli / needsSignIn", () => {
     const ready = instance({ state: "available", authenticated: true, version: "0.36.1" });
     expect(needsCli(ready)).toBe(false);
     expect(needsSignIn(ready)).toBe(false);
+  });
+});
+
+describe("managed engine setup errors", () => {
+  function managed(snapshot: InstanceInfo["snapshot"]): InstanceInfo {
+    return {
+      ...instance(snapshot),
+      instanceId: "antigravity",
+      driverKind: "antigravityAgent",
+      displayName: "Antigravity",
+      install: { managed: { label: "Install official Antigravity", downloadBytes: 1024 } },
+    };
+  }
+
+  function render(engine: InstanceInfo): string {
+    vi.stubGlobal("window", { ogb: { platform: "darwin" } });
+    return renderToStaticMarkup(createElement(StoreProvider, null, createElement(EngineSetup, { instance: engine })));
+  }
+
+  it("shows profile failures without claiming the runtime is missing", () => {
+    const reason = "Cannot write Antigravity profile settings (EACCES).";
+    const engine = managed({ state: "unavailable", reason });
+    const markup = render(engine);
+    expect(markup).toContain(reason);
+    expect(markup).toContain('role="alert"');
+    expect(markup).toContain("Install official Antigravity");
+    expect(engineStatus(engine)).toBe("Setup required");
+    expect(markup).not.toMatch(/CLI not found|Not installed/);
+  });
+
+  it("renders an initialization failure reported by the snapshot", () => {
+    const engine = managed({ state: "unavailable", reason: "initialize timed out." });
+    expect(render(engine)).toContain("initialize timed out.");
+    expect(engineStatus(engine)).toBe("Setup required");
+  });
+
+  it("preserves the installed engine's sign-in flow", () => {
+    const engine = managed({ state: "available", authenticated: false, version: "1.1.1" });
+    const markup = render(engine);
+    expect(engineStatus(engine)).toBe("Sign-in required");
+    expect(markup).toContain("Sign in with Google");
+    expect(markup).not.toContain("Install official Antigravity");
   });
 });

--- a/src/components/EngineSetup.tsx
+++ b/src/components/EngineSetup.tsx
@@ -28,8 +28,8 @@ export function needsSignIn(instance: InstanceInfo | undefined): boolean {
   return instance?.snapshot.state === "available" && instance.snapshot.authenticated === false;
 }
 
-/** The agent CLI itself is absent. Local-model injection needs the CLI but
- * does not need its cloud account to be signed in. */
+/** The engine needs setup; unavailable does not prove its CLI is absent.
+ * Local-model injection still requires an available engine, but no cloud sign-in. */
 export function needsCli(instance: InstanceInfo | undefined): boolean {
   return instance?.snapshot.state !== "available";
 }
@@ -195,8 +195,13 @@ function ManagedEngineSetup({ instance, signInOnly }: { instance: InstanceInfo; 
   };
 
   const install = () => run("install", async () => {
-    await api(`/api/instances/${encodeURIComponent(instance.instanceId)}/install`, { method: "POST" });
-    await refreshInstances();
+    try {
+      await api(`/api/instances/${encodeURIComponent(instance.instanceId)}/install`, { method: "POST" });
+    } finally {
+      // Keep the latest setup reason without replacing the install error if
+      // the status refresh also fails.
+      await refreshInstances().catch(() => {});
+    }
   });
 
   const signIn = () => run("signin", async () => {
@@ -340,6 +345,12 @@ export function EngineSetup({
           <p className="mt-0.5 text-[12px] leading-relaxed text-ink-secondary">{description}</p>
         </div>
       </div>
+
+      {instance.snapshot.state === "unavailable" && instance.snapshot.reason && (
+        <p role="alert" className="mt-2 text-[12px] leading-relaxed text-danger">
+          {instance.snapshot.reason}
+        </p>
+      )}
 
       {install.managed ? (
         <ManagedEngineSetup instance={instance} signInOnly={signInOnly} />

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -23,8 +23,8 @@ function modelProvider(instance: InstanceInfo | undefined, model: string): strin
   return instance?.models.options.find((option) => option.id === model)?.provider;
 }
 
-function engineStatus(instance: InstanceInfo): string {
-  if (needsCli(instance)) return "Not installed";
+export function engineStatus(instance: InstanceInfo): string {
+  if (needsCli(instance)) return "Setup required";
   if (needsSignIn(instance)) return "Sign-in required";
   return instance.snapshot.version ?? "Ready";
 }


### PR DESCRIPTION
## Summary

Fix confirmed setup/discovery problems uncovered while investigating a report of `initialize timed out` followed by `CLI not found`.

- Use the same discovered PATH for Antigravity Google sign-in as engine readiness/chat. A PATH-only official runtime could previously appear ready but fail sign-in discovery.
- Keep failed-install reasons visible when setup is reopened in the same app session; clear them after retry or external recovery. Label unavailable engines “Setup required” instead of falsely asserting they are not installed.
- Report initialization duration, platform, output byte counts, and fixed native-startup failure categories. Never expose raw stderr, OAuth links, credentials, or paths from native output.
- Contain Windows verification's native temporary extraction inside its existing owned verification profile. Cleanup remains gated on confirmed process shutdown; no global temporary-directory sweep or deletion of an existing installation.

## Research and scope

Compared T3 Code main `dd64072917193195479f6907cfb081267bff7301` and nightly `v0.0.39-nightly.20260906.1293`: both use the same official Google 1.1.1 runtime, Windows launch flags, and 90-second startup validation budget as OpenMausBot. There is no verified newer-runtime or missing-flag fix to copy. The timeout budget is unchanged.

- [T3 startup report](https://github.com/pingdotgg/t3code/issues/9432)
- [T3 Windows extraction cleanup report](https://github.com/pingdotgg/t3code/issues/9650)
- [Google's official ACP setup guide](https://antigravity.google/docs/ide/extensions/zed/)

**The customer's timeout root cause is not confirmed.** Their OS, app version, and redacted diagnostics are still needed. This PR fixes the reproduced discovery mismatch and misleading/lost error reporting, and hardens verification cleanup; it does not claim a physical Windows startup reproduction or a completed Google OAuth/model turn.

## Verification

- 71 tests across Antigravity driver/runtime/lifecycle and EngineSetup suites pass.
- New discovery test was demonstrated failing before the PATH fix and passing afterward.
- Tests cover failed-install persistence, retry/external recovery, startup timeout/exit diagnostics, privacy, and confirmed-shutdown cleanup. Windows TEMP/TMP assertions are conditional and require Windows CI.
- Typecheck, targeted lint, and diff whitespace checks pass.
- Packaged server smoke passes with no node_modules in reach, including spawned proxies and MCP stdio.
- Official Google 1.1.1 runtime initializes successfully on macOS arm64 with a fresh temporary verification profile (1.25 seconds); no sign-in or account mutation.
- Isolated fixture doctor succeeds, new bot receives `hello`, wait settles, transcript contains `hello from fake claude`. This is a general harness regression check, not Antigravity authentication proof. Exact fixture was stopped and its temporary data cleaned.
- Renderer coverage is static render coverage, not an interactive Windows UI test.

No version bump, release, or user-profile migration in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved engine startup diagnostics with clearer, categorized failure messages and initialization timeout details.
  - Preserved installation errors across retries while clearing them after successful recovery.
  - Improved runtime discovery for engines launched from desktop applications.
  - Fixed Windows runtime setup and cleanup behavior.

- **User Experience**
  - Engine setup now displays actionable error reasons directly in the interface.
  - Installation status refreshes reliably after setup attempts.
  - Updated the model picker label from “Not installed” to “Setup required.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->