### PR TITLE
fix: keep highlighted code readable in light skins

### DIFF
--- a/src/components/ChatMarkdown.test.ts
+++ b/src/components/ChatMarkdown.test.ts
@@ -1,6 +1,7 @@
 import { createElement } from "react";
+import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   ChatMarkdown,
@@ -9,6 +10,33 @@ import {
   markdownImageOpenUrl,
   localFilePath,
 } from "./ChatMarkdown";
+
+vi.mock("react", async (importOriginal) => {
+  const react = await importOriginal<typeof React>();
+  return { ...react, useEffect: vi.fn(react.useEffect) };
+});
+
+it("requests both code palettes for skin-aware highlighting", async () => {
+  const originalUseEffect = (await vi.importActual<typeof React>("react")).useEffect;
+  const effects: React.EffectCallback[] = [];
+  const effect = vi.mocked(React.useEffect).mockImplementation((callback) => { effects.push(callback); });
+  const codeToHtml = vi.fn().mockResolvedValue("<pre>dual palette</pre>");
+  vi.doMock("shiki", () => ({ codeToHtml }));
+  const cleanup: ReturnType<React.EffectCallback>[] = [];
+  try {
+    renderToStaticMarkup(createElement(ChatMarkdown, { text: "```text\nPalette regression sample\n```" }));
+    for (const callback of effects) cleanup.push(callback());
+    await vi.waitFor(() => expect(codeToHtml).toHaveBeenCalledWith("Palette regression sample", {
+      lang: "text",
+      themes: { light: "github-light-default", dark: "github-dark-default" },
+      defaultColor: "light-dark()",
+    }));
+  } finally {
+    for (const close of cleanup) if (typeof close === "function") close();
+    effect.mockImplementation(originalUseEffect);
+    vi.doUnmock("shiki");
+  }
+});
 
 describe("Markdown image metadata", () => {
   it("prefers alt text and otherwise derives a readable filename", () => {

--- a/src/components/ChatMarkdown.tsx
+++ b/src/components/ChatMarkdown.tsx
@@ -113,7 +113,11 @@ function CodeBlock({ code, lang, streaming }: { code: string; lang: string; stre
         .then((shiki) =>
           shiki.codeToHtml(code, {
             lang: lang || "text",
-            theme: "github-dark-default",
+            themes: {
+              light: "github-light-default",
+              dark: "github-dark-default",
+            },
+            defaultColor: "light-dark()",
           }),
         )
         .then((out) => {

--- a/src/lib/skins.test.ts
+++ b/src/lib/skins.test.ts
@@ -39,6 +39,15 @@ describe("skins", () => {
     }
   });
 
+  it("selects a code-only light or dark palette in every nearest skin", () => {
+    for (const id of SKIN_IDS) {
+      const body = css.match(new RegExp(`\\[data-skin="${id}"\\]\\s*\\{([^}]*)\\}`))?.[1] ?? "";
+      const scheme = ["atelier", "lagoon", "linen"].includes(id) ? "light" : "dark";
+      expect(body).toContain(`--code-color-scheme: ${scheme};`);
+    }
+    expect(css).toMatch(/\.chat-md \.shiki\s*\{\s*color-scheme:\s*var\(--code-color-scheme\);\s*\}/);
+  });
+
   it("describes each skin exactly once", () => {
     expect(SKINS.map((s) => s.id).sort()).toEqual([...SKIN_IDS].sort());
     for (const skin of SKINS) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -62,6 +62,7 @@
 /* Tokens that no utility generates — declared outside `@theme` so Tailwind
    can't tree-shake them away, and so a skin can redefine them freely. */
 :root {
+  --code-color-scheme: dark;
   /* ink carried by a filled accent / danger surface (see the rule at the
      bottom of this file, which is what makes them take effect) */
   --color-accent-ink: #ffffff;
@@ -83,6 +84,7 @@
    they carry. Atelier and Foundry fix this via --color-accent-ink.
    ───────────────────────────────────────────────────────────────────────── */
 [data-skin="midnight"] {
+  --code-color-scheme: dark;
   --color-app: #070707;
   --color-panel: #111111;
   --color-raised: #2f2f2f;
@@ -122,6 +124,7 @@
    value is named next to each, so the drift stays auditable.
    ───────────────────────────────────────────────────────────────────────── */
 [data-skin="atelier"] {
+  --code-color-scheme: light;
   --color-app: #f5f1eb;           /* outermost ground */
   --color-panel: #fbf8f2;         /* sidebar */
   --color-raised: #ffffff;        /* content — raised means lighter here */
@@ -177,6 +180,7 @@
    8px — because sheet metal doesn't round the way paper does.
    ───────────────────────────────────────────────────────────────────────── */
 [data-skin="foundry"] {
+  --code-color-scheme: dark;
   --color-app: #100e0b;           /* deepest ground, warm black */
   --color-panel: #171410;         /* sidebar */
   --color-raised: #262019;        /* raised means warmer, not just lighter */
@@ -226,6 +230,7 @@
    round more than paper does, and far more than sheet metal.
    ───────────────────────────────────────────────────────────────────────── */
 [data-skin="lagoon"] {
+  --code-color-scheme: light;
   /* The tint is the point, so it is carried by the surfaces, not by a button:
      the ground sits 13 points of green-blue above its red channel, roughly
      three times Atelier's cream cast, which is what makes the skin read as
@@ -276,6 +281,7 @@
    desaturated: it marks actions and focus without making the chrome glow.
    ───────────────────────────────────────────────────────────────────────── */
 [data-skin="graphite"] {
+  --code-color-scheme: dark;
   --color-app: #111214;
   --color-panel: #181a1d;
   --color-raised: #2a2d32;
@@ -315,6 +321,7 @@
    crisp and familiar instead of colourful.
    ───────────────────────────────────────────────────────────────────────── */
 [data-skin="linen"] {
+  --code-color-scheme: light;
   --color-app: #eceff3;
   --color-panel: #f5f6f8;
   --color-raised: #ffffff;
@@ -353,6 +360,7 @@
    much as the accent, so the skin feels cohesive rather than neon or themed.
    ───────────────────────────────────────────────────────────────────────── */
 [data-skin="dusk"] {
+  --code-color-scheme: dark;
   --color-app: #121014;
   --color-panel: #19161c;
   --color-raised: #2b2630;
@@ -384,6 +392,12 @@
     "Segoe UI", system-ui, sans-serif;
   --radius-lg: 8px;
   --radius-xl: 12px;
+}
+
+/* Shiki emits both palettes so cached blocks follow the nearest skin without
+   re-tokenizing. Scope the scheme to code; native controls keep their styling. */
+.chat-md .shiki {
+  color-scheme: var(--code-color-scheme);
 }
 
 html,


### PR DESCRIPTION
## What changed

Use Shiki's light and dark GitHub palettes for fenced code, with a code-only color scheme selected by each skin. Existing and cached blocks update when the skin changes; dark skins keep their existing palette, and nested skin previews inherit the nearest skin.

## Why

In Linen, highlighted plain text used `#e6edf3` on the skin's `#e6e9ee` inset because the renderer always selected the dark palette and cleared its background. That is about 1.03:1 contrast. The light palette uses `#1f2328`, raising the same plain-text contrast to 12.98:1. Atelier and Lagoon share the same underlying issue.

## How it was verified

- `pnpm typecheck` — passed.
- `pnpm test` — passed: 3,965 main-suite tests, 7 broker tests, 137 Electron tests, and the packaged-server smoke check (20 main-suite skips and 1 todo).
- `pnpm check:contrast` — passed, retaining the documented Midnight baseline exceptions.
- `pnpm exec vite build` — passed.
- Actual `ChatMarkdown` rendered in an isolated browser fixture: Linen → Midnight → Linen, cached remount, settled streaming, unknown-language fallback and inline code. Computed styles checked across all seven skins and both nested light/dark cases; the color scheme outside code remains unchanged. Browser recording: zero console/server errors.
- macOS arm64, Node 24.0.1, pnpm 10.33.0, Chrome for Testing 152. The visual check used the real renderer, not a full Electron session.

The initial full run inherited OpenMaus runtime environment variables and failed two MCP discovery tests; both files passed (36 tests) after removing those inherited app settings from the child process. The final full run uses that clean environment. No server code changed.

[Reproducible fixture and color evidence](https://github.com/FsDevNinja/OpenMausBot/tree/d782fadf3ff27b168c7883422da529a86c8c08d8) are kept on a separate evidence branch so the product diff stays limited to two source files.

Upstream comparison base: `6aa058ebbea9e6c5f6d715ab459bb0e0cd91a9ed`. Head branch: `fix/linen-code-block-contrast`; verified commit: `284ee6307e1f3499c0401b3046a559ef7e65abbe`.

## Screenshots (UI changes)

Generic sample text in the same Linen fixture and viewport:

| Before | After |
| --- | --- |
| ![Linen before: pale code nearly disappears](https://raw.githubusercontent.com/FsDevNinja/OpenMausBot/d782fadf3ff27b168c7883422da529a86c8c08d8/before-linen.png) | ![Linen after: code text is readable](https://raw.githubusercontent.com/FsDevNinja/OpenMausBot/d782fadf3ff27b168c7883422da529a86c8c08d8/after-linen.png) |

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests — no server behavior changes
- [x] No `dist-server/` edits or dependency/lockfile churn
- [x] No platform-specific code, `shell: true`, or command-string building
- [x] No secrets or machine/account-specific configuration in the product diff or screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Code blocks now adapt automatically to the selected light or dark skin.
  - Syntax highlighting uses distinct themes for light and dark appearances.
  - Cached code blocks update their color scheme when switching skins.
  - Native controls retain their independent styling.
  - Existing markdown rendering behavior remains unchanged.
- **Tests**
  - Added coverage to verify skin-aware syntax highlighting and color-scheme settings across all available skins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->