### PR TITLE
feat(antigravity): add composer Auto full access and prepare 0.1.60

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Run tests
         run: pnpm test
       - run: pnpm check:electron
+      - name: Verify native approval mode transitions
+        if: matrix.os == 'macos-latest'
+        run: pnpm exec electron scripts/smoke-approval-modes.cjs
       - name: Verify paired phone authorization against packaged harness
         if: matrix.os == 'macos-latest'
         run: pnpm build:companion && pnpm exec electron scripts/smoke-phone-relay-auth.cjs

--- a/docs/approval-levels.md
+++ b/docs/approval-levels.md
@@ -18,9 +18,27 @@ system privacy controls, authentication, CAPTCHA or MFA, service permissions,
 or OpenMausBot's separate confirmations for credentials, routines, skills, and
 peer communication.
 
+### Antigravity: Ask or Auto
+
+For Antigravity, the composer and bot settings offer **Ask for approval** and
+**Auto (full access)**. Auto enables native `yolo` mode and automatically approves
+remaining tool-permission requests for commands, edits, and computer actions,
+without an automatic reviewer. The composer chip reads **Auto**. This uses the
+existing Full access grant and confirmation, not a separate permission setting,
+and applies to every model in that Antigravity instance, including Gemini.
+
+Choose Auto explicitly in the local packaged desktop app. Old Antigravity
+`auto` / `autoApprove` settings still behave as Ask and are now displayed as Ask;
+they never become unrestricted access on upgrade. Existing Full access bots
+now automatically answer remaining tool-permission requests too. Switching back
+to Ask restores prompts on the next turn. Questions, credential forms, and the
+separate confirmations described above still require an answer. Existing
+peer-started turn restrictions remain unchanged.
+
 Existing bots that used the old **Auto mode** keep that selection under
-**Approve for me**, but now use native review rather than the app's heuristic
-auto-approval. Providers without native review ask instead. No bot is migrated
+**Approve for me** (except Antigravity, as described above), but now use native
+review rather than the app's heuristic auto-approval. Providers without native
+review ask instead. No bot is migrated
 to Full access automatically.
 The selected bot level also overrides older provider-instance bypass settings
 for each app turn, so **Ask for approval** cannot silently inherit a Grok,
@@ -33,13 +51,14 @@ Cursor, Claude, or other engine's legacy full-auto mode.
 | Codex | Native automatic reviewer; workspace sandbox | No native approval prompts; unrestricted native sandbox |
 | Claude | Native `auto` mode | Native `bypassPermissions` |
 | Cursor | Native `--auto-review` | Native `--force` |
-| Antigravity | Ask | Native `yolo`; remaining native requests still appear |
+| Antigravity | Legacy `auto` behaves as Ask; UI Auto selects Full access | Native `yolo` plus automatic approval of remaining tool-permission requests; shown as Auto |
 | Grok Build | Ask | Native `bypassPermissions`; remaining native requests still appear |
 | OpenCode | Ask | Approve individual ACP permission requests, never task questions |
 | Other/custom engines | Ask | Not offered until a provider mapping is implemented |
 
 These settings apply on each turn, including resumed conversations. Switching
-to a different provider while elevated requires choosing Ask or Auto first.
+to a different provider while elevated requires leaving Full/Custom first;
+choose Ask. Switching models within Antigravity keeps the selected level.
 Native modes require a CLI version that supports them; OpenMausBot does not
 silently substitute unrestricted access when a mode is rejected.
 
@@ -52,6 +71,8 @@ OpenMausBot keeps its own opt-in desktop confirmation; Full access is not the de
 Run `pnpm exec electron scripts/smoke-approval-modes.cjs` to exercise the real
 private desktop-to-server grant protocol in a disposable fixture. It verifies
 HTTP elevation rejection, Full → Auto → Ask on resumed Claude turns, and
-Antigravity approval cards that remain answerable even in Full access. Provider
+Antigravity automatic tool approvals on new and resumed Full access turns across
+multiple model variants. It also checks that Ask and legacy Auto still prompt,
+peer-started Full turns still prompt, and questions remain interactive. Provider
 processes are scripted fakes; this does not verify live account eligibility or
 the quality of a provider's automatic reviewer. No live user data is used.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.59",
+  "version": "0.1.60",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {

--- a/scripts/smoke-approval-modes.cjs
+++ b/scripts/smoke-approval-modes.cjs
@@ -46,14 +46,20 @@ app.whenReady().then(async () => {
   const harness = join(home, process.platform === "win32" ? "localharness_external.exe" : "localharness_external");
   writeFileSync(harness, "fake harness");
   if (process.platform !== "win32") { chmodSync(agy, 0o755); chmodSync(harness, 0o755); }
-  const auth = join(home, "providers/antigravity", createHash("sha256").update("agy").digest("hex"), "antigravity-acp");
-  mkdirSync(auth, { recursive: true });
-  writeFileSync(join(auth, "acp_token.json"), "{}");
+  for (const instanceId of ["agy", "agy-question"]) {
+    const auth = join(home, "providers/antigravity", createHash("sha256").update(instanceId).digest("hex"), "antigravity-acp");
+    mkdirSync(auth, { recursive: true });
+    writeFileSync(join(auth, "acp_token.json"), "{}");
+  }
+  const agyDump = join(home, "agy.json");
+  const agyRpc = join(home, "agy-rpc.json");
   writeFileSync(join(home, "config.json"), JSON.stringify({ instances: {
     claude: { driver: "claudeAgent", config: { cli: join(root, "server/testing/fake-claude-cli.ts") } },
-    agy: { driver: "antigravityAgent", config: { cli: agy } },
+    agy: { driver: "antigravityAgent", config: { cli: agy }, environment: { FAKE_ACP_DUMP: agyDump, FAKE_ACP_RPC_DUMP: agyRpc } },
+    "agy-question": { driver: "antigravityAgent", config: { cli: agy }, environment: { FAKE_ACP_MODE: "question" } },
   } }));
   const dump = join(home, "claude-argv.json");
+  const testCapabilityKey = randomUUID();
   const coordinator = createTrustedApprovalModeCoordinator({ randomId: randomUUID });
   child = utilityProcess.fork(join(root, "server/index.ts"), [], {
     cwd: root,
@@ -62,9 +68,10 @@ app.whenReady().then(async () => {
       HOME: home, USERPROFILE: home, OMB_DATA_DIR: home, PATH: "",
       ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
       OMB_PORT: String(port), OMB_WEBHOOK_PORT: String(webhookPort),
+      OMB_TEST_INTERNAL_CAPABILITY_KEY: testCapabilityKey,
       FAKE_CLAUDE_MODE: "happy", FAKE_CLAUDE_DUMP: dump,
       FAKE_ACP_MODE: "permission", FAKE_ACP_AUTH_METHOD: "oauth-personal",
-      FAKE_ACP_MODELS: "gemini-3.8-flash-high", FAKE_ACP_MODES: "default,yolo",
+      FAKE_ACP_MODELS: "gemini-3.8-flash-high,gemini-3.8-flash-low", FAKE_ACP_MODES: "default,yolo",
     },
     stdio: "pipe",
   });
@@ -72,9 +79,9 @@ app.whenReady().then(async () => {
   child.stderr.on("data", (chunk) => { logs += chunk; });
   child.on("message", (message) => coordinator.receive(child, message));
   child.on("exit", () => coordinator.rejectProcess(child));
-  const api = async (path, method = "GET", body) => {
+  const api = async (path, method = "GET", body, headers = {}) => {
     const response = await fetch(`http://127.0.0.1:${port}${path}`, {
-      method, headers: { "content-type": "application/json" },
+      method, headers: { "content-type": "application/json", ...headers },
       ...(body ? { body: JSON.stringify(body) } : {}),
     });
     return { status: response.status, body: await response.json() };
@@ -95,20 +102,68 @@ app.whenReady().then(async () => {
     console.log(JSON.stringify({ mode, native, privateGrant: true, turnSettled: true }));
   }
   await assert.rejects(coordinator.request(child, id, "custom"), /only for Codex/);
-  const agyBot = (await api("/api/bots", "POST", { modelSelection: { instanceId: "agy", model: "gemini-3.8-flash-high" } })).body.bot;
-  for (const mode of ["full", "auto", "ask"]) {
-    await coordinator.request(child, agyBot.id, mode);
-    await until(async () => (await api("/api/bots?messages=0")).body.bots.find((bot) => bot.id === agyBot.id)?.approvalMode === mode);
-    assert.equal((await api(`/api/bots/${agyBot.id}/messages`, "POST", { text: `Verify native ${mode} approval` })).status, 202);
-    const card = await until(async () => {
-      const bot = (await api("/api/bots")).body.bots.find((bot) => bot.id === agyBot.id);
-      return bot.messages.find((message) => message.card?.requestId && !message.card.answered && !message.card.dismissed)?.card;
-    });
-    if (mode !== "ask") assert.equal(card.held, "The provider requires your approval for this action.");
-    assert.equal((await api(`/api/bots/${agyBot.id}/respond`, "POST", { requestId: card.requestId, behavior: "allow" })).status, 200);
-    await until(async () => !(await api("/api/bots?messages=0")).body.bots.find((bot) => bot.id === agyBot.id)?.busy);
-    console.log(JSON.stringify({ provider: "antigravity", mode, nativeApprovalShown: true, humanApproved: true }));
+  const pendingCard = (bot) => bot.messages.find((message) => message.card?.requestId && !message.card.answered && !message.card.dismissed)?.card;
+  for (const model of ["gemini-3.8-flash-high", "gemini-3.8-flash-low"]) {
+    const agyBot = (await api("/api/bots", "POST", { modelSelection: { instanceId: "agy", model } })).body.bot;
+    assert.equal((await api(`/api/bots/${agyBot.id}`, "PATCH", { approvalMode: "full", acknowledgeFullAccess: true })).status, 403);
+    for (const [turn, mode] of ["full", "full", "ask", "auto"].entries()) {
+      await coordinator.request(child, agyBot.id, mode);
+      await until(async () => (await api("/api/bots?messages=0")).body.bots.find((bot) => bot.id === agyBot.id)?.approvalMode === mode);
+      const before = (await api("/api/bots")).body.bots.find((bot) => bot.id === agyBot.id).messages.length;
+      assert.equal((await api(`/api/bots/${agyBot.id}/messages`, "POST", { text: `Verify ${model} ${mode} turn ${turn}` })).status, 202);
+      if (mode === "full") {
+        const settled = await until(async () => {
+          const bot = (await api("/api/bots")).body.bots.find((bot) => bot.id === agyBot.id);
+          assert.equal(pendingCard(bot), undefined, "Full must answer residual tool permissions without a manual card");
+          return !bot.busy && bot;
+        });
+        assert.ok(settled.messages.slice(before).some((message) => message.tool?.name.includes("(full access)")));
+        await until(async () => (await api("/api/decisions")).body.decisions.filter((row) => row.botId === agyBot.id && row.source === "full-access" && row.decision === "auto-approved").length === turn + 1);
+      } else {
+        const card = await until(async () => pendingCard((await api("/api/bots")).body.bots.find((bot) => bot.id === agyBot.id)));
+        if (mode === "auto") assert.equal(card.held, "The provider requires your approval for this action.");
+        assert.equal((await api(`/api/bots/${agyBot.id}/respond`, "POST", { requestId: card.requestId, behavior: "allow" })).status, 200);
+        await until(async () => !(await api("/api/bots?messages=0")).body.bots.find((bot) => bot.id === agyBot.id)?.busy);
+      }
+      const native = mode === "full" ? "yolo" : "default";
+      const calls = JSON.parse(readFileSync(`${agyDump}.config.json`, "utf8"));
+      assert.equal(calls.find((call) => call.params.configId === "mode")?.params.value, native);
+      // The first advertised model is already selected by session/new/load.
+      assert.equal(calls.find((call) => call.params.configId === "model")?.params.value ?? "gemini-3.8-flash-high", model);
+      const rpc = JSON.parse(readFileSync(agyRpc, "utf8"));
+      assert.ok(rpc.includes(turn === 0 ? "session/new" : "session/resume"));
+      console.log(JSON.stringify({ provider: "antigravity", model, mode, native, resumed: turn > 0, autoApproved: mode === "full", humanApproved: mode !== "full" }));
+    }
   }
+  const questionBot = (await api("/api/bots", "POST", { modelSelection: { instanceId: "agy-question", model: "gemini-3.8-flash-high" } })).body.bot;
+  await coordinator.request(child, questionBot.id, "full");
+  assert.equal((await api(`/api/bots/${questionBot.id}/messages`, "POST", { text: "Ask me a question under Full" })).status, 202);
+  const question = await until(async () => pendingCard((await api("/api/bots")).body.bots.find((bot) => bot.id === questionBot.id)));
+  assert.deepEqual(question.options, ["Blue", "Green"]);
+  assert.equal((await api(`/api/bots/${questionBot.id}/respond`, "POST", { requestId: question.requestId, behavior: "answer", message: "Green" })).status, 200);
+  await until(async () => !(await api("/api/bots?messages=0")).body.bots.find((bot) => bot.id === questionBot.id)?.busy);
+  console.log(JSON.stringify({ provider: "antigravity", mode: "full", questionRemainedInteractive: true }));
+  // The test-only capability drives the real peer dispatch route without
+  // introducing another fake-agent workflow or weakening production auth.
+  const peerTarget = (await api("/api/bots", "POST", { modelSelection: { instanceId: "agy", model: "gemini-3.8-flash-high" } })).body.bot;
+  await coordinator.request(child, peerTarget.id, "full");
+  assert.equal((await api(`/api/bots/${id}`, "PATCH", { approvePeerComms: false })).status, 200);
+  const capability = await api("/api/testing/internal-capability", "POST", { botId: id, threadId: created.body.bot.threadId }, { "x-openmausbot-test-capability": testCapabilityKey });
+  assert.equal(capability.status, 201);
+  const peerRequest = api("/api/internal/ask-bot", "POST", { toBotId: peerTarget.id, message: "Peer-initiated permission fixture" }, { authorization: `Bearer ${capability.body.token}` });
+  void peerRequest.catch(() => {});
+  const peerCard = await until(async () => pendingCard((await api("/api/bots")).body.bots.find((bot) => bot.id === peerTarget.id)));
+  assert.equal(peerCard.held, "The provider requires your approval for this action.");
+  const peerCalls = JSON.parse(readFileSync(`${agyDump}.config.json`, "utf8"));
+  assert.equal(peerCalls.find((call) => call.params.configId === "mode")?.params.value, "default");
+  assert.equal((await api(`/api/bots/${peerTarget.id}/respond`, "POST", { requestId: peerCard.requestId, behavior: "allow" })).status, 200);
+  assert.equal((await peerRequest).status, 200);
+  const peerDecisions = await until(async () => {
+    const rows = (await api("/api/decisions")).body.decisions.filter((row) => row.botId === peerTarget.id);
+    return rows.some((row) => row.source === "native-approval" && row.decision === "card-shown") && rows;
+  });
+  assert.ok(!peerDecisions.some((row) => row.source === "full-access"));
+  console.log(JSON.stringify({ provider: "antigravity", mode: "full", peerInitiated: true, native: "default", nativeApprovalShown: true, humanApproved: true }));
   console.log("Approval smoke passed; HTTP elevation rejected, private grant and resumed mode transitions verified.");
 }).catch((error) => {
   console.error(error);

--- a/server/approval-mode.test.ts
+++ b/server/approval-mode.test.ts
@@ -19,8 +19,13 @@ describe("approval modes", () => {
       expect(requiresNativeApproval(driver, "auto")).toBe(true);
     }
     for (const driver of [undefined, "customAgent", "pi"]) expect(supportsApprovalMode(driver, "full")).toBe(false);
-    expect(requiresNativeApproval("antigravityAgent", "full")).toBe(true);
+    expect(requiresNativeApproval("antigravityAgent", "full")).toBe(false);
+    expect(requiresNativeApproval("antigravityAgent", "ask")).toBe(false);
     expect(requiresNativeApproval("opencodeGo", "full")).toBe(false);
+    expect(requiresNativeApproval("codex", "full")).toBe(false);
+    for (const driver of ["claudeAgent", "cursorAgent", "grokAgent"]) {
+      expect(requiresNativeApproval(driver, "full")).toBe(true);
+    }
   });
   it("recognizes only the four durable values", () => {
     expect(APPROVAL_MODES).toEqual(["ask", "auto", "full", "custom"]);

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -3196,7 +3196,7 @@ describe("harness HTTP API", () => {
       for (const seeded of trustedBots) {
         const rejected = await isolatedApi("PATCH", `/api/bots/${seeded.id}/model`, targetSelection);
         expect(rejected.status, seeded.approvalMode).toBe(400);
-        expect(rejected.body.error).toMatch(/requires choosing Ask or Auto first/i);
+        expect(rejected.body.error).toMatch(/requires choosing Ask first/i);
         const unchanged = (await isolatedApi("GET", "/api/bots?messages=0")).body.bots.find(
           (candidate: { id: string }) => candidate.id === seeded.id,
         );

--- a/server/index.ts
+++ b/server/index.ts
@@ -2903,18 +2903,23 @@ bus.subscribe((event: RuntimeEvent) => {
       // the guards in auto-approve.ts; explicitly acknowledged Full does not.
       const asker = bot ?? (speaker ? store.bot(speaker.botId) : undefined);
       const unattended = permission && asker && event.requestId ? isUnattended(asker.id) : false;
+      const effectiveApprovalMode = asker ? approvalModeForTurn(asker, isInternalTurn(event.threadId)) : "ask";
       const verdict = permission && asker && event.requestId
         ? autoVerdict({
             // the same origin the dispatch used, so a peer-started turn's
             // residual asks are judged as Approve for me here too
-            approvalMode: approvalModeForTurn(asker, isInternalTurn(event.threadId)),
+            approvalMode: effectiveApprovalMode,
             autoApprove: false,
             alwaysAllow: asker.alwaysAllow,
           }, event.tool, event.summary, {
             unattended,
             scope: event.approvalScope,
             requiresExplicitApproval: event.requiresExplicitApproval,
-            nativeApproval: requiresNativeApproval(event.provider, approvalModeForTurn(asker)),
+            // Antigravity's residual asks must use a peer-started turn's
+            // effective safe Auto mode, not its durable Full grant.
+            // Preserve the existing policy of every other provider.
+            nativeApproval: requiresNativeApproval(event.provider, event.provider === "antigravityAgent"
+              ? effectiveApprovalMode : approvalModeForTurn(asker)),
           })
         : null;
       if (verdict?.approve && asker && event.requestId) {
@@ -10192,7 +10197,7 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
           registry.cliTarget(checked.selection.instanceId)?.driverKind !== registry.cliTarget(existing.modelSelection.instanceId)?.driverKind)
       ) {
         return json(res, 400, {
-          error: "Changing providers with elevated permissions requires choosing Ask or Auto first",
+          error: "Changing providers with elevated permissions requires choosing Ask first",
         });
       }
       // patchBot persists first and emits the canonical bot change, which the
@@ -10426,7 +10431,7 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
           (existingBot && normalizedSelection && registry.cliTarget(normalizedSelection.instanceId)?.driverKind !== registry.cliTarget(existingBot.modelSelection.instanceId)?.driverKind))
       ) {
         return json(res, 400, {
-          error: "This provider does not support the selected approval level, or changing providers requires choosing Ask or Auto first",
+          error: "This provider does not support the selected approval level, or changing providers requires choosing Ask first",
         });
       }
       const requiresPrivateApprovalTransition =

--- a/shared/approval-mode.ts
+++ b/shared/approval-mode.ts
@@ -16,9 +16,10 @@ export function hasNativeAutoReview(driverKind: string | undefined): boolean {
 
 /** A native reviewer has already declined to decide, or Auto has no native
  * equivalent. Never second-guess that request with the app's heuristic rules.
- * OpenCode's Full mode is implemented by approving individual ACP requests. */
+ * Antigravity and OpenCode Full approve residual ACP tool-permission requests
+ * through the app's explicit Full-access grant. Questions remain interactive. */
 export function requiresNativeApproval(driverKind: string, mode: ApprovalMode): boolean {
-  return mode === "auto" || (mode === "full" && ["claudeAgent", "antigravityAgent", "cursorAgent", "grokAgent"].includes(driverKind));
+  return mode === "auto" || (mode === "full" && ["claudeAgent", "cursorAgent", "grokAgent"].includes(driverKind));
 }
 
 export function isApprovalMode(value: unknown): value is ApprovalMode {

--- a/src/components/ApprovalModeSelector.test.ts
+++ b/src/components/ApprovalModeSelector.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 
 import {
   APPROVAL_MODE_OPTIONS,
+  ApprovalModeSelector,
   approvalModeOptionsFor,
   approvalModeSelectionRequiresLocalDesktop,
 } from "./ApprovalModeSelector";
@@ -46,13 +49,37 @@ describe("approval mode selector", () => {
     ]);
   });
 
-  it.each(["antigravityAgent", "cursorAgent", "grokAgent", "opencodeGo"])("offers Full access for %s", (kind) => {
+  it.each(["cursorAgent", "grokAgent", "opencodeGo"])("offers Full access for %s", (kind) => {
     expect(approvalModeOptionsFor(kind).map((option) => option.mode)).toEqual(["ask", "auto", "full"]);
     expect(approvalModeOptionsFor(kind, false).map((option) => option.mode)).toEqual(["ask", "auto"]);
   });
 
+  it("offers Antigravity Auto as the explicit full-access grant, not native review", () => {
+    const options = approvalModeOptionsFor("antigravityAgent");
+    expect(options.map(({ mode, label }) => ({ mode, label }))).toEqual([
+      { mode: "ask", label: "Ask for approval" },
+      { mode: "full", label: "Auto (full access)" },
+    ]);
+    expect(options[1].chip).toBe("Auto");
+    expect(options[1].description).toContain("Automatically approve tool requests");
+    expect(approvalModeOptionsFor("antigravityAgent", false).map((option) => option.mode)).toEqual(["ask"]);
+  });
+
+  it("shows the effective Antigravity mode without upgrading saved Auto settings", () => {
+    const render = (mode: "ask" | "auto" | "full" | undefined, autoApprove = false, trustedModesAvailable = true) => renderToStaticMarkup(createElement(ApprovalModeSelector, {
+      approvalMode: mode, autoApprove, trustedModesAvailable,
+      providerName: "Antigravity", driverKind: "antigravityAgent", onSelect: () => {},
+    }));
+    for (const html of [render("ask"), render("auto"), render(undefined, true)]) {
+      expect(html).toContain('aria-label="Ask for approval for Antigravity"');
+      expect(html).not.toContain('aria-label="Auto (full access)');
+    }
+    expect(render("full")).toContain('aria-label="Auto (full access) for Antigravity"');
+    expect(render("full", false, false)).toContain('aria-label="Auto (full access) for Antigravity"');
+  });
+
   it("explains Auto fallbacks and does not elevate unknown providers", () => {
-    expect(approvalModeOptionsFor("antigravityAgent").find((option) => option.mode === "auto")?.description).toContain("behaves like Ask");
+    expect(approvalModeOptionsFor("grokAgent").find((option) => option.mode === "auto")?.description).toContain("behaves like Ask");
     expect(approvalModeOptionsFor("customAgent").map((option) => option.mode)).toEqual(["ask", "auto"]);
   });
 
@@ -67,5 +94,10 @@ describe("approval mode selector", () => {
     expect(approvalModeSelectionRequiresLocalDesktop("custom", false)).toBe(true);
     expect(approvalModeSelectionRequiresLocalDesktop("ask", false)).toBe(false);
     expect(approvalModeSelectionRequiresLocalDesktop("custom", true)).toBe(false);
+    const html = renderToStaticMarkup(createElement(ApprovalModeSelector, {
+      approvalMode: "custom", trustedModesAvailable: false,
+      providerName: "Missing provider", driverKind: "", onSelect: () => {},
+    }));
+    expect(html).toContain('aria-label="Custom (config.toml) for Missing provider"');
   });
 });

--- a/src/components/ApprovalModeSelector.tsx
+++ b/src/components/ApprovalModeSelector.tsx
@@ -45,10 +45,23 @@ export const APPROVAL_MODE_OPTIONS: ReadonlyArray<{
 export function approvalModeOptionsFor(driverKind: string, trustedModesAvailable = true) {
   return APPROVAL_MODE_OPTIONS
     .filter((option) => supportsApprovalMode(driverKind, option.mode)
+      // Antigravity has no native reviewer. Offer its explicit full-access
+      // grant as Auto instead of a second choice that actually behaves as Ask.
+      && (driverKind !== "antigravityAgent" || option.mode !== "auto")
       && (trustedModesAvailable || option.mode === "ask" || option.mode === "auto"))
-    .map((option) => option.mode === "auto" && !hasNativeAutoReview(driverKind)
-      ? { ...option, description: "This provider has no automatic review; behaves like Ask" }
-      : option);
+    .map((option) => {
+      if (driverKind === "antigravityAgent" && option.mode === "full") {
+        return {
+          ...option,
+          label: "Auto (full access)",
+          chip: "Auto",
+          description: "Automatically approve tool requests for this bot, including commands, edits, and computer actions. No automatic review.",
+        };
+      }
+      return option.mode === "auto" && !hasNativeAutoReview(driverKind)
+        ? { ...option, description: "This provider has no automatic review; behaves like Ask" }
+        : option;
+    });
 }
 
 export function approvalModeSelectionRequiresLocalDesktop(
@@ -86,8 +99,13 @@ export function ApprovalModeSelector({
 }) {
   const [open, setOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
-  const mode = approvalModeFor({ approvalMode, autoApprove });
-  const current = APPROVAL_MODE_OPTIONS.find((option) => option.mode === mode) ?? APPROVAL_MODE_OPTIONS[0];
+  const savedMode = approvalModeFor({ approvalMode, autoApprove });
+  // Old Antigravity Auto settings still ask. Do not display or silently grant
+  // the new Auto/full-access behavior until the user explicitly selects it.
+  const mode = driverKind === "antigravityAgent" && savedMode === "auto" ? "ask" : savedMode;
+  const current = approvalModeOptionsFor(driverKind).find((option) => option.mode === mode)
+    ?? APPROVAL_MODE_OPTIONS.find((option) => option.mode === mode)
+    ?? APPROVAL_MODE_OPTIONS[0];
   const visibleOptions = approvalModeOptionsFor(driverKind, trustedModesAvailable);
   const requiresLocalDesktop = approvalModeSelectionRequiresLocalDesktop(
     mode,
@@ -196,11 +214,13 @@ export function ApprovalModeSelector({
                 </button>
               );
             })}
-            {!trustedModesAvailable && (driverKind === "codex" || requiresLocalDesktop) && (
+            {!trustedModesAvailable && (driverKind === "codex" || driverKind === "antigravityAgent" || requiresLocalDesktop) && (
               <div className="border-t border-hairline/20 px-4 py-2.5 text-[11.5px] leading-snug text-ink-secondary">
                 {requiresLocalDesktop
                   ? "Custom approval must be changed in the local packaged desktop app."
-                  : "Full and Custom are available in the packaged desktop app."}
+                  : driverKind === "antigravityAgent"
+                    ? "Auto (full access) is available in the local packaged desktop app."
+                    : "Full and Custom are available in the packaged desktop app."}
               </div>
             )}
           </div>

--- a/src/components/bot-settings/PermissionsSection.tsx
+++ b/src/components/bot-settings/PermissionsSection.tsx
@@ -129,7 +129,7 @@ export function PermissionsSection({
         </div>
       </div>
 
-      <div className="rounded-xl bg-card p-4">
+      {!(engine?.driverKind === "antigravityAgent" && approvalMode === "full") && <div className="rounded-xl bg-card p-4">
         <div className="text-[15px] font-medium text-ink">Review routine approvals</div>
         <div className="mt-0.5 text-[13px] text-ink-secondary">
           {approvalMode === "custom"
@@ -172,7 +172,7 @@ export function PermissionsSection({
             );
           })}
         </div>
-      </div>
+      </div>}
 
       <LocalComputerAutoWarning
         open={localAutoWarning !== null}


### PR DESCRIPTION
## What changes

- Antigravity's composer and bot settings now offer **Ask** and **Auto (full access)**. This applies to every model using Antigravity, including Gemini.
- Auto reuses the existing explicit Full grant, enables native `yolo`, and automatically answers residual tool-permission requests. No separate permission mode or automatic reviewer.
- Old stored Auto remains Ask-like and is displayed as Ask, without silently elevating existing users. Existing Full grants gain automatic residual tool approvals. Switching back to Ask restores prompts.
- Keep other providers, question/credential cards, and peer-started turn policy unchanged. Hide the irrelevant routine-review controls for Antigravity Full.
- Run the native approval transition smoke in macOS CI, and bump to **0.1.60** for the requested release.

## Verification

- 134 focused selector/approval/Antigravity tests passed.
- HTTP model-switch boundary regression passed.
- Typecheck and production build passed; targeted lint has only the pre-existing `server/index.ts:2123` warning.
- Real Electron private-grant smoke passed in an isolated home: new and resumed Full turns across two model variants automatically settle; Ask and legacy Auto prompt; questions remain interactive; peer-started Full stays on its existing approval path.
- Headless browser exercised the real selector and existing confirmation: menu placement, cancel/confirm, Auto chip, switching back, busy state, old settings, and untrusted-browser availability. No console errors.

Provider processes in verification are scripted fakes; these tests do not claim a live Google account run. No live user app or data was touched.

## Release

0.1.59 is already published. After merge, let the version-bump release workflow build and verify the 0.1.60 draft, then publish it and verify the legacy updater mirror. Do not start a second overlapping build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Antigravity’s Full access option is now labeled **Auto (full access)** and automatically handles remaining tool-permission requests.
  * Existing Antigravity Auto selections now appear as Ask until explicitly changed.
  * Provider-switching guidance now requires choosing Ask before leaving elevated access modes.

* **Bug Fixes**
  * Updated approval handling for Antigravity and other providers to ensure permission prompts and interactive questions behave correctly.
  * Removed the review-routine approvals card when Antigravity uses Full access.

* **Documentation**
  * Updated approval-mode documentation and verification guidance.

* **Chores**
  * Version updated to 0.1.60.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->