### PR TITLE
fix: ignore Codex output after turn settlement

### DIFF
--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -169,6 +169,13 @@ describe("CodexDriver turns (fake app-server)", () => {
     expect(threadStart.params).toMatchObject({ model: "gpt-5.6-sol", modelProvider: "openai" });
   });
 
+  it("ignores requests received after turn completion", async () => {
+    await create({ mode: "late-request" });
+    await instance.adapter.sendTurn({ threadId: "t-late-request", text: "finish" });
+    await recorder.until((event) => event.type === "turn.completed");
+    expect(recorder.events.some((event) => event.type === "request.opened")).toBe(false);
+  });
+
   it.each([
     ["ask", "on-request", "workspace-write", "workspaceWrite"],
     ["auto", "on-request", "workspace-write", "workspaceWrite"],

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -898,10 +898,10 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       // multibyte characters that straddle two reads and corrupts the text
       child.stdout.setEncoding("utf8");
       child.stdout.on("data", (chunk) => {
-        if (abandoned) return;
+        if (abandoned || state.settled) return;
         buf += chunk;
         let nl;
-        while ((nl = buf.indexOf("\n")) !== -1) {
+        while (!state.settled && (nl = buf.indexOf("\n")) !== -1) {
           const line = buf.slice(0, nl);
           buf = buf.slice(nl + 1);
           if (!line.trim()) continue;

--- a/server/testing/fake-codex-app-server.ts
+++ b/server/testing/fake-codex-app-server.ts
@@ -7,7 +7,7 @@
 //   FAKE_CODEX_MODE   happy (default) | approval | resume | stream | windows-command |
 //                     mcp-elicitation | mcp-app-approval | mcp-form | permissions-approval | config-profile |
 //                     config-profile-unsupported | config-read-error | image |
-//                     logged-in-stdout | logged-out | unauthorized
+//                     logged-in-stdout | logged-out | unauthorized | late-request
 //   FAKE_CODEX_DUMP   path to write {pid, argv, env, calls, decision} as JSON
 //
 // Keep this file dependency-free — it runs as a bare `node` subprocess.
@@ -69,7 +69,12 @@ const finishTurn = () => {
   notify("item/completed", { item: { id: "m1", type: "agentMessage", text: "done from fake codex" } });
   notify("thread/tokenUsage/updated", { tokenUsage: { total: { inputTokens: 7, cachedInputTokens: 4, outputTokens: 3 } } });
   dump();
+  if (mode === "late-request") process.stdout.cork();
   notify("turn/completed", { turn: { status: "completed" } });
+  if (mode === "late-request") {
+    out({ jsonrpc: "2.0", id: 100, method: "execCommandApproval", params: { command: "echo too late" } });
+    process.stdout.uncork();
+  }
 };
 
 let buf = "";


### PR DESCRIPTION
## Summary

- stop buffering Codex output once a turn starts settling
- stop processing remaining messages in the same stdout chunk after `turn/completed`
- add a regression where an approval request follows completion in the same write

## Why

Follow-up to #852. During the bounded shutdown wait, a late app-server request could still be processed after settlement began. In Full access that request could receive an automatic approval.

## Validation

- `pnpm typecheck`
- `pnpm vitest run server/drivers/codex.test.ts` — 54 passed
- regression fails without the guard and passes with it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented approval requests received after a turn completes from being processed or surfaced.
  - Ensured completion events reliably stop further response handling.

- **Tests**
  - Added coverage verifying that late approval requests are ignored after turn completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->