### PR TITLE
fix(chat): keep thinking row above composer

### DIFF
--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -67,7 +67,7 @@ import { ActivityRun } from "./ActivityRun";
 import { TurnNarrationRun } from "./TurnNarrationRun";
 import { webhookMessageView } from "@/lib/webhook-message";
 import { splitTranscriptAttachments } from "@/lib/composer-attachments";
-import { BOTTOM_FOLLOW_THRESHOLD, shouldResumeBottomFollow } from "@/lib/bottom-follow";
+import { BOTTOM_FOLLOW_THRESHOLD, shouldResumeBottomFollow, useBottomFollowResize } from "@/lib/bottom-follow";
 import { useComposerDockPad } from "@/lib/composer-dock";
 import {
   TRANSCRIPT_WINDOW_SIZE,
@@ -869,6 +869,7 @@ export function ChatView({ bot }: { bot: Bot }) {
   const { state, dispatch } = useStore();
   const remoteClient = window.ogb?.remoteClient?.active === true;
   const scrollRef = useRef<HTMLDivElement>(null);
+  const transcriptRef = useRef<HTMLDivElement>(null);
   const composerDockRef = useRef<HTMLDivElement>(null);
   const composerDock = useComposerDockPad(composerDockRef);
 
@@ -1021,6 +1022,7 @@ export function ChatView({ bot }: { bot: Bot }) {
     followRef.current = next;
     setFollow(next);
   }, []);
+  useBottomFollowResize(scrollRef, transcriptRef, followRef, transcriptKey);
 
   useEffect(() => setBottomFollow(true), [bot.id, setBottomFollow]);
 
@@ -1277,6 +1279,7 @@ export function ChatView({ bot }: { bot: Bot }) {
         }}
       >
         <div
+          ref={transcriptRef}
           className="flex w-full flex-col gap-3"
           style={{ paddingBottom: composerDock.pad }}
           role="log"

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -41,7 +41,7 @@ import { useDesktopCapabilities } from "./DesktopCapabilities";
 import { cn } from "@/lib/cn";
 import { useFocusMessage } from "@/lib/focus-message";
 import { shortPath } from "@/lib/short-path";
-import { BOTTOM_FOLLOW_THRESHOLD, shouldResumeBottomFollow } from "@/lib/bottom-follow";
+import { BOTTOM_FOLLOW_THRESHOLD, shouldResumeBottomFollow, useBottomFollowResize } from "@/lib/bottom-follow";
 import { useComposerDockPad } from "@/lib/composer-dock";
 import { awaitedMemberId, showWorkingDots } from "@/lib/turn-tail";
 import { liveActivityLabel } from "@/lib/live-activity";
@@ -879,6 +879,7 @@ export function GroupView({ group }: { group: Group }) {
   const stream = useStreaming();
   const streaming = stream.streaming[group.threadId];
   const scrollRef = useRef<HTMLDivElement>(null);
+  const transcriptRef = useRef<HTMLDivElement>(null);
   const composerDockRef = useRef<HTMLDivElement>(null);
   const composerDock = useComposerDockPad(composerDockRef);
   const [follow, setFollow] = useState(true);
@@ -996,6 +997,7 @@ export function GroupView({ group }: { group: Group }) {
     followRef.current = next;
     setFollow(next);
   }, []);
+  useBottomFollowResize(scrollRef, transcriptRef, followRef, setupPending ? null : transcriptKey);
 
   useEffect(() => setBottomFollow(true), [group.id, setBottomFollow]);
 
@@ -1252,6 +1254,7 @@ export function GroupView({ group }: { group: Group }) {
           </div>
         ) : (
         <div
+          ref={transcriptRef}
           className="flex w-full flex-col gap-3"
           style={{ paddingBottom: composerDock.pad }}
           role="log"

--- a/src/lib/bottom-follow.test.ts
+++ b/src/lib/bottom-follow.test.ts
@@ -1,6 +1,30 @@
 import { describe, expect, it } from "vitest";
 
-import { BOTTOM_FOLLOW_THRESHOLD, shouldResumeBottomFollow } from "./bottom-follow";
+import { BOTTOM_FOLLOW_THRESHOLD, followBottomGrowth, shouldResumeBottomFollow } from "./bottom-follow";
+
+describe("followBottomGrowth", () => {
+  it("scrolls resized content to its new bottom while following", () => {
+    const calls: ScrollToOptions[] = [];
+    const scroller = {
+      scrollHeight: 1_240,
+      scrollTo: (options: ScrollToOptions) => calls.push(options),
+    };
+
+    expect(followBottomGrowth(scroller, true)).toBe(true);
+    expect(calls).toEqual([{ top: 1_240 }]);
+  });
+
+  it("preserves scrollback when bottom-follow is detached", () => {
+    const calls: ScrollToOptions[] = [];
+    const scroller = {
+      scrollHeight: 1_240,
+      scrollTo: (options: ScrollToOptions) => calls.push(options),
+    };
+
+    expect(followBottomGrowth(scroller, false)).toBe(false);
+    expect(calls).toEqual([]);
+  });
+});
 
 describe("shouldResumeBottomFollow", () => {
   it("does not re-pin a small upward scroll inside the near-bottom zone", () => {

--- a/src/lib/bottom-follow.ts
+++ b/src/lib/bottom-follow.ts
@@ -1,3 +1,5 @@
+import { useLayoutEffect, type RefObject } from "react";
+
 /** Subpixel slack for "at the rest position" — not a magnet zone. A larger
  * value used to re-pin follow ~48px early and then jump the pane to the end. */
 export const BOTTOM_FOLLOW_THRESHOLD = 4;
@@ -19,4 +21,39 @@ export function shouldResumeBottomFollow({
   distanceFromBottom: number;
 }): boolean {
   return !following && scrollTop > previousScrollTop && distanceFromBottom < BOTTOM_FOLLOW_THRESHOLD;
+}
+
+interface BottomFollowScroller {
+  scrollHeight: number;
+  scrollTo(options?: ScrollToOptions): void;
+}
+
+/** Follow content growth only while the reader remains pinned to the tail. */
+export function followBottomGrowth(scroller: BottomFollowScroller, following: boolean): boolean {
+  if (!following) return false;
+  scroller.scrollTo({ top: scroller.scrollHeight });
+  return true;
+}
+
+/**
+ * Keep a pinned transcript at its true bottom when descendants mount or
+ * resize after the parent's one-shot message scroll (for example TurnPresence).
+ */
+export function useBottomFollowResize(
+  scrollRef: RefObject<HTMLElement | null>,
+  transcriptRef: RefObject<HTMLElement | null>,
+  followingRef: RefObject<boolean>,
+  observeKey: string | null,
+): void {
+  useLayoutEffect(() => {
+    const scroller = scrollRef.current;
+    const transcript = transcriptRef.current;
+    if (!scroller || !transcript || observeKey === null) return;
+
+    const observer = new ResizeObserver(() => {
+      followBottomGrowth(scroller, followingRef.current);
+    });
+    observer.observe(transcript);
+    return () => observer.disconnect();
+  }, [followingRef, observeKey, scrollRef, transcriptRef]);
 }


### PR DESCRIPTION
## Summary

- observe transcript size changes while bottom-follow remains armed
- scroll after delayed rows such as TurnPresence mount, in both direct chats and rooms
- preserve detached scrollback instead of snapping readers back to the tail
- add regression coverage for active and detached bottom-follow behavior

## Verification

- focused bottom-follow/composer tests: 11 passed
- pnpm lint: passed with pre-existing warnings only
- pnpm typecheck: passed
- pnpm build: passed
- full suite: 3,830 tests passed; two environment-dependent fixture failures were isolated to a random occupied port and inherited ELECTRON_RUN_AS_NODE, then both files passed on clean focused rerun (26 tests)
- ProofShot against the repository's isolated fake-agent fixture: thinking row fully visible with 15.11px clearance above the composer; zero browser errors and zero server errors

No live conversation data was used during verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transcript scrolling so conversations remain pinned to the latest content while users are following the bottom.
  - Updated scrolling to respond when transcript content changes size or new content is rendered.
  - Preserved the user’s current position when they have intentionally scrolled away from the bottom.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->