### PR TITLE
fix(claude): route a signed-out turn to the sign-in card

### DIFF
--- a/server/drivers/claude-auth.test.ts
+++ b/server/drivers/claude-auth.test.ts
@@ -2,7 +2,7 @@
 // runner, so they never read or mutate the developer's real credentials.
 import { describe, expect, it } from "vitest";
 
-import { claudeSignedIn } from "./claude.ts";
+import { claudeAuthFailure, claudeSignedIn } from "./claude.ts";
 
 describe("claudeSignedIn", () => {
   it("uses the CLI's machine-readable auth status", async () => {
@@ -34,5 +34,30 @@ describe("claudeSignedIn", () => {
 
     expect(await claudeSignedIn("claude", {}, failed)).toBe(false);
     expect(await claudeSignedIn("claude", {}, malformed)).toBe(false);
+  });
+});
+
+describe("claudeAuthFailure", () => {
+  const LOGIN_TEXT = "Not logged in \u00b7 Please run /login";
+
+  it("reads the signed-out turn the CLI actually sends", () => {
+    // captured from claude 2.1.263 run with an empty CLAUDE_CONFIG_DIR
+    expect(claudeAuthFailure({ error: "authentication_failed", is_api_error_message: true }, LOGIN_TEXT)).toBe(true);
+  });
+
+  it("still catches a flagged frame that does not name the reason", () => {
+    expect(claudeAuthFailure({ is_api_error_message: true }, LOGIN_TEXT)).toBe(true);
+    expect(claudeAuthFailure({ error: "api_error" }, "401 unauthorized")).toBe(true);
+  });
+
+  it("leaves a model's own words alone", () => {
+    // the flag is the gate: a reply that merely discusses logging in is a
+    // reply, and must keep rendering as one
+    expect(claudeAuthFailure({}, LOGIN_TEXT)).toBe(false);
+    expect(claudeAuthFailure({}, "You are not logged in to npm; run npm login.")).toBe(false);
+  });
+
+  it("leaves other api errors to the retry classifier", () => {
+    expect(claudeAuthFailure({ error: "api_error", is_api_error_message: true }, "API Error (529): overloaded")).toBe(false);
   });
 });

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -333,6 +333,25 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     expect((settled[0] as any).text).toBe("hello from fake claude");
   });
 
+  it("turns a signed-out CLI into a setup error, not a bot reply", async () => {
+    // issue #674: the CLI answers a signed-out turn with "Please run /login",
+    // a command this app has no terminal to run. Relaying it as assistant
+    // text left the user in a dead end; `setup: true` is what the chat reads
+    // to offer the sign-in card instead.
+    await create("not-logged-in");
+    await instance.adapter.sendTurn({ threadId: "t-auth", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const failure = recorder.events.find((e: any) => e.type === "runtime.error") as any;
+    expect(failure).toMatchObject({ message: "Not logged in \u00b7 Please run /login", setup: true });
+    // the CLI's instruction must not also land as something the bot said
+    expect(recorder.events.some((e: any) => e.type === "item.completed" && e.itemType === "assistant_text")).toBe(false);
+    expect(recorder.events.some((e: any) => e.type === "content.delta")).toBe(false);
+    // the same vocabulary codex and the ACP engines settle an unauthenticated
+    // turn with — not the CLI's "stop_sequence", which says nothing
+    expect(recorder.events.at(-1)).toMatchObject({ type: "turn.completed", ok: false, stopReason: "auth_required" });
+  });
+
   it("keeps user and system prompts off argv and strips identity env vars", async () => {
     await create();
     const dump = join(scratch, "dump.json");

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -67,6 +67,23 @@ export function claudeSignedIn(
   });
 }
 
+/** Whether a stream frame is the CLI reporting that it has no login.
+ *
+ * The CLI flags its own api-error frames (`error`, `is_api_error_message`);
+ * a model reply never carries them. Requiring that flag first is what keeps
+ * an answer that merely discusses being logged out from being read as a
+ * failure — the text classifier runs only once the CLI has already called
+ * the frame an error, and covers CLI builds that flag the frame without
+ * naming the reason.
+ */
+export function claudeAuthFailure(
+  frame: { error?: unknown; is_api_error_message?: unknown },
+  text: string,
+): boolean {
+  if (frame.is_api_error_message !== true && typeof frame.error !== "string") return false;
+  return frame.error === "authentication_failed" || classifyError({ text }).reason === "auth";
+}
+
 /** The CLI environment shared by auth probes and real turns.
  *
  * Subscription users can be billed pay-as-you-go if an inherited API key
@@ -615,7 +632,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       /** the CLI's session id from `init`, what --resume takes later */
       sessionId: string | null;
       /** the running turn, or null between turns */
-      turn: { turnId: string; settled: boolean; sawStreamDelta: boolean } | null;
+      turn: { turnId: string; settled: boolean; sawStreamDelta: boolean; authFailed?: boolean } | null;
       idleTimer: ReturnType<typeof setTimeout> | null;
       closing: boolean;
       stderr: string;
@@ -1071,6 +1088,16 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
           case "assistant": {
             const msg = o.message ?? {};
             const text = firstText(msg.content);
+            // An unauthenticated turn comes back as an api-error frame whose
+            // only content is the CLI's own "run /login" instruction — a
+            // command this app has no terminal to run, so relaying it as a
+            // reply strands the user. Every other engine reports this as a
+            // setup error; that is what routes them to the sign-in card.
+            if (claudeAuthFailure(o, text)) {
+              if (session.turn) session.turn.authFailed = true;
+              emit({ ...base(threadId, currentTurnId()), type: "runtime.error", message: text, setup: true });
+              break;
+            }
             if (text.trim()) {
               // fallback delta for CLIs/paths that never streamed the block
               if (!session.turn?.sawStreamDelta) {
@@ -1116,7 +1143,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
             // of the figure was context re-read rather than new text.
             settle(
               o.is_error !== true,
-              o.stop_reason ?? o.terminal_reason ?? null,
+              session.turn?.authFailed ? "auth_required" : o.stop_reason ?? o.terminal_reason ?? null,
               o.total_cost_usd ?? null,
               o.usage
                 ? {

--- a/server/testing/fake-claude-cli.ts
+++ b/server/testing/fake-claude-cli.ts
@@ -7,6 +7,8 @@
 //   FAKE_CLAUDE_MODE   happy (default) | exit-early | hang | malformed
 //                      | stream (partial-message text deltas before the
 //                        whole-message frame, plus subagent noise to drop)
+//                      | not-logged-in (the frames a signed-out CLI really
+//                        sends, captured from 2.1.263)
 //   FAKE_CLAUDE_DUMP   path to write {argv, env, prompt, systemPrompt,
 //                      mcpConfig} as JSON,
 //                      so the test can assert on argv shape and env hygiene.
@@ -222,6 +224,28 @@ const playTurn = (prompt: JsonValue) => {
 
   if (mode === "malformed") {
     process.stdout.write("this is not json\n{broken\n");
+  }
+
+  // A signed-out CLI answers every prompt with this, verbatim: the login
+  // instruction arrives as assistant text, and only the frame's own error
+  // fields say it is a failure at all.
+  if (mode === "not-logged-in") {
+    out({
+      type: "assistant",
+      message: { model: "<synthetic>", content: [{ type: "text", text: "Not logged in \u00b7 Please run /login" }] },
+      error: "authentication_failed",
+      is_api_error_message: true,
+    });
+    out({
+      type: "result",
+      is_error: true,
+      stop_reason: "stop_sequence",
+      terminal_reason: "api_error",
+      result: "Not logged in \u00b7 Please run /login",
+    });
+    turnRunning = false;
+    finishIfDone();
+    return;
   }
 
   if (mode === "stream") {


### PR DESCRIPTION
Closes #674

## The dead end

On an unauthenticated Claude Code CLI, a turn ended with nowhere to go:

1. bot: `Not logged in · Please run /login`
2. user: `/login`
3. bot: `/login isn't available in this environment.`

The app asks the user to run a command, and then tells them that command does
not exist here. There is no way out from inside the product.

Reproduced on the current `main` by pointing `CLAUDE_CONFIG_DIR` at an empty
directory, against the real `claude` CLI (2.1.263) — all three messages, in
order.

## The cause

Neither phrase is ours; both are CLI output relayed verbatim into the
transcript.

The CLI does report the failure properly. Its assistant frame carries the
machine-readable verdict:

```json
{"type":"assistant",
 "message":{"model":"<synthetic>",
            "content":[{"type":"text","text":"Not logged in · Please run /login"}]},
 "error":"authentication_failed","is_api_error_message":true}
```

`server/drivers/claude.ts` read neither field. The `assistant` case took only
`message.content` and emitted it as `assistant_text`, so the CLI's instruction
became an ordinary bot bubble. The turn did settle as failed, but with
`stop_reason: "stop_sequence"` winning over `terminal_reason: "api_error"`, so
the recorded reason said nothing either.

The path to the sign-in card already exists and already works:

`runtime.error { setup: true }` → `server/index.ts:3155` → an `activity`
message with `tool.setup` → `ChatView.tsx:781` → `ErrorRow` → `<EngineSetup>`.

`codex.ts:1127` and `acp/core.ts:437,459,990` all emit it. The Claude driver
was the only engine with no auth classification on turn output.

Note that `authenticated` from the driver snapshot is produced but never
consumed server-side, so nothing gates a turn on it — a fresh snapshot would
not have prevented this. The gap is in classifying the turn's own output.

## The change

- `claudeAuthFailure()` — reads the CLI's error flag first, then confirms with
  the existing `classifyError` from `retry.ts`. The flag gate is what keeps a
  model answer that merely discusses being logged out from being read as a
  failure; a real reply never carries `error` or `is_api_error_message`.
- The `assistant` case emits `runtime.error { setup: true }` instead of the
  text bubble, so the chat offers the sign-in card that is already built.
- `result` settles `auth_required` — the same vocabulary `codex.ts:1129` and
  `acp/core.ts:992` already use. Every `stopReason` consumer treats it as an
  opaque display string, so a routine that fails this way now names the real
  reason instead of `stop_sequence`.

25 lines of production code in one driver.

## Scope

**This is presentation, not an authentication fix.** It changes nothing about
how sign-in works; it carries the user to the path the app already has.

Deliberately out of scope: the second balloon
(`/login isn't available in this environment.`) arrives with `is_error: false`
and no error field at all — indistinguishable from a normal reply at the
protocol level, so it cannot be classified. It also stops mattering: once the
first message becomes the sign-in card, nobody types `/login` into the chat.

## Tests

`server/testing/fake-claude-cli.ts` gains a `not-logged-in` mode replaying the
frames captured from the real CLI.

- `claude.test.ts` — the turn produces `runtime.error { setup: true }`, emits
  no `assistant_text` and no `content.delta`, and settles
  `ok: false, stopReason: "auth_required"`.
- `claude-auth.test.ts` — the classifier, including the false-positive gate.

Verified in both directions: reverting the two behavioral hunks fails the
end-to-end test on the missing `runtime.error`; removing the flag gate fails
the false-positive test.

Full suite: **3896 passed, 20 skipped, 0 failed** (333 files).
`tsc -b` and `tsc -p tsconfig.server.json` clean. `oxlint .` exits 0 with the
same 31 pre-existing warnings as `main` — no delta.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Claude authentication failures.
  * Signed-out sessions now show a setup error instead of displaying authentication messages as assistant responses.
  * Completed turns now clearly indicate when authentication is required.
  * Other API errors, such as service overloads, continue through normal retry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->