### PR TITLE
fix(ios,android): preserve earlier dictated text when a new speech segment starts

### DIFF
--- a/android/app/src/main/kotlin/com/openmausbot/companion/dictation/SpeechDictation.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/dictation/SpeechDictation.kt
@@ -332,14 +332,14 @@ class SpeechDictation internal constructor(
         override fun onPartial(text: String) {
             synchronized(lock) {
                 if (!live() || !_isListening.value) return
-                _transcript.value = text
+                _transcript.value = Dictation.updateTranscript(_transcript.value, text)
             }
         }
 
         override fun onFinal(text: String) {
             synchronized(lock) {
                 if (!live() || !_isListening.value) return
-                if (text.isNotEmpty()) _transcript.value = text
+                if (text.isNotEmpty()) _transcript.value = Dictation.updateTranscript(_transcript.value, text)
                 // Composer dictation does not wait for a later final beyond
                 // this — matching iOS stopping when the recognizer finalizes.
                 stopLocked()

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Dictation.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Dictation.kt
@@ -59,6 +59,40 @@ object Dictation {
     }
 
     /**
+     * Merge a new formatted partial into the accumulated transcript.
+     *
+     * Partials for the same segment extend or revise the current text in
+     * place. A fresh segment after a pause does not start with the previous
+     * partial, so it is appended instead of replacing the accumulated text.
+     */
+    fun updateTranscript(current: String, new: String): String {
+        val current = current.trim()
+        val new = new.trim()
+        if (new.isEmpty()) return current
+        if (current.isEmpty()) return new
+
+        // Same segment: the recognizer lengthened the current text.
+        if (new.startsWith(current)) return new
+
+        // Same segment with a brief backtrack: keep the longer version.
+        if (current.startsWith(new)) return current
+
+        // Same segment with a word-level revision: most leading words match.
+        val currentWords = current.split(" ").filter { it.isNotEmpty() }
+        val newWords = new.split(" ").filter { it.isNotEmpty() }
+        val commonWordCount = currentWords
+            .zip(newWords)
+            .takeWhile { it.first.lowercase() == it.second.lowercase() }
+            .count()
+        if (commonWordCount >= 2 && commonWordCount * 2 >= currentWords.size) {
+            return new
+        }
+
+        // New segment after a pause: append, separated by a space.
+        return draft(base = current, transcript = new)
+    }
+
+    /**
      * Typing while clean updates the saveable snapshot. Typing after any
      * partial/final leaves the snapshot alone — the live string may still
      * contain speech. Emptying the field resets like send: a contaminated

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/DictationTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/DictationTest.kt
@@ -67,6 +67,68 @@ class DictationTest {
         assertEquals("", Dictation.draft(base = "  ", transcript = "\n"))
     }
 
+    // --- Transcript updates across segments --------------------------------
+
+    @Test
+    fun emptyTranscriptTakesTheNewPartial() {
+        assertEquals("hello", Dictation.updateTranscript("", "hello"))
+    }
+
+    @Test
+    fun emptyPartialLeavesTheTranscript() {
+        assertEquals("hello", Dictation.updateTranscript("hello", ""))
+        assertEquals("hello", Dictation.updateTranscript("hello", "   "))
+    }
+
+    /** Same segment: each longer partial replaces the last in place. */
+    @Test
+    fun aLongerPartialReplacesTheCurrentOne() {
+        assertEquals(
+            "first sentence",
+            Dictation.updateTranscript("first sent", "first sentence"),
+        )
+        assertEquals(
+            "first sentence.",
+            Dictation.updateTranscript("first sentence", "first sentence."),
+        )
+    }
+
+    /** A fresh segment after a pause does not start with the old one. */
+    @Test
+    fun aFreshSegmentIsAppendedAfterThePreviousText() {
+        assertEquals(
+            "first sentence. second sentence.",
+            Dictation.updateTranscript("first sentence.", "second sentence."),
+        )
+    }
+
+    /** If the recognizer revises a word in the same segment, most leading words match. */
+    @Test
+    fun aWordLevelRevisionReplacesInPlace() {
+        assertEquals(
+            "I walked to a store",
+            Dictation.updateTranscript("I walked to the store", "I walked to a store"),
+        )
+    }
+
+    /** A brief backtrack (new partial shorter but still a prefix) keeps the longer text. */
+    @Test
+    fun aBacktrackKeepsTheLongerTranscript() {
+        assertEquals(
+            "first sentence",
+            Dictation.updateTranscript("first sentence", "first"),
+        )
+    }
+
+    /** A new sentence that shares the first word is still treated as a new segment. */
+    @Test
+    fun aSharedFirstWordIsNotEnoughToMergeAcrossSegments() {
+        assertEquals(
+            "first sentence first word",
+            Dictation.updateTranscript("first sentence", "first word"),
+        )
+    }
+
     @Test
     fun preferredLanguageComesFirst() {
         val locales = Dictation.localeCandidates(

--- a/ios/App/SpeechDictation.swift
+++ b/ios/App/SpeechDictation.swift
@@ -204,7 +204,7 @@ final class SpeechDictation: ObservableObject {
         // new draft or stopping the new capture.
         guard gen == generation, !stopping, isListening else { return }
         if let result {
-            transcript = result.bestTranscription.formattedString
+            transcript = Dictation.updateTranscript(transcript, new: result.bestTranscription.formattedString)
             // Composer dictation does not wait for isFinal — the last
             // partial is what you send. If the recognizer finalizes on
             // its own (rare without endAudio), just stop listening.

--- a/ios/Sources/CompanionCore/Dictation.swift
+++ b/ios/Sources/CompanionCore/Dictation.swift
@@ -31,6 +31,37 @@ public enum Dictation {
         return "\(typed) \(spoken)"
     }
 
+    /// Merge a new formatted partial into the accumulated transcript.
+    ///
+    /// Partials for the same segment extend or revise the current text in
+    /// place. A fresh segment after a pause does not start with the previous
+    /// partial, so it is appended instead of replacing the accumulated text.
+    public static func updateTranscript(_ current: String, new: String) -> String {
+        let current = current.trimmingCharacters(in: .whitespacesAndNewlines)
+        let new = new.trimmingCharacters(in: .whitespacesAndNewlines)
+        if new.isEmpty { return current }
+        if current.isEmpty { return new }
+
+        // Same segment: the recognizer lengthened the current text.
+        if new.hasPrefix(current) { return new }
+
+        // Same segment with a brief backtrack: keep the longer version.
+        if current.hasPrefix(new) { return current }
+
+        // Same segment with a word-level revision: most leading words match.
+        let currentWords = current.split(separator: " ")
+        let newWords = new.split(separator: " ")
+        let commonWordCount = zip(currentWords, newWords)
+            .prefix(while: { $0.lowercased() == $1.lowercased() })
+            .count
+        if commonWordCount >= 2, commonWordCount * 2 >= currentWords.count {
+            return new
+        }
+
+        // New segment after a pause: append, separated by a space.
+        return draft(base: current, transcript: new)
+    }
+
     /// Locales to try, in order. First available recognizer wins.
     ///
     /// Preferred languages, then the current locale, then en-US as a last

--- a/ios/Tests/CompanionCoreTests/DictationTests.swift
+++ b/ios/Tests/CompanionCoreTests/DictationTests.swift
@@ -43,6 +43,65 @@ final class DictationTests: XCTestCase {
         XCTAssertEqual(Dictation.draft(base: "  ", transcript: "\n"), "")
     }
 
+    // MARK: - Transcript updates across segments
+
+    func testEmptyTranscriptTakesTheNewPartial() {
+        XCTAssertEqual(Dictation.updateTranscript("", new: "hello"), "hello")
+    }
+
+    func testEmptyPartialLeavesTheTranscript() {
+        XCTAssertEqual(Dictation.updateTranscript("hello", new: ""), "hello")
+        XCTAssertEqual(Dictation.updateTranscript("hello", new: "   "), "hello")
+    }
+
+    /// Same segment: each longer partial replaces the last in place.
+    func testALongerPartialReplacesTheCurrentOne() {
+        XCTAssertEqual(
+            Dictation.updateTranscript("first sent", new: "first sentence"),
+            "first sentence"
+        )
+        XCTAssertEqual(
+            Dictation.updateTranscript("first sentence", new: "first sentence."),
+            "first sentence."
+        )
+    }
+
+    /// A fresh segment after a pause does not start with the old one, so the
+    /// old text is preserved and the new segment is appended.
+    func testAFreshSegmentIsAppendedAfterThePreviousText() {
+        XCTAssertEqual(
+            Dictation.updateTranscript("first sentence.", new: "second sentence."),
+            "first sentence. second sentence."
+        )
+    }
+
+    /// If the recognizer revises a word in the middle of the same segment,
+    /// most leading words still match, so we take the latest best reading.
+    func testAWordLevelRevisionReplacesInPlace() {
+        XCTAssertEqual(
+            Dictation.updateTranscript("I walked to the store", new: "I walked to a store"),
+            "I walked to a store"
+        )
+    }
+
+    /// A brief backtrack (new partial shorter but still a prefix) keeps the
+    /// longer accumulated text.
+    func testABacktrackKeepsTheLongerTranscript() {
+        XCTAssertEqual(
+            Dictation.updateTranscript("first sentence", new: "first"),
+            "first sentence"
+        )
+    }
+
+    /// A new sentence that happens to share the first word with the previous
+    /// sentence is still treated as a new segment.
+    func testASharedFirstWordIsNotEnoughToMergeAcrossSegments() {
+        XCTAssertEqual(
+            Dictation.updateTranscript("first sentence", new: "first word"),
+            "first sentence first word"
+        )
+    }
+
     // MARK: - Locale candidates
 
     func testPreferredLanguageComesFirst() {


### PR DESCRIPTION
## What changed

- Added `Dictation.updateTranscript(_:new:)` in `ios/Sources/CompanionCore/Dictation.swift` and `Dictation.updateTranscript(current, new)` in `android/core/src/main/kotlin/com/openmausbot/companion/core/Dictation.kt`.
  - Partials for the same segment extend or revise the accumulated text in place.
  - A fresh segment that does not start with the current text is appended, preserving earlier dictated text.
- Updated `ios/App/SpeechDictation.swift` to merge each `SFSpeechRecognitionResult.bestTranscription.formattedString` through the helper instead of overwriting `transcript`.
- Updated `android/app/src/main/kotlin/com/openmausbot/companion/dictation/SpeechDictation.kt` to merge partial/final text the same way.
- Added unit tests for both `ios/Tests/CompanionCoreTests/DictationTests.swift` and `android/core/src/test/kotlin/com/openmausbot/companion/core/DictationTest.kt`.

## Why

OpenMausBot#707: when a user dictates more than one sentence, Speech.framework can reset `bestTranscription.formattedString` to only the new segment after a pause. The iOS code did `transcript = result.bestTranscription.formattedString`, which replaced the previous sentence. The Android recognizer partial callback had the same `transcript = newText` shape, so the same helper fixes both.

## How it was verified

- Android: `./gradlew :core:test --tests \"com.openmausbot.companion.core.DictationTest\"` passes.
- iOS: the Linux dev box does not have a Swift toolchain, so `swift test --filter DictationTests` could not be run locally. The test cases are deterministic and mirror the Android tests; they will run on the iOS CI.
- The iOS simulator/device iPad repro from the issue is quoted below for maintainer/device verification.

## Screenshots (UI changes)

No UI changes; this is a dictation transcription bug fix.

## Checklist

- [ ] `pnpm typecheck` and `pnpm test` pass locally (not applicable — no JS/TS changes)
- [x] Server behavior changes come with tests (core dictation tests added for iOS and Android)
- [x] No `dist-server/` edits
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv

## Problem

During dictation into the composer, pausing and speaking again drops the first sentence. `transcript` is replaced with the new `bestTranscription.formattedString` instead of accumulating across segments.

## Triage

- `ios/App/SpeechDictation.swift` line ~207 assigned `transcript = result.bestTranscription.formattedString` directly.
- `ChatView` already correctly re-joins `base + spoken` on `onChange(of: dictation.transcript)`, but the bug is upstream: `spoken` itself gets clobbered.
- Android `SpeechDictation.kt` mirrored the same `transcript = text` replacement.

## Fix

Introduced `Dictation.updateTranscript` to decide whether a new partial is:
1. The same segment (new starts with current, or current starts with new, or most leading words match) — replace in place.
2. A fresh segment (no significant overlap) — append with a space.

Both iOS and Android call this helper for every partial and final.

## Verification

- Android `DictationTest` passes locally with the new cases.
- iOS `DictationTests` could not be run locally due to missing `swift` toolchain; the new cases are included and will be exercised by the iOS CI.

## Notes

- Issue link: https://github.com/milind-soni/OpenMausBot/issues/707
- iPad repro from the issue: dictate "first sentence", pause ~1s, dictate "second sentence." The composer should now show "first sentence. second sentence." instead of only "second sentence."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speech dictation transcript handling on Android and iOS.
  * Partial and final recognition results now accumulate correctly instead of replacing previously captured text.
  * Better handling of speech revisions, brief backtracking, and new segments after pauses.

* **Tests**
  * Added coverage for transcript accumulation, revisions, empty results, and segment boundaries across both platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->