### PR TITLE
fix(browser): repair upgrade recovery and prepare 0.1.59

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.58",
+  "version": "0.1.59",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -7,7 +7,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
 import { once } from "node:events";
 import { createServer, request, type Server } from "node:http";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -797,7 +797,23 @@ beforeAll(async () => {
   await new Promise<void>((r) => boxStub.listen(0, "127.0.0.1", r));
   boxStubPort = (boxStub.address() as { port: number }).port;
 
-  child = spawn(process.execPath, [join(SERVER_DIR, "index.ts")], {
+  // Emulate only our temporary browser executable, including on Windows where
+  // the shell-script marker is not executable. No installed browser is used.
+  const browserPrelude = `data:text/javascript,${encodeURIComponent(`
+    import childProcess from "node:child_process";
+    import { syncBuiltinESMExports } from "node:module";
+    const spawn = childProcess.spawn;
+    childProcess.spawn = function(command, args, options) {
+      if (command !== process.env.OMB_AGENT_BROWSER_PATH) return spawn(command, args, options);
+      const program = 'const fs = require("node:fs"); const path = require("node:path"); '
+        + 'const base = path.dirname(process.env.OMB_AGENT_BROWSER_PATH); '
+        + 'fs.appendFileSync(path.join(base, "browser-calls.jsonl"), JSON.stringify({args: process.argv.slice(1), session: process.env.AGENT_BROWSER_SESSION}) + "\\\\n"); '
+        + 'process.exit(fs.existsSync(path.join(base, "browser-clear-fails")) ? 1 : 0);';
+      return spawn(process.execPath, ["-e", program, ...args], options);
+    };
+    syncBuiltinESMExports();
+  `)}`;
+  child = spawn(process.execPath, ["--import", browserPrelude, join(SERVER_DIR, "index.ts")], {
     cwd: ROOT,
     env: {
       ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
@@ -1877,6 +1893,49 @@ describe("harness HTTP API", () => {
     expect(deleted.status).toBe(200);
     const after = await api("GET", "/api/bots");
     expect(after.body.bots.find((b: { id: string }) => b.id === bot.id)).toBeUndefined();
+  });
+
+  it.each([
+    ["bot", "key-write"], ["bot", "engine-exit"],
+    ["profile", "key-write"], ["profile", "engine-exit"],
+  ])("keeps failed browser %s cleanup pending without crashing (%s)", async (target, failure) => {
+    const bot = (await api("POST", "/api/bots")).body.bot;
+    const id = target === "bot" ? bot.id : `cleanup-${failure}`;
+    if (target === "profile") {
+      expect((await api("PATCH", "/api/config", { browserProfiles: [{ id, name: "Cleanup fixture" }] })).status).toBe(200);
+      expect((await api("PATCH", `/api/bots/${bot.id}`, { browserProfile: id })).status).toBe(200);
+    }
+    const key = join(home, ".openmausbot", "browser-engine-key");
+    const backup = `${key}.fixture-backup`;
+    const failureMarker = join(home, "browser-clear-fails");
+    const hadKey = existsSync(key);
+    if (failure === "key-write") {
+      if (hadKey) renameSync(key, backup);
+      mkdirSync(key); // deterministic EISDIR, even when the fixture runs as root
+    } else {
+      writeFileSync(failureMarker, "fail");
+    }
+    const journal = () => JSON.parse(readFileSync(join(home, ".openmausbot", "browser-cleanups.json"), "utf8")) as Array<{ id: string; phase: string }>;
+    try {
+      const deleted = target === "bot"
+        ? await api("DELETE", `/api/bots/${bot.id}`)
+        : await api("PATCH", "/api/config", { browserProfiles: [] });
+      expect(deleted.status).toBe(503);
+      expect(deleted.body.error).toMatch(/could not confirm.*browser data was erased/i);
+      expect(journal()).toContainEqual(expect.objectContaining({ id, phase: "committed" }));
+      expect((await api("GET", "/api/health")).status).toBe(200);
+      expect(child.exitCode).toBeNull();
+    } finally {
+      if (failure === "key-write") {
+        rmSync(key, { recursive: true });
+        if (hadKey) renameSync(backup, key);
+      } else {
+        rmSync(failureMarker);
+      }
+    }
+    // The existing coordinator retries the durable request after recovery.
+    await expect.poll(() => journal().some((request) => request.id === id), { timeout: 8_000 }).toBe(false);
+    if (target === "profile") expect((await api("DELETE", `/api/bots/${bot.id}`)).status).toBe(200);
   });
 
   it("clears an explicit computer to Auto and refuses passive Auto Box provisioning", async () => {
@@ -5689,7 +5748,12 @@ describe("harness HTTP API", () => {
         browserProfiles: [{ id: "client", name: "Client" }],
       })).status).toBe(200);
       expect((await api("PATCH", `/api/bots/${bot.id}`, { browserProfile: "client" })).body.bot.browserProfile).toBe("client");
+      const config = JSON.parse(readFileSync(join(home, ".openmausbot", "config.json"), "utf8"));
+      const profile = config.browserProfiles.find((entry: { id: string }) => entry.id === "client");
+      rmSync(join(home, "browser-calls.jsonl"), { force: true });
       expect((await api("PATCH", "/api/config", { browserProfiles: [] })).status).toBe(200);
+      const calls = readFileSync(join(home, "browser-calls.jsonl"), "utf8").trim().split("\n").map((line) => JSON.parse(line));
+      expect(calls).toContainEqual({ args: ["state", "clear", "--all"], session: profile.partitionId ?? profile.id });
       const state = (await api("GET", "/api/bots")).body;
       expect(state.bots.find((candidate: { id: string }) => candidate.id === bot.id)).not.toHaveProperty("browserProfile");
     } finally {

--- a/server/index.ts
+++ b/server/index.ts
@@ -465,10 +465,8 @@ const browserCleanup: BrowserCleanupCoordinator = new BrowserCleanupCoordinator(
       : request.partitionId
         ? [browserSessionId("", request.partitionId)]
         : [];
-    // Best effort, never a reason to keep a deleted bot or profile around:
-    // the engine's saved state is a per-session file set, and an engine that
-    // cannot run here (or was never installed) has nothing to clear. A real
-    // failure is logged with the session name so it can be cleared by hand.
+    // Failed erasure leaves the committed intent pending for retry; it must
+    // never acknowledge that saved state was removed when it was not.
     const work = status.kind === "ready" && sessions.length
       ? Promise.all(sessions.map(async (session) => {
           const ok = await clearBrowserSessionState(status.binaryPath, session, { encryptionKey: browserEngineEncryptionKey() });
@@ -476,8 +474,13 @@ const browserCleanup: BrowserCleanupCoordinator = new BrowserCleanupCoordinator(
           return ok;
         }))
       : Promise.resolve([true]);
-    void work.finally(() => {
-      browserCleanup.receive({ type: "openmausbot:browser-lifecycle-result", requestId: request.requestId, ok: true });
+    void work.then((results) => results.every(Boolean), (error) => {
+      console.warn("browser cleanup: could not clear saved session state", error);
+      return false;
+    }).then((ok) => {
+      browserCleanup.receive({ type: "openmausbot:browser-lifecycle-result", requestId: request.requestId, ok });
+    }).catch((error) => {
+      console.warn("browser cleanup: could not acknowledge cleanup", error);
     });
     return true;
   },
@@ -12256,14 +12259,12 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
       }
       const browserCleanupRequests: BrowserCleanupRequest[] = [];
       try {
-        if (utilityParentPort) {
-          for (const profileId of removedBrowserProfileIds) {
-            const target = browserProfilePartitionTarget(cfg, profileId);
-            if (!target) throw new Error(`browser profile cleanup target “${profileId}” is unavailable`);
-            browserCleanupRequests.push(
-              browserCleanup.prepare("profile", target.profileId, target.partitionId),
-            );
-          }
+        for (const profileId of removedBrowserProfileIds) {
+          const target = browserProfilePartitionTarget(cfg, profileId);
+          if (!target) throw new Error(`browser profile cleanup target “${profileId}” is unavailable`);
+          browserCleanupRequests.push(
+            browserCleanup.prepare("profile", target.profileId, target.partitionId),
+          );
         }
       } catch (error) {
         for (const request of browserCleanupRequests) browserCleanup.abort(request);

--- a/src/components/BrowserPanel.tsx
+++ b/src/components/BrowserPanel.tsx
@@ -23,10 +23,12 @@ export function BrowserPanel({ bot }: { bot: Bot }) {
       if (!response.ok) {
         const body = (await response.json().catch(() => ({}))) as { error?: string };
         setError(body.error ?? `The server answered ${response.status}.`);
-        setRequested(false);
       }
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      // The request only starts installation; subsequent progress/failure is
+      // server-owned. Do not latch the button after a successful HTTP 202.
       setRequested(false);
     }
   };

--- a/src/components/ComputerPanel.browser.test.ts
+++ b/src/components/ComputerPanel.browser.test.ts
@@ -1,0 +1,48 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import type { Bot } from "@/state/store";
+import { browserAvailable, type FeatureFlagConfig } from "@/lib/feature-flags";
+
+const fixture = vi.hoisted(() => {
+  vi.stubGlobal("window", {});
+  vi.stubGlobal("document", { visibilityState: "visible" });
+  vi.stubGlobal("localStorage", { getItem: () => "browser" });
+  return { config: {} as FeatureFlagConfig };
+});
+vi.mock("@/state/store", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@/state/store")>(),
+  useStore: () => ({
+    state: { config: { box: { configured: false }, ...fixture.config }, instances: [], computerControl: {}, screens: {}, routines: [], routineRuns: [] },
+    dispatch: vi.fn(),
+    flushBotPatches: vi.fn(),
+  }),
+}));
+import { ComputerPanel } from "./ComputerPanel";
+
+afterAll(() => vi.unstubAllGlobals());
+const bot = { id: "browser-fixture", name: "Browser fixture", modelSelection: { instanceId: "fixture" } } as Bot;
+const render = (config: FeatureFlagConfig, browser?: boolean) => {
+  fixture.config = config;
+  return renderToStaticMarkup(createElement(ComputerPanel, { bot: { ...bot, browser } }));
+};
+
+describe("Browser panel installation access", () => {
+  const missing = { kind: "unavailable", installable: true } as const;
+
+  it("shows the real install panel before the engine is available", () => {
+    const config = { features: { browser: true }, browserEngine: missing };
+    expect(render(config)).toContain("Install the browser engine");
+    expect(browserAvailable(config)).toBe(false);
+  });
+
+  it("retains the global and per-bot opt-in gates", () => {
+    expect(render({ browserEngine: missing })).not.toContain("Install the browser engine");
+    expect(render({ features: { browser: true }, browserEngine: missing }, false)).not.toContain("Install the browser engine");
+  });
+
+  it("does not offer an install on unsupported hosts and still shows a ready engine", () => {
+    expect(render({ features: { browser: true }, browserEngine: { kind: "unavailable", installable: false } })).not.toContain("Browser engine not installed");
+    expect(render({ features: { browser: true }, browserEngine: { kind: "engine" } })).toContain("has its own browser");
+  });
+});

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -283,9 +283,11 @@ export function ComputerPanel({
   const [panelView, setPanelView] = useState<ComputerPanelView>(() => readComputerPanelView(bot.id));
   const androidStatus = useAndroidUsbDevices();
   const androidConnected = androidStatus.devices.length > 0;
-  // the built-in browser: a per-bot switch in Settings, and only the desktop app has one
+  // Keep installation reachable before the engine is ready. Actual browser
+  // operations below still require browserAvailableHere.
   const browserAvailableHere = browserAvailable(state.config);
-  const browserEnabled = builtInBrowserEnabled(state.config) && bot.browser !== false && browserAvailableHere;
+  const browserEnabled = builtInBrowserEnabled(state.config) && bot.browser !== false
+    && (browserAvailableHere || state.config?.browserEngine?.installable === true);
   // bumped when a Box API key is saved inline, to re-run the spin-up flow
   const [retry, setRetry] = useState(0);
   const vmReadinessAttempts = useRef(0);


### PR DESCRIPTION
## Summary

Prepare **0.1.59**, the first release containing #836's Codex bot-instruction/history fix. 0.1.58 predates that merge; successful no-op Release runs did not publish a newer version.

The release audit also found four narrowly scoped browser migration regressions, fixed here:

- Keep the Browser install panel reachable on supported hosts before the engine is installed, preserving the experimental and per-bot opt-ins. Actual browser actions still require a ready engine.
- Release the local install-request latch after HTTP acceptance so a later asynchronous installation failure can be retried. Broadcast installation progress immediately, and preserve error/retry controls when the engine binary exists but Chrome setup fails.
- Handle rejected/failed browser cleanup without an unhandled rejection or a false-success acknowledgement; retain the existing durable retry journal.
- Prepare shared browser-profile cleanup on headless servers too, now that the browser engine is server-owned.

No change to approval policy, updater feeds, signing/notarization, or release verification gates. The release will be pinned to the exact merged commit and published only after its existing platform/artifact gates pass.

## Verification

- TypeScript checks, production renderer build, and packaged-server/MCP smoke passed locally.
- 31 updater tests passed.
- Isolated API regressions pass for bot and profile cleanup failures (key-write exceptions and engine exit failures): truthful 503, retained committed intent, server remains healthy, automatic retry clears the journal after recovery.
- Headless profile deletion verifies the exact session cleanup command.
- Real ComputerPanel render tests cover fresh-install access, disabled global/per-bot opt-ins, unsupported hosts, and a ready engine.
- Actual Chromium interaction passed against the real ComputerPanel in an isolated fixture: the same DOM button survives HTTP 202, asynchronous failure, retry, binary-present Chrome setup failure, and recovery to ready. Installation was stubbed; no real user data or download was used.
- 83 Codex driver/instruction/catalog regressions passed; 217 API/browser regressions passed before the final retry-progress addition, followed by 10 focused final-state API/renderer regressions and typecheck.
- Cross-platform CI must pass on the final head before merging.

The Codex fix prevents further system-prompt duplication; it does not remove historical copies from existing conversations or promise a particular cache/billing reduction.
