### PR TITLE
ux(desktop): put reasoning effort beside the model picker

### DIFF
--- a/src/components/BotSettingsDialog.tsx
+++ b/src/components/BotSettingsDialog.tsx
@@ -349,7 +349,7 @@ export function BotSettingsDialog({ bot }: { bot: Bot }) {
 
             {section === "access" && <AccessSection bot={bot} derived={derived} />}
 
-            {section === "model" && <ModelSection bot={bot} derived={derived} />}
+            {section === "model" && <ModelSection bot={bot} />}
 
             {section === "permissions" && <PermissionsSection bot={bot} derived={derived} />}
 

--- a/src/components/ModelPicker.test.ts
+++ b/src/components/ModelPicker.test.ts
@@ -1,0 +1,132 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+import type { Bot, InstanceInfo } from "@/state/store";
+import type { EffortLevel } from "../../server/contracts.ts";
+
+// The picker reads the engine catalog off the store, and the store module
+// touches window/localStorage at import time — the same shape
+// ComputerPanel.browser.test.ts uses to render a store-backed component
+// under vitest's "node" environment.
+const fixture = vi.hoisted(() => {
+  vi.stubGlobal("window", {});
+  vi.stubGlobal("localStorage", { getItem: () => null, setItem: () => {} });
+  return { instances: [] as InstanceInfo[] };
+});
+vi.mock("@/state/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/state/store")>()),
+  useStore: () => ({
+    state: { instances: fixture.instances },
+    dispatch: vi.fn(),
+    refreshInstances: vi.fn(),
+    refreshModels: vi.fn(),
+  }),
+}));
+
+const { EffortRow, ModelPicker } = await import("./ModelPicker");
+
+afterAll(() => vi.unstubAllGlobals());
+
+function engine(effortLevels?: readonly EffortLevel[]): InstanceInfo {
+  return {
+    instanceId: "codex",
+    driverKind: "codex",
+    displayName: "Codex",
+    snapshot: { state: "available", version: "1.0.0" },
+    models: { default: "gpt-5.6", options: [{ id: "gpt-5.6", label: "GPT-5.6" }] },
+    ...(effortLevels ? { capabilities: { effortLevels } } : {}),
+  };
+}
+
+function bot(effort?: EffortLevel): Bot {
+  return {
+    id: "atlas",
+    threadId: "thread-atlas",
+    name: "Atlas",
+    title: "",
+    description: "",
+    notifications: true,
+    color: "green",
+    unread: false,
+    modelSelection: { instanceId: "codex", model: "gpt-5.6", ...(effort ? { effort } : {}) },
+    messages: [],
+  };
+}
+
+/** Every effort button as rendered, with the state a screen reader announces. */
+function levelButtons(markup: string): Array<{ label: string; pressed: boolean }> {
+  return [...markup.matchAll(/<button[^>]*aria-pressed="(true|false)"[^>]*>([^<]+)</g)].map((match) => ({
+    label: match[2],
+    pressed: match[1] === "true",
+  }));
+}
+
+function renderEffort(instances: InstanceInfo[], effort?: EffortLevel): string {
+  fixture.instances = instances;
+  return renderToStaticMarkup(createElement(EffortRow, { bot: bot(effort) }));
+}
+
+describe("EffortRow", () => {
+  it("renders nothing for an engine that declares no effort levels", () => {
+    expect(renderEffort([engine()])).toBe("");
+    // an engine that declares an empty list is the same promise as none
+    expect(renderEffort([engine([])])).toBe("");
+    // and so is a bot whose engine is not in the catalog at all
+    expect(renderEffort([])).toBe("");
+  });
+
+  it("offers only the levels the selected engine accepts, plus Default", () => {
+    const markup = renderEffort([engine(["low", "medium", "high"])]);
+
+    expect(levelButtons(markup).map((button) => button.label)).toEqual(["Default", "Low", "Medium", "High"]);
+    // the server rejects a level its engine does not offer, so one that is
+    // never shown is one that can never be persisted
+    expect(markup).not.toContain(">X-High<");
+    expect(markup).not.toContain(">Max<");
+  });
+
+  it("keeps Default and None apart — Default sends no level, None sends one", () => {
+    const markup = renderEffort([engine(["none", "low"])]);
+
+    expect(levelButtons(markup).map((button) => button.label)).toEqual(["Default", "None", "Low"]);
+  });
+
+  it("marks the active level, and Default when the bot carries no level", () => {
+    const pressed = (markup: string) => levelButtons(markup).find((button) => button.pressed)?.label;
+
+    expect(pressed(renderEffort([engine(["low", "high"])], "high"))).toBe("High");
+    expect(pressed(renderEffort([engine(["low", "high"])]))).toBe("Default");
+  });
+
+  it("renames xhigh, the one level that does not capitalize cleanly", () => {
+    expect(renderEffort([engine(["xhigh"])])).toContain(">X-High<");
+  });
+});
+
+describe("ModelPicker trigger", () => {
+  const renderTrigger = (effort?: EffortLevel) => {
+    fixture.instances = [engine(["low", "high"])];
+    return renderToStaticMarkup(createElement(ModelPicker, { bot: bot(effort) }));
+  };
+
+  /** The visible effort suffix, not the tooltip that also names the level. */
+  const effortChip = (markup: string) =>
+    markup.match(/<span data-model-effort[^>]*>(.*?)<\/span>/s)?.[1].replace(/<!--.*?-->/g, "").trim();
+
+  it("shows the model and its effort together in the header", () => {
+    const markup = renderTrigger("high");
+
+    expect(markup).toContain("GPT-5.6");
+    expect(effortChip(markup)).toBe("· High");
+    expect(markup).toContain("Codex · GPT-5.6 · High effort");
+  });
+
+  it("says nothing about effort when the bot sends no level", () => {
+    const markup = renderTrigger();
+
+    expect(markup).toContain("GPT-5.6");
+    expect(effortChip(markup)).toBeUndefined();
+    expect(markup).not.toContain("effort");
+  });
+});

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -1,9 +1,13 @@
 // Compact model picker: providers live on a Cloud/Local rail. Ready engines
 // show a short suggested list with search and an explicit all-models view;
 // engines that need setup show one focused action instead of a disabled wall.
+// Reasoning effort rides along (EffortRow): model and effort are one choice to
+// the person making it, so the chat header and the settings dialog render the
+// same row and write through the same action.
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { Check, ChevronDown, ChevronLeft, ChevronRight, Loader2, RefreshCw, Search } from "lucide-react";
 import { useStore, type Bot, type InstanceInfo, type ModelSelection } from "@/state/store";
+import type { EffortLevel } from "../../server/contracts.ts";
 import { filterCustomModels, partitionCustomModels, suggestedModels } from "@/lib/custom-models";
 import { isCustomOnly, splitEngineRail } from "@/lib/engine-rail";
 import { ProviderMark } from "./ProviderIcons";
@@ -27,6 +31,67 @@ export function engineStatus(instance: InstanceInfo): string {
   if (needsCli(instance)) return "Setup required";
   if (needsSignIn(instance)) return "Sign-in required";
   return instance.snapshot.version ?? "Ready";
+}
+
+/** The others capitalize cleanly; "xhigh" would read "Xhigh". */
+export function effortLabel(level: EffortLevel): string {
+  return level === "xhigh" ? "X-High" : level[0].toUpperCase() + level.slice(1);
+}
+
+/** How hard the bot thinks, for the engine it currently runs on. Rendered
+ * both in the picker's popover and in the settings dialog's Model section so
+ * the two cannot drift: one list of levels, one `setModel` dispatch.
+ *
+ * `undefined` ("Default") is not the `none` level — Default sends nothing and
+ * lets the engine decide, `none` is a level the engine is told to use. Only
+ * pi offers both, and dropping either would change what an existing bot
+ * sends, so both stay and the tooltips say which is which. */
+export function EffortRow({
+  bot,
+  className,
+  label,
+}: {
+  bot: Bot;
+  className?: string;
+  label?: ReactNode;
+}) {
+  const { state, dispatch } = useStore();
+  const selection = bot.modelSelection;
+  const levels = state.instances.find((instance) => instance.instanceId === selection.instanceId)?.capabilities
+    ?.effortLevels;
+  // An engine with no levels gets no control at all, not an empty one.
+  if (!levels?.length) return null;
+
+  return (
+    <div className={className}>
+      {label}
+      {/* wraps rather than dividing a fixed width: pi offers Default plus six
+          levels, which a segmented control would squeeze in the popover */}
+      <div className="mt-2 flex flex-wrap gap-1" role="group" aria-label="Reasoning effort">
+        {[undefined, ...levels].map((level) => (
+          <button
+            key={level ?? "default"}
+            type="button"
+            aria-pressed={selection.effort === level}
+            title={
+              level === undefined
+                ? "Send no effort level and let the engine decide"
+                : `Ask for ${effortLabel(level)} reasoning effort`
+            }
+            onClick={() => dispatch({ type: "setModel", botId: bot.id, selection: { ...selection, effort: level } })}
+            className={cn(
+              "rounded-full border px-2.5 py-1 text-[12px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70",
+              selection.effort === level
+                ? "border-accent/60 bg-control text-ink"
+                : "border-hairline/40 text-ink-secondary hover:bg-control/60 hover:text-ink",
+            )}
+          >
+            {level === undefined ? "Default" : effortLabel(level)}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 function ModelRow({
@@ -282,15 +347,24 @@ export function ModelPicker({
           : active
           ? `${active.displayName} · ${modelLabel(active, selection.model)}${
               modelProvider(active, selection.model) ? ` · ${modelProvider(active, selection.model)}` : ""
-            }`
+            }${selection.effort ? ` · ${effortLabel(selection.effort)} effort` : ""}`
           : selection.model
       }
     >
       {active && <ProviderMark driverKind={active.driverKind} size={14} />}
-      <span className={cn("max-w-[160px] truncate", !contained && active && "@max-4xl/chathead:hidden")}>
-        {modelLabel(active, selection.model)}
-        {active && modelProvider(active, selection.model) && (
-          <span className="text-ink-secondary"> · {modelProvider(active, selection.model)}</span>
+      <span className={cn("flex min-w-0 items-center gap-1", !contained && active && "@max-4xl/chathead:hidden")}>
+        <span className="max-w-[160px] truncate">
+          {modelLabel(active, selection.model)}
+          {active && modelProvider(active, selection.model) && (
+            <span className="text-ink-secondary"> · {modelProvider(active, selection.model)}</span>
+          )}
+        </span>
+        {/* outside the truncating span: a long model name must not be what
+            hides the effort the header exists to surface */}
+        {selection.effort && (
+          <span data-model-effort className="shrink-0 text-ink-secondary">
+            · {effortLabel(selection.effort)}
+          </span>
         )}
       </span>
       <ChevronDown
@@ -512,6 +586,21 @@ export function ModelPicker({
                       )}
                     </div>
                   </>
+                )}
+
+                {/* The header has nowhere else to put effort, so the popover
+                    carries it. `contained` callers (the settings dialog) render
+                    their own EffortRow card, and two copies of one control in
+                    one view read as a bug. Reads the bot's active engine, not
+                    the rail being browsed: effort applies to the model this bot
+                    runs on now, and picking a model on another rail closes the
+                    popover. */}
+                {!contained && (
+                  <EffortRow
+                    bot={bot}
+                    className="shrink-0 border-t border-hairline/40 px-4 py-3"
+                    label={<span className="text-[12.5px] font-medium text-ink">Effort</span>}
+                  />
                 )}
 
                 {pane === "main" && (

--- a/src/components/bot-settings/ModelSection.tsx
+++ b/src/components/bot-settings/ModelSection.tsx
@@ -4,20 +4,10 @@
 // picker's floating popover (absolute, ~480px tall) would open below the
 // fold and only become visible by scrolling; the in-flow menu pushes the
 // Effort card down instead and is fully visible where it opens.
-import { ModelPicker } from "../ModelPicker";
-import { cn } from "@/lib/cn";
+import { EffortRow, ModelPicker } from "../ModelPicker";
 import type { Bot } from "@/state/store";
-import type { useBotSettingsDerived } from "./useBotSettingsDerived";
 
-export function ModelSection({
-  bot,
-  derived,
-}: {
-  bot: Bot;
-  derived: ReturnType<typeof useBotSettingsDerived>;
-}) {
-  const { patch, engine } = derived;
-
+export function ModelSection({ bot }: { bot: Bot }) {
   return (
     <div className="flex flex-col gap-4">
       <div className="rounded-xl bg-card p-4">
@@ -35,38 +25,25 @@ export function ModelSection({
         />
       </div>
 
-      {!!engine?.capabilities?.effortLevels?.length && (
-        <div className="rounded-xl bg-card p-4">
-          <div className="text-[15px] font-medium text-ink">Effort</div>
-          {/* Says what the app does, not what the engine ends up at:
-              Codex applies a level to the whole thread and has no way to
-              take one back, so "currently: engine default" was a promise
-              we could not keep for a thread that had already been sent
-              one. Sending nothing is true on every engine. */}
-          <div className="mt-0.5 text-[13px] text-ink-secondary">
-            How hard this bot thinks{bot.modelSelection.effort ? "" : " (Default: no level is sent)"}
+      {/* The same row the chat header's picker shows, so the two cannot
+          disagree about which levels exist or what is selected. */}
+      <EffortRow
+        bot={bot}
+        className="rounded-xl bg-card p-4"
+        label={
+          <div>
+            <div className="text-[15px] font-medium text-ink">Effort</div>
+            {/* Says what the app does, not what the engine ends up at:
+                Codex applies a level to the whole thread and has no way to
+                take one back, so "currently: engine default" was a promise
+                we could not keep for a thread that had already been sent
+                one. Sending nothing is true on every engine. */}
+            <div className="mt-0.5 text-[13px] text-ink-secondary">
+              How hard this bot thinks{bot.modelSelection.effort ? "" : " (Default: no level is sent)"}
+            </div>
           </div>
-          <div className="mt-3 flex overflow-hidden rounded-lg border border-hairline/40">
-            {([undefined, ...engine.capabilities.effortLevels] as const).map((level, i) => (
-              <button
-                key={level ?? "default"}
-                aria-pressed={bot.modelSelection.effort === level}
-                onClick={() => patch({ modelSelection: { ...bot.modelSelection, effort: level } })}
-                className={cn(
-                  "flex-1 py-1.5 text-[13px] capitalize",
-                  i > 0 && "border-l border-hairline/40",
-                  bot.modelSelection.effort === level
-                    ? "bg-control text-ink"
-                    : "text-ink-secondary hover:bg-control/60 hover:text-ink",
-                )}
-              >
-                {/* the others capitalize cleanly; "xhigh" would read "Xhigh" */}
-                {level === "xhigh" ? "X-High" : (level ?? "Default")}
-              </button>
-            ))}
-          </div>
-        </div>
-      )}
+        }
+      />
     </div>
   );
 }


### PR DESCRIPTION
Closes #633

## Problem

Reasoning effort lived only in the per-bot settings dialog, while the model it qualifies is chosen from the conversation header. Model and effort are one decision to the person making it, so the control was easy to miss where it sat.

## Solution

The levels moved into an `EffortRow` that both surfaces render, writing through the same `setModel` dispatch:

- **Chat header** — the picker's trigger now reads `Claude Sonnet 5 · High`, and the popover carries an Effort row between the model list and *Use a local model*.
- **Settings dialog** — the Model section's hand-rolled segmented control is gone; it renders the same `EffortRow` in its card.

Sharing one component is what keeps the two from drifting. Before this, the dialog patched the bot record through `updateBot` while the picker dispatched `setModel` — two write paths to one field. Both already funnelled into the same `botPatchQueue.enqueue(botId, { modelSelection }, before)`, so consolidating on `setModel` changes no persistence behavior.

The row reads levels off the engine the bot actually runs on, so a level the server would reject (`server/index.ts:1020`, 400; `server/index.ts:3909`, 409) is never offered in the first place.

### Two calls worth flagging

**Default is not the `none` level.** Default sends no level and lets the engine decide; `none` is a level the engine is told to use. Only `pi` declares both, so on that engine they appear side by side. Collapsing them would change what already-configured bots send, so both stay and the tooltips say which is which.

**Pills that wrap, not a segmented control.** `pi` offers Default plus six levels, which a fixed-width segmented control would squeeze in a 380px popover. Measured in the running app with the full union rendered: two rows, 60px, no horizontal overflow. Horizontal scroll was the alternative and would hide options behind an affordance — the opposite of what this issue asks for.

## Acceptance criteria

| Criterion | How it is met |
|---|---|
| Current model and effort discoverable from the header | Trigger reads `Model · Level`; the tooltip carries `engine · model · Level effort` |
| Effort choices update when model or provider changes | The row reads `capabilities.effortLevels` off the bot's active engine; effort is per-engine, and `pick()` already drops it when the instance changes |
| Only supported levels shown | Same source the server validates against; nothing else is rendered |
| No empty or disabled control without effort | `EffortRow` returns `null` — no heading, no card, no placeholder |
| Usable at narrow widths | The effort suffix sits inside the existing `@max-4xl/chathead:hidden` span, so the chip folds to the provider mark exactly as before; the tooltip keeps the level |
| Keyboard, focus, labels, screen reader | Real `<button>`s in DOM order, `aria-pressed` on each, `role="group"` + `aria-label="Reasoning effort"`, per-level `title`, and the repo's `focus-visible:ring-2 ring-accent/70` |
| Existing selection and persistence preserved | Same `{ ...modelSelection, effort }` shape and the same queue as before |
| One shared selection flow | One `EffortRow`, one `setModel` dispatch, rendered by both surfaces |

## Verification

Driven against a disposable fake-engine instance (`scripts/control-omb.ts launch`), never a live install.

- Picking **High** in the header wrote `modelSelection: { instanceId: "claude", model: "claude-sonnet-5", effort: "high" }` to the server, left the other bot untouched, and survived a reload.
- Focusing a level and pressing **Enter** flipped `aria-pressed`, updated the header, persisted, and left focus in place.
- The engine-without-effort case was checked against a second fixture whose driver declares no `effortLevels`: the popover goes straight from the model list to *Use a local model*, and the settings section shows only the Model card.
- The settings dialog's `contained` in-flow popover still opens inside the scroller. While checking it I found the popover and the settings card rendering the effort control twice in one view, which reads as a bug — the popover now skips its own row when `contained`, since that caller renders one.

## Tests

`src/components/ModelPicker.test.ts` is new — there was no test for this component. Seven cases: no levels renders nothing (declared-empty and unknown-engine included), only the engine's levels appear, Default and None stay distinct, the active level is marked, `xhigh` renders as `X-High`, and the trigger shows the effort only when the bot carries one.

Each assertion was checked against a mutated implementation; all six mutations (dropping the empty guard, rendering the full union, removing `aria-pressed`, removing the trigger suffix, removing the tooltip suffix) break at least one test. One of them exposed a weak assertion — `toContain("· High")` passed via the tooltip — which is why the trigger's effort span carries a `data-model-effort` hook.

- `vitest run` — 3884 passed, 20 skipped, 1 todo, 0 failed
- `tsc -b` and `tsc -p tsconfig.server.json` — clean
- `oxlint .` — byte-identical to `main` (exit 0, same 31 pre-existing warnings)

No server or iOS files are touched; #632 and #631 cover the iOS side separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reasoning-effort selection alongside model selection.
  * Added clear labels for available effort levels, including an “xhigh” option and a “Default” setting.
  * Model picker displays the selected effort level alongside the model name, including in compact views.
  * Bot settings now use the same effort-selection controls for a consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->