### PR TITLE
feat(sessions): sliding expiry, so a device in use never has to pair again

### DIFF
--- a/apps/docs/content/docs/self-hosting/deploy-vps.mdx
+++ b/apps/docs/content/docs/self-hosting/deploy-vps.mdx
@@ -5,7 +5,7 @@ icon: Cloud
 ---
 
 <Callout title="Three ways in, one login">
-  A public address with one command, your own domain with Docker, or your Tailscale network. Whichever you pick, devices pair once with a short code and stay signed in. A session lasts 30 days from its last use, so a device you keep using never pairs again. No password.
+  A public address with one command, your own domain with Docker, or your Tailscale network. Whichever you pick, devices pair once with a short code and stay signed in: a session lasts 30 days, and using it with 15 days or fewer left renews it to a full 30, up to 180 days from pairing. A device in regular use re-pairs twice a year; one that goes quiet for a month re-pairs. No password.
 </Callout>
 
 From a blank Linux server to OpenMausBot running on it around the clock, reachable from your laptop, the desktop app and your phone, with your bots working while every laptop is closed. It assumes nothing beyond being able to open a terminal and paste commands. About twenty minutes, most of it waiting.
@@ -18,7 +18,7 @@ Three ways to make the server reachable are covered. Pick one; the rest of the g
 | **B. Your own domain** (Docker + Caddy) | a domain name, ports 80/443 | anyone with a pairing code, over HTTPS | a permanent address you own |
 | **C. Your Tailscale network** (`serve --tailscale`) | Tailscale on the server and your devices | only your tailnet | the most private; nothing public at all |
 
-Whichever you pick, the login is the same: you **pair** each device once with a short code and it stays signed in for 30 days from its last use (`OMB_SESSION_TTL_DAYS` changes the term). There is no password.
+Whichever you pick, the login is the same: you **pair** each device once with a short code and it stays signed in. A session lasts 30 days; using it with half that or less left renews it to a full 30, up to 180 days from pairing (`OMB_SESSION_TTL_DAYS` and `OMB_SESSION_MAX_DAYS` change both numbers). There is no password.
 
 ## What runs on a server, and what does not
 
@@ -142,7 +142,7 @@ expires:       10:59:45 AM (single use)
 open or scan:  https://c-7f3a9c.openmausbot.com/pair#code=RR8Y-BLR6-H939
 ```
 
-- **A browser:** open the link. The code is filled in; press **Connect**. That browser is paired for 30 days.
+- **A browser:** open the link. The code is filled in; press **Connect**. That browser is paired for 30 days, renewed on use as above.
 - **The desktop app:** copy the link, then in the app's **Server** menu choose **Add Server from Copied Pairing Link…**. The menu switches between your own machine and every server you added.
 - **The phone:** scan the QR code from the iOS app's pairing screen, or paste the whole link into its address field. The phone can chat, approve, and read; creating bots, changing models, and connecting apps stay with you in the server's UI.
 

--- a/apps/docs/content/docs/self-hosting/deploy-vps.mdx
+++ b/apps/docs/content/docs/self-hosting/deploy-vps.mdx
@@ -5,7 +5,7 @@ icon: Cloud
 ---
 
 <Callout title="Three ways in, one login">
-  A public address with one command, your own domain with Docker, or your Tailscale network. Whichever you pick, devices pair once with a short code and stay signed in: a session lasts 30 days, and using it with 15 days or fewer left renews it to a full 30, up to 180 days from pairing. A device in regular use re-pairs twice a year; one that goes quiet for a month re-pairs. No password.
+  A public address with one command, your own domain with Docker, or your Tailscale network. Whichever you pick, devices pair once with a short code and stay signed in: a session lasts 30 days, and using it with half that or less left renews it to a full 30, up to 180 days from pairing. A device in regular use re-pairs twice a year; one that goes quiet for a month re-pairs. No password.
 </Callout>
 
 From a blank Linux server to OpenMausBot running on it around the clock, reachable from your laptop, the desktop app and your phone, with your bots working while every laptop is closed. It assumes nothing beyond being able to open a terminal and paste commands. About twenty minutes, most of it waiting.

--- a/apps/docs/content/docs/self-hosting/deploy-vps.mdx
+++ b/apps/docs/content/docs/self-hosting/deploy-vps.mdx
@@ -5,7 +5,7 @@ icon: Cloud
 ---
 
 <Callout title="Three ways in, one login">
-  A public address with one command, your own domain with Docker, or your Tailscale network. Whichever you pick, devices pair once with a short code and stay signed in for 30 days. No password.
+  A public address with one command, your own domain with Docker, or your Tailscale network. Whichever you pick, devices pair once with a short code and stay signed in. A session lasts 30 days from its last use, so a device you keep using never pairs again. No password.
 </Callout>
 
 From a blank Linux server to OpenMausBot running on it around the clock, reachable from your laptop, the desktop app and your phone, with your bots working while every laptop is closed. It assumes nothing beyond being able to open a terminal and paste commands. About twenty minutes, most of it waiting.
@@ -18,7 +18,7 @@ Three ways to make the server reachable are covered. Pick one; the rest of the g
 | **B. Your own domain** (Docker + Caddy) | a domain name, ports 80/443 | anyone with a pairing code, over HTTPS | a permanent address you own |
 | **C. Your Tailscale network** (`serve --tailscale`) | Tailscale on the server and your devices | only your tailnet | the most private; nothing public at all |
 
-Whichever you pick, the login is the same: you **pair** each device once with a short code and it stays signed in for 30 days. There is no password.
+Whichever you pick, the login is the same: you **pair** each device once with a short code and it stays signed in for 30 days from its last use (`OMB_SESSION_TTL_DAYS` changes the term). There is no password.
 
 ## What runs on a server, and what does not
 

--- a/docs/deploy-vps.md
+++ b/docs/deploy-vps.md
@@ -10,7 +10,7 @@ Three ways to make the server reachable are covered. Pick one; the rest of the g
 | **B. Your own domain** (Docker + Caddy) | a domain name, ports 80/443 | anyone with a pairing code, over HTTPS | a permanent address you own |
 | **C. Your Tailscale network** (`serve --tailscale`) | Tailscale on the server and your devices | only your tailnet | the most private; nothing public at all |
 
-Whichever you pick, the login is the same: you **pair** each device once with a short code and it stays signed in for 30 days. There is no password.
+Whichever you pick, the login is the same: you **pair** each device once with a short code and it stays signed in. A session lasts 30 days; using it with half that or less left renews it to a full 30, up to 180 days from pairing (`OMB_SESSION_TTL_DAYS` and `OMB_SESSION_MAX_DAYS` change both numbers). There is no password.
 
 ## What runs on a server, and what does not
 
@@ -134,7 +134,7 @@ expires:       10:59:45 AM (single use)
 open or scan:  https://c-7f3a9c.openmausbot.com/pair#code=RR8Y-BLR6-H939
 ```
 
-- **A browser:** open the link. The code is filled in; press **Connect**. That browser is paired for 30 days.
+- **A browser:** open the link. The code is filled in; press **Connect**. That browser is paired for 30 days, renewed on use as above.
 - **The desktop app:** copy the link, then in the app's **Server** menu choose **Add Server from Copied Pairing Link…**. The menu switches between your own machine and every server you added.
 - **The phone:** scan the QR code from the iOS app's pairing screen, or paste the whole link into its address field. The phone can chat, approve, and read; creating bots, changing models, and connecting apps stay with you in the server's UI.
 

--- a/docs/plans/remote-workspace.md
+++ b/docs/plans/remote-workspace.md
@@ -50,7 +50,7 @@ desktop-first agent app and adopt these points as requirements:
    ambiguity-free alphabet (60 bits), rejection-sampled, **5-minute** TTL,
    single use. Exchange it once at `POST /api/auth/pair` for an opaque
    session token: random bytes, **sha256 at rest** (the companion's
-   discipline), 30-day expiry, per-device label recorded, revocable from
+   discipline), 30-day expiry renewed on use up to 180 days from pairing, per-device label recorded, revocable from
    Settings. Pairing URLs carry the code in the **hash**, never the query.
 3. **Never put the session token in a URL.** The event stream is SSE and
    `EventSource` cannot set headers, so an authenticated `POST

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -192,7 +192,7 @@ It prints a 12-character code (single use, five minutes) and, when the
 server knows its public address (`OMB_PUBLIC_URL`, set by the Docker stack),
 a link like `https://maus.example.com/pair#code=XXXX-XXXX-XXXX`. Open the
 link, or open `/pair` on the address you use and type the code. The browser
-gets a session cookie (30 days, revocable) and the app loads. Sessions are
+gets a session cookie (30 days, renewed on use up to 180 days from pairing, revocable) and the app loads. Sessions are
 listed and revoked at `GET`/`DELETE /api/auth/sessions` for now; a Settings
 screen follows.
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -326,7 +326,7 @@ import {
   serializeSessionCookie,
   sessionCookieName,
 } from "./request-auth.ts";
-import { cookieMaxAgeSeconds, formatPairingCode, SESSION_TTL_MS, SessionRegistry, type Scope } from "./sessions.ts";
+import { cookieMaxAgeSeconds, formatPairingCode, SessionRegistry, type Scope } from "./sessions.ts";
 import { describeBrand, loadBrand } from "./brand.ts";
 import {
   PHONE_SECRET_PROTOCOL_VERSION,
@@ -7559,7 +7559,7 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
       const environment = environmentDescriptor({ environmentId: ENVIRONMENT_ID, desktopManaged: DESKTOP_MANAGED });
       if (wantsCookie) {
         const secure = requestOrigin(req)?.startsWith("https://") === true;
-        res.setHeader("set-cookie", serializeSessionCookie(SESSION_COOKIE, result.token, { secure, maxAgeSeconds: SESSION_TTL_MS / 1000 }));
+        res.setHeader("set-cookie", serializeSessionCookie(SESSION_COOKIE, result.token, { secure, maxAgeSeconds: cookieMaxAgeSeconds(result.session) }));
         return json(res, 200, { session: result.session, environment });
       }
       return json(res, 200, { token: result.token, session: result.session, environment });

--- a/server/index.ts
+++ b/server/index.ts
@@ -326,7 +326,7 @@ import {
   serializeSessionCookie,
   sessionCookieName,
 } from "./request-auth.ts";
-import { formatPairingCode, SESSION_TTL_MS, SessionRegistry, type Scope } from "./sessions.ts";
+import { cookieMaxAgeSeconds, formatPairingCode, SESSION_TTL_MS, SessionRegistry, type Scope } from "./sessions.ts";
 import { describeBrand, loadBrand } from "./brand.ts";
 import {
   PHONE_SECRET_PROTOCOL_VERSION,
@@ -7572,16 +7572,17 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
       loopbackMutationToken: desktopMutationToken,
       companionMutationToken,
     });
-    // A browser's cookie carries the term the session had when it was set.
-    // Once the server renews the session (sessions.ts, sliding expiry), the
-    // cookie is re-issued so the browser's copy does not lapse first. Sent
-    // once per renewal, not on every request.
+    // The browser's cookie carries the term it was set with, and the
+    // session's term slides on use (sessions.ts `renew`), so re-issue the
+    // cookie on every cookie-authenticated request. One small header; and
+    // unlike "send once per renewal" it survives a lost response and a
+    // restart. Later handlers that clear the cookie (logout, self-revoke)
+    // overwrite this header, which is the order we want.
     if (gate.auth?.kind === "session" && gate.auth.via === "cookie") {
-      const refresh = sessions.cookieRefreshSeconds(gate.auth.session.id);
       const presented = parseCookies(req.headers.cookie).get(SESSION_COOKIE);
-      if (refresh !== null && presented) {
+      if (presented) {
         const secure = requestOrigin(req)?.startsWith("https://") === true;
-        res.setHeader("set-cookie", serializeSessionCookie(SESSION_COOKIE, presented, { secure, maxAgeSeconds: refresh }));
+        res.setHeader("set-cookie", serializeSessionCookie(SESSION_COOKIE, presented, { secure, maxAgeSeconds: cookieMaxAgeSeconds(gate.auth.session) }));
       }
     }
     // Reachability probe, public: the phone races it across a server's

--- a/server/index.ts
+++ b/server/index.ts
@@ -322,6 +322,7 @@ import {
   requestOrigin,
   requestSource,
   resolveRequestAuth,
+  parseCookies,
   serializeSessionCookie,
   sessionCookieName,
 } from "./request-auth.ts";
@@ -7571,6 +7572,18 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
       loopbackMutationToken: desktopMutationToken,
       companionMutationToken,
     });
+    // A browser's cookie carries the term the session had when it was set.
+    // Once the server renews the session (sessions.ts, sliding expiry), the
+    // cookie is re-issued so the browser's copy does not lapse first. Sent
+    // once per renewal, not on every request.
+    if (gate.auth?.kind === "session" && gate.auth.via === "cookie") {
+      const refresh = sessions.cookieRefreshSeconds(gate.auth.session.id);
+      const presented = parseCookies(req.headers.cookie).get(SESSION_COOKIE);
+      if (refresh !== null && presented) {
+        const secure = requestOrigin(req)?.startsWith("https://") === true;
+        res.setHeader("set-cookie", serializeSessionCookie(SESSION_COOKIE, presented, { secure, maxAgeSeconds: refresh }));
+      }
+    }
     // Reachability probe, public: the phone races it across a server's
     // addresses before it has a session, and the tunnel verifier polls it.
     // A stranger learns only the app name; pid (the desktop boot probe keys

--- a/server/remote-sessions.test.ts
+++ b/server/remote-sessions.test.ts
@@ -232,6 +232,15 @@ describe("pairing", () => {
 
     const sameOrigin = await call("/api/bots", { headers: remote("10.0.0.4", { cookie, origin: `http://${REMOTE_HOST}` }) });
     expect(sameOrigin.status).toBe(200);
+    // Every cookie-authenticated response re-issues the cookie with the
+    // session's current remaining life (sliding expiry), never on a 401.
+    const refreshed = header(sameOrigin.headers, "set-cookie");
+    expect(refreshed.split(";")[0]).toBe(cookie);
+    expect(refreshed).toMatch(/Max-Age=\d+/);
+    expect(refreshed).toContain("HttpOnly");
+    const stranger = await call("/api/bots", { headers: remote("10.0.0.4", { cookie: `${cookie.split("=")[0]}=omb_sess_nope`, origin: `http://${REMOTE_HOST}` }) });
+    expect(stranger.status).toBe(401);
+    expect(header(stranger.headers, "set-cookie")).toBe("");
     const noOrigin = await call("/api/auth/session", { headers: remote("10.0.0.4", { cookie }) });
     expect(noOrigin.body).toMatchObject({ kind: "session", via: "cookie", label: "iPad in the kitchen" });
     const csrf = await call("/api/bots", { method: "POST", headers: remote("10.0.0.4", { cookie, origin: "https://evil.example" }), body: "{}" });

--- a/server/request-auth.test.ts
+++ b/server/request-auth.test.ts
@@ -22,7 +22,7 @@ import {
   serializeSessionCookie,
   sessionCookieName,
 } from "./request-auth.ts";
-import { SessionRegistry } from "./sessions.ts";
+import { SESSION_TTL_MS, SessionRegistry } from "./sessions.ts";
 
 function request(headers: Record<string, string>, method = "GET"): IncomingMessage {
   // SAFETY: the resolver reads only headers and method; a bare object is the whole contract here
@@ -189,6 +189,25 @@ describe("resolveRequestAuth", () => {
     const foreignOrigin = resolve({ host: "127.0.0.1:8799", origin: "https://evil.example" });
     expect(foreignOrigin.status).toBe(403);
     expect(foreignOrigin.error).toBe("forbidden: cross-origin request");
+  });
+
+  it("renews a session only for a request that passed the origin and scope checks", () => {
+    let clock = 1_700_000_000_000;
+    sessions = new SessionRegistry({ file: join(dir, "sessions.json"), now: () => clock });
+    const { code } = sessions.openPairing({ scopes: ["client"] });
+    const result = sessions.exchange({ code, label: "phone", source: "10.0.0.2" });
+    if (!result.ok) throw new Error(result.error);
+    const { token, session } = result;
+    clock += SESSION_TTL_MS / 2 + 1; // renewal is due from here on
+    const csrf = resolve({ host: "bots.example.com", cookie: `${cookieName}=${token}`, origin: "https://evil.example" }, "/api/bots", "POST");
+    expect(csrf.error).toBe("forbidden: cross-origin request");
+    expect(sessions.list()[0]?.expiresAt).toBe(session.expiresAt); // a rejected request is not use
+    const overScope = resolve({ authorization: `Bearer ${token}` }, "/api/bots", "POST");
+    expect(overScope.status).toBe(403);
+    expect(sessions.list()[0]?.expiresAt).toBe(session.expiresAt);
+    const ok = resolve({ host: "bots.example.com", cookie: `${cookieName}=${token}`, origin: "http://bots.example.com" });
+    expect(ok.auth?.kind).toBe("session");
+    expect(sessions.list()[0]?.expiresAt).toBe(clock + SESSION_TTL_MS);
   });
 
   it("requires the packaged desktop capability for public loopback mutations", () => {

--- a/server/request-auth.test.ts
+++ b/server/request-auth.test.ts
@@ -205,9 +205,17 @@ describe("resolveRequestAuth", () => {
     const overScope = resolve({ authorization: `Bearer ${token}` }, "/api/bots", "POST");
     expect(overScope.status).toBe(403);
     expect(sessions.list()[0]?.expiresAt).toBe(session.expiresAt);
+    const { ticket } = sessions.issueStreamTicket(session.id);
+    const stream = resolve({ host: "bots.example.com" }, `/api/events?ticket=${ticket}`);
+    expect(stream.auth?.kind === "session" && stream.auth.via).toBe("ticket");
+    expect(sessions.list()[0]?.expiresAt).toBe(session.expiresAt); // a stream alone is not use
     const ok = resolve({ host: "bots.example.com", cookie: `${cookieName}=${token}`, origin: "http://bots.example.com" });
     expect(ok.auth?.kind).toBe("session");
     expect(sessions.list()[0]?.expiresAt).toBe(clock + SESSION_TTL_MS);
+    clock += SESSION_TTL_MS + 1;
+    const expired = resolve({ host: "bots.example.com", cookie: `${cookieName}=${token}`, origin: "http://bots.example.com" });
+    expect(expired.status).toBe(401);
+    expect(sessions.list()).toEqual([]); // expired: gone, not renewed
   });
 
   it("requires the packaged desktop capability for public loopback mutations", () => {

--- a/server/request-auth.ts
+++ b/server/request-auth.ts
@@ -345,8 +345,11 @@ export function resolveRequestAuth(req: IncomingMessage, options: ResolveOptions
     if (!session.scopes.includes(needed)) {
       return deny(403, `forbidden: this session lacks the ${needed} scope`);
     }
-    // Only a request that passed both checks counts as use of the session.
-    options.sessions.renew(session.id);
+    // Only a request that passed both checks counts as use of the session,
+    // and only a request the client made itself: redeeming a stream ticket
+    // is the tail of an API call that already counted, and a stream left
+    // open unattended must not keep a session alive on its own.
+    if (via !== "ticket") options.sessions.renew(session.id);
     return { auth: { kind: "session", session, via, scopes: session.scopes }, status: 401, error: "" };
   }
 

--- a/server/request-auth.ts
+++ b/server/request-auth.ts
@@ -345,6 +345,8 @@ export function resolveRequestAuth(req: IncomingMessage, options: ResolveOptions
     if (!session.scopes.includes(needed)) {
       return deny(403, `forbidden: this session lacks the ${needed} scope`);
     }
+    // Only a request that passed both checks counts as use of the session.
+    options.sessions.renew(session.id);
     return { auth: { kind: "session", session, via, scopes: session.scopes }, status: 401, error: "" };
   }
 

--- a/server/sessions.test.ts
+++ b/server/sessions.test.ts
@@ -14,6 +14,7 @@ import {
   SESSION_TTL_MS,
   SessionRegistry,
   STREAM_TICKET_TTL_MS,
+  sessionTtlMs,
 } from "./sessions.ts";
 
 let dir: string;
@@ -142,11 +143,11 @@ describe("sessions", () => {
     expect(reloaded.authenticate("omb_sess_nope")).toBeNull();
   });
 
-  it("expires after 30 days and can be revoked", () => {
+  it("expires after 30 days without use and can be revoked", () => {
     const { token, session } = pair();
-    clock += SESSION_TTL_MS - 1;
-    expect(registry.authenticate(token)?.id).toBe(session.id);
-    clock += 2;
+    clock += SESSION_TTL_MS / 2 - 1;
+    expect(registry.authenticate(token)?.id).toBe(session.id); // before the halfway mark: no renewal
+    clock += SESSION_TTL_MS / 2 + 2;
     expect(registry.authenticate(token)).toBeNull();
     const other = pair("iPad");
     expect(registry.list().map((s) => s.label)).toEqual(["iPad"]);
@@ -165,6 +166,31 @@ describe("sessions", () => {
     registry.authenticate(token);
     expect(registry.list()[0]?.lastSeenAt).toBe(clock);
     expect(statSync(file()).mtimeMs).toBeGreaterThanOrEqual(before);
+  });
+
+  it("renews a session used past its halfway mark, and re-issues the cookie once", () => {
+    const { token, session } = pair();
+    expect(registry.cookieRefreshSeconds(session.id)).toBeNull(); // the exchange's cookie is current
+    clock += SESSION_TTL_MS / 2 - 60_000;
+    registry.authenticate(token);
+    expect(registry.list()[0]?.expiresAt).toBe(session.expiresAt); // not yet halfway: untouched
+    clock += 120_000;
+    expect(registry.authenticate(token)?.id).toBe(session.id);
+    expect(registry.list()[0]?.expiresAt).toBe(clock + SESSION_TTL_MS);
+    expect(registry.cookieRefreshSeconds(session.id)).toBe(SESSION_TTL_MS / 1000);
+    expect(registry.cookieRefreshSeconds(session.id)).toBeNull(); // sent once, then quiet
+    clock += SESSION_TTL_MS - 1;
+    expect(registry.authenticate(token)?.id).toBe(session.id); // alive well past the original term
+    const reloaded = new SessionRegistry({ file: file(), now: () => clock });
+    expect(reloaded.cookieRefreshSeconds(session.id)).not.toBeNull(); // a fresh process re-sends once
+  });
+
+  it("reads the term from OMB_SESSION_TTL_DAYS and falls back to 30 days", () => {
+    const month = 30 * 24 * 60 * 60_000;
+    expect(sessionTtlMs(undefined)).toBe(month);
+    expect(sessionTtlMs("7")).toBe(7 * 24 * 60 * 60_000);
+    expect(sessionTtlMs("0")).toBe(month);
+    expect(sessionTtlMs("soon")).toBe(month);
   });
 });
 

--- a/server/sessions.test.ts
+++ b/server/sessions.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -208,6 +208,23 @@ describe("sessions", () => {
     expect(registry.renew(session.id)).toBe(false); // at the cap: no further extension
     clock = cap + 1;
     expect(registry.authenticate(token)).toBeNull();
+  });
+
+  it("applies the cap to a session paired long before this version", () => {
+    const day = 24 * 60 * 60_000;
+    const old = {
+      id: "old-device", tokenHash: "0".repeat(64), label: "old laptop", scopes: ["admin"],
+      createdAt: clock - 160 * day, lastSeenAt: clock - day, expiresAt: clock + 15 * day,
+    };
+    const older = { ...old, id: "older-device", tokenHash: "1".repeat(64), createdAt: clock - 175 * day };
+    writeFileSync(file(), JSON.stringify({ version: 1, sessions: [old, older] }));
+    const loaded = new SessionRegistry({ file: file(), now: () => clock });
+    // 160 days in with 15 left: the cap allows 20, so the renewal reaches the cap, not a full term
+    expect(loaded.renew("old-device")).toBe(true);
+    expect(loaded.list()[0]?.expiresAt).toBe(old.createdAt + SESSION_MAX_AGE_MS);
+    // 175 days in with 15 left: the cap (5 days out) is already below the term it has; nothing is taken away
+    expect(loaded.renew("older-device")).toBe(false);
+    expect(loaded.list()[1]?.expiresAt).toBe(older.expiresAt);
   });
 
   it("reads whole days from the environment and falls back on anything else", () => {

--- a/server/sessions.test.ts
+++ b/server/sessions.test.ts
@@ -14,7 +14,9 @@ import {
   SESSION_TTL_MS,
   SessionRegistry,
   STREAM_TICKET_TTL_MS,
-  sessionTtlMs,
+  SESSION_MAX_AGE_MS,
+  cookieMaxAgeSeconds,
+  daysMs,
 } from "./sessions.ts";
 
 let dir: string;
@@ -143,11 +145,11 @@ describe("sessions", () => {
     expect(reloaded.authenticate("omb_sess_nope")).toBeNull();
   });
 
-  it("expires after 30 days without use and can be revoked", () => {
+  it("expires after 30 days and can be revoked", () => {
     const { token, session } = pair();
-    clock += SESSION_TTL_MS / 2 - 1;
-    expect(registry.authenticate(token)?.id).toBe(session.id); // before the halfway mark: no renewal
-    clock += SESSION_TTL_MS / 2 + 2;
+    clock += SESSION_TTL_MS - 1;
+    expect(registry.authenticate(token)?.id).toBe(session.id);
+    clock += 2;
     expect(registry.authenticate(token)).toBeNull();
     const other = pair("iPad");
     expect(registry.list().map((s) => s.label)).toEqual(["iPad"]);
@@ -168,29 +170,58 @@ describe("sessions", () => {
     expect(statSync(file()).mtimeMs).toBeGreaterThanOrEqual(before);
   });
 
-  it("renews a session used past its halfway mark, and re-issues the cookie once", () => {
+  it("renews a session with half its term or less left, and never revives an expired one", () => {
     const { token, session } = pair();
-    expect(registry.cookieRefreshSeconds(session.id)).toBeNull(); // the exchange's cookie is current
     clock += SESSION_TTL_MS / 2 - 60_000;
-    registry.authenticate(token);
-    expect(registry.list()[0]?.expiresAt).toBe(session.expiresAt); // not yet halfway: untouched
+    expect(registry.renew(session.id)).toBe(false); // more than half left: untouched
+    expect(registry.list()[0]?.expiresAt).toBe(session.expiresAt);
     clock += 120_000;
-    expect(registry.authenticate(token)?.id).toBe(session.id);
+    expect(registry.renew(session.id)).toBe(true);
     expect(registry.list()[0]?.expiresAt).toBe(clock + SESSION_TTL_MS);
-    expect(registry.cookieRefreshSeconds(session.id)).toBe(SESSION_TTL_MS / 1000);
-    expect(registry.cookieRefreshSeconds(session.id)).toBeNull(); // sent once, then quiet
+    expect(registry.renew(session.id)).toBe(false); // just renewed: nothing to do
     clock += SESSION_TTL_MS - 1;
     expect(registry.authenticate(token)?.id).toBe(session.id); // alive well past the original term
+    expect(registry.renew(session.id)).toBe(true);
     const reloaded = new SessionRegistry({ file: file(), now: () => clock });
-    expect(reloaded.cookieRefreshSeconds(session.id)).not.toBeNull(); // a fresh process re-sends once
+    expect(reloaded.list()[0]?.expiresAt).toBe(clock + SESSION_TTL_MS); // the renewal reached disk
+    const quiet = pair("iPad");
+    clock += SESSION_TTL_MS + 1;
+    expect(registry.renew(quiet.session.id)).toBe(false);
+    expect(registry.authenticate(quiet.token)).toBeNull();
   });
 
-  it("reads the term from OMB_SESSION_TTL_DAYS and falls back to 30 days", () => {
-    const month = 30 * 24 * 60 * 60_000;
-    expect(sessionTtlMs(undefined)).toBe(month);
-    expect(sessionTtlMs("7")).toBe(7 * 24 * 60 * 60_000);
-    expect(sessionTtlMs("0")).toBe(month);
-    expect(sessionTtlMs("soon")).toBe(month);
+  it("stops renewing at the absolute cap counted from pairing", () => {
+    const { token, session } = pair();
+    const cap = session.createdAt + SESSION_MAX_AGE_MS;
+    let last = session.expiresAt;
+    for (let i = 0; i < 20; i += 1) {
+      clock = last - SESSION_TTL_MS / 2; // exactly at the halfway mark, each time
+      registry.renew(session.id);
+      const now = registry.list()[0]?.expiresAt ?? 0;
+      expect(now).toBeLessThanOrEqual(cap);
+      expect(now).toBeGreaterThanOrEqual(last);
+      last = now;
+    }
+    expect(last).toBe(cap);
+    clock = cap - 1;
+    expect(registry.authenticate(token)?.id).toBe(session.id);
+    expect(registry.renew(session.id)).toBe(false); // at the cap: no further extension
+    clock = cap + 1;
+    expect(registry.authenticate(token)).toBeNull();
+  });
+
+  it("reads whole days from the environment and falls back on anything else", () => {
+    const day = 24 * 60 * 60_000;
+    expect(daysMs(undefined, 30)).toBe(30 * day);
+    expect(daysMs("7", 30)).toBe(7 * day);
+    for (const bad of ["0", "-1", "0.5", "soon", "1e308", "3651", ""]) expect(daysMs(bad, 30)).toBe(30 * day);
+    expect(daysMs("3650", 30)).toBe(3650 * day);
+  });
+
+  it("gives a cookie whole seconds, never less than one", () => {
+    expect(cookieMaxAgeSeconds({ expiresAt: 10_500 }, 0)).toBe(10);
+    expect(cookieMaxAgeSeconds({ expiresAt: 100 }, 0)).toBe(1);
+    expect(cookieMaxAgeSeconds({ expiresAt: 0 }, 5_000)).toBe(1);
   });
 });
 

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -4,8 +4,8 @@
 //
 // A pairing code is 12 characters from a 32-symbol alphabet with no 0/O/1/I
 // (60 bits), single use, five minutes. Exchanging it yields an opaque
-// session token (`omb_sess_…`, 256 bits) that lives 30 days; only its sha256
-// is stored. A stream ticket is a 5-minute single-use credential for the SSE
+// session token (`omb_sess_…`, 256 bits) that lives 30 days, renewed on use
+// up to 180 days from pairing (`renew`); only its sha256 is stored. A stream ticket is a 5-minute single-use credential for the SSE
 // endpoint, because EventSource cannot set headers. Failed exchanges are
 // counted per source: five in a minute lock that source out for ten.
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
@@ -318,7 +318,9 @@ export class SessionRegistry {
       scopes: [...pairing.scopes],
       createdAt: now,
       lastSeenAt: now,
-      expiresAt: now + SESSION_TTL_MS,
+      // The absolute cap applies from the first term, so a TTL configured
+      // longer than the cap does not hand out a session the cap forbids.
+      expiresAt: now + Math.min(SESSION_TTL_MS, SESSION_MAX_AGE_MS),
     };
     this.sessions.push(record);
     this.lastSeenWrites.set(record.id, now); // the exchange itself was the first sighting

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -19,15 +19,32 @@ export const SCOPES: readonly Scope[] = ["admin", "client"];
 export const PAIRING_CODE_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ";
 export const PAIRING_CODE_LENGTH = 12;
 export const PAIRING_CODE_TTL_MS = 5 * 60_000;
-/** How long a paired device stays signed in without being used. A session
- * used past its halfway mark is renewed for the full term (see
- * `authenticate`), so a device in regular use never has to pair again; one
- * that goes quiet lapses. OMB_SESSION_TTL_DAYS overrides the 30-day default. */
-export function sessionTtlMs(value: string | undefined): number {
+/** A whole number of days from an environment variable, as milliseconds.
+ * Anything that is not a whole number of days between 1 and 3650 falls back
+ * to the default rather than being clamped, so a typo is not silently
+ * turned into a policy. */
+export function daysMs(value: string | undefined, fallbackDays: number): number {
   const days = Number(value);
-  return Number.isFinite(days) && days > 0 ? days * 24 * 60 * 60_000 : 30 * 24 * 60 * 60_000;
+  const ok = Number.isInteger(days) && days >= 1 && days <= 3650;
+  return (ok ? days : fallbackDays) * 24 * 60 * 60_000;
 }
-export const SESSION_TTL_MS = sessionTtlMs(process.env.OMB_SESSION_TTL_DAYS);
+/** How long a session lives after its last renewal. A session used with half
+ * the term or less left is renewed for the full term again (see `renew`), so
+ * a device in regular use keeps working; one that goes quiet lapses.
+ * OMB_SESSION_TTL_DAYS overrides the 30-day default. */
+export const SESSION_TTL_MS = daysMs(process.env.OMB_SESSION_TTL_DAYS, 30);
+/** The most a session may live from the day it was paired, however often it
+ * is used. Renewal never pushes a session past this, so a stolen cookie has a
+ * bounded life and every device re-pairs occasionally. OMB_SESSION_MAX_DAYS
+ * overrides the 180-day default. */
+export const SESSION_MAX_AGE_MS = daysMs(process.env.OMB_SESSION_MAX_DAYS, 180);
+/** Renewal is due once half the term or less is left. */
+export const SESSION_RENEW_WHEN_LEFT_MS = SESSION_TTL_MS / 2;
+
+/** Max-Age for a cookie that should die with its session: whole seconds, at least one. */
+export function cookieMaxAgeSeconds(session: { expiresAt: number }, now = Date.now()): number {
+  return Math.max(1, Math.floor((session.expiresAt - now) / 1000));
+}
 export const STREAM_TICKET_TTL_MS = 5 * 60_000;
 /** Per-source slow-down only. A 60-bit code cannot be guessed online in
  * five minutes whatever the rate, so the lock exists to make noise visible,
@@ -147,10 +164,6 @@ export class SessionRegistry {
   private replays: Array<{ codeHash: string; attemptId: string; result: ExchangeResult; expiresAt: number }> = [];
   private readonly onRevoked = new Set<(sessionId: string) => void>();
   private lastSeenWrites = new Map<string, number>();
-  /** The expiry the browser's cookie was last issued with, per session, so a
-   * renewal can be noticed and the cookie re-sent exactly once. Memory only:
-   * after a restart every cookie session is refreshed on its next request. */
-  private cookieExpiry = new Map<string, number>();
   private readonly now: () => number;
   private readonly options: { file: string; now?: () => number };
 
@@ -209,7 +222,6 @@ export class SessionRegistry {
 
   private forget(sessionId: string): void {
     this.lastSeenWrites.delete(sessionId);
-    this.cookieExpiry.delete(sessionId);
     for (const [hash, ticket] of this.tickets) if (ticket.sessionId === sessionId) this.tickets.delete(hash);
     for (const listener of this.onRevoked) listener(sessionId);
   }
@@ -310,7 +322,6 @@ export class SessionRegistry {
     };
     this.sessions.push(record);
     this.lastSeenWrites.set(record.id, now); // the exchange itself was the first sighting
-    this.cookieExpiry.set(record.id, record.expiresAt); // the cookie the exchange hands out carries this term
     this.persist();
     const result: ExchangeResult = { ok: true, token, session: publicSession(record) };
     if (attemptId) this.replays.push({ codeHash: presented, attemptId, result, expiresAt: now + EXCHANGE_REPLAY_MS });
@@ -325,17 +336,6 @@ export class SessionRegistry {
     const now = this.now();
     const record = this.sessions.find((s) => sameDigest(s.tokenHash, hash));
     if (!record || record.expiresAt <= now) return null;
-    // Sliding expiry: a session used past its halfway mark is renewed for
-    // the full term. Only a still-valid session gets here, so nothing
-    // expired is ever revived, and the write happens at most once per
-    // half-term, so it adds nothing to the last-seen traffic below.
-    if (record.expiresAt - now <= SESSION_TTL_MS / 2) {
-      record.expiresAt = now + SESSION_TTL_MS;
-      record.lastSeenAt = now;
-      this.lastSeenWrites.set(record.id, now);
-      this.persist();
-      return record;
-    }
     const lastWrite = this.lastSeenWrites.get(record.id) ?? 0;
     if (now - lastWrite >= LAST_SEEN_WRITE_INTERVAL_MS) {
       record.lastSeenAt = now;
@@ -345,18 +345,24 @@ export class SessionRegistry {
     return record;
   }
 
-  /** Seconds a re-issued cookie should live, when the browser's copy is
-   * behind the record (the session was renewed since the cookie was last
-   * set, or this process has not seen the session yet). Null when the
-   * browser's cookie is already current, so ordinary requests carry no
-   * Set-Cookie. */
-  cookieRefreshSeconds(sessionId: string): number | null {
+  /** Sliding expiry. Called by the request gate once a request has passed
+   * the origin and scope checks (so a rejected request never extends
+   * anything): a still-valid session with half its term or less left is
+   * renewed for the full term, capped at SESSION_MAX_AGE_MS from pairing.
+   * Nothing expired is revived. Writes at most once per half-term, so it
+   * adds nothing to the last-seen traffic. Returns whether it renewed. */
+  renew(sessionId: string): boolean {
     const record = this.sessions.find((s) => s.id === sessionId);
-    if (!record) return null;
-    const known = this.cookieExpiry.get(sessionId);
-    if (known !== undefined && known >= record.expiresAt) return null;
-    this.cookieExpiry.set(sessionId, record.expiresAt);
-    return Math.max(1, Math.floor((record.expiresAt - this.now()) / 1000));
+    const now = this.now();
+    if (!record || record.expiresAt <= now) return false;
+    if (record.expiresAt - now > SESSION_RENEW_WHEN_LEFT_MS) return false;
+    const next = Math.min(now + SESSION_TTL_MS, record.createdAt + SESSION_MAX_AGE_MS);
+    if (next <= record.expiresAt) return false; // already at the absolute cap
+    record.expiresAt = next;
+    record.lastSeenAt = now;
+    this.lastSeenWrites.set(record.id, now);
+    this.persist();
+    return true;
   }
 
   /** Still valid right now (prunes expiry first). */

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -19,7 +19,15 @@ export const SCOPES: readonly Scope[] = ["admin", "client"];
 export const PAIRING_CODE_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ";
 export const PAIRING_CODE_LENGTH = 12;
 export const PAIRING_CODE_TTL_MS = 5 * 60_000;
-export const SESSION_TTL_MS = 30 * 24 * 60 * 60_000;
+/** How long a paired device stays signed in without being used. A session
+ * used past its halfway mark is renewed for the full term (see
+ * `authenticate`), so a device in regular use never has to pair again; one
+ * that goes quiet lapses. OMB_SESSION_TTL_DAYS overrides the 30-day default. */
+export function sessionTtlMs(value: string | undefined): number {
+  const days = Number(value);
+  return Number.isFinite(days) && days > 0 ? days * 24 * 60 * 60_000 : 30 * 24 * 60 * 60_000;
+}
+export const SESSION_TTL_MS = sessionTtlMs(process.env.OMB_SESSION_TTL_DAYS);
 export const STREAM_TICKET_TTL_MS = 5 * 60_000;
 /** Per-source slow-down only. A 60-bit code cannot be guessed online in
  * five minutes whatever the rate, so the lock exists to make noise visible,
@@ -139,6 +147,10 @@ export class SessionRegistry {
   private replays: Array<{ codeHash: string; attemptId: string; result: ExchangeResult; expiresAt: number }> = [];
   private readonly onRevoked = new Set<(sessionId: string) => void>();
   private lastSeenWrites = new Map<string, number>();
+  /** The expiry the browser's cookie was last issued with, per session, so a
+   * renewal can be noticed and the cookie re-sent exactly once. Memory only:
+   * after a restart every cookie session is refreshed on its next request. */
+  private cookieExpiry = new Map<string, number>();
   private readonly now: () => number;
   private readonly options: { file: string; now?: () => number };
 
@@ -197,6 +209,7 @@ export class SessionRegistry {
 
   private forget(sessionId: string): void {
     this.lastSeenWrites.delete(sessionId);
+    this.cookieExpiry.delete(sessionId);
     for (const [hash, ticket] of this.tickets) if (ticket.sessionId === sessionId) this.tickets.delete(hash);
     for (const listener of this.onRevoked) listener(sessionId);
   }
@@ -297,6 +310,7 @@ export class SessionRegistry {
     };
     this.sessions.push(record);
     this.lastSeenWrites.set(record.id, now); // the exchange itself was the first sighting
+    this.cookieExpiry.set(record.id, record.expiresAt); // the cookie the exchange hands out carries this term
     this.persist();
     const result: ExchangeResult = { ok: true, token, session: publicSession(record) };
     if (attemptId) this.replays.push({ codeHash: presented, attemptId, result, expiresAt: now + EXCHANGE_REPLAY_MS });
@@ -311,6 +325,17 @@ export class SessionRegistry {
     const now = this.now();
     const record = this.sessions.find((s) => sameDigest(s.tokenHash, hash));
     if (!record || record.expiresAt <= now) return null;
+    // Sliding expiry: a session used past its halfway mark is renewed for
+    // the full term. Only a still-valid session gets here, so nothing
+    // expired is ever revived, and the write happens at most once per
+    // half-term, so it adds nothing to the last-seen traffic below.
+    if (record.expiresAt - now <= SESSION_TTL_MS / 2) {
+      record.expiresAt = now + SESSION_TTL_MS;
+      record.lastSeenAt = now;
+      this.lastSeenWrites.set(record.id, now);
+      this.persist();
+      return record;
+    }
     const lastWrite = this.lastSeenWrites.get(record.id) ?? 0;
     if (now - lastWrite >= LAST_SEEN_WRITE_INTERVAL_MS) {
       record.lastSeenAt = now;
@@ -318,6 +343,20 @@ export class SessionRegistry {
       this.persist();
     }
     return record;
+  }
+
+  /** Seconds a re-issued cookie should live, when the browser's copy is
+   * behind the record (the session was renewed since the cookie was last
+   * set, or this process has not seen the session yet). Null when the
+   * browser's cookie is already current, so ordinary requests carry no
+   * Set-Cookie. */
+  cookieRefreshSeconds(sessionId: string): number | null {
+    const record = this.sessions.find((s) => s.id === sessionId);
+    if (!record) return null;
+    const known = this.cookieExpiry.get(sessionId);
+    if (known !== undefined && known >= record.expiresAt) return null;
+    this.cookieExpiry.set(sessionId, record.expiresAt);
+    return Math.max(1, Math.floor((record.expiresAt - this.now()) / 1000));
   }
 
   /** Still valid right now (prunes expiry first). */


### PR DESCRIPTION
## Why

A paired device's session ends exactly 30 days after pairing, however often it is used (`SESSION_TTL_MS` is applied once at exchange; `authenticate` only touches `lastSeenAt`). On a server that runs around the clock (the "Deploy on a VPS" setup) every laptop and the desktop app has to re-pair monthly even when opened daily.

## What

- **Sliding expiry** (`server/sessions.ts` `renew`): a still-valid session with half its term or less left is renewed to a full term. Nothing expired is revived; an existing term is never shortened. The write happens at most once per half-term, so it adds nothing to the last-seen traffic.
- **Renewal counts only real use** (`server/request-auth.ts`): `renew` runs after the origin and scope checks pass, so a cross-origin or over-scope request that gets a 403 does not extend anything. Redeeming a stream ticket does not count either: the API call that minted it already did, and a stream left open unattended must not keep a session alive on its own.
- **Absolute cap**: renewal never pushes a session past `SESSION_MAX_AGE_MS` from the day it was paired, and the first term is capped the same way (default 180 days, `OMB_SESSION_MAX_DAYS`). A stolen cookie has a bounded life and every device re-pairs occasionally. The number is a policy choice; happy to change the default.
- **Cookie follow-up** (`server/index.ts`): the browser's cookie carries the term it was set with, so every cookie-authenticated response re-issues it with the session's current remaining life (`Max-Age`), and the pairing response uses the same remaining-life rule. One small header; unlike "send once per renewal" it survives a lost response and a restart. Later handlers that clear the cookie (logout, self-revoke) overwrite it, which is the order we want. A 401 sends no cookie.
- **`OMB_SESSION_TTL_DAYS`** overrides the 30-day term. Both env values must be a whole number of days between 1 and 3650; anything else falls back to the default rather than being clamped.
- Docs (`apps/docs` VPS guide, `docs/deploy-vps.md`, `docs/self-hosting.md`, `docs/plans/remote-workspace.md`, the header of `sessions.ts`) now say what actually happens: 30 days, renewed on use, up to 180 days from pairing.

Known limit, unchanged by this PR: the `Secure` attribute on the re-issued cookie follows the same `X-Forwarded-Proto` rule as pairing. A proxy that drops that header already breaks the same-origin check on pairing, so nothing new is exposed, but it is the thing to look at if a browser's cookie ever lapses before the server's record.

## Tests

- `server/sessions.test.ts`: renewal at the halfway mark and not before, renewal persisted to disk, no revival of an expired session, the cap reached and held, an old `sessions.json` meeting the cap (renewed up to it, never shortened), env parsing (whole days, bounds, junk), cookie `Max-Age` as whole seconds.
- `server/request-auth.test.ts`: a cross-origin or over-scope request does not renew; a stream ticket does not; an expired token gets 401 and is gone; an accepted request renews.
- `server/remote-sessions.test.ts` (real server over HTTP): a cookie-authenticated `GET /api/bots` re-issues the cookie with `Max-Age` and `HttpOnly`; a 401 carries no cookie.
- `vitest run` on those three files: 48 passed. `tsc -p tsconfig.server.json --noEmit` clean. Node 24 / Ubuntu 24.04.

Written with Claude Code. Two review passes by other models (Codex, Grok) shaped it: renew after the checks and not on a stream ticket, no "send once", the cap at pairing as well as at renewal, env bounds, the docs wording. Run and read by a human who hit the 30-day wall on a home server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now renew during regular authenticated use when nearing expiration.
  * Sessions remain limited to 30 days at a time and a maximum of 180 days from pairing.
  * Session cookies now reflect the session’s current remaining lifetime.
  * Deployment settings can customize session duration and maximum lifetime.

* **Bug Fixes**
  * Stream-ticket authentication no longer extends session lifetime.
  * Expired or invalid session cookies are rejected correctly.

* **Documentation**
  * Updated self-hosting and deployment guidance to explain session renewal and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->