### PR TITLE
fix(approvals): let a held card name the guard that stopped it

### DIFF
--- a/server/auto-approve.test.ts
+++ b/server/auto-approve.test.ts
@@ -303,4 +303,66 @@ describe("approvalHeldReason", () => {
     expect(approvalHeldReason({ ...auto, unattended: true, mode: "ask" })).toBeUndefined();
     expect(approvalHeldReason({ ...auto, unattended: true, mode: "full" })).toBeUndefined();
   });
+
+  // Reported as "safe reads look destructive": both guards stopped the same
+  // mode, so both cards read the same, and a read-only .env card claimed the
+  // action was destructive. Each guard now says which one it was.
+  it("names the guard that stopped the action", () => {
+    expect(approvalHeldReason({ ...auto, unattended: false, source: "destructive-guard" }))
+      .toBe("This looks destructive, so Approve for me stopped to ask.");
+    expect(approvalHeldReason({ ...auto, unattended: false, source: "sensitive-guard" }))
+      .toBe("This touches credentials, so Approve for me stopped to ask.");
+  });
+
+  it("keeps the generic note for a hold no guard explains", () => {
+    expect(approvalHeldReason({ ...auto, unattended: false, source: "no-grant" }))
+      .toBe("This action needs you, so Approve for me stopped to ask.");
+  });
+
+  // The paused mode outranks the guard: a fleet operator reading a guard card
+  // would otherwise think the next action passes, which is what #809 fixed.
+  it("keeps the unattended note ahead of either guard", () => {
+    for (const source of ["destructive-guard", "sensitive-guard"] as const) {
+      expect(approvalHeldReason({ ...auto, unattended: true, source })).toContain("every action asks");
+    }
+  });
+
+  it("keeps the native and sandbox notes ahead of either guard", () => {
+    expect(approvalHeldReason({ ...auto, unattended: false, source: "native-approval" }))
+      .toBe("The provider requires your approval for this action.");
+    expect(approvalHeldReason({ ...auto, unattended: false, source: "destructive-guard", requiresExplicitApproval: true }))
+      .toContain("only Full access can approve it automatically");
+  });
+
+  // This one reaches the card only over a grant that would have fired, in Ask,
+  // where nothing else speaks — so it explained itself not at all.
+  it("explains a remembered grant that host control refuses", () => {
+    expect(approvalHeldReason({ ...auto, mode: "ask", unattended: false, source: "local-computer-block" }))
+      .toBe("Controlling your computer is never covered by Always allow, so this needs you.");
+  });
+});
+
+// The issue's own reproduction, end to end: the verdict already knew these
+// two apart, and only the card threw that away.
+describe("approvalHeldReason over a real verdict", () => {
+  const held = (summary: string) => {
+    const verdict = autoVerdict({ approvalMode: "auto" }, "Bash", summary);
+    return {
+      source: verdict.source,
+      text: approvalHeldReason({
+        source: verdict.source, permission: true, mode: "auto",
+        unattended: false, fullAccessAvailable: true,
+      }),
+    };
+  };
+
+  it("tells a read-only .env apart from an rm -rf", () => {
+    const sensitive = held("cat .env");
+    const destructive = held("rm -rf /tmp/build");
+    expect(sensitive.source).toBe("sensitive-guard");
+    expect(destructive.source).toBe("destructive-guard");
+    expect(sensitive.text).not.toBe(destructive.text);
+    expect(sensitive.text).not.toContain("destructive");
+    expect(destructive.text).toContain("destructive");
+  });
 });

--- a/server/auto-approve.ts
+++ b/server/auto-approve.ts
@@ -280,8 +280,21 @@ export function approvalHeldReason(context: {
   if (context.requiresExplicitApproval) {
     return "This changes the provider sandbox, so only Full access can approve it automatically.";
   }
+  // Host control reaches this only over a grant that would otherwise have
+  // fired, in a mode that explains nothing else. "I pressed Always allow and
+  // it asked anyway" is the whole confusion, so answer that and not the mode.
+  if (context.source === "local-computer-block") {
+    return "Controlling your computer is never covered by Always allow, so this needs you.";
+  }
   if (context.mode !== "auto") return undefined;
-  if (!context.unattended) return "This action needs you, so Approve for me stopped to ask.";
-  const hint = context.fullAccessAvailable ? " Full access keeps working unattended." : "";
-  return `A webhook or another bot started this turn, so Approve for me is paused and every action asks.${hint}`;
+  if (context.unattended) {
+    const hint = context.fullAccessAvailable ? " Full access keeps working unattended." : "";
+    return `A webhook or another bot started this turn, so Approve for me is paused and every action asks.${hint}`;
+  }
+  // A guard names itself. Both stop the same mode, but one is about damage
+  // and the other about secrets, and a read-only .env card that says
+  // "destructive" teaches people to stop reading these.
+  if (context.source === "destructive-guard") return "This looks destructive, so Approve for me stopped to ask.";
+  if (context.source === "sensitive-guard") return "This touches credentials, so Approve for me stopped to ask.";
+  return "This action needs you, so Approve for me stopped to ask.";
 }

--- a/server/store.ts
+++ b/server/store.ts
@@ -55,7 +55,9 @@ export interface OptionCardData {
   /** permission cards: the tool being requested, so the card can show what
    * is actually being asked and offer "always allow this tool". */
   tool?: string;
-  /** why this stopped despite auto mode (destructive-looking command) */
+  /** why this card is waiting: the guard, mode, sandbox or native note from
+   * approvalHeldReason, or a delivery/apply error from a routine or profile
+   * request. Free text either way, so it is shown verbatim. */
   held?: string;
   /** the narrow grant "always allow" remembers, e.g. "Bash:git" */
   allowKey?: string;


### PR DESCRIPTION
Closes #705

## First, what the issue asked for that is already done

The issue quotes the visible string:

> This looked destructive, so auto mode stopped to ask.

That string is gone, and has been for a while. `git log -S "looked destructive"` puts its
removal in `3e27620b` ("feat: add per-bot approval levels"), which replaced it with
`"This action needs you, so Approve for me stopped to ask."` — no longer claiming anything
about destruction. `b668441d` (#809) came later and only lifted that text out of a nested
ternary in the `request.opened` fold into `approvalHeldReason`, adding the unattended branch.

So the misleading word is not what this PR fixes. **The second half of the issue is still
true**, and that is what this changes.

## The part that was still broken

`autoVerdict()` distinguishes `destructive-guard` from `sensitive-guard`, and `index.ts`
already passes `source: verdict?.source` into `approvalHeldReason()`. But that function
branched only on `native-approval` and `requiresExplicitApproval` — every other source fell
through to the same mode-level sentence.

Driving the two functions end to end on `main`, in Approve for me:

```
cat .env       -> source: sensitive-guard    held: "This action needs you, so Approve for me stopped to ask."
rm -rf /tmp/x  -> source: destructive-guard  held: "This action needs you, so Approve for me stopped to ask."
```

Byte-identical. The verdict knew; the card discarded it. A read-only secrets access and a
recursive delete were presented to the user as exactly the same event.

## What changed

`approvalHeldReason` in `server/auto-approve.ts` only — 19 lines:

| source | card now says |
| --- | --- |
| `destructive-guard` | This looks destructive, so Approve for me stopped to ask. |
| `sensitive-guard` | This touches credentials, so Approve for me stopped to ask. |
| `local-computer-block` | Controlling your computer is never covered by Always allow, so this needs you. |

The mode is called "Approve for me" here rather than the issue's "Auto mode", matching
`ApprovalModeSelector.tsx` and the copy #809 established.

**No guard changed.** `autoVerdict()` is untouched and refuses exactly what it refused
before; this only rewords a card that was already being held.

## Two deliberate departures from the issue's list

**`unattended-block` keeps its #809 copy, and the unattended branch stays ahead of both
guards.** So an unattended `rm -rf` still reads "Approve for me is paused and every action
asks" rather than naming the guard. That is on purpose: with a fleet delegating between
bots every card looks like this until someone answers, and a guard-specific message would
imply the next action passes. It will not. Naming the guard is for turns a person started.
The issue's suggested `unattended-block` wording is already covered, and more precisely, by
what #809 shipped.

**`no-grant` keeps the generic note.** Enumerating every `mode × unattended × scope`
combination shows `no-grant` cannot occur in Approve for me at all — an unguarded action
always takes the auto grant first. It appears only in Ask and Custom, where `held` is
`undefined` and no mode explanation is shown. The issue's suggested "Auto mode could not
approve this request" would name a mode that is not even on.

## One thing the issue did not mention

`local-computer-block` reaches a card only when an always-allow grant *would* have fired,
in a non-auto mode — where `approvalHeldReason` returned `undefined`. So the user pressed
Always allow, host control refused to honour it, and the card explained nothing. It does now.

## Verified

- `vitest run` — **3840 passed, 20 skipped, 1 todo, 0 failed** (331 files; `main` is 3834 passed, and the delta is exactly the 6 tests added here)
- `vitest run server/auto-approve.test.ts server/auto-review.test.ts` — 76 passed. `auto-approve.test.ts` alone goes 62 → 68
- **Each new assertion was checked in both directions.** With `auto-approve.ts` reverted to
  `main` and the new tests kept, exactly the three behaviour tests fail:
  `names the guard that stopped the action`, `explains a remembered grant that host control
  refuses`, and `tells a read-only .env apart from an rm -rf`. The remaining new tests are
  precedence pins and pass either way by design — that is their job.
- `tsc -b` and `tsc -p tsconfig.server.json` — exit 0
- `oxlint .` — exit 0, warning set byte-identical to `main` (31 pre-existing, none in
  `auto-approve`)

Tests live in the existing `describe("approvalHeldReason")` in `server/auto-approve.test.ts`,
plus one block that drives `autoVerdict` → `approvalHeldReason` together, so the issue's own
reproduction is pinned end to end rather than only at the wording layer.

## Out of scope

`held` is rendered raw from the server in `ApprovalCard.tsx` and `PendingApproval.tsx` and
does not pass through `src/lib/i18n.ts`. The rest of the card *is* translated — `approval.*`
already carries 25+ keys across 8 locale packs — so `held` is the one line that stays English
in a localized card, and this PR adds three more strings to it. Fixing that means giving the
card a `heldCode` alongside the text (the text has to stay: it is persisted in the message
DB, and some `held` values are free-text apply errors with no catalog key), which is a change
to a stored shape rather than to wording. Sent separately so this PR stays reviewable as
"no guard moves, only the copy".

The follow-up comment on #705 asks for something larger — a plain-English TLDR per card, an
explicit risk line, spelled-out Always Allow scope, and collapsed technical details. That is
a card redesign rather than a classification fix, and none of it is in here. Happy to have
this retitled to `Refs #705` if you would rather keep the issue open for that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Approval prompts now explain why an action was held, including destructive actions, credential access, unattended turns, and host-control restrictions.
  - Auto-mode approval messages now distinguish between sensitive file access and destructive commands.
  - More specific approval guidance is shown when native approval or sandbox restrictions apply.

- **Bug Fixes**
  - Corrected approval cards that previously displayed the same generic explanation for different guard conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->