### PR TITLE
Localize the iOS app: the seam, a Language setting, and Settings in pt-BR

### DIFF
--- a/ios/App/AppLanguage.swift
+++ b/ios/App/AppLanguage.swift
@@ -1,0 +1,43 @@
+// The language the app draws itself in.
+//
+// English is the source catalog: every key in `Localizable.xcstrings` *is* the
+// English literal from the Swift, so a key a translation omits falls back to
+// copy that reads correctly rather than to a key name. A partial pack is a
+// usable pack, which is the same contract `docs/localization.md` sets for the
+// renderer.
+//
+// Adding a language is one case here and one column in the catalog. Nothing
+// else in the app has to know.
+import Foundation
+import SwiftUI
+
+enum AppLanguage: String, CaseIterable, Identifiable {
+    /// Whatever the phone is set to, which is also what an app with no
+    /// language setting at all would do.
+    case system
+    case english = "en"
+    case portugueseBrazil = "pt-BR"
+
+    var id: String { rawValue }
+
+    var label: LocalizedStringKey {
+        switch self {
+        case .system: "Follow the system"
+        // A language names itself. Someone who cannot read the language the app
+        // is currently in still has to be able to find their own in this list,
+        // so these two are marked `shouldTranslate: false` in the catalog.
+        case .english: "English"
+        case .portugueseBrazil: "Português (Brasil)"
+        }
+    }
+
+    /// `nil` follows the system: the environment keeps the locale SwiftUI
+    /// already handed it, so no choice here means no behaviour change.
+    var locale: Locale? {
+        self == .system ? nil : Locale(identifier: rawValue)
+    }
+
+    static func resolved(_ stored: String) -> AppLanguage {
+        AppLanguage(rawValue: stored) ?? .system
+    }
+}

--- a/ios/App/CompanionApp.swift
+++ b/ios/App/CompanionApp.swift
@@ -14,11 +14,21 @@ struct CompanionApp: App {
     @StateObject private var session = Session()
     @Environment(\.scenePhase) private var scenePhase
     @State private var liveActivities = LiveActivityCoordinator()
+    @AppStorage(PrefKey.language) private var language = AppLanguage.system.rawValue
 
     var body: some Scene {
         WindowGroup {
             RootView()
                 .environmentObject(session)
+                // One modifier is the whole language seam. SwiftUI resolves a
+                // `LocalizedStringKey` against the environment's locale, so
+                // every `Text("…")`, `Button("…")`, `Section("…")` and
+                // `navigationTitle("…")` already in the app — including the
+                // ones inside sheets and pushed screens — follows this line
+                // without a call site changing. Following the system means
+                // leaving it on the phone's own locale, which is what an app
+                // with no language setting would use anyway.
+                .environment(\.locale, AppLanguage.resolved(language).locale ?? .autoupdatingCurrent)
                 .onAppear {
                     OpenMausSharedInbox.removeDirectories(olderThan: 60 * 60)
                     session.connect()

--- a/ios/App/CompanionApp.swift
+++ b/ios/App/CompanionApp.swift
@@ -29,6 +29,15 @@ struct CompanionApp: App {
                 // leaving it on the phone's own locale, which is what an app
                 // with no language setting would use anyway.
                 .environment(\.locale, AppLanguage.resolved(language).locale ?? .autoupdatingCurrent)
+                // A navigation title is drawn by UIKit, which reads its string
+                // once and does not re-read it when the environment changes —
+                // so the body would switch language while the title above it
+                // stayed behind. Re-identifying the tree on the chosen language
+                // rebuilds that chrome. It costs the navigation stack and any
+                // view state below, which is the right trade for something a
+                // person changes deliberately and almost never. `session` lives
+                // on the App, not here, so the connection survives.
+                .id(language)
                 .onAppear {
                     OpenMausSharedInbox.removeDirectories(olderThan: 60 * 60)
                     session.connect()

--- a/ios/App/Localizable.xcstrings
+++ b/ios/App/Localizable.xcstrings
@@ -1,0 +1,762 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "%lld saved": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld salvos"
+          }
+        }
+      }
+    },
+    "Activity": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atividade"
+          }
+        }
+      }
+    },
+    "Alerts arrive while OpenMausBot is open or was recently in the background. Closed-app delivery is not available yet.": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os alertas chegam enquanto o OpenMausBot está aberto ou esteve em segundo plano há pouco. A entrega com o app fechado ainda não está disponível."
+          }
+        }
+      }
+    },
+    "Always": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sempre"
+          }
+        }
+      }
+    },
+    "Asks for permission to send notifications": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pede permissão para enviar notificações"
+          }
+        }
+      }
+    },
+    "Bot intro animation": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Animação de entrada do bot"
+          }
+        }
+      }
+    },
+    "Cancel": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
+          }
+        }
+      }
+    },
+    "Changes the language inside OpenMausMobile. Buttons drawn by iOS itself follow the phone's language, which you can set for this app in iOS Settings.": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muda o idioma dentro do OpenMausMobile. Os botões desenhados pelo próprio iOS seguem o idioma do telefone, que você pode definir para este app nos Ajustes do iOS."
+          }
+        }
+      }
+    },
+    "Chat": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conversa"
+          }
+        }
+      }
+    },
+    "Computer": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Computador"
+          }
+        }
+      }
+    },
+    "Computer address": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Endereço do computador"
+          }
+        }
+      }
+    },
+    "Computers": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Computadores"
+          }
+        }
+      }
+    },
+    "Connect a computer": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectar um computador"
+          }
+        }
+      }
+    },
+    "Connect another computer": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectar outro computador"
+          }
+        }
+      }
+    },
+    "Connected": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectado"
+          }
+        }
+      }
+    },
+    "Connected Apps": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps conectados"
+          }
+        }
+      }
+    },
+    "Connecting…": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectando…"
+          }
+        }
+      }
+    },
+    "Connection & Security": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conexão e segurança"
+          }
+        }
+      }
+    },
+    "Connection details": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalhes da conexão"
+          }
+        }
+      }
+    },
+    "Copied": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiado"
+          }
+        }
+      }
+    },
+    "Copy": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar"
+          }
+        }
+      }
+    },
+    "Current computer": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Computador atual"
+          }
+        }
+      }
+    },
+    "Each computer is paired separately. Only the selected computer is active at a time.": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cada computador é pareado separadamente. Só o computador selecionado fica ativo por vez."
+          }
+        }
+      }
+    },
+    "Edit address": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar endereço"
+          }
+        }
+      }
+    },
+    "English": {
+      "shouldTranslate": false
+    },
+    "Every step a bot takes.": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cada passo que um bot dá."
+          }
+        }
+      }
+    },
+    "First time per bot": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Na primeira vez de cada bot"
+          }
+        }
+      }
+    },
+    "Follow the system": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seguir o sistema"
+          }
+        }
+      }
+    },
+    "Full": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completa"
+          }
+        }
+      }
+    },
+    "Hidden": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oculta"
+          }
+        }
+      }
+    },
+    "Hide full address": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar endereço completo"
+          }
+        }
+      }
+    },
+    "Language": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idioma"
+          }
+        }
+      }
+    },
+    "Needs pairing": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Precisa parear"
+          }
+        }
+      }
+    },
+    "Never": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nunca"
+          }
+        }
+      }
+    },
+    "No activity, only messages.": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sem atividade, apenas mensagens."
+          }
+        }
+      }
+    },
+    "No computer connected": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum computador conectado"
+          }
+        }
+      }
+    },
+    "Not connected": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não conectado"
+          }
+        }
+      }
+    },
+    "Not enabled": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não ativadas"
+          }
+        }
+      }
+    },
+    "Not paired": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não pareado"
+          }
+        }
+      }
+    },
+    "Notifications": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notificações"
+          }
+        }
+      }
+    },
+    "Notifications are enabled": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As notificações estão ativadas"
+          }
+        }
+      }
+    },
+    "Off in Settings": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desativadas nos Ajustes"
+          }
+        }
+      }
+    },
+    "Offline": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Offline"
+          }
+        }
+      }
+    },
+    "On": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ativadas"
+          }
+        }
+      }
+    },
+    "OpenMausBot is trying the saved connection automatically.": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O OpenMausBot está tentando a conexão salva automaticamente."
+          }
+        }
+      }
+    },
+    "Opens device Settings": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre os Ajustes do dispositivo"
+          }
+        }
+      }
+    },
+    "Other computers": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Outros computadores"
+          }
+        }
+      }
+    },
+    "Português (Brasil)": {
+      "shouldTranslate": false
+    },
+    "Quick Replies": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Respostas rápidas"
+          }
+        }
+      }
+    },
+    "Quietly on": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ativadas em silêncio"
+          }
+        }
+      }
+    },
+    "Reduced": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reduzida"
+          }
+        }
+      }
+    },
+    "Remove": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover"
+          }
+        }
+      }
+    },
+    "Remove %@?": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover %@?"
+          }
+        }
+      }
+    },
+    "Remove connection from this device": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover conexão deste dispositivo"
+          }
+        }
+      }
+    },
+    "Remove from this device": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover deste dispositivo"
+          }
+        }
+      }
+    },
+    "Remove this computer?": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover este computador?"
+          }
+        }
+      }
+    },
+    "Remove this connection?": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover esta conexão?"
+          }
+        }
+      }
+    },
+    "Save": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salvar"
+          }
+        }
+      }
+    },
+    "Settings": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes"
+          }
+        }
+      }
+    },
+    "Show full address": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar endereço completo"
+          }
+        }
+      }
+    },
+    "Steps fold into one line. Failures always show.": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os passos se juntam em uma linha. As falhas sempre aparecem."
+          }
+        }
+      }
+    },
+    "Switches OpenMausMobile to this computer": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muda o OpenMausMobile para este computador"
+          }
+        }
+      }
+    },
+    "Tap to switch": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toque para trocar"
+          }
+        }
+      }
+    },
+    "Tasks & Routines": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tarefas e rotinas"
+          }
+        }
+      }
+    },
+    "Temporarily on": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ativadas temporariamente"
+          }
+        }
+      }
+    },
+    "That address doesn't look right. Copy it from Phone settings and try again.": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esse endereço não parece certo. Copie-o dos ajustes de Telefone e tente de novo."
+          }
+        }
+      }
+    },
+    "This computer is connected and responding normally.": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este computador está conectado e respondendo normalmente."
+          }
+        }
+      }
+    },
+    "This device is not paired with a computer.": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este dispositivo não está pareado com um computador."
+          }
+        }
+      }
+    },
+    "This device was removed from the computer. Pair it again to reconnect.": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este dispositivo foi removido do computador. Pareie novamente para reconectar."
+          }
+        }
+      }
+    },
+    "This removes the connection from this device only. It does not revoke this device on your Mac. To remove Mac-side access, open OpenMausBot → Settings → Phone and remove it there.": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isto remove a conexão apenas deste dispositivo. Não revoga este dispositivo no seu Mac. Para remover o acesso do lado do Mac, abra OpenMausBot → Ajustes → Telefone e remova por lá."
+          }
+        }
+      }
+    },
+    "This removes the saved connection from this device only.": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isto remove a conexão salva apenas deste dispositivo."
+          }
+        }
+      }
+    },
+    "Troubleshooting": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solução de problemas"
+          }
+        }
+      }
+    },
+    "Try reconnecting": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tentar reconectar"
+          }
+        }
+      }
+    },
+    "Unknown": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconhecido"
+          }
+        }
+      }
+    },
+    "Use": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usar"
+          }
+        }
+      }
+    },
+    "Use the address shown in Phone settings on your computer. Your pairing is kept.": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use o endereço mostrado nos ajustes de Telefone no seu computador. O pareamento é mantido."
+          }
+        }
+      }
+    },
+    "Workspace": {
+      "localizations": {
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Espaço de trabalho"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/ios/App/Preferences.swift
+++ b/ios/App/Preferences.swift
@@ -13,6 +13,7 @@ enum PrefKey {
     static let islandSeen = "companion.prefs.islandSeen"
     static let activityDetail = "companion.prefs.activityDetail"
     static let quickReplies = "companion.prefs.quickReplies"
+    static let language = "companion.prefs.language"
 }
 
 /// The set of chats whose island intro has already played.

--- a/ios/App/SettingsView.swift
+++ b/ios/App/SettingsView.swift
@@ -9,6 +9,7 @@ struct SettingsView: View {
     @State private var enablingNotifications = false
     @AppStorage(PrefKey.activityDetail) private var activityDetail = ActivityDetail.full.rawValue
     @AppStorage(PrefKey.islandIntro) private var islandIntro = IslandIntro.oncePerBot.rawValue
+    @AppStorage(PrefKey.language) private var language = AppLanguage.system.rawValue
     private let onConnect: (() -> Void)?
 
     init(onConnect: (() -> Void)? = nil) {
@@ -23,7 +24,7 @@ struct SettingsView: View {
                         ConnectedComputersView()
                     } label: {
                         ComputerSettingsRow(
-                            name: connection.name,
+                            name: Text(verbatim: connection.name),
                             status: computerStatusText,
                             connected: session.status == .live
                         )
@@ -33,8 +34,8 @@ struct SettingsView: View {
                         onConnect?()
                     } label: {
                         ComputerSettingsRow(
-                            name: "Connect a computer",
-                            status: "Not connected",
+                            name: Text("Connect a computer"),
+                            status: Text("Not connected"),
                             connected: false
                         )
                     }
@@ -66,7 +67,7 @@ struct SettingsView: View {
             Section {
                 Picker(selection: $activityDetail) {
                     ForEach(ActivityDetail.allCases, id: \.rawValue) { level in
-                        Text(level.label).tag(level.rawValue)
+                        Text(LocalizedStringKey(level.label)).tag(level.rawValue)
                     }
                 } label: {
                     Label {
@@ -78,7 +79,7 @@ struct SettingsView: View {
 
                 Picker(selection: $islandIntro) {
                     ForEach(IslandIntro.allCases, id: \.rawValue) { option in
-                        Text(option.label).tag(option.rawValue)
+                        Text(LocalizedStringKey(option.label)).tag(option.rawValue)
                     }
                 } label: {
                     Label {
@@ -100,7 +101,23 @@ struct SettingsView: View {
             } header: {
                 Text("Chat")
             } footer: {
-                Text(ActivityDetail(rawValue: activityDetail)?.caption ?? "")
+                Text(LocalizedStringKey(ActivityDetail(rawValue: activityDetail)?.caption ?? ""))
+            }
+
+            Section {
+                Picker(selection: $language) {
+                    ForEach(AppLanguage.allCases) { option in
+                        Text(option.label).tag(option.rawValue)
+                    }
+                } label: {
+                    Label {
+                        Text("Language")
+                    } icon: {
+                        SettingsIcon(symbol: "globe", color: .teal)
+                    }
+                }
+            } footer: {
+                Text("Changes the language inside OpenMausMobile. Buttons drawn by iOS itself follow the phone's language, which you can set for this app in iOS Settings.")
             }
 
             if session.connection != nil {
@@ -143,7 +160,7 @@ struct SettingsView: View {
         }
     }
 
-    private var notificationAccessibilityHint: String {
+    private var notificationAccessibilityHint: LocalizedStringKey {
         if notificationsAreEnabled { return "Notifications are enabled" }
         if session.notificationAuthorization == .denied { return "Opens device Settings" }
         return "Asks for permission to send notifications"
@@ -159,23 +176,23 @@ struct SettingsView: View {
                 ProgressView()
                     .controlSize(.small)
             } else {
-                Text(session.notificationStatusText)
+                Text(LocalizedStringKey(session.notificationStatusText))
                     .foregroundStyle(.secondary)
             }
         }
     }
 
-    private var statusText: String { session.status.settingsText }
+    private var statusText: Text { session.status.settingsText }
 
-    private var computerStatusText: String {
+    private var computerStatusText: Text {
         guard session.connections.count > 1 else { return statusText }
-        return "\(statusText) · \(session.connections.count) saved"
+        return statusText + Text(verbatim: " · ") + Text("\(session.connections.count) saved")
     }
 }
 
 private struct ComputerSettingsRow: View {
-    let name: String
-    let status: String
+    let name: Text
+    let status: Text
     let connected: Bool
 
     var body: some View {
@@ -190,14 +207,14 @@ private struct ComputerSettingsRow: View {
             .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 3) {
-                Text(name)
+                name
                     .foregroundStyle(.primary)
                     .lineLimit(1)
                 HStack(spacing: 5) {
                     Circle()
                         .fill(connected ? Color.green : Color.secondary)
                         .frame(width: 7, height: 7)
-                    Text(status)
+                    status
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
@@ -227,6 +244,14 @@ struct ConnectedComputersView: View {
     @EnvironmentObject private var session: Session
     @State private var pendingRemoval: Connection?
 
+    /// The dialog interpolates the computer's own name. With no name there is
+    /// copy to fall back to, rather than an English word inside a translated
+    /// sentence.
+    private var removalTitle: LocalizedStringKey {
+        guard let name = pendingRemoval?.name else { return "Remove this computer?" }
+        return "Remove \(name)?"
+    }
+
     private var otherComputers: [Connection] {
         session.connections.filter { $0.id != session.connection?.id }
     }
@@ -239,7 +264,7 @@ struct ConnectedComputersView: View {
                         ConnectionSecurityView()
                     } label: {
                         ComputerSettingsRow(
-                            name: active.name,
+                            name: Text(verbatim: active.name),
                             status: session.status.settingsText,
                             connected: session.status == .live
                         )
@@ -296,7 +321,7 @@ struct ConnectedComputersView: View {
         .navigationTitle("Computers")
         .navigationBarTitleDisplayMode(.inline)
         .confirmationDialog(
-            "Remove \(pendingRemoval?.name ?? "this computer")?",
+            removalTitle,
             isPresented: Binding(
                 get: { pendingRemoval != nil },
                 set: { if !$0 { pendingRemoval = nil } }
@@ -334,8 +359,11 @@ struct ConnectionSecurityView: View {
                         VStack(alignment: .leading, spacing: 4) {
                             Text(connection.name)
                                 .font(.headline)
-                            Label(session.status.settingsText,
-                                  systemImage: session.status == .live ? "checkmark.circle.fill" : "circle.dotted")
+                            Label {
+                                session.status.settingsText
+                            } icon: {
+                                Image(systemName: session.status == .live ? "checkmark.circle.fill" : "circle.dotted")
+                            }
                                 .font(.subheadline)
                                 .foregroundStyle(session.status == .live ? Color.green : Color.secondary)
                         }
@@ -385,7 +413,7 @@ struct ConnectionSecurityView: View {
                 }
 
                 Section("Troubleshooting") {
-                    Text(troubleshootingText)
+                    troubleshootingText
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
 
@@ -446,18 +474,20 @@ struct ConnectionSecurityView: View {
         }
     }
 
-    private var troubleshootingText: String {
+    /// Our copy, except for `.offline`, whose text the computer itself sent and
+    /// which is shown exactly as it arrived.
+    private var troubleshootingText: Text {
         switch session.status {
         case .live:
-            return "This computer is connected and responding normally."
+            return Text("This computer is connected and responding normally.")
         case .connecting:
-            return "OpenMausBot is trying the saved connection automatically."
+            return Text("OpenMausBot is trying the saved connection automatically.")
         case let .offline(reason):
-            return reason
+            return Text(verbatim: reason)
         case .unauthorized:
-            return "This device was removed from the computer. Pair it again to reconnect."
+            return Text("This device was removed from the computer. Pair it again to reconnect.")
         case .unpaired:
-            return "This device is not paired with a computer."
+            return Text("This device is not paired with a computer.")
         }
     }
 
@@ -469,13 +499,13 @@ struct ConnectionSecurityView: View {
 }
 
 private extension Session.Status {
-    var settingsText: String {
+    var settingsText: Text {
         switch self {
-        case .live: return "Connected"
-        case .connecting: return "Connecting…"
-        case .unpaired: return "Not paired"
-        case .unauthorized: return "Needs pairing"
-        case .offline: return "Offline"
+        case .live: return Text("Connected")
+        case .connecting: return Text("Connecting…")
+        case .unpaired: return Text("Not paired")
+        case .unauthorized: return Text("Needs pairing")
+        case .offline: return Text("Offline")
         }
     }
 }


### PR DESCRIPTION
Part 1 of #864. Adds the iOS string catalog, a **Language** setting, and
Brazilian Portuguese — with Settings as the first translated screen, since that
is where the picker lives and so the screen proves itself.

## Why this is small

SwiftUI's `Text`, `Button`, `Section`, `navigationTitle`, `Label` and
`TextField` take a `LocalizedStringKey`, not a `String`. Every literal already
passing through them was *already* a localization lookup — against a table that
did not exist. Counted on `main`, that is **319 unique keys across 375 call
sites**.

So the seam is one modifier at the root:

```swift
.environment(\.locale, AppLanguage.resolved(language).locale ?? .autoupdatingCurrent)
```

Verified on the simulator that this carries plain `Text`, `Section` headers,
`Button` titles, `NavigationLink` labels, `navigationTitle`, **and sheets** —
no call site changes, no bundle swizzling, no relaunch.

## English cannot regress

English is the source catalog: every key *is* the English literal already in the
Swift. An English reader sees the same copy as before, and any key a translation
omits falls back to it — the same contract `docs/localization.md` sets for the
renderer. Adding a language is one case in `AppLanguage` and one column in the
catalog.

## The part that was not free

Settings also carried copy typed as `String`, which SwiftUI cannot localize.
Those move to `Text` / `LocalizedStringKey`. The values that are the *user's*
— a computer's name, the offline reason the computer itself sent — become
`Text(verbatim:)`, so the type now records which strings must never be
translated. That distinction is the thing worth reviewing here.

Two things I tried first and rejected, both caught by actually running it:

- **`String(localized:locale:)`** looks right and is not: its `locale` formats
  the interpolations, while the *translation* is chosen by the bundle. Strings
  built that way silently followed the phone's language.
- **Resolving an `.lproj` bundle by hand** then fails the other way. There is no
  `en.lproj` — English is the key itself — so English fell through to
  `Bundle.main`, which means "whatever the system prefers", which on a
  Portuguese phone is Portuguese. An app forced to English rendered half in
  Portuguese.

Letting the type system carry it removes that whole class of bug.

## Deliberately not here

- **Other screens.** Catalog-only follow-ups, no Swift, per #864.
- **`CompanionCore`'s user-facing enums.** `ActivityDetail` and `IslandIntro`
  produce their labels as `String` inside the package. The Settings pickers show
  them translated by looking their English text up as a key at the point of
  drawing; localizing the package properly needs `defaultLocalization` and its
  own catalog, which is its own change.
- **`session.actionError`.** Model-level error copy, still English; it belongs
  with the rest of the `Text(String)` work in part 3.

## Testing

- `swift test` in `ios/`: **337 tests, 0 failures.**
- Built and run on the iPhone 17 Pro simulator, both directions:
  app in pt-BR on an English system, and app in English on a pt-BR system.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added language selection in Settings, including System, English, and Brazilian Portuguese options.
  * Added Brazilian Portuguese translations across connection, notification, activity, pairing, settings, and troubleshooting screens.
  * The selected language is saved and applied throughout the app.
* **Improvements**
  * Updated settings labels, statuses, accessibility text, and confirmation dialogs to support localization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->