### PR TITLE
fix(local-vm): allow Firefox sandbox chroot under Podman

### DIFF
--- a/docs/verification/podman-firefox.md
+++ b/docs/verification/podman-firefox.md
@@ -32,14 +32,22 @@ node --experimental-strip-types scripts/verify-podman-firefox.ts
 
 The script creates disposable desktops and engine-host temporary workspaces.
 It compares identical generated arguments with and without `SYS_CHROOT`, runs
-Firefox headlessly with a fresh profile, validates PNG bytes and cleans up only
+Firefox headlessly with a fresh profile and validates PNG bytes. The patched
+container also runs `scripts/testing/firefox-sandbox.py` with Python's standard
+library and Firefox's bundled Marionette server on guest loopback; no debug
+port is published. It reads the [about:support sandbox fields](https://searchfox.org/firefox-main/source/toolkit/content/aboutSupport.js)
+and requires a positive effective content-process sandbox level. A separate
+fresh-profile control sets `MOZ_DISABLE_CONTENT_SANDBOX=1`, requires level zero,
+and must fail the same enabled-sandbox assertion. Both levels are recorded in
+`receipt.json`. The script cleans up only
 the containers and workspaces it created. Logs and receipt remain under
 `.omb-scratch/firefox` (override with `OMB_VERIFY_OUTPUT`).
 
 2026-09-06: Windows/WSL2 Linux x86_64, rootless Podman 5.8.3, managed driver
 0.20.0-v4 image. Baseline: `chroot: EPERM`, timeout exit 124, no PNG. Patched:
-Firefox exit 0, valid PNG, no `chroot: EPERM`. Browser sandbox remained enabled.
-Related container/VPS tests: 64 passed; server TypeScript checking passed.
+Firefox exit 0, valid PNG, no `chroot: EPERM`. Firefox reported configured/effective content sandbox levels 6/6; the disabled
+control reported 6/0 and was rejected by the enabled-sandbox assertion.
+Related container/VPS tests: 71 passed; server TypeScript checking passed.
 
 This is browser startup/rendering evidence, not an interactive-input test.
 Native Linux, ARM64, SELinux enforcing and other runtime versions were not

--- a/docs/verification/podman-firefox.md
+++ b/docs/verification/podman-firefox.md
@@ -11,6 +11,16 @@ the normal Local VM lifecycle. Retain the workspace bind mount; do not delete
 user files or silently recreate a busy desktop. Privileged mode and unconfined
 security profiles are not required or accepted by this repair.
 
+An old container is reported as unsafe/not ready with a request to recreate it;
+status checks and chat turns do not automatically replace it. Once its current
+work has finished, save any needed files under `/home/cua/workspace`. For a
+per-bot desktop, use that bot's Computer panel to recreate it and confirm the
+existing prompt. For the shared desktop, use **Delete and recreate** in the
+Local VM settings. The existing remove/run lifecycle retains the same workspace
+bind mount. Files elsewhere in the container, including Firefox profiles outside
+the workspace, are discarded; copy anything needed into the workspace first.
+Restarting the old container does not add the new capability.
+
 ## Isolated before/after acceptance
 
 Set `OMB_VERIFY_PODMAN` and `OMB_VERIFY_MACHINE` explicitly, with the managed

--- a/docs/verification/podman-firefox.md
+++ b/docs/verification/podman-firefox.md
@@ -1,0 +1,36 @@
+# Firefox sandbox in Podman Local VMs
+
+Fixes #853. Podman's default seccomp policy gates `chroot` on `SYS_CHROOT`;
+Firefox uses this syscall while establishing its own Linux sandbox. Managed
+Podman desktops now retain that capability alongside `SETUID` and `SETGID`.
+Effective and bounding capability validation requires the same exact set.
+Docker and VPS policies remain unchanged.
+
+Existing Podman desktops with the old capability set require recreation through
+the normal Local VM lifecycle. Retain the workspace bind mount; do not delete
+user files or silently recreate a busy desktop. Privileged mode and unconfined
+security profiles are not required or accepted by this repair.
+
+## Isolated before/after acceptance
+
+Set `OMB_VERIFY_PODMAN` and `OMB_VERIFY_MACHINE` explicitly, with the managed
+image already prepared on that test engine, then run:
+
+```sh
+node --experimental-strip-types scripts/verify-podman-firefox.ts
+```
+
+The script creates disposable desktops and engine-host temporary workspaces.
+It compares identical generated arguments with and without `SYS_CHROOT`, runs
+Firefox headlessly with a fresh profile, validates PNG bytes and cleans up only
+the containers and workspaces it created. Logs and receipt remain under
+`.omb-scratch/firefox` (override with `OMB_VERIFY_OUTPUT`).
+
+2026-09-06: Windows/WSL2 Linux x86_64, rootless Podman 5.8.3, managed driver
+0.20.0-v4 image. Baseline: `chroot: EPERM`, timeout exit 124, no PNG. Patched:
+Firefox exit 0, valid PNG, no `chroot: EPERM`. Browser sandbox remained enabled.
+Related container/VPS tests: 64 passed; server TypeScript checking passed.
+
+This is browser startup/rendering evidence, not an interactive-input test.
+Native Linux, ARM64, SELinux enforcing and other runtime versions were not
+certified by this run; the full repository suite was not repeated.

--- a/scripts/testing/firefox-sandbox.py
+++ b/scripts/testing/firefox-sandbox.py
@@ -1,0 +1,91 @@
+"""Read Firefox's about:support sandbox fields inside a disposable container.
+
+Uses the bundled Marionette server on guest loopback and Python's standard
+library only. No browser chrome/system access or published debug port.
+"""
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+with tempfile.TemporaryDirectory(prefix="omb-firefox-sandbox-") as profile:
+    env = dict(os.environ)
+    if sys.argv[1] == "disabled":
+        env["MOZ_DISABLE_CONTENT_SANDBOX"] = "1"
+    with open(os.path.join(profile, "firefox.log"), "w+") as log:
+        browser = subprocess.Popen(
+            ["firefox-esr", "--headless", "--no-remote", "--marionette",
+             "--profile", profile, "about:blank"],
+            env=env, stdout=log, stderr=log,
+        )
+        connection = None
+        try:
+            deadline = time.monotonic() + 30
+            while connection is None:
+                if browser.poll() is not None or time.monotonic() > deadline:
+                    raise RuntimeError("Firefox did not start Marionette")
+                try:
+                    connection = socket.create_connection(("127.0.0.1", 2828), timeout=1)
+                except OSError:
+                    time.sleep(0.1)
+            connection.settimeout(30)
+            stream = connection.makefile("rb")
+
+            def receive():
+                length = b""
+                while True:
+                    byte = stream.read(1)
+                    if not byte:
+                        raise RuntimeError("Marionette disconnected")
+                    if byte == b":":
+                        break
+                    length += byte
+                return json.loads(stream.read(int(length)))
+
+            receive()  # Protocol greeting.
+            sequence = 0
+
+            def command(name, parameters):
+                global sequence
+                sequence += 1
+                payload = json.dumps([0, sequence, name, parameters]).encode()
+                connection.sendall(str(len(payload)).encode() + b":" + payload)
+                response = receive()
+                if response[1] != sequence or response[2] is not None:
+                    raise RuntimeError(str(response))
+                return response[3]
+
+            command("WebDriver:NewSession", {"capabilities": {}})
+            command("WebDriver:Navigate", {"url": "about:support"})
+            fields = {}
+            deadline = time.monotonic() + 30
+            while "effective-content-sandbox-level" not in fields:
+                result = command("WebDriver:ExecuteScript", {
+                    "script": "return Object.fromEntries(Array.from(document.querySelectorAll('#sandbox-tbody tr'), row => [row.querySelector('th').getAttribute('data-l10n-id'), row.querySelector('td').textContent]));",
+                    "args": [], "newSandbox": True,
+                })
+                fields = result["value"]
+                if time.monotonic() > deadline:
+                    raise RuntimeError("Missing about:support sandbox fields: " + str(fields))
+                time.sleep(0.1)
+            print(json.dumps({
+                "configuredContentSandboxLevel": int(fields["content-sandbox-level"]),
+                "effectiveContentSandboxLevel": int(fields["effective-content-sandbox-level"]),
+            }))
+        except Exception:
+            log.flush()
+            log.seek(0)
+            sys.stderr.write(log.read())
+            raise
+        finally:
+            if connection is not None:
+                connection.close()
+            browser.terminate()
+            try:
+                browser.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                browser.kill()
+                browser.wait(timeout=10)

--- a/scripts/verify-podman-firefox.ts
+++ b/scripts/verify-podman-firefox.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const podman = process.env.OMB_VERIFY_PODMAN;
@@ -18,6 +18,11 @@ process.env.USERPROFILE = fixtureHome;
 process.env.OMB_DATA_DIR = resolve(fixtureHome, "app-data");
 const { containerRunArgs, perBotLocalVmTarget, IMAGE } = await import("../server/container-computer.ts");
 const run = (args: string[]) => execFileSync(podman, ["--connection", machine, ...args], { env: engineEnv, encoding: "utf8", timeout: 90_000 }).trim();
+const sandboxProbe = readFileSync(new URL("./testing/firefox-sandbox.py", import.meta.url), "utf8");
+const assertSandboxEnabled = (report: { effectiveContentSandboxLevel: number }) => {
+  assert(Number.isInteger(report.effectiveContentSandboxLevel) && report.effectiveContentSandboxLevel > 0,
+    "Firefox effective content sandbox must be enabled");
+};
 const receipt = [];
 for (const mode of ["before", "after"] as const) {
   const workspace = execFileSync(podman, ["machine", "ssh", machine, "mktemp", "-d", "/tmp/omb-firefox-XXXXXXXX"], { env: engineEnv, encoding: "utf8", timeout: 30_000 }).trim();
@@ -40,6 +45,8 @@ for (const mode of ["before", "after"] as const) {
     writeFileSync(resolve(output, `${mode}.log`), log);
     const screenshot = spawnSync(podman, ["--connection", machine, "exec", target.containerName, "cat", "/tmp/firefox-proof.png"], { env: engineEnv, timeout: 10_000, maxBuffer: 8 * 1024 * 1024 });
     const png = screenshot.status === 0 && screenshot.stdout.subarray(0, 8).equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]));
+    let sandbox;
+    let disabledControl;
     if (mode === "before") {
       assert(!png, "Baseline unexpectedly renders: investigate before claiming reproduction");
       assert.match(log, /chroot.*EPERM/);
@@ -48,8 +55,16 @@ for (const mode of ["before", "after"] as const) {
       assert.doesNotMatch(log, /chroot.*EPERM/);
       assert(png, "Patched Firefox must generate an actual PNG with sandbox enabled");
       writeFileSync(resolve(output, "after.png"), screenshot.stdout);
+      const inspectSandbox = (mode: "enabled" | "disabled") => JSON.parse(execFileSync(podman,
+        ["--connection", machine, "exec", "-i", "--user", "cua", target.containerName, "python3", "-", mode],
+        { env: engineEnv, input: sandboxProbe, encoding: "utf8", timeout: 90_000 }).trim());
+      sandbox = inspectSandbox("enabled");
+      assertSandboxEnabled(sandbox);
+      disabledControl = inspectSandbox("disabled");
+      assert.equal(disabledControl.effectiveContentSandboxLevel, 0);
+      assert.throws(() => assertSandboxEnabled(disabledControl), /effective content sandbox/);
     }
-    receipt.push({ mode, image: IMAGE, target: target.containerName, firefoxExit: probe.status, png, chrootEperm: /chroot.*EPERM/.test(log) });
+    receipt.push({ mode, image: IMAGE, target: target.containerName, firefoxExit: probe.status, png, chrootEperm: /chroot.*EPERM/.test(log), sandbox, disabledControl });
     console.log(JSON.stringify(receipt.at(-1)));
   } finally {
     if (created) run(["rm", "-f", target.containerName]);

--- a/scripts/verify-podman-firefox.ts
+++ b/scripts/verify-podman-firefox.ts
@@ -1,0 +1,54 @@
+// Opt-in acceptance against disposable containers only. No app or provider data.
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const podman = process.env.OMB_VERIFY_PODMAN;
+const machine = process.env.OMB_VERIFY_MACHINE;
+if (!podman || !machine) throw new Error("Set OMB_VERIFY_PODMAN and OMB_VERIFY_MACHINE to an explicit test engine");
+const output = resolve(process.env.OMB_VERIFY_OUTPUT || ".omb-scratch/firefox");
+mkdirSync(output, { recursive: true });
+process.env.OMB_DATA_DIR = resolve(output, "app-data");
+const { containerRunArgs, perBotLocalVmTarget, IMAGE } = await import("../server/container-computer.ts");
+const run = (args: string[]) => execFileSync(podman, ["--connection", machine, ...args], { encoding: "utf8", timeout: 90_000 }).trim();
+const receipt = [];
+for (const mode of ["before", "after"] as const) {
+  const workspace = execFileSync(podman, ["machine", "ssh", machine, "mktemp", "-d", "/tmp/omb-firefox-XXXXXXXX"], { encoding: "utf8" }).trim();
+  assert.match(workspace, /^\/tmp\/omb-firefox-[A-Za-z0-9]+$/);
+  const target = { ...perBotLocalVmTarget(randomUUID()), workspaceDir: workspace };
+  const args = containerRunArgs("podman", randomUUID(), target);
+  if (mode === "before") {
+    const cap = args.indexOf("SYS_CHROOT");
+    assert.equal(args[cap - 1], "--cap-add");
+    args.splice(cap - 1, 2);
+  }
+  let created = false;
+  try {
+    run(args);
+    created = true;
+    const script = "timeout 30 firefox-esr --headless --no-remote --profile /tmp/firefox-proof-profile --screenshot /tmp/firefox-proof.png about:blank";
+    run(["exec", "--user", "cua", target.containerName, "mkdir", "-p", "/tmp/firefox-proof-profile"]);
+    const probe = spawnSync(podman, ["--connection", machine, "exec", "--user", "cua", target.containerName, "sh", "-c", script], { encoding: "utf8", timeout: 45_000 });
+    const log = `${probe.stdout || ""}\n${probe.stderr || ""}`;
+    writeFileSync(resolve(output, `${mode}.log`), log);
+    const screenshot = spawnSync(podman, ["--connection", machine, "exec", target.containerName, "cat", "/tmp/firefox-proof.png"], { timeout: 10_000, maxBuffer: 8 * 1024 * 1024 });
+    const png = screenshot.status === 0 && screenshot.stdout.subarray(0, 8).equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]));
+    if (mode === "before") {
+      assert(!png, "Baseline unexpectedly renders: investigate before claiming reproduction");
+      assert.match(log, /chroot.*EPERM/);
+    } else {
+      assert.equal(probe.status, 0, log);
+      assert(png, "Patched Firefox must generate an actual PNG with sandbox enabled");
+      writeFileSync(resolve(output, "after.png"), screenshot.stdout);
+    }
+    receipt.push({ mode, image: IMAGE, target: target.containerName, firefoxExit: probe.status, png, chrootEperm: /chroot.*EPERM/.test(log) });
+    console.log(JSON.stringify(receipt.at(-1)));
+  } finally {
+    if (created) run(["rm", "-f", target.containerName]);
+    // Only the literal mktemp result validated above, never an app workspace.
+    execFileSync(podman, ["machine", "ssh", machine, "rm", "-rf", "--", workspace]);
+  }
+}
+writeFileSync(resolve(output, "receipt.json"), JSON.stringify({ passed: true, receipt }, null, 2));

--- a/scripts/verify-podman-firefox.ts
+++ b/scripts/verify-podman-firefox.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const podman = process.env.OMB_VERIFY_PODMAN;
@@ -10,12 +10,17 @@ const machine = process.env.OMB_VERIFY_MACHINE;
 if (!podman || !machine) throw new Error("Set OMB_VERIFY_PODMAN and OMB_VERIFY_MACHINE to an explicit test engine");
 const output = resolve(process.env.OMB_VERIFY_OUTPUT || ".omb-scratch/firefox");
 mkdirSync(output, { recursive: true });
-process.env.OMB_DATA_DIR = resolve(output, "app-data");
+// Keep Podman's connection/config lookup intact while isolating app imports.
+const engineEnv = { ...process.env };
+const fixtureHome = mkdtempSync(resolve(output, "home-"));
+process.env.HOME = fixtureHome;
+process.env.USERPROFILE = fixtureHome;
+process.env.OMB_DATA_DIR = resolve(fixtureHome, "app-data");
 const { containerRunArgs, perBotLocalVmTarget, IMAGE } = await import("../server/container-computer.ts");
-const run = (args: string[]) => execFileSync(podman, ["--connection", machine, ...args], { encoding: "utf8", timeout: 90_000 }).trim();
+const run = (args: string[]) => execFileSync(podman, ["--connection", machine, ...args], { env: engineEnv, encoding: "utf8", timeout: 90_000 }).trim();
 const receipt = [];
 for (const mode of ["before", "after"] as const) {
-  const workspace = execFileSync(podman, ["machine", "ssh", machine, "mktemp", "-d", "/tmp/omb-firefox-XXXXXXXX"], { encoding: "utf8" }).trim();
+  const workspace = execFileSync(podman, ["machine", "ssh", machine, "mktemp", "-d", "/tmp/omb-firefox-XXXXXXXX"], { env: engineEnv, encoding: "utf8", timeout: 30_000 }).trim();
   assert.match(workspace, /^\/tmp\/omb-firefox-[A-Za-z0-9]+$/);
   const target = { ...perBotLocalVmTarget(randomUUID()), workspaceDir: workspace };
   const args = containerRunArgs("podman", randomUUID(), target);
@@ -30,16 +35,17 @@ for (const mode of ["before", "after"] as const) {
     created = true;
     const script = "timeout 30 firefox-esr --headless --no-remote --profile /tmp/firefox-proof-profile --screenshot /tmp/firefox-proof.png about:blank";
     run(["exec", "--user", "cua", target.containerName, "mkdir", "-p", "/tmp/firefox-proof-profile"]);
-    const probe = spawnSync(podman, ["--connection", machine, "exec", "--user", "cua", target.containerName, "sh", "-c", script], { encoding: "utf8", timeout: 45_000 });
+    const probe = spawnSync(podman, ["--connection", machine, "exec", "--user", "cua", target.containerName, "sh", "-c", script], { env: engineEnv, encoding: "utf8", timeout: 45_000 });
     const log = `${probe.stdout || ""}\n${probe.stderr || ""}`;
     writeFileSync(resolve(output, `${mode}.log`), log);
-    const screenshot = spawnSync(podman, ["--connection", machine, "exec", target.containerName, "cat", "/tmp/firefox-proof.png"], { timeout: 10_000, maxBuffer: 8 * 1024 * 1024 });
+    const screenshot = spawnSync(podman, ["--connection", machine, "exec", target.containerName, "cat", "/tmp/firefox-proof.png"], { env: engineEnv, timeout: 10_000, maxBuffer: 8 * 1024 * 1024 });
     const png = screenshot.status === 0 && screenshot.stdout.subarray(0, 8).equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]));
     if (mode === "before") {
       assert(!png, "Baseline unexpectedly renders: investigate before claiming reproduction");
       assert.match(log, /chroot.*EPERM/);
     } else {
       assert.equal(probe.status, 0, log);
+      assert.doesNotMatch(log, /chroot.*EPERM/);
       assert(png, "Patched Firefox must generate an actual PNG with sandbox enabled");
       writeFileSync(resolve(output, "after.png"), screenshot.stdout);
     }
@@ -48,7 +54,7 @@ for (const mode of ["before", "after"] as const) {
   } finally {
     if (created) run(["rm", "-f", target.containerName]);
     // Only the literal mktemp result validated above, never an app workspace.
-    execFileSync(podman, ["machine", "ssh", machine, "rm", "-rf", "--", workspace]);
+    execFileSync(podman, ["machine", "ssh", machine, "rm", "-rf", "--", workspace], { env: engineEnv, timeout: 30_000 });
   }
 }
 writeFileSync(resolve(output, "receipt.json"), JSON.stringify({ passed: true, receipt }, null, 2));

--- a/server/container-computer.test.ts
+++ b/server/container-computer.test.ts
@@ -172,8 +172,8 @@ describe("containerComputerStatus", () => {
       UTSMode: "private",
       CgroupnsMode: null,
     };
-    detail.EffectiveCaps = ["CAP_SETGID", "CAP_SETUID"];
-    detail.BoundingCaps = ["CAP_SETGID", "CAP_SETUID"];
+    detail.EffectiveCaps = ["CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT"];
+    detail.BoundingCaps = ["CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT"];
     const targetDriverExec =
       `podman exec -u cua -e HOME=/home/cua -e DISPLAY=:1 -e CUA_DRIVER_INSTALL_CHANNEL=python_package ` +
       `-e CUA_DRIVER_RS_TELEMETRY_ENABLED=0 ${target.containerName} ${CUA_EXECUTABLE}`;
@@ -229,18 +229,22 @@ describe("containerComputerStatus", () => {
     };
     expect(podmanSecurityIsHardened(
       config,
-      ["CAP_SETGID", "CAP_SETUID"],
-      ["CAP_SETGID", "CAP_SETUID"],
+      ["CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT"],
+      ["CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT"],
     )).toBe(true);
+    // Existing two-capability containers must be recreated, not accepted as ready.
+    expect(podmanSecurityIsHardened(
+      config, ["CAP_SETGID", "CAP_SETUID"], ["CAP_SETGID", "CAP_SETUID"],
+    )).toBe(false);
     for (const mode of ["private", "keep-id:uid=1000,gid=1000", "host", "container:other", "keep-id:uid=0,gid=0", "auto"]) {
       expect(podmanSecurityIsHardened(
-        { ...config, UsernsMode: mode }, ["CAP_SETGID", "CAP_SETUID"], ["CAP_SETGID", "CAP_SETUID"],
+        { ...config, UsernsMode: mode }, ["CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT"], ["CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT"],
       )).toBe(mode === "private" || mode === "keep-id:uid=1000,gid=1000");
     }
     expect(podmanSecurityIsHardened(
       config,
-      ["CAP_NET_RAW", "CAP_SETGID", "CAP_SETUID"],
-      ["CAP_SETGID", "CAP_SETUID"],
+      ["CAP_NET_RAW", "CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT"],
+      ["CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT"],
     )).toBe(false);
   });
 
@@ -844,6 +848,10 @@ describe("setupCommands", () => {
 
   it("asks rootless Podman to map and privately relabel the durable workspace", () => {
     const command = setupCommands("podman", "linux").run!;
+    expect(command).toContain("--cap-add SYS_CHROOT");
+    expect(command).not.toContain("--privileged");
+    expect(command).not.toContain("unconfined");
+    expect(setupCommands("docker", "linux").run).not.toContain("SYS_CHROOT");
     expect(command).toContain(
       `--mount type=bind,source=${VM_WORKSPACE_DIR},target=${VM_WORKSPACE_GUEST},relabel=private`,
     );

--- a/server/container-computer.test.ts
+++ b/server/container-computer.test.ts
@@ -25,6 +25,7 @@ import {
   containerComputerStatus,
   containerRuntimeStatus,
   containerRunArgs,
+  dockerSecurityIsHardened,
   localVmRecreatableOnDemand,
   managedImageDockerfile,
   perBotLocalVmTarget,
@@ -156,7 +157,8 @@ describe("containerComputerStatus", () => {
     });
   });
 
-  it("accepts exact Podman-on-Windows hardening and its WSL-translated durable mount", async () => {
+  it.each(["exact", "legacy", "missing-effective", "missing-bounding", "extra-effective", "extra-bounding"])(
+    "checks Podman-on-Windows readiness with %s capabilities and a WSL-translated durable mount", async (caps) => {
     const derived = perBotLocalVmTarget("bot-win");
     const target: LocalVmTarget = {
       ...derived,
@@ -174,6 +176,10 @@ describe("containerComputerStatus", () => {
     };
     detail.EffectiveCaps = ["CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT"];
     detail.BoundingCaps = ["CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT"];
+    if (caps === "legacy" || caps === "missing-effective") detail.EffectiveCaps.pop();
+    if (caps === "legacy" || caps === "missing-bounding") detail.BoundingCaps.pop();
+    if (caps === "extra-effective") detail.EffectiveCaps.push("CAP_SYS_ADMIN");
+    if (caps === "extra-bounding") detail.BoundingCaps.push("CAP_SYS_ADMIN");
     const targetDriverExec =
       `podman exec -u cua -e HOME=/home/cua -e DISPLAY=:1 -e CUA_DRIVER_INSTALL_CHANNEL=python_package ` +
       `-e CUA_DRIVER_RS_TELEMETRY_ENABLED=0 ${target.containerName} ${CUA_EXECUTABLE}`;
@@ -195,6 +201,14 @@ describe("containerComputerStatus", () => {
     });
 
     const status = await containerComputerStatus(fake.run, "win32", target);
+    if (caps !== "exact") {
+      expect(status).toMatchObject({ security: "unsafe", ready: false });
+      expect(status.problem).toContain("recreate");
+      expect(localVmRecreatableOnDemand(status)).toBe(false);
+      expect(fake.calls.some((call) => call.startsWith("podman exec "))).toBe(false);
+      expect(fake.calls.some((call) => /^podman (run|rm|start|stop) /.test(call))).toBe(false);
+      return;
+    }
 
     expect(status).toMatchObject({
       runtime: "podman",
@@ -246,6 +260,14 @@ describe("containerComputerStatus", () => {
       ["CAP_NET_RAW", "CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT"],
       ["CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT"],
     )).toBe(false);
+  });
+
+  it.each(["no", "unless-stopped"] as const)("does not extend Docker/VPS capabilities with restart policy %s", (restartPolicy) => {
+    const config = JSON.parse(readyInspect())[0].HostConfig;
+    config.RestartPolicy.Name = restartPolicy;
+    expect(dockerSecurityIsHardened(config, { restartPolicy })).toBe(true);
+    config.CapAdd.push("CAP_SYS_CHROOT");
+    expect(dockerSecurityIsHardened(config, { restartPolicy })).toBe(false);
   });
 
   it("keeps per-bot identities, workspaces, and ephemeral viewer ports separate", async () => {

--- a/server/container-computer.ts
+++ b/server/container-computer.ts
@@ -770,7 +770,8 @@ export interface DockerHardeningConfig {
 /** One hardening contract for both managed containers (Local VM here, the
  * BYO-VPS backend in vps-computer.ts): exact resource limits, no privilege,
  * no host namespaces or devices, no disabled security profiles. The only
- * knob the callers legitimately disagree on is the restart policy — the VPS
+ * runtime-specific capability exception is Podman's Firefox sandbox chroot.
+ * Callers also differ on restart policy — the VPS
  * container must survive a reboot nobody is watching ("unless-stopped"),
  * while the Local VM must NOT auto-resume: its desktop leaves a stale X lock
  * on stop, so a restarted container is a broken one. */
@@ -815,7 +816,7 @@ export function dockerSecurityIsHardened(
 /** Podman normalizes HostConfig capability and namespace fields when it
  * serializes inspect output. Validate its authoritative effective/bounding
  * sets, then normalize only those known representation differences through
- * the unchanged Docker hardening contract. */
+ * the shared hardening contract with the Podman-only chroot exception. */
 export function podmanSecurityIsHardened(
   config: DockerHardeningConfig | undefined,
   effectiveCaps: string[] | undefined,

--- a/server/container-computer.ts
+++ b/server/container-computer.ts
@@ -776,7 +776,7 @@ export interface DockerHardeningConfig {
  * on stop, so a restarted container is a broken one. */
 export function dockerSecurityIsHardened(
   config: DockerHardeningConfig | undefined,
-  options: { restartPolicy?: "no" | "unless-stopped" } = {},
+  options: { restartPolicy?: "no" | "unless-stopped"; podmanBrowserSandbox?: boolean } = {},
 ): boolean {
   if (!config) return false;
   const capDrop = (config.CapDrop ?? []).map((cap) => cap.toLowerCase());
@@ -795,7 +795,7 @@ export function dockerSecurityIsHardened(
     (config.NanoCpus ?? 0) === NANO_CPUS &&
     config.PidsLimit === PIDS_LIMIT &&
     capDrop.includes("all") &&
-    capAdd.join(",") === "setgid,setuid" &&
+    capAdd.join(",") === (options.podmanBrowserSandbox ? "setgid,setuid,sys_chroot" : "setgid,setuid") &&
     config.Privileged === false &&
     !config.PidMode &&
     config.IpcMode === "private" &&
@@ -825,7 +825,7 @@ export function podmanSecurityIsHardened(
   const normalizeCaps = (caps: string[] | undefined) => (caps ?? [])
     .map((cap) => cap.toLowerCase().replace(/^cap_/, ""))
     .sort();
-  const exactCaps = "setgid,setuid";
+  const exactCaps = "setgid,setuid,sys_chroot";
   if (normalizeCaps(effectiveCaps).join(",") !== exactCaps) return false;
   if (normalizeCaps(boundingCaps).join(",") !== exactCaps) return false;
   return dockerSecurityIsHardened({
@@ -839,7 +839,7 @@ export function podmanSecurityIsHardened(
     UsernsMode: config.UsernsMode === "private" || config.UsernsMode === "keep-id:uid=1000,gid=1000"
       ? "" : config.UsernsMode,
     CgroupnsMode: config.CgroupnsMode || "private",
-  });
+  }, { podmanBrowserSandbox: true });
 }
 
 export function containerRunArgs(
@@ -916,6 +916,9 @@ export function containerRunArgs(
       "512m",
     );
   }
+  // Podman's default seccomp profile gates chroot on this capability.
+  // Firefox uses chroot inside its own namespace to establish its sandbox.
+  if (runtime === "podman") common.push("--cap-add", "SYS_CHROOT");
   common.push(
     "--mount",
     runtime === "podman"


### PR DESCRIPTION
Fixes #853.

Firefox in managed rootless Podman desktops failed with `Sandbox: chroot: EPERM`. Add `SYS_CHROOT` for Podman only and require the same exact effective/bounding capability set in its acceptance checks. Firefox's sandbox stays enabled; privileged/unconfined modes are not used. Docker and VPS policies stay unchanged.

Existing two-capability Podman desktops require the normal explicit recreation flow while retaining workspace data. Migration instructions identify the per-bot/shared controls and explain that files and Firefox profiles outside the durable workspace are discarded. There is no silent migration or recreation of running user desktops.

## Verification

- Separate worktree based on upstream `6aa058eb`.
- Container/VPS tests: **71 passed**, including independent effective/bounding capability mismatches, refusal to auto-recreate legacy desktops, and unchanged Docker/VPS capability policies.
- Server TypeScript and targeted lint: passed.
- Real before/after fixture: Windows/WSL2 Linux x86_64, rootless Podman 5.8.3, managed driver 0.20.0-v4 image. Disposable containers differ only by the added capability. Before: `chroot: EPERM`, timeout exit 124, no PNG. After: Firefox exit 0 and actual PNG. Follow-up about:support probe reports configured/effective content sandbox levels 6/6; a fresh-profile sandbox-disabled control reports 6/0 and is rejected by the same enabled-sandbox assertion. Levels are included in receipt.json. Repeated successfully after the review changes with an isolated app HOME/data directory. Both containers and their temporary workspaces were removed.
- `git diff --check`: passed.

Reproduction: `scripts/verify-podman-firefox.ts`; details: `docs/verification/podman-firefox.md`. No live app data or model calls. The smoke proves browser startup/rendering, not interactive input. Native Linux/SELinux enforcing/ARM64 Podman browser acceptance and other runtime versions were not rerun locally; the repository CI suite ran on all three host platforms.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Firefox compatibility in managed Podman environments by enabling the required browser sandbox capability.
  - Existing Podman desktops with outdated capability settings must be recreated through the normal Local VM lifecycle.

- **Verification**
  - Added automated checks confirming Firefox launches successfully, produces valid screenshots, and avoids sandbox permission errors.
  - Expanded coverage for Podman capability configurations and container security behavior.
  - Documented verification steps for confirming Firefox sandbox functionality in Podman-based Local VMs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Final CI and review

Head `6da4f8d69dad3a19873ddea9fdc167370c90d661`: [upstream CI run 34039452044](https://github.com/milind-soni/OpenMausBot/actions/runs/34039452044) passed all seven jobs, including Windows/macOS/Ubuntu typecheck/tests, package smoke, control-plane, iOS and Android. CodeRabbit's sandbox-evidence finding is resolved and re-review completed with no unresolved threads.

The non-blocking Windows Electron canary still exits with `2147483651` in `browser-closed-shadow.electron.test.mjs`; the same error is present in the [unchanged base 6aa058eb CI run](https://github.com/milind-soni/OpenMausBot/actions/runs/34030172225). Required tests passed. Vercel remains an external SupaMaus-team deployment authorization gate.
