### PR TITLE
fix(sidebar): keep the bot name readable beside the title pill

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -807,7 +807,7 @@ export function BotListItem({
       </span>
       <div className={cn("min-w-0 flex-1", iconOnly && "hidden")}>
         <div className="flex items-baseline justify-between gap-2">
-          <span className="flex min-w-0 items-center gap-1.5 truncate text-[15px] font-semibold text-ink">
+          <span className="flex min-w-0 grow items-center gap-1.5 truncate text-[15px] font-semibold text-ink">
             {bot.pinned && <Pin size={12} className="shrink-0 text-ink-secondary" />}
             <RenameTitle
               key={iconOnly ? "icons" : "expanded"}
@@ -826,7 +826,7 @@ export function BotListItem({
               inputClassName="w-full rounded bg-inset px-1 py-0.5 text-[15px] font-semibold"
             />
             {title && !renaming && (
-              <span className="max-w-[120px] shrink-0 truncate rounded-full bg-control px-1.5 py-px text-[10.5px] font-medium text-ink-secondary">
+              <span className="max-w-[45%] shrink-0 truncate rounded-full bg-control px-1.5 py-px text-[10.5px] font-medium text-ink-secondary">
                 {title}
               </span>
             )}

--- a/src/components/SidebarBotListItem.test.ts
+++ b/src/components/SidebarBotListItem.test.ts
@@ -68,6 +68,18 @@ describe("BotListItem", () => {
     expect(renderRow(bot({ title: "  " }), false)).not.toContain(">Developer</span>");
   });
 
+  it("caps the title badge to a share of the name line, not a fixed width", () => {
+    // a fixed cap freezes the badge at its full width and crushes the name
+    const markup = renderRow(bot({ title: "Meta-Agent — opensource team maintainer" }), false);
+    const badge = /<span class="([^"]*)"[^>]*>Meta-Agent/.exec(markup);
+
+    expect(badge?.[1]).toContain("max-w-[45%]");
+    expect(badge?.[1]).not.toMatch(/max-w-\[\d+px\]/);
+    // the share is of the whole row, so the name line has to fill it
+    const line = /<span class="([^"]*)"><span class="cursor-text truncate"/.exec(markup);
+    expect(line?.[1]).toContain("grow");
+  });
+
   it("shows typing dots instead of preview text while the bot works", () => {
     const markup = renderRow(bot({ busy: true }), false);
 


### PR DESCRIPTION
Closes #866.

## What was wrong

A bot with a Title shows the name crushed to a couple of characters — `Tea…` — while the pill keeps its full width.

The name line inside a sidebar row is narrow: `320px` sidebar − `px-2` list − row `px-3 pr-12` − 56px avatar − `gap-3` leaves **174px**, and compact density leaves **150px**. The pill capped itself at `max-w-[120px]`, so it took 69% of that line (80% at compact) and the name got whatever was left.

Measured on the real build, comfortable density, name `Team Meta` + title `Meta-Agent — opensource team maintainer`:

| row state | before | |
|---|---|---|
| normal (320px) | name **48px** / 78px needed | pill 120px |
| normal (272px, compact) | name **24px** / 78px needed | pill 120px |
| selected, compact (timestamp present) | name **0px** | pill 120px |
| pinned, compact | name **6px** | pill 120px |

## Why `min-w-0` on `RenameTitle` is not the fix

The issue suggests adding `min-w-0` to the span `RenameTitle` renders. I rendered both versions side by side against the app's own compiled CSS and they are **byte-identical in layout** — name 48px, pill 120px, either way.

`truncate` already sets `overflow: hidden`, and per CSS Flexbox §4.5 a flex item whose overflow is not `visible` gets an automatic minimum size of `0`. So the name span was already free to shrink; it was already truncating. `min-w-0` there changes nothing.

The real cause is on the other side of the line. Flexbox freezes an item whose flex base size is larger than its hypothetical main size — which is exactly what `max-width: 120px` on a 235px-wide title produces. The pill was therefore inflexible, and `shrink-0` was redundant: it would have claimed the full 120px with or without it. Nothing the name span does can win space back from a frozen item.

## The fix

Two utilities in `Sidebar.tsx`:

- the pill's cap becomes a **share of the line**, `max-w-[120px]` → `max-w-[45%]`, so it scales with the space actually available — compact density, a pin icon, the timestamp on the selected row;
- the name line gets `grow`, so that share is measured against the whole row instead of the line's own shrink-to-fit content width.

The second one matters: `45%` alone regressed short titles. With `Pip` + `Dev` the line shrank to fit its content (61px), and 45% of that clipped `Dev` to `D…`. With `grow` the percentage resolves against the full row, and short titles render in full again.

## After

| row state | after | |
|---|---|---|
| normal (320px) | name **78px** — full | pill 78px |
| normal (272px, compact) | name **76.5px** / 78px | pill 67.5px |
| selected, compact | name **54.7px** | pill 49.6px |
| pinned, compact | name **58.5px** | pill 67.5px |

Short and medium titles are untouched — `Dev` (32px) and `Maintainer` (66px) render in full at both densities, before and after. Only a title long enough to have been truncated anyway loses width, and it loses it to the name.

## Verification

The row does not have a layout test today (the suite renders static markup, which has no box model), so I reproduced the row in isolation against `dist/assets/*.css` from `vite build` — the app's own compiled Tailwind — using the exact class strings from `Sidebar.tsx` and `RenameTitle.tsx`, and measured `getBoundingClientRect()` at both densities across name/title length combinations, with and without the pin and the selected-row timestamp. Every number above comes from that harness.

The regression test added here guards what static markup can see: that the cap is relative rather than a fixed pixel width, and that the name line grows — the two are only correct together.

`vitest run`: 3835 passed, 20 skipped, 0 failed. `tsc -b`, `tsc -p tsconfig.server.json` and `oxlint .` clean (no new warnings).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved bot list item layout so names use available space more effectively.
  * Updated title badges to scale responsively, with a maximum width based on the row rather than a fixed size.

* **Tests**
  * Added coverage for long title badges and responsive name and badge sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->