### PR TITLE
fix: honor uploaded bot portraits across identity surfaces

### DIFF
--- a/src/components/BotIdentityAvatars.test.ts
+++ b/src/components/BotIdentityAvatars.test.ts
@@ -1,0 +1,79 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Bot, Group, Message } from "@/state/store";
+const fixtureAt = Date.UTC(2026, 8, 7, 12);
+const avatarBots: Bot[] = ["Atlas", "Juniper"].map((name, i) => ({
+  id: name.toLowerCase(), threadId: "thread-" + name.toLowerCase(), name,
+  title: "Test bot", description: "",
+  notifications: false, color: i ? "purple" : "green", unread: false,
+  avatarUrl: "/api/attachments/fixture-" + i + ".png", avatarCrop: i ? "rounded" : "circle",
+  modelSelection: { instanceId: "fixture", model: "fixture-model" },
+  tasks: [{ threadId: "thread-" + name.toLowerCase(), title: "Task", createdAt: fixtureAt,
+    usage: { input: 100, output: 20, costUsd: 0.01, turns: 1 } }],
+  messages: [],
+}));
+const receipt: Message = { id: "receipt", role: "bot", kind: "activity", at: fixtureAt,
+  tool: { name: "Message from @Juniper", ok: true },
+  comm: { withBotId: "juniper", withName: "Juniper", withColor: "purple", groupId: "fixture-dm" } };
+const avatarGroup: Group = {
+  id: "fixture-room", threadId: "thread-room", name: "Group",
+  memberIds: ["atlas", "juniper"], defaultResponder: { kind: "member", botId: "atlas" },
+  bulletin: "", unread: false, createdAt: fixtureAt, setupCompletedAt: fixtureAt,
+  messages: [
+    { id: "atlas-message", role: "bot", kind: "text", text: "Hello",
+      from: { botId: "atlas", name: "Atlas", color: "green" }, at: fixtureAt },
+    { ...receipt, from: { botId: "atlas", name: "Atlas", color: "green" } },
+    { id: "deleted-message", role: "bot", kind: "text", text: "Historical message",
+      from: { botId: "deleted", name: "Former teammate", color: "orange" }, at: fixtureAt },
+  ],
+};
+
+
+vi.mock("@/state/store", async (original) => {
+  const actual = await original<typeof import("@/state/store")>();
+  return { ...actual, useStore: () => ({ state: { ...actual.initialState, bots: avatarBots, groups: [avatarGroup] }, dispatch: vi.fn() }) };
+});
+vi.mock("./DesktopCapabilities", () => ({ useDesktopCapabilities: () => ({ capabilities: { dictation: { available: false } } }) }));
+vi.mock("react-dom", async (original) => ({ ...await original<object>(), createPortal: (children: unknown) => children }));
+import { GroupView, RoomToolChip } from "./GroupView";
+import { UsageSection } from "./UsageSection";
+import { TeamMapPage } from "./TeamMapPage";
+import { BotInstructionsDialog } from "./BotInstructionsDialog";
+const render = (component: Parameters<typeof renderToStaticMarkup>[0]) => {
+  vi.stubGlobal("window", { ogb: undefined });
+  vi.stubGlobal("document", { body: {} });
+  return renderToStaticMarkup(component);
+};
+afterEach(() => vi.unstubAllGlobals());
+describe("uploaded bot identity portraits", () => {
+  it("renders the receipt sender image while preserving its navigation button", () => {
+    const html = render(createElement(RoomToolChip, { message: receipt }));
+    expect(html).toContain('<img src="/api/attachments/fixture-1.png"');
+    expect(html).toContain('title="Open Juniper"');
+    expect(html).toContain("Message from @Juniper");
+  });
+  it("keeps a deleted receipt sender readable with a mascot fallback", () => {
+    const html = render(createElement(RoomToolChip, { message: { ...receipt, comm: { ...receipt.comm!, withBotId: "deleted" } } }));
+    expect(html).toContain("<svg");
+    expect(html).not.toContain("<img");
+    expect(html).toContain("Message from @Juniper");
+  });
+  it("renders uploaded group header and sender portraits", () => {
+    const html = render(createElement(GroupView, { group: avatarGroup }));
+    expect(html.match(/<img src="\/api\/attachments\/fixture-0.png"/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+    expect(html).toContain("Historical message");
+  });
+  it("renders uploaded empty-room portraits as well as member headers", () => {
+    const html = render(createElement(GroupView, { group: { ...avatarGroup, messages: [] } }));
+    expect(html.match(/<img src="\/api\/attachments\/fixture-0.png"/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+  it.each([["usage", UsageSection], ["team map", TeamMapPage]] as const)("renders the uploaded portrait in %s", (_name, Component) => {
+    expect(render(createElement(Component))).toContain('<img src="/api/attachments/fixture-0.png"');
+  });
+  it("renders the instructions portrait without losing dialog semantics", () => {
+    const html = render(createElement(BotInstructionsDialog, { bot: avatarBots[0]!, onClose: vi.fn() }));
+    expect(html).toContain('<img src="/api/attachments/fixture-0.png"');
+    expect(html).toContain('role="dialog"');
+  });
+});

--- a/src/components/BotInstructionsDialog.tsx
+++ b/src/components/BotInstructionsDialog.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { BookOpen, X } from "lucide-react";
 
-import { MausAvatar } from "./Avatar";
+import { BotAvatar } from "./Avatar";
 import { normalizeState } from "@/lib/mascot";
 import type { Bot } from "@/state/store";
 
@@ -65,9 +65,8 @@ export function BotInstructionsDialog({ bot, onClose }: { bot: Bot; onClose: () 
       >
         <header className="flex items-start justify-between gap-4 border-b border-hairline/40 px-6 pb-4 pt-6 sm:px-8 sm:pt-7">
           <div className="flex min-w-0 items-center gap-3">
-            <MausAvatar
-              color={bot.color}
-              bodyId={bot.mascotBody ?? undefined}
+            <BotAvatar
+              bot={bot}
               state={normalizeState(bot.mascotExpression) ?? "idle"}
               size={38}
               motion="none"

--- a/src/components/CallView.tsx
+++ b/src/components/CallView.tsx
@@ -26,7 +26,7 @@ import { speaker } from "@/lib/tts";
 import { localSystemVoiceActive } from "@/lib/local-voice";
 import { useSpeech } from "@/lib/tts/useSpeech";
 import { usePushToTalk } from "@/lib/push-to-talk";
-import { MausAvatar } from "./Avatar";
+import { BotAvatar } from "./Avatar";
 import { isRoutineApproval, isSkillApproval, pendingApprovals, spokenApprovalPrompt } from "./PendingApproval";
 import { cn } from "@/lib/cn";
 import { track } from "@/lib/analytics";
@@ -543,7 +543,7 @@ function Call({ bot }: { bot: Bot }) {
         <X size={18} />
       </button>
 
-      <MausAvatar color={bot.color} bodyId={bot.mascotBody ?? undefined} state={mascotState} size={220} animated trackPointer />
+      <BotAvatar bot={bot} state={mascotState} size={220} animated trackPointer />
 
       <div className="flex flex-col items-center gap-1.5 text-center">
         <div className="text-[20px] font-medium text-ink">{bot.name}</div>

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -37,7 +37,7 @@ import {
   type Message,
 } from "@/state/store";
 import { EngineSetup } from "./EngineSetup";
-import { BotAvatar, MausAvatar } from "./Avatar";
+import { BotAvatar } from "./Avatar";
 import { TurnPresence } from "./TurnPresence";
 import { showToolCallsEnabled } from "@/lib/feature-flags";
 import { stateForBot } from "@/lib/mascot";
@@ -576,7 +576,7 @@ function ActivityChip({ message }: { message: Message }) {
           title={`Open the conversation with ${comm.withName}`}
           className="flex items-center gap-2 rounded-full border border-hairline/40 bg-panel px-3 py-1.5 text-[13px] text-ink-secondary hover:bg-raised hover:text-ink"
         >
-          <MausAvatar color={comm.withColor} bodyId={withBot?.mascotBody ?? undefined} state="happy" size={16} />
+          <BotAvatar bot={withBot ?? { name: comm.withName, color: comm.withColor }} state="happy" size={16} />
           <span className="max-w-[480px] truncate">{tool.name}</span>
           <ChevronRight size={13} />
         </button>

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -20,7 +20,7 @@ import {
   type ComposerSendSnapshot,
   type FailedComposerSend,
 } from "@/lib/drafts";
-import { MausAvatar } from "./Avatar";
+import { BotAvatar } from "./Avatar";
 import { ComposerAttachments, pathForFile } from "./ComposerAttachments";
 import { LocalComputerAutoWarning } from "./LocalComputerAutoWarning";
 import { ApprovalModeSelector } from "./ApprovalModeSelector";
@@ -720,9 +720,8 @@ export function Composer({
                 )}
               >
                 {peer.bot ? (
-                  <MausAvatar
-                    color={peer.bot.color}
-                    bodyId={peer.bot.mascotBody ?? undefined}
+                  <BotAvatar
+                    bot={peer.bot}
                     state={normalizeState(peer.bot.mascotExpression) ?? "happy"}
                     size={24}
                   />

--- a/src/components/GroupCallView.tsx
+++ b/src/components/GroupCallView.tsx
@@ -15,7 +15,7 @@ import { useSpeech } from "@/lib/tts/useSpeech";
 import { usePushToTalk } from "@/lib/push-to-talk";
 import { useStore, type Bot, type Group, type Message } from "@/state/store";
 import { cn } from "@/lib/cn";
-import { MausAvatar } from "./Avatar";
+import { BotAvatar } from "./Avatar";
 import { CallTargetButton } from "./CallView";
 import { isRoutineApproval, isSkillApproval, pendingApprovals, spokenApprovalPrompt } from "./PendingApproval";
 
@@ -482,9 +482,8 @@ function GroupCall({ group, members }: { group: Group; members: Bot[] }) {
                   focused ? "scale-105 bg-raised/70 shadow-lg" : "opacity-75",
                 )}
               >
-                <MausAvatar
-                  color={member.color}
-                  bodyId={member.mascotBody ?? undefined}
+                <BotAvatar
+                  bot={member}
                   state={state}
                   size={94}
                   animated

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -15,7 +15,7 @@ import {
   type GroupDefaultResponder,
   type Message,
 } from "@/state/store";
-import { BotAvatar, MausAvatar } from "./Avatar";
+import { BotAvatar } from "./Avatar";
 import { TurnPresence } from "./TurnPresence";
 import { showToolCallsEnabled } from "@/lib/feature-flags";
 import { roomActivityVisible } from "@/lib/room-activity";
@@ -87,7 +87,7 @@ export function RoomToolChip({ message, roomId }: { message: Message; roomId?: s
           title={`Open ${comm.withName}`}
           className="flex items-center gap-2 rounded-full border border-hairline/40 bg-panel px-3 py-1.5 text-[13px] text-ink-secondary hover:bg-raised hover:text-ink"
         >
-          <MausAvatar color={comm.withColor} bodyId={withBot?.mascotBody ?? undefined} state="happy" size={16} />
+          <BotAvatar bot={withBot ?? { name: comm.withName, color: comm.withColor }} state="happy" size={16} />
           <span className="max-w-[480px] truncate">{tool.name}</span>
           <ChevronRight size={13} />
         </button>
@@ -108,13 +108,12 @@ export function RoomToolChip({ message, roomId }: { message: Message; roomId?: s
   );
 }
 
-/** 16px maus + name, shown once per sender cluster. */
+/** 16px profile avatar + name, shown once per sender cluster. */
 function ClusterLabel({ bot, name, color }: { bot?: Bot; name: string; color: string }) {
   return (
     <div className="mt-1 flex items-center gap-1.5 pl-0.5">
-      <MausAvatar
-        color={(bot?.color ?? color) as Bot["color"]}
-        bodyId={bot?.mascotBody ?? undefined}
+      <BotAvatar
+        bot={bot ?? { name, color: color as Bot["color"] }}
         state={normalizeState(bot?.mascotExpression) ?? "happy"}
         size={16}
         motion="none"
@@ -756,9 +755,8 @@ function RoomSetup({ group, members }: { group: Group; members: Bot[] }) {
                             selected ? "bg-accent/10" : "hover:bg-raised",
                           )}
                         >
-                          <MausAvatar
-                            color={member.color}
-                            bodyId={member.mascotBody ?? undefined}
+                          <BotAvatar
+                            bot={member}
                             state={normalizeState(member.mascotExpression) ?? "happy"}
                             size={24}
                             animated={false}
@@ -1068,7 +1066,7 @@ export function GroupView({ group }: { group: Group }) {
     }
   };
 
-  // Static mauses: one per member, a ring + dot on whoever is working.
+  // Static profile avatars: one per member, a ring + dot on whoever is working.
   const memberMauses = members.map((b) => (
     <span
       key={b.id}
@@ -1078,7 +1076,7 @@ export function GroupView({ group }: { group: Group }) {
         group.busyBotId === b.id && "ring-2 ring-accent/50 ring-offset-1 ring-offset-app",
       )}
     >
-      <MausAvatar color={b.color} bodyId={b.mascotBody ?? undefined} state={normalizeState(b.mascotExpression) ?? "happy"} size={24} animated={false} />
+      <BotAvatar bot={b} state={normalizeState(b.mascotExpression) ?? "happy"} size={24} animated={false} />
       {group.busyBotId === b.id && (
         <span className="absolute -right-0.5 -top-0.5 size-2 rounded-full border border-app bg-accent" />
       )}
@@ -1091,7 +1089,7 @@ export function GroupView({ group }: { group: Group }) {
       {membersOpen && !remoteClient && !group.dm && (
         <ManageMembersPanel group={group} onClose={closeMembers} triggerRef={membersTriggerRef} />
       )}
-      {/* Header: static member mauses; a ring + dot marks the working bot. */}
+      {/* Header: static member avatars; a ring + dot marks the working bot. */}
       <div
         className={cn(
           "flex items-center justify-between px-5 py-3",
@@ -1265,10 +1263,9 @@ export function GroupView({ group }: { group: Group }) {
             <div className="flex flex-1 flex-col items-center justify-center gap-3 py-24 text-center">
               <div className="flex -space-x-2">
                 {members.slice(0, 3).map((b) => (
-                  <MausAvatar
+                  <BotAvatar
                     key={b.id}
-                    color={b.color}
-                    bodyId={b.mascotBody ?? undefined}
+                    bot={b}
                     state="happy"
                     size={44}
                     motion="none"

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -5,7 +5,7 @@
 import { useEffect, useState } from "react";
 import { GitBranch, Wrench } from "lucide-react";
 import { api, useStore, formatTime } from "@/state/store";
-import { MausAvatar } from "./Avatar";
+import { BotAvatar } from "./Avatar";
 import { cn } from "@/lib/cn";
 import type { SearchHit } from "@/lib/search-hit";
 import { landOnSearchHit } from "@/lib/focus-message";
@@ -71,7 +71,7 @@ export function SearchResults({ query, onLanded }: { query: string; onLanded: ()
             className="flex w-full items-start gap-2.5 rounded-lg px-3 py-2 text-left hover:bg-raised/60"
           >
             {bot ? (
-              <MausAvatar color={bot.color} bodyId={bot.mascotBody ?? undefined} state="idle" size={26} animated={false} />
+              <BotAvatar bot={bot} state="idle" size={26} animated={false} />
             ) : (
               <span className="flex size-[26px] shrink-0 items-center justify-center rounded-full bg-raised text-[11px] text-ink-secondary">#</span>
             )}

--- a/src/components/TeamMapPage.tsx
+++ b/src/components/TeamMapPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { ArrowRight, BookOpen, Crown, Loader2, Network, RefreshCw, Save, X } from "lucide-react";
 
-import { MausAvatar } from "./Avatar";
+import { BotAvatar } from "./Avatar";
 import { api, formatTime, useStore, type Bot } from "@/state/store";
 import { normalizeState } from "@/lib/mascot";
 import {
@@ -42,9 +42,8 @@ function BotNode({
         className="flex min-w-0 flex-1 items-center gap-3 px-3 py-3 text-left"
         aria-label={`Open chat with ${bot.name}`}
       >
-        <MausAvatar
-          color={bot.color}
-          bodyId={bot.mascotBody ?? undefined}
+        <BotAvatar
+          bot={bot}
           state={normalizeState(bot.mascotExpression) ?? "idle"}
           size={34}
           motion="none"

--- a/src/components/UsageSection.tsx
+++ b/src/components/UsageSection.tsx
@@ -3,7 +3,7 @@
 // banked per settled turn on each task (server/store.ts addTaskUsage) and
 // summed here; nothing is fetched.
 import { useStore } from "@/state/store";
-import { MausAvatar } from "./Avatar";
+import { BotAvatar } from "./Avatar";
 import { Card } from "./SettingsPrimitives";
 import { botUsage, cachedInput, costCaption, formatTokens, formatUsd, hasFiniteCost, sumUsage, usageDetail } from "@/lib/usage";
 
@@ -41,7 +41,7 @@ export function UsageSection() {
           {rows.map(({ bot, usage }) => (
             <div key={bot.id} className="grid grid-cols-[1fr_auto_auto_auto] items-center gap-x-5 border-b border-hairline/20 py-2 text-[13px]">
               <span className="flex min-w-0 items-center gap-2 text-ink">
-                <MausAvatar color={bot.color} bodyId={bot.mascotBody ?? undefined} state="idle" size={22} animated={false} />
+                <BotAvatar bot={bot} state="idle" size={22} animated={false} />
                 <span className="truncate">{bot.name}</span>
               </span>
               <span className="text-right tabular-nums text-ink-secondary">{usage.turns}</span>


### PR DESCRIPTION
## What changed

Use uploaded bot portraits consistently in chat and group senders, message receipts, member headers, mentions, lead selection, search results, usage, team map, instructions and call views. Preserve mascot selection and fallbacks for missing, deleted, invalid or failed images.

Several views rendered the mascot directly instead of using the bot’s profile portrait. This change uses the existing BotAvatar component and adds focused regression coverage for portraits, historical senders and dialog semantics.

## Verification

23 focused regression tests passed. App/server type checks, lint, renderer build, broker tests, Electron tests and packaged-server smoke checks passed. Before/after rendering, keyboard selection, navigation, dialog behavior and image-failure recovery were verified.

Full suite: 3,908 passed, 9 skipped, 1 todo and one Electron handoff failure also reproduced on the base revision. The handoff test passed in a subsequent targeted rerun; the complete suite was not rerun.

Live upload persistence, native voice transport and cross-platform release behavior are not covered by this change’s verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Uploaded bot identity portraits now appear consistently across chats, rooms, calls, search results, usage views, team maps, mention pickers, and instruction dialogs.
  * Group rooms display uploaded portraits for headers, senders, members, and empty-room states.
  * Deleted receipt senders display a mascot fallback.
  * Chat and room views now better maintain bottom-follow behavior as transcript content grows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->