### PR TITLE
fix(sidebar): show the bot title above the name, not beside it

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -759,7 +759,9 @@ export function BotListItem({
   // the visible branch, so a version switch changes the row with the chat
   const visible = visibleMessages(bot);
   const last = visible.at(-1);
-  // the role from Bot Settings → Title, shown as a pill beside the name
+  // the role from Bot Settings → Title. A badge or tooltip beside the name
+  // (#866, #871) always traded the name's width against the title's; its own
+  // line above the name lets both truncate independently instead.
   const title = bot.title.trim();
   const rowClass = cn(
     "flex w-full items-center rounded-xl border text-left",
@@ -806,6 +808,13 @@ export function BotListItem({
         )}
       </span>
       <div className={cn("min-w-0 flex-1", iconOnly && "hidden")}>
+        {title && !renaming && (
+          // Its own line above the name: a badge or tooltip beside the name
+          // (#866, #871) always traded the name's width against the title's —
+          // stacking the two removes the competition entirely, so both can
+          // truncate independently against the full row width.
+          <div className="truncate text-[11px] font-medium leading-4 text-ink-secondary">{title}</div>
+        )}
         <div className="flex items-baseline justify-between gap-2">
           <span className="flex min-w-0 grow items-center gap-1.5 truncate text-[15px] font-semibold text-ink">
             {bot.pinned && <Pin size={12} className="shrink-0 text-ink-secondary" />}
@@ -825,11 +834,6 @@ export function BotListItem({
               className="truncate"
               inputClassName="w-full rounded bg-inset px-1 py-0.5 text-[15px] font-semibold"
             />
-            {title && !renaming && (
-              <span className="max-w-[45%] shrink-0 truncate rounded-full bg-control px-1.5 py-px text-[10.5px] font-medium text-ink-secondary">
-                {title}
-              </span>
-            )}
           </span>
           {selected && last && !renaming && (
             <span className="shrink-0 text-xs text-ink-secondary transition-opacity group-hover:opacity-0 group-focus-within:opacity-0">

--- a/src/components/SidebarBotListItem.test.ts
+++ b/src/components/SidebarBotListItem.test.ts
@@ -49,10 +49,9 @@ describe("BotListItem", () => {
 
   it("shows the Chief of Staff label on its own line under the name", () => {
     const withTitle = renderRow(bot({ chiefOfStaff: true, title: "Developer" }), false);
-    expect(withTitle).toContain(">Developer</span>");
     expect(withTitle).toContain("Chief of Staff</span>");
     // the label sits after the name line, never inside it
-    expect(withTitle.indexOf("Chief of Staff</span>")).toBeGreaterThan(withTitle.indexOf(">Developer</span>"));
+    expect(withTitle.indexOf("Chief of Staff</span>")).toBeGreaterThan(withTitle.indexOf(">Atlas<"));
 
     const withoutTitle = renderRow(bot({ chiefOfStaff: true }), false);
     expect(withoutTitle).toContain("Chief of Staff</span>");
@@ -61,23 +60,28 @@ describe("BotListItem", () => {
     expect(renderRow(bot(), false)).not.toContain("Chief of Staff");
   });
 
-  it("shows the bot's title as a badge beside the name", () => {
+  it("shows the bot's title on its own line above the name, not a badge beside it", () => {
+    // #866 / #871: a badge next to the name always had to fight the name for
+    // width — a long name crushed the badge, and a long title crushed a long
+    // name right back. Its own line above the name never competes with it.
     const markup = renderRow(bot({ title: "Developer" }), false);
 
-    expect(markup).toContain(">Developer</span>");
-    expect(renderRow(bot({ title: "  " }), false)).not.toContain(">Developer</span>");
+    expect(markup).toContain(">Developer<");
+    expect(markup.indexOf(">Developer<")).toBeLessThan(markup.indexOf(">Atlas<"));
+    // the rename hint is unrelated to the bot's title
+    expect(markup).toContain('title="Double-click to rename"');
+
+    expect(renderRow(bot(), false)).not.toContain(">Developer<");
+    expect(renderRow(bot({ title: "  " }), false)).not.toContain('<div class="truncate text-[11px]');
   });
 
-  it("caps the title badge to a share of the name line, not a fixed width", () => {
-    // a fixed cap freezes the badge at its full width and crushes the name
-    const markup = renderRow(bot({ title: "Meta-Agent — opensource team maintainer" }), false);
-    const badge = /<span class="([^"]*)"[^>]*>Meta-Agent/.exec(markup);
+  it("shows a long title in full above the name, never truncated or width-capped", () => {
+    const longTitle = "Meta-Agent — opensource team maintainer";
+    const markup = renderRow(bot({ name: "Team Maintainer", title: longTitle }), false);
 
-    expect(badge?.[1]).toContain("max-w-[45%]");
-    expect(badge?.[1]).not.toMatch(/max-w-\[\d+px\]/);
-    // the share is of the whole row, so the name line has to fill it
-    const line = /<span class="([^"]*)"><span class="cursor-text truncate"/.exec(markup);
-    expect(line?.[1]).toContain("grow");
+    expect(markup).toContain(`>${longTitle}<`);
+    expect(markup).toContain(">Team Maintainer<");
+    expect(markup).not.toContain("max-w-[45%]");
   });
 
   it("shows typing dots instead of preview text while the bot works", () => {

--- a/src/components/SidebarBotListItem.test.ts
+++ b/src/components/SidebarBotListItem.test.ts
@@ -60,26 +60,35 @@ describe("BotListItem", () => {
     expect(renderRow(bot(), false)).not.toContain("Chief of Staff");
   });
 
+  // matches the title line's own class list (see Sidebar.tsx) — used to
+  // assert the marker element itself is present or absent, since checking
+  // for the title text alone can pass by accident when there's no title.
+  const titleLine = /<div class="truncate text-\[11px\][^"]*">([^<]*)<\/div>/;
+
   it("shows the bot's title on its own line above the name, not a badge beside it", () => {
     // #866 / #871: a badge next to the name always had to fight the name for
     // width — a long name crushed the badge, and a long title crushed a long
     // name right back. Its own line above the name never competes with it.
     const markup = renderRow(bot({ title: "Developer" }), false);
 
-    expect(markup).toContain(">Developer<");
+    expect(titleLine.exec(markup)?.[1]).toBe("Developer");
     expect(markup.indexOf(">Developer<")).toBeLessThan(markup.indexOf(">Atlas<"));
     // the rename hint is unrelated to the bot's title
     expect(markup).toContain('title="Double-click to rename"');
 
-    expect(renderRow(bot(), false)).not.toContain(">Developer<");
-    expect(renderRow(bot({ title: "  " }), false)).not.toContain('<div class="truncate text-[11px]');
+    expect(titleLine.test(renderRow(bot(), false))).toBe(false);
+    expect(titleLine.test(renderRow(bot({ title: "  " }), false))).toBe(false);
   });
 
-  it("shows a long title in full above the name, never truncated or width-capped", () => {
+  it("keeps the title line's own truncate class instead of a shared-line width cap", () => {
+    // renderToStaticMarkup keeps the full text regardless of CSS, so this
+    // can't observe an actual ellipsis — it asserts the title line still
+    // carries `truncate` (so a too-long title clips on its own line) and,
+    // unlike the #871 badge, never a max-width cap shared with the name.
     const longTitle = "Meta-Agent — opensource team maintainer";
     const markup = renderRow(bot({ name: "Team Maintainer", title: longTitle }), false);
 
-    expect(markup).toContain(`>${longTitle}<`);
+    expect(titleLine.exec(markup)?.[1]).toBe(longTitle);
     expect(markup).toContain(">Team Maintainer<");
     expect(markup).not.toContain("max-w-[45%]");
   });


### PR DESCRIPTION
Closes #866.

## The badge fix (#871) wasn't enough

#871 changed the title badge's cap from a fixed `120px` to `max-w-[45%]` of the name line, but left it `shrink-0`. A `shrink-0` element never actually shrinks — it claims its full basis up to that cap regardless of whether the name needs the room. Since a title long enough to matter (e.g. `Meta-Agent — openmausbot-team`) almost always exceeds 45% of a ~150–174px line anyway, the badge kept grabbing its guaranteed share and the name kept losing.

Reproduced against the real component markup + compiled Tailwind classes, measured with Playwright at both densities:

| bot | name width available | rendered |
|---|---|---|
| Team Maintainer / Meta-Agent — openmausbot-team (compact) | 76.5px of 118px needed | `Team Mai…` |
| CMP Agent / Project Agent — cmp (compact) | 76.5px of 80px needed | `CMP Ag…` |

Same failure mode as the original issue, just with a smaller, percentage-shaped guarantee instead of a pixel one. Any fixed *split* of the line between name and title regresses one of them once either string is long enough — the badge can't be sized correctly against the name, only differently wrong.

## The fix

Stop splitting one line between the two strings. The title now renders on its own line above the name (`Sidebar.tsx`), so each line truncates independently against the full row width:

- the name is always shown in full unless the name itself is wider than the entire row
- the title truncates only when the title itself is too long — never because the name pushed into its space

`RenameTitle.tsx` is untouched.

## Verification

- New/updated tests in `SidebarBotListItem.test.ts`: title renders as its own line before the name (not a width-capped badge beside it), a long title never truncates the name, blank/absent titles render nothing.
- `tsc -b`, `tsc -p tsconfig.server.json`, `oxlint .`: clean.
- `vitest run`: 3880 passed, 20 skipped, 1 todo, 11 failed — all 11 pre-existing and unrelated (9 `ApprovalCard.test.ts` failures from this machine's German locale, 2 `control-omb.test.ts` failures from a local `hermes` engine on PATH); same failures reproduce on `main` before this change.
- Re-measured the same three real-world name/title pairs from the table above with a Playwright harness against the new markup: all three names now render in full at both densities.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Bot titles now appear on a separate line above the bot name.
  * Titles and names can truncate independently for improved readability.
  * Chief of Staff labels are positioned relative to the bot name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->