### PR TITLE
fix(composio): page the marketplace catalog past its first 500 toolkits

### DIFF
--- a/cloudflare/composio-broker/src/index.test.ts
+++ b/cloudflare/composio-broker/src/index.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   authorize,
+  catalog,
   connectedServices,
   connectionStatus,
   createSession,
@@ -277,6 +278,26 @@ describe("connected-apps broker boundaries", () => {
     await expect(authorized.json()).resolves.toEqual({ url: "https://connect.composio.dev/link/gmail" });
     const linkCall = fetchCalls.find((call) => call.url.endsWith("/tool_router/session/trs_multi/link"));
     expect(JSON.parse(String(linkCall?.init?.body))).toEqual({ toolkit: "gmail", alias: "second" });
+  });
+
+  it("pages the catalog by forwarding a well-formed cursor only", async () => {
+    const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+    const { env } = testEnv(fetchCalls);
+    vi.stubGlobal("fetch", async (input: string | URL | Request, init?: RequestInit) => {
+      fetchCalls.push({ url: String(input), init });
+      return Response.json({ items: [{ slug: "deepgram" }] });
+    });
+    const catalogEnv = { ...env, COMPOSIO_TOOLKIT_BASE: "https://backend.composio.dev/api/v3" } as never;
+
+    await catalog(catalogEnv, new URL("https://broker.test/v1/catalog"));
+    await catalog(catalogEnv, new URL("https://broker.test/v1/catalog?cursor=eyJwYWdlIjoyfQ=="));
+    await catalog(catalogEnv, new URL("https://broker.test/v1/catalog?cursor=%20%26limit%3D1"));
+
+    expect(fetchCalls.map((call) => new URL(call.url).searchParams.get("cursor"))).toEqual([
+      null,
+      "eyJwYWdlIjoyfQ==",
+      null,
+    ]);
   });
 
   it("validates aliases at the broker boundary", () => {

--- a/cloudflare/composio-broker/src/index.ts
+++ b/cloudflare/composio-broker/src/index.ts
@@ -96,6 +96,8 @@ const MULTI_ACCOUNT_CONFIG = {
 // accounts per page nobody real is near the ceiling.
 const MAX_CONNECTED_ACCOUNT_PAGES = 20;
 const ACCOUNT_ID = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
+/** Composio's catalog cursor is base64 of the page and limit. */
+const CATALOG_CURSOR = /^[A-Za-z0-9+/_=-]{1,256}$/;
 const printableAliasSchema = z.string().min(1).max(64).refine((value) => {
   for (const character of value) {
     const codePoint = character.codePointAt(0);
@@ -291,8 +293,13 @@ async function proxyMcp(request: Request, installation: InstallationRow, env: En
   return new Response(response.body, { status: response.status, headers });
 }
 
-async function catalog(env: Env) {
-  const response = await fetch(`${env.COMPOSIO_TOOLKIT_BASE}/toolkits?limit=500&sort_by=usage`, {
+async function catalog(env: Env, url: URL) {
+  // The catalog runs past a thousand toolkits, so pass the caller's cursor
+  // through — dropping it capped the marketplace at one page.
+  const params = new URLSearchParams({ limit: "500", sort_by: "usage" });
+  const cursor = url.searchParams.get("cursor");
+  if (cursor && CATALOG_CURSOR.test(cursor)) params.set("cursor", cursor);
+  const response = await fetch(`${env.COMPOSIO_TOOLKIT_BASE}/toolkits?${params}`, {
     headers: { accept: "application/json", "x-api-key": env.COMPOSIO_API_KEY },
     signal: AbortSignal.timeout(20_000),
   });
@@ -577,7 +584,7 @@ async function route(request: Request, env: Env, ctx: ExecutionContext) {
   if (!installation) return json({ error: "unauthorized" }, 401);
   if (request.method === "GET" && url.pathname === "/v1/me") return json({ installationId: installation.id });
   if (request.method === "POST" && url.pathname === "/v1/mcp") return proxyMcp(request, installation, env, ctx);
-  if (request.method === "GET" && url.pathname === "/v1/catalog") return catalog(env);
+  if (request.method === "GET" && url.pathname === "/v1/catalog") return catalog(env, url);
   if (request.method === "GET" && url.pathname === "/v1/connectors/connected") return connectedServices(installation, env, ctx);
   if (request.method === "GET" && url.pathname === "/v1/connectors") return connectionStatus(url, installation, env, ctx);
   const accountMatch = url.pathname.match(/^\/v1\/connectors\/([a-z0-9][a-z0-9_-]{0,80})\/accounts\/([A-Za-z0-9][A-Za-z0-9_-]{0,127})$/);
@@ -604,6 +611,7 @@ export default {
 
 export {
   authorize,
+  catalog,
   connectedServices,
   connectionStatus,
   createSession,

--- a/server/composio.test.ts
+++ b/server/composio.test.ts
@@ -93,7 +93,7 @@ beforeAll(async () => {
     }
 
     const apiKey = String(req.headers["x-api-key"] ?? "");
-    if (!["ak_test", "ak_catalog_a", "ak_catalog_b"].includes(apiKey)) {
+    if (!["ak_test", "ak_catalog_a", "ak_catalog_b", "ak_catalog_pages", "ak_catalog_partial", "ak_catalog_stuck"].includes(apiKey)) {
       res.writeHead(401, { "content-type": "application/json" });
       return res.end(JSON.stringify({ error: { message: "invalid project key" } }));
     }
@@ -105,6 +105,37 @@ beforeAll(async () => {
         session_id: "trs_test",
         mcp: { type: "http", url: "https://app.composio.dev/tool_router/v3/trs_test/mcp" },
         config: { user_id: body.user_id, multi_account: body.multi_account, auth_configs: sessionAuthConfigs },
+      }));
+    }
+    if (
+      req.method === "GET" && url.pathname === "/api/v3/toolkits"
+      && (apiKey === "ak_catalog_pages" || apiKey === "ak_catalog_partial" || apiKey === "ak_catalog_stuck")
+    ) {
+      if (apiKey === "ak_catalog_stuck") {
+        // A broker deployed before this fix ignores the cursor and replays page one.
+        res.writeHead(200, { "content-type": "application/json" });
+        return res.end(JSON.stringify({ items: [{ slug: "gmail", name: "Gmail" }], next_cursor: "catalog-page-2" }));
+      }
+      // Mirrors the real marketplace: a usage-sorted head, then an alphabetical
+      // tail only a second page reaches. ak_catalog_partial loses that page.
+      if (url.searchParams.get("cursor") === "catalog-page-2") {
+        if (apiKey === "ak_catalog_partial") {
+          res.writeHead(502, { "content-type": "application/json" });
+          return res.end(JSON.stringify({ error: "catalog page unavailable" }));
+        }
+        res.writeHead(200, { "content-type": "application/json" });
+        return res.end(JSON.stringify({
+          items: [{ slug: "deepgram", name: "Deepgram" }, { slug: "zoom", name: "Zoom" }],
+        }));
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      return res.end(JSON.stringify({
+        items: [
+          { slug: "gmail", name: "Gmail" },
+          { slug: "bland_ai", name: "Bland AI" },
+          { slug: "currencyscoop", name: "CurrencyScoop" },
+        ],
+        next_cursor: "catalog-page-2",
       }));
     }
     if (req.method === "GET" && url.pathname === "/api/v3/toolkits") {
@@ -289,6 +320,33 @@ describe.sequential("Composio Sessions", () => {
       "ak_catalog_a",
       "ak_catalog_b",
     ]);
+  });
+
+  it("pages the marketplace catalog past the first page", async () => {
+    const before = calls.length;
+    const { cards } = await listToolkits({ composio: { apiKey: "ak_catalog_pages" } });
+
+    // "Deepgram" only exists on page two: #634 saw the catalog stop at "CurrencyScoop".
+    expect(cards.map((card) => card.slug)).toEqual(["gmail", "bland_ai", "currencyscoop", "deepgram", "zoom"]);
+    const pages = calls.slice(before).filter((call) => call.path === "/api/v3/toolkits");
+    expect(pages).toHaveLength(2);
+    expect(pages[0]?.query).not.toContain("cursor=");
+    expect(pages[1]?.query).toContain("cursor=catalog-page-2");
+  });
+
+  it("keeps the catalog pages already read when a later page fails", async () => {
+    await expect(listToolkits({ composio: { apiKey: "ak_catalog_partial" } })).resolves.toMatchObject({
+      source: "api",
+      cards: [{ slug: "gmail" }, { slug: "bland_ai" }, { slug: "currencyscoop" }],
+    });
+  });
+
+  it("stops paging a catalog endpoint that replays the same cursor", async () => {
+    const before = calls.length;
+    const { cards } = await listToolkits({ composio: { apiKey: "ak_catalog_stuck" } });
+
+    expect(cards).toEqual([expect.objectContaining({ slug: "gmail" })]);
+    expect(calls.slice(before).filter((call) => call.path === "/api/v3/toolkits")).toHaveLength(2);
   });
 
   it("drops a managed MCP session when routing switches to a user project", async () => {

--- a/server/composio.ts
+++ b/server/composio.ts
@@ -1029,30 +1029,48 @@ export async function listToolkits(cfg: AppConfig): Promise<{ cards: ToolkitCard
   }
   if (backendKey || broker) {
     try {
-      const res = backendKey
-        ? await fetch(`${toolkitBase()}/toolkits?limit=500&sort_by=usage`, {
-            headers: { "x-api-key": backendKey },
-            signal: AbortSignal.timeout(15_000),
-          })
-        : await brokerRequest("/v1/catalog", { signal: AbortSignal.timeout(15_000) });
-      if (res.ok) {
+      // The marketplace runs to well over a thousand toolkits and the endpoint
+      // is cursor-paginated, so one page stops partway through the alphabet.
+      // Follow next_cursor, and keep the pages already collected if a later
+      // one fails — a partial catalog still beats the curated two dozen.
+      const items: any[] = [];
+      const seenCursors = new Set<string>();
+      let cursor: string | undefined;
+      for (let page = 0; page < MAX_CONNECTED_ACCOUNT_PAGES; page += 1) {
+        const params = new URLSearchParams({ limit: "500", sort_by: "usage" });
+        if (cursor) params.set("cursor", cursor);
+        const res = backendKey
+          ? await fetch(`${toolkitBase()}/toolkits?${params}`, {
+              headers: { "x-api-key": backendKey },
+              signal: AbortSignal.timeout(15_000),
+            })
+          : await brokerRequest(cursor ? `/v1/catalog?cursor=${encodeURIComponent(cursor)}` : "/v1/catalog", {
+              signal: AbortSignal.timeout(15_000),
+            });
+        if (!res.ok) break;
         const json: any = await res.json();
-        const items = json.items ?? json.data ?? [];
-        if (Array.isArray(items) && items.length) {
-          const cards: ToolkitCard[] = items.map((t: any) => ({
-            slug: canonicalToolkitSlug(String(t.slug ?? t.key ?? t.name ?? "")),
-            label: t.name ?? t.slug ?? "",
-            blurb: (t.meta?.description ?? t.description ?? "").slice(0, 90),
-            logo: t.meta?.logo ?? t.logo ?? null,
-            noAuth: t.no_auth === true,
-            domain: null,
-          }));
-          const uniqueCards = cards.filter(
-            (card, index) => card.slug && cards.findIndex((candidate) => candidate.slug === card.slug) === index,
-          );
-          toolkitCache = { at: Date.now(), cards: uniqueCards, identity: identity! };
-          return { cards: uniqueCards, source: "api" };
-        }
+        const pageItems = json.items ?? json.data ?? [];
+        if (!Array.isArray(pageItems)) break;
+        items.push(...pageItems);
+        const next = typeof json.next_cursor === "string" ? json.next_cursor.trim() : "";
+        if (!next || seenCursors.has(next)) break;
+        seenCursors.add(next);
+        cursor = next;
+      }
+      if (items.length) {
+        const cards: ToolkitCard[] = items.map((t: any) => ({
+          slug: canonicalToolkitSlug(String(t.slug ?? t.key ?? t.name ?? "")),
+          label: t.name ?? t.slug ?? "",
+          blurb: (t.meta?.description ?? t.description ?? "").slice(0, 90),
+          logo: t.meta?.logo ?? t.logo ?? null,
+          noAuth: t.no_auth === true,
+          domain: null,
+        }));
+        const uniqueCards = cards.filter(
+          (card, index) => card.slug && cards.findIndex((candidate) => candidate.slug === card.slug) === index,
+        );
+        toolkitCache = { at: Date.now(), cards: uniqueCards, identity: identity! };
+        return { cards: uniqueCards, source: "api" };
       }
     } catch {
       /* fall through to curated */

--- a/src/components/PluginsPanel.tsx
+++ b/src/components/PluginsPanel.tsx
@@ -177,14 +177,25 @@ export function onlyLatestConnectorResponses(
 function ServiceIcon({ card }: { card: ToolkitCard }) {
   // 0 = official logo, 1 = favicon by domain, 2 = monogram
   const [stage, setStage] = useState(card.logo ? 0 : card.domain ? 1 : 2);
+  // The full catalog is well over a thousand cards, so let the browser skip
+  // the logos that are scrolled out of view instead of fetching every one.
   if (stage === 0 && card.logo) {
-    return <img src={card.logo} alt="" className="size-11 rounded-xl object-contain" onError={() => setStage(1)} />;
+    return (
+      <img
+        src={card.logo}
+        alt=""
+        loading="lazy"
+        className="size-11 rounded-xl object-contain"
+        onError={() => setStage(1)}
+      />
+    );
   }
   if (stage === 1 && card.domain) {
     return (
       <img
         src={`https://www.google.com/s2/favicons?domain=${card.domain}&sz=64`}
         alt=""
+        loading="lazy"
         className="size-11 rounded-xl object-contain"
         onError={() => setStage(2)}
       />


### PR DESCRIPTION
Closes #634.

## What was wrong

The marketplace listed the popular apps, then ran alphabetically to
`CurrencyScoop` and stopped. `Bland AI` was reachable, `Deepgram` was not,
even though both toolkits exist upstream.

## The cause

`listToolkits` asked Composio for the catalog exactly once:

```
GET /api/v3/toolkits?limit=500&sort_by=usage
```

and never looked at the `next_cursor` that endpoint returns.

Composio's own OpenAPI description of `GET /api/v3/toolkits`
(`backend.composio.dev/api/v3/openapi.json`) documents the endpoint as
cursor-paginated:

* `limit` — "Number of items per page, max allowed is 1000"
* `cursor` — "Cursor for pagination … not required for the first page"
* the 200 body carries `items`, **`next_cursor`**, `total_pages`,
  `current_page`, `total_items`

Composio's public toolkit directory currently lists **1470 toolkits**, so a
single 500-item page left **970 of them unreachable** — the UI's search is a
client-side filter over the cards it was given (`PluginsPanel.tsx`), so an
app that never arrived could not be found by searching for it either.

The cut-off in the report is exactly the 500-item boundary. Sorting those
1470 slugs alphabetically:

| toolkit | alphabetical index | reported |
| --- | --- | --- |
| `bland_ai` | 142 | visible |
| `currencyscoop` | 338 | last one visible |
| `deepgram` | 365 | missing |

With `sort_by=usage` the high-usage apps fill the head of the page and the
remainder comes out alphabetically, so ~160 popular apps + 338 alphabetical
entries ≈ the 500 the request asked for. That is why the catalog stopped in
the middle of "C" rather than anywhere else.

Raising the limit is not a fix: even `limit=1000`, the documented maximum,
would still strand 470 toolkits.

### The managed path had the same bug

`cloudflare/composio-broker` serves `/v1/catalog` for every installation
without its own Composio key — the default. It made the same single
un-paginated `limit=500` request and dropped any `cursor` the caller sent,
so fixing only `server/composio.ts` would have left managed users just as
truncated.

## The fix

Follow `next_cursor` on both paths.

* `server/composio.ts` — `listToolkits` now loops over pages, reusing the
  `seenCursors` + page-ceiling guard already used by the connected-account
  and session-toolkit listings. That guard matters here: a broker deployed
  before this change replays page one, and the loop stops on the repeated
  cursor instead of spinning to the ceiling.
* `cloudflare/composio-broker` — `/v1/catalog` forwards a well-formed
  cursor upstream (base64 shape, length-bounded) and ignores anything else.
* Pages already read are kept when a later page returns an error response,
  instead of discarding the catalog and falling back to the 24 curated
  cards.

### One regression this introduced, and its fix

Tripling the catalog also triples what the panel renders. `ServiceIcon`
issues one image request per card with no lazy loading, so the full catalog
would have fired roughly 1400 logo requests when the panel opened. The two
`<img>` tags now carry `loading="lazy"`, leaving the browser to fetch only
the logos actually scrolled into view.

Not changed: the panel still renders every row rather than virtualising the
list, and the catalog response grows from roughly 75 KB to 220 KB (cached
ten minutes server-side). Both are worth revisiting if the catalog keeps
growing, but neither is a regression this change needs to carry.

## Verified

Every new test was run against the unfixed code first to confirm it fails
for the right reason, then against the fix.

* `server/composio.test.ts` — "pages the marketplace catalog past the first
  page" fails without the fix with
  `expected [ Array(3) ] to deeply equal [ 'gmail', 'bland_ai', …(3) ]`,
  i.e. the page-two toolkit (`deepgram`) never arrives. Also covers keeping
  partial pages when a later page 502s, and stopping when an endpoint
  replays the same cursor.
* `cloudflare/composio-broker/src/index.test.ts` — "pages the catalog by
  forwarding a well-formed cursor only" fails without the broker fix with
  `expected [ null, null, null ] to deeply equal [ null, 'eyJwYWdlIjoyfQ==', null ]`.

Results:

* `vitest run server/composio.test.ts` — 26 passed
* `vitest run --config cloudflare/composio-broker/vitest.config.ts` — 8 passed
* `vitest run` — 331 files, 3837 passed, 20 skipped, 1 todo, 0 failed (exit 0)
* `tsc -b` and `tsc -p tsconfig.server.json` — clean
* `vite build` — clean
* `oxlint .` — exit 0, 31 warnings, identical to `origin/main` (none in the
  touched files)

`tsc -p cloudflare/composio-broker/tsconfig.json` reports `Cannot find name
'Env'` both before and after this change: `worker-configuration.d.ts` is
generated by `broker:types` and is not in the tree. Unrelated and untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded the marketplace catalog to load additional pages of available toolkits, providing a more complete catalog.
  - Preserves successfully loaded catalog items when a later page cannot be retrieved.
  - Prevents repeated catalog pages from causing endless loading.

- **Performance**
  - Toolkit logos now load lazily, improving initial loading performance when browsing large catalogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->