### PR TITLE
fix(ios,android): tapping the transcript dismisses the keyboard

### DIFF
--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/ChatScreen.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/ChatScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -79,6 +80,7 @@ import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalUriHandler
@@ -731,7 +733,15 @@ private fun LoadedChat(
             Box(
                 modifier = Modifier
                     .weight(1f)
-                    .fillMaxWidth(),
+                    .fillMaxWidth()
+                    // Tapping the transcript puts the keyboard away, the way
+                    // it does on iOS. `detectTapGestures` and not `clickable`:
+                    // the transcript is not a button, so it should not answer
+                    // to TalkBack as one, and a tap a row has already taken —
+                    // a link, a card button — never reaches this far.
+                    .pointerInput(Unit) {
+                        detectTapGestures { focusManager.clearFocus() }
+                    },
             ) {
                 LazyColumn(
                     state = listState,

--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -265,6 +265,19 @@ struct ChatView: View {
                 // than the screen rests at the bottom, and opening a chat
                 // starts on the newest message rather than the oldest.
                 .defaultScrollAnchor(.bottom)
+                // Tapping the transcript puts the keyboard away. The composer
+                // is a sibling of this scroll view rather than inside it, so
+                // nothing else here drops its focus — until this, the only way
+                // back to the whole conversation was to leave the chat.
+                // Simultaneous, not `.onTapGesture`: a tap that lands on a
+                // link, a card button or a selected word still reaches the row
+                // that owns it, and only also closes the keyboard.
+                .simultaneousGesture(TapGesture().onEnded {
+                    if composerFocused { composerFocused = false }
+                })
+                // And a drag down over the transcript pushes it away, the way
+                // it does in Mail and Messages.
+                .scrollDismissesKeyboard(.interactively)
                 .onChange(of: transcript.last?.id) { _, _ in
                     guard let last = transcript.last else { return }
                     withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }


### PR DESCRIPTION
## The bug

Open a chat on iPhone, tap the composer, and the keyboard is there for good. Tapping the transcript does nothing, dragging it down does nothing, and the only way to see the whole conversation again is Back to the roster — which costs you the chat you were reading. Android has the same gap for a tap; its back gesture hides the IME first, so it shows up less there.

The cause is the same on both: the composer is a *sibling* of the transcript rather than a view inside it, so nothing in the scroll area ever drops its focus. On iOS that also leaves `.scrollDismissesKeyboard`'s automatic behaviour with no text field of its own to key on, so the drag has to be asked for as explicitly as the tap.

## The fix

**iOS** (`ios/App/ChatView.swift`) — a tap gesture on the transcript's scroll view plus the drag behaviour the platform already has:

- `.simultaneousGesture(TapGesture())`, not `.onTapGesture`, so a tap that lands on a link, a card button or a selected word still reaches the row that owns it and *also* closes the keyboard.
- `.scrollDismissesKeyboard(.interactively)`, the way Mail and Messages behave.

**Android** (`ChatScreen.kt`) — `detectTapGestures { focusManager.clearFocus() }` on the box that holds the transcript. Not `clickable`: the transcript is not a button and should not answer to TalkBack as one, and a tap a row has already taken never reaches this far.

Both are additive — no existing gesture changes hands.

## Verified in the Simulator

iPhone 17 Pro, the repo's own `-store-preview -open-first` route, driven by a throwaway XCUITest (not committed) that asserts on `app.keyboards.count` and the composer's keyboard focus:

| | tap the transcript | drag the transcript |
|---|---|---|
| before | keyboards 1 → **1** (fails) | keyboards 1 → **1** (fails) |
| after | keyboards 1 → **0** (passes) | keyboards 1 → **0** (passes) |

Removing either line on its own puts its case back to failing, so neither is redundant. A third case checks the header controls are still hittable with the keyboard up, and that Back still returns to the roster.

Android is the mirror of the same change; it is not compiled here (no Android SDK on this machine), and CI's `:app:assembleDebug` covers it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Tapping the chat transcript now dismisses the on-screen keyboard on Android and iOS.
  - Existing transcript interactions, including links, cards, and text selection, remain available.
  - Scrolling downward on iOS can now dismiss the keyboard interactively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->