### PR TITLE
fix: wait for Codex process shutdown

### DIFF
--- a/server/drivers/antigravity-acp.ts
+++ b/server/drivers/antigravity-acp.ts
@@ -330,8 +330,7 @@ export class AntigravityAcpClient {
     killCliTree(this.child);
   }
 
-  /** Close, then wait (bounded) for the process to be gone. `killCliTree`
-   * on Windows asks taskkill and returns at once; the exit lands later. */
+  /** Close, then wait (bounded) for the process to be gone. */
   async closeAndWait(timeoutMs = 5_000): Promise<boolean> {
     this.close();
     let timer: NodeJS.Timeout | undefined;

--- a/server/drivers/antigravity-lifecycle.test.ts
+++ b/server/drivers/antigravity-lifecycle.test.ts
@@ -131,7 +131,7 @@ describe("Antigravity initialization diagnostics", () => {
 describe("Antigravity validation shutdown", () => {
   it("contains Windows one-file extraction in the owned verification profile", async () => {
     const child = fakeChild();
-    vi.mocked(killCliTree).mockImplementation(() => { child.emit("close", 0); });
+    vi.mocked(killCliTree).mockImplementation(async () => { child.emit("close", 0); return true; });
     await validateAntigravityRuntime(runtime, "1.1.1");
     const environment = vi.mocked(spawnCli).mock.calls[0][2].env!;
     if (process.platform === "win32") {
@@ -176,7 +176,7 @@ describe("Antigravity validation shutdown", () => {
     fakeChild();
     let killed!: () => void;
     const stopping = new Promise<void>((resolve) => { killed = resolve; });
-    vi.mocked(killCliTree).mockImplementation(killed);
+    vi.mocked(killCliTree).mockImplementation(async () => { killed(); return false; });
     const validation = validateAntigravityRuntime(runtime, "1.1.1");
     const rejected = expect(validation).rejects.toThrow("did not shut down");
     await stopping;
@@ -193,7 +193,7 @@ describe("Antigravity validation shutdown", () => {
     fakeChild(reply);
     let killed!: () => void;
     const stopping = new Promise<void>((resolve) => { killed = resolve; });
-    vi.mocked(killCliTree).mockImplementation(killed);
+    vi.mocked(killCliTree).mockImplementation(async () => { killed(); return false; });
     const rejected = expect(validateAntigravityRuntime(runtime, "1.1.1")).rejects.toThrow(error);
     await stopping;
     await vi.advanceTimersByTimeAsync(5_000);
@@ -207,7 +207,7 @@ describe("Antigravity validation shutdown", () => {
     { reply: { result: {} }, error: "did not identify" },
   ])("preserves $error when profile cleanup fails after close", async ({ reply, error }) => {
     const child = fakeChild(reply);
-    vi.mocked(killCliTree).mockImplementation(() => { child.emit("close", 0); });
+    vi.mocked(killCliTree).mockImplementation(async () => { child.emit("close", 0); return true; });
     vi.mocked(rm).mockRejectedValueOnce(Object.assign(new Error("cleanup EPERM"), { code: "EPERM" }));
     await expect(validateAntigravityRuntime(runtime, "1.1.1")).rejects.toThrow(error);
     expect(rm).toHaveBeenCalledWith(scratch[0], { recursive: true, force: true, maxRetries: 4, retryDelay: 250 });
@@ -216,7 +216,7 @@ describe("Antigravity validation shutdown", () => {
 
   it("keeps successful validation when profile cleanup remains locked after close", async () => {
     const child = fakeChild();
-    vi.mocked(killCliTree).mockImplementation(() => { child.emit("close", 0); });
+    vi.mocked(killCliTree).mockImplementation(async () => { child.emit("close", 0); return true; });
     vi.mocked(rm).mockRejectedValueOnce(Object.assign(new Error("cleanup EPERM"), { code: "EPERM" }));
     await expect(validateAntigravityRuntime(runtime, "1.1.1")).resolves.toBeUndefined();
     expect(rm).toHaveBeenCalledWith(scratch[0], { recursive: true, force: true, maxRetries: 4, retryDelay: 250 });

--- a/server/drivers/antigravity-runtime.ts
+++ b/server/drivers/antigravity-runtime.ts
@@ -32,8 +32,8 @@ const STAGING_PREFIX = ".install-";
 
 /** Windows refuses to rename or delete a file something still holds open,
  * with EPERM/EBUSY/EACCES rather than a clear "in use": the runtime the
- * validator just stopped (taskkill is asynchronous) or an antivirus scan of
- * a brand-new executable. Retry briefly; persistent refusals still fail. */
+ * validator just stopped or an antivirus scan of a brand-new executable.
+ * Retry briefly; persistent refusals still fail. */
 export function transientWindowsFileError(error: unknown): boolean {
   const code = typeof error === "object" && error !== null ? Reflect.get(error, "code") : undefined;
   return code === "EPERM" || code === "EBUSY" || code === "EACCES" || code === "ENOTEMPTY";

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -848,12 +848,12 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     const running = await instance.adapter.sendTurn({ threadId, text: "stop this turn" });
     await recorder.until((e) => e.type === "item.completed" && e.itemType === "tool" && e.turnId === running.turnId);
     const stoppedPid = JSON.parse(readFileSync(dump, "utf8")).pid;
-    // Windows taskkill returns before the child exits. Hold that window open
-    // deterministically: the pipe remains writable until we release the kill.
+    // Hold the interrupt-before-exit window open deterministically: the pipe
+    // remains writable until we release the kill.
     const conn = await connectSocket(permissionSocketPath(threadId));
     const nextAnswer = answerQueue(conn);
     const kill = procs.killCliTree;
-    const delayedKill = vi.spyOn(procs, "killCliTree").mockImplementation(() => {});
+    const delayedKill = vi.spyOn(procs, "killCliTree").mockImplementation(async () => false);
     try {
       const pendingAnswer = nextAnswer();
       conn.write(JSON.stringify({ t: "ask", id: "before-stop", tool: "Bash", input: { command: "sleep 60" } }) + "\n");

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -24,6 +24,15 @@ import { removeTempDir } from "../testing/cleanup.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-codex-app-server.ts");
 
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 describe("CodexDriver.decodeConfig", () => {
   it("defaults to the codex binary with fullAuto off", () => {
     expect(CodexDriver.decodeConfig({})).toEqual({ cli: "codex", fullAuto: false });
@@ -147,6 +156,7 @@ describe("CodexDriver turns (fake app-server)", () => {
     expect(recorder.events.at(-1)).toMatchObject({ type: "turn.completed", ok: true, usage: { input: 7, output: 3, cachedInput: 4 } });
 
     const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(processIsAlive(seen.pid)).toBe(false);
     expect(seen.env.OPENAI_API_KEY).toBeUndefined();
     expect(seen.env.BOX_TOKEN).toBeUndefined();
     expect(seen.env.OMB_TTS_KEY).toBeUndefined();

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -483,7 +483,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
     await refreshModels();
     const listeners = new Set<RuntimeEventListener>();
     interface Turn {
-      stop: () => void;
+      stop: () => Promise<boolean>;
       turnId: string;
       asks: Map<string, (behavior: "allow" | "deny" | "answer", message?: string, source?: "user" | "timeout" | "system") => void>;
     }
@@ -626,20 +626,31 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
           send({ jsonrpc: "2.0", id, method, params });
         });
 
+      let stopping: Promise<boolean> | undefined;
+      const terminate = () => stopping ??= killCliTree(child);
       const stop = () => {
         stopRequested = true;
-        killCliTree(child);
+        return terminate();
       };
 
-      const settle = (ok: boolean, stopReason: string | null) => {
+      const settle = async (ok: boolean, stopReason: string | null) => {
         if (state.settled) return;
         state.settled = true;
         for (const finish of [...asks.values()]) finish("deny", "OpenMausBot: the turn ended", "system");
         for (const p of rpcPending.values()) p.reject(new Error("turn settled"));
         rpcPending.clear();
-        active.delete(threadId);
-        emit({ ...base(threadId, turnId), type: "turn.completed", ok, stopReason, cost: null, ...(state.usage ? { usage: state.usage } : {}) });
-        stop(); // the app-server never exits on its own
+        const complete = () => {
+          if (active.get(threadId)?.stop !== stop) return;
+          active.delete(threadId);
+          emit({ ...base(threadId, turnId), type: "turn.completed", ok, stopReason, cost: null, ...(state.usage ? { usage: state.usage } : {}) });
+        };
+        if (await stop()) {
+          complete();
+        } else {
+          emit({ ...base(threadId, turnId), type: "runtime.error", message: "codex did not shut down after termination was requested" });
+          if (child.exitCode !== null || child.signalCode !== null) complete();
+          else child.once("close", complete);
+        }
       };
 
       // server→client approval request → canonical request.opened
@@ -868,7 +879,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
           }
           case "turn/completed": {
             const t = p.turn ?? {};
-            settle(t.status === "completed", t.status === "completed" ? null : (t.error?.message ?? t.status ?? "failed"));
+            void settle(t.status === "completed", t.status === "completed" ? null : (t.error?.message ?? t.status ?? "failed"));
             break;
           }
           case "error":
@@ -887,6 +898,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       // multibyte characters that straddle two reads and corrupts the text
       child.stdout.setEncoding("utf8");
       child.stdout.on("data", (chunk) => {
+        if (abandoned) return;
         buf += chunk;
         let nl;
         while ((nl = buf.indexOf("\n")) !== -1) {
@@ -924,7 +936,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       child.on("error", (e) => {
         if (abandoned) return;
         emit({ ...base(threadId, turnId), type: "runtime.error", ...describeSpawnFailure(e, config.cli) });
-        settle(false, "spawn_error");
+        void settle(false, "spawn_error");
       });
       child.on("close", (code) => {
         if (abandoned) return;
@@ -934,7 +946,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
             type: "runtime.error",
             message: `codex exited ${code} before turn/completed${stderr ? `: ${stderr.trim().slice(-300)}` : ""}`,
           });
-          settle(false, "exit_before_result");
+          void settle(false, "exit_before_result");
         }
       });
 
@@ -1078,7 +1090,10 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
           // This app-server never exits by itself. Retire the failed attempt
           // and silence its late handlers before the replacement launches.
           abandoned = true;
-          killCliTree(child);
+          if (!await terminate()) {
+            void settle(false, "shutdown_timeout");
+            return;
+          }
           await new Promise<void>((resolve) => {
             const timer = setTimeout(resolve, Math.max(1, Math.round(delayMs * retryScale)));
             timer.unref?.();
@@ -1086,7 +1101,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
           if (!stopRequested) {
             void launchAttempt(attempt).catch(() => {});
           } else {
-            settle(false, "interrupted");
+            await settle(false, "interrupted");
           }
           return;
         }
@@ -1097,7 +1112,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
             message,
             ...(needsAuth ? { setup: true } : {}),
           });
-          settle(false, needsAuth ? "auth_required" : "rpc_error");
+          await settle(false, needsAuth ? "auth_required" : "rpc_error");
         }
       }
     };
@@ -1155,7 +1170,9 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
         effortLevels: ["low", "medium", "high", "xhigh", "max"],
       },
       sendTurn,
-      interruptTurn: async (threadId) => active.get(threadId)?.stop(),
+      interruptTurn: async (threadId) => {
+        await active.get(threadId)?.stop();
+      },
       respondToRequest: async (threadId, requestId, decision) => {
         const turn = active.get(threadId);
         const finish = turn?.asks.get(requestId);
@@ -1165,7 +1182,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       },
       hasSession: (threadId) => active.has(threadId),
       stopAll: async () => {
-        for (const { stop } of active.values()) stop();
+        await Promise.all([...active.values()].map(({ stop }) => stop()));
       },
       onEvent: (listener) => {
         listeners.add(listener);
@@ -1173,7 +1190,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       },
     },
     dispose: async () => {
-      for (const { stop } of active.values()) stop();
+      await Promise.all([...active.values()].map(({ stop }) => stop()));
       listeners.clear();
     },
   };

--- a/server/kill-tree.test.ts
+++ b/server/kill-tree.test.ts
@@ -24,11 +24,7 @@ describe("killCliTree", () => {
     try {
       expect(child.stdin.listenerCount("error")).toBeGreaterThan(0);
     } finally {
-      killCliTree(child);
-      await Promise.race([
-        new Promise<void>((resolve) => child.once("close", () => resolve())),
-        new Promise<void>((resolve) => setTimeout(resolve, 5_000)),
-      ]);
+      await expect(killCliTree(child)).resolves.toBe(true);
     }
   });
 
@@ -55,7 +51,7 @@ describe("killCliTree", () => {
       expect(grandchild).toBeGreaterThan(0);
       expect(alive(grandchild)).toBe(true);
 
-      killCliTree(parent);
+      await expect(killCliTree(parent)).resolves.toBe(true);
 
       // Read the parent's death off the child object: a POSIX parent stays a
       // live pid as a zombie until Node reaps it. The grandchild has no Child
@@ -68,7 +64,7 @@ describe("killCliTree", () => {
       expect(alive(grandchild)).toBe(false);
       expect(exited()).toBe(true);
     } finally {
-      killCliTree(parent);
+      await killCliTree(parent);
       if (grandchild && alive(grandchild)) {
         try {
           process.kill(grandchild, "SIGKILL");

--- a/server/procs.ts
+++ b/server/procs.ts
@@ -123,32 +123,46 @@ export function describeSpawnFailure(err: NodeJS.ErrnoException, cli: string): S
 }
 
 /** Stop a CLI and every process it spawned (MCP proxies included). */
-export function killCliTree(child: ChildProcess): void {
+export function killCliTree(child: ChildProcess, timeoutMs = 5_000): Promise<boolean> {
   const pid = child.pid;
-  if (!pid || child.exitCode !== null || child.signalCode !== null) return;
+  if (!pid || child.exitCode !== null || child.signalCode !== null) return Promise.resolve(true);
 
-  if (process.platform === "win32") {
-    execFile("taskkill", ["/PID", String(pid), "/T", "/F"], { windowsHide: true }, (err) => {
-      if (!err) return;
+  return new Promise((resolve) => {
+    let timer: NodeJS.Timeout;
+    const done = (stopped: boolean) => {
+      clearTimeout(timer);
+      child.off("close", closed);
+      resolve(stopped);
+    };
+    const closed = () => done(true);
+    child.once("close", closed);
+    timer = setTimeout(() => done(false), timeoutMs);
+    timer.unref?.();
+
+    if (process.platform === "win32") {
+      execFile("taskkill", ["/PID", String(pid), "/T", "/F"], { windowsHide: true }, (err) => {
+        if (!err) return;
+        try {
+          // taskkill is unavailable or the tree lookup failed. At least stop
+          // the process we own instead of leaving the entire turn running.
+          child.kill();
+        } catch {
+          /* already gone */
+        }
+      });
+      return;
+    }
+
+    try {
+      process.kill(-pid, "SIGTERM");
+    } catch {
       try {
-        // taskkill is unavailable or the tree lookup failed. At least stop
-        // the process we own instead of leaving the entire turn running.
-        child.kill();
+        child.kill("SIGTERM");
       } catch {
         /* already gone */
       }
-    });
-    return;
-  }
-  try {
-    process.kill(-pid, "SIGTERM");
-  } catch {
-    try {
-      child.kill("SIGTERM");
-    } catch {
-      /* already gone */
     }
-  }
+  });
 }
 
 /** Per-turn broker channel: unix socket on POSIX, named pipe on Windows

--- a/server/testing/fake-codex-app-server.ts
+++ b/server/testing/fake-codex-app-server.ts
@@ -8,7 +8,7 @@
 //                     mcp-elicitation | mcp-app-approval | mcp-form | permissions-approval | config-profile |
 //                     config-profile-unsupported | config-read-error | image |
 //                     logged-in-stdout | logged-out | unauthorized
-//   FAKE_CODEX_DUMP   path to write {argv, env, calls, decision} as JSON
+//   FAKE_CODEX_DUMP   path to write {pid, argv, env, calls, decision} as JSON
 //
 // Keep this file dependency-free — it runs as a bare `node` subprocess.
 import { readFileSync, writeFileSync } from "node:fs";
@@ -41,7 +41,7 @@ const dump = () => {
   if (process.env.FAKE_CODEX_DUMP) {
     writeFileSync(
       process.env.FAKE_CODEX_DUMP,
-      JSON.stringify({ argv: process.argv.slice(2), env: process.env, calls, decision }, null, 2),
+      JSON.stringify({ pid: process.pid, argv: process.argv.slice(2), env: process.env, calls, decision }, null, 2),
     );
   }
 };


### PR DESCRIPTION
## Summary

- make `killCliTree` report whether the owned child closed within a bounded timeout
- wait for Codex app-server shutdown before completion, reuse, retry, interruption, and disposal
- ignore late output from abandoned retry attempts
- verify the fake Codex PID is gone when `turn.completed` is emitted

## Why

On Windows, `taskkill /T /F` was started asynchronously. A replacement Codex app-server could launch and reuse its thread while the old process tree was still exiting, causing overlapping access to Codex state such as SQLite files.

## Validation

- `pnpm typecheck`
- focused lifecycle suite: 140 passed, 2 skipped
- `pnpm broker:test`
- `pnpm test:packaged-server`
- full `pnpm test`: 3867 passed, 107 skipped, 1 todo; remaining failures were unrelated Windows environment limitations (symlink permission, transient file lock, ambient CODEX_HOME, and Electron fixture exit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when stopping background processes, ensuring shutdown completes before an operation is marked finished.
  - Added a bounded wait for process termination, with clearer runtime errors when a process cannot stop in time.
  - Improved handling of interrupted and retried Codex turns to prevent lingering processes and premature completion states.
  - Enhanced cleanup behavior across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->