### PR TITLE
fix(updater): stop premature restarts and update loops (0.1.61)

### DIFF
--- a/apps/docs/content/docs/troubleshooting/updates.mdx
+++ b/apps/docs/content/docs/troubleshooting/updates.mdx
@@ -23,9 +23,19 @@ Reopen OpenMausBot once it finishes to be running the new version.
 
 Leave the app open long enough for one complete attempt, then quit and reopen it. A failed differential update should fall back to the full package. If the same release remains stuck, download the current installer from the [official releases page](https://github.com/milind-soni/OpenMausBot/releases/latest) and install it over the existing copy.
 
+On macOS, **Preparing update** is a separate step after the download finishes. macOS must stage the update before **Restart to update** becomes available. A completed download does not mean this preparation is finished.
+
+If an update fails, its error stays visible instead of being replaced by a background update check. If a restart is taking longer than expected, quit the app completely before trying again; repeatedly clicking Restart cannot speed it up.
+
 ## Restart to update does nothing
 
 Quit OpenMausBot completely and launch it again. If the version did not change, install the latest release manually. Your conversations and settings live outside the application bundle and are not removed by replacing the app.
+
+The installed version runs the updater, not the version being downloaded. If you are upgrading from an older build with a stuck updater, you may need to install the new version manually once to receive the fix. Do not delete your OpenMausBot data directory.
+
+## Report an update failure
+
+Open **App settings → General → Diagnostics → Export Diagnostics…**. Include your operating system, the currently installed version, the target version, and whether the failure happened during download, preparation, or restart. Newer builds include a bounded, redacted updater log alongside the server and desktop logs. Review the exported file before sharing it privately with support.
 
 ## No terminal opened
 

--- a/electron/diagnostics.mjs
+++ b/electron/diagnostics.mjs
@@ -1,5 +1,5 @@
 // One-click bug-report bundle: app facts, a safe config summary and the
-// server.log tail, formatted for pasting into a public issue. Formatting and
+// server/updater log tails, formatted for pasting into a public issue. Formatting and
 // bounded log reads live here so redaction and path safety stay unit-testable
 // without Electron; main.mjs owns the dialog plumbing. Safety is layered: the
 // collector never reads secret fields at all (only the server's booleans-only config status),
@@ -41,9 +41,10 @@ const CREDENTIAL_TOKEN_FORMATS = [
   /\bnpm_[A-Za-z0-9]{20,}/g,
 ];
 const KEY_VALUE_PAIR =
-  /\b([A-Za-z0-9_.-]*(?:api[_-]?key|apikey|secret|token|password|passwd|authorization|auth[_-]?token|access[_-]?key|private[_-]?key)s?)\s*[:=]\s*("[^"]*"|'[^']*'|[^\s"',;)\]}]+)/gi;
+  /\b([A-Za-z0-9_.-]*(?:api[_-]?key|apikey|secret|token|password|passwd|authorization|auth[_-]?token|access[_-]?key|private[_-]?key)s?)["']?\s*[:=]\s*("[^"]*"|'[^']*'|[^\s"',;)\]}]+)/gi;
 const AUTHORIZATION =
-  /\b(authorization)\s*[:=]\s*(?:"|')?([A-Za-z][A-Za-z0-9_-]*\s+[A-Za-z0-9._~+/=-]+)(?:"|')?/gi;
+  /\b(authorization)["']?\s*[:=]\s*(?:"|')?([A-Za-z][A-Za-z0-9_-]*\s+[A-Za-z0-9._~+/=-]+)(?:"|')?/gi;
+const COOKIE = /\b((?:set-)?cookie)["']?\s*[:=]\s*("[^"\r\n]*"|'[^'\r\n]*'|[^\r\n]+)/gi;
 const BEARER = /(\bbearer\s+)([A-Za-z0-9._~+/=-]{8,})/gi;
 const PEM_BLOCK =
   /(-----BEGIN [A-Z ]*PRIVATE KEY-----)[\s\S]*?(-----END [A-Z ]*PRIVATE KEY-----)/g;
@@ -57,14 +58,24 @@ const VALUE_PART = String.raw`("[^"]*"|'[^']*'|[^\s"',;)\]}]+)`;
 
 export function redactSecretsInLine(line) {
   let out = String(line ?? "");
+  // Updater HTTP errors include signed redirect URLs. Keep the host/path for
+  // diagnosis, but never export userinfo or any query/fragment, even when a
+  // provider gives its capability an unfamiliar or percent-encoded name.
+  out = out.replace(/\bhttps?:\/\/[^\s"'<>]+/gi, (url) => {
+    const query = url.search(/[?#]/);
+    const address = query < 0 ? url : url.slice(0, query);
+    return address.replace(/^(https?:\/\/)[^/]*@/i, "$1«redacted credentials»@")
+      + (query < 0 ? "" : "?«redacted URL parameters»");
+  });
   const alreadyMasked = (value) => String(value).includes("«redacted");
   for (const name of CREDENTIAL_ENV_NAMES) {
     out = out.replace(
-      new RegExp(`\\b(${name})\\s*[:=]\\s*${VALUE_PART}`, "gi"),
+      new RegExp(`\\b(${name})["']?\\s*[:=]\\s*${VALUE_PART}`, "gi"),
       (_match, key, value) => `${key}=${mask(unquote(value))}`,
     );
   }
   out = out.replace(AUTHORIZATION, (_match, key, value) => `${key}=${mask(value)}`);
+  out = out.replace(COOKIE, (_match, key, value) => `${key}=${mask(unquote(value))}`);
   out = out.replace(BEARER, (_match, lead, token) => `${lead}${mask(token)}`);
   out = out.replace(PEM_BLOCK, (_match, open, close) => `${open}«redacted private key»${close}`);
   out = out.replace(KEY_VALUE_PAIR, (_match, key, value) =>
@@ -264,6 +275,7 @@ export function buildDiagnosticsReport({
   appInfo = {},
   configSummary = {},
   desktopLogTail,
+  updaterLogTail,
   logTail,
   now = new Date().toISOString(),
 } = {}) {
@@ -300,6 +312,13 @@ export function buildDiagnosticsReport({
     for (const line of redactSecretsInLine(logTail).split(/\r?\n/)) lines.push(line);
   } else {
     lines.push("(server log unavailable)");
+  }
+  lines.push("");
+  lines.push("## Updater log tail — credentials and URL parameters auto-masked");
+  if (updaterLogTail && updaterLogTail.trim()) {
+    for (const line of redactSecretsInLine(updaterLogTail).split(/\r?\n/)) lines.push(line);
+  } else {
+    lines.push("(updater log unavailable)");
   }
   lines.push("");
   return lines.join("\n");

--- a/electron/diagnostics.test.mjs
+++ b/electron/diagnostics.test.mjs
@@ -60,6 +60,54 @@ describe("buildDiagnosticsReport", () => {
     expect(report).toContain("rooms.turnTimeoutMinutes=5");
     expect(report).toContain("(no desktop crash events available)");
     expect(report).toContain("(server log unavailable)");
+    expect(report).toContain("(updater log unavailable)");
+  });
+
+  it("includes updater diagnostics separately and redacts signed redirects and headers", () => {
+    const report = buildDiagnosticsReport({
+      appInfo,
+      logTail: "server ready",
+      updaterLogTail: [
+        "[info] Downloading version 0.1.61",
+        "[error] GET https://release-assets.example.test/update.zip?X-Amz-Credential=private-account&X-Amz-Signature=signed-secret&jwt=private-jwt HTTP 403",
+        'headers {"authorization":"Basic dXNlcjpwYXNzd29yZA==","apiKey":"opaque-private-key"}',
+        "Set-Cookie: session=private-session; Secure; HttpOnly",
+      ].join("\n"),
+    });
+    expect(report).toContain("## Updater log tail — credentials and URL parameters auto-masked");
+    expect(report).toContain("Downloading version 0.1.61");
+    expect(report).toContain("https://release-assets.example.test/update.zip?«redacted URL parameters» HTTP 403");
+    for (const secret of ["private-account", "signed-secret", "private-jwt", "dXNlcjpwYXNzd29yZA==", "opaque-private-key", "private-session"]) {
+      expect(report).not.toContain(secret);
+    }
+    expect(report.indexOf("server ready")).toBeLessThan(report.indexOf("Downloading version 0.1.61"));
+  });
+
+  it.each(["", null, undefined])("handles an absent updater log (%s)", (updaterLogTail) => {
+    expect(buildDiagnosticsReport({ appInfo, updaterLogTail })).toContain("(updater log unavailable)");
+  });
+
+  it("removes URL userinfo, fragments, and unfamiliar query capabilities without hiding public paths", () => {
+    const line = "GET https://private-user:private-password@updates.example.test/update.zip?%73ig=encoded-secret#fragment-secret\n"
+      + "GET https://updates.example.test/latest-mac.yml\n"
+      + "GET https://updates.example.test/update.zip#private-fragment";
+    const redacted = redactSecretsInLine(line);
+    expect(redacted).toContain("https://«redacted credentials»@updates.example.test/update.zip?«redacted URL parameters»");
+    expect(redacted).toContain("https://updates.example.test/latest-mac.yml");
+    for (const secret of ["private-user", "private-password", "encoded-secret", "fragment-secret", "private-fragment"]) {
+      expect(redacted).not.toContain(secret);
+    }
+  });
+
+  it("masks JSON credential fields and cookies in updater HTTP dumps", () => {
+    const redacted = redactSecretsInLine([
+      '{"OMB_COMPOSIO_BROKER_TOKEN":"opaque-broker-value","password":"opaque-password-value"}',
+      '{"Cookie":"session=private-cookie; tracking=private-tracker"}',
+      "Cookie: session=private-session; tracking=private-tracking",
+    ].join("\n"));
+    for (const secret of ["opaque-broker-value", "opaque-password-value", "private-cookie", "private-tracker", "private-session", "private-tracking"]) {
+      expect(redacted).not.toContain(secret);
+    }
   });
 
   it("includes privacy-safe desktop crash metadata separately from the server log", () => {
@@ -319,6 +367,25 @@ describe("decodeLogTail", () => {
 });
 
 describe("readSafeLogTail", () => {
+  it("exports only a bounded complete-line updater tail from an isolated log fixture", () => {
+    const directory = mkdtempSync(join(tmpdir(), "openmausbot-updater-diagnostics-"));
+    try {
+      const log = join(directory, "updater.log");
+      const tail = "[info] update staged\n[error] https://updates.example.test/app.zip?jwt=private-query-token\n";
+      writeFileSync(log, `${"old-private-line\n".repeat(20_000)}${tail}`, { mode: 0o600 });
+      const result = readSafeLogTail(log);
+      expect(result.bytes).toBeLessThanOrEqual(256 * 1024);
+      expect(result.tail.endsWith(tail)).toBe(true);
+      const report = buildDiagnosticsReport({ updaterLogTail: result.tail });
+      expect(report).toContain("[info] update staged");
+      expect(report).not.toContain("private-query-token");
+      expect(report).not.toContain(directory);
+      expect(readSafeLogTail(join(directory, "absent-updater.log"))).toBeNull();
+    } finally {
+      rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
   it("reads a bounded tail from a regular app-owned log", () => {
     const directory = mkdtempSync(join(tmpdir(), "openmausbot-log-tail-"));
     try {

--- a/electron/mac-updater.node-test.mjs
+++ b/electron/mac-updater.node-test.mjs
@@ -1,0 +1,210 @@
+// Exercise the shipped MacUpdater's real authenticated loopback ZIP proxy and
+// coordinator together. Only Electron's native updater is fake: no installed
+// app, signing identity, account, or live data is touched.
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { get } from "node:http";
+import Module, { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createUpdaterCoordinator } from "./updater-coordinator.mjs";
+import { patchMacUpdater } from "../scripts/patch-mac-updater.mjs";
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+function readHttp(url, headers) {
+  return new Promise((resolve, reject) => {
+    get(url, { headers, agent: false }, (response) => {
+      const bytes = [];
+      response.on("data", (chunk) => bytes.push(chunk));
+      response.on("error", reject);
+      response.on("end", () => resolve({ status: response.statusCode, body: Buffer.concat(bytes) }));
+    }).on("error", reject);
+  });
+}
+
+function harness(t, { fetchZip = true } = {}) {
+  const native = new EventEmitter();
+  const nativeCalled = deferred();
+  const transferred = deferred();
+  let feed;
+  let quitCalls = 0;
+  let downloads = 0;
+  let checks = 0;
+  native.setFeedURL = (value) => { feed = value; };
+  native.quitAndInstall = () => { quitCalls += 1; };
+  native.checkForUpdates = () => {
+    nativeCalled.resolve();
+    if (!fetchZip) return;
+    void (async () => {
+      // The real proxy still requires its random per-attempt credentials.
+      assert.equal((await readHttp(feed.url)).status, 401);
+      const metadata = await readHttp(feed.url, feed.headers);
+      assert.equal(metadata.status, 200);
+      const zip = await readHttp(JSON.parse(metadata.body).url);
+      assert.equal(zip.status, 200);
+      assert.equal(zip.body.toString(), "fixture ZIP bytes");
+      transferred.resolve();
+    })().catch(transferred.reject);
+  };
+  const originalLoad = Module._load;
+  Module._load = (name, ...args) => name === "electron" ? { autoUpdater: native } : originalLoad(name, ...args);
+  let updater;
+  try {
+    const { MacUpdater } = createRequire(import.meta.url)("./vendor/electron-updater.cjs");
+    updater = new MacUpdater(null, { version: "1.0.0", quit: () => assert.fail("unexpected app quit") });
+  } finally {
+    Module._load = originalLoad;
+  }
+  const warnings = [];
+  updater.logger = { info() {}, warn(message) { warnings.push(message); }, error() {}, debug() {} };
+  updater.autoInstallOnAppQuit = true;
+  const workspace = mkdtempSync(join(tmpdir(), "omb-native-stage-"));
+  const zip = join(workspace, "update.zip");
+  writeFileSync(zip, "fixture ZIP bytes");
+  t.after(async () => {
+    if (updater.server?.listening) {
+      await new Promise((resolve) => updater.server.close(resolve));
+    }
+    native.removeAllListeners();
+    rmSync(workspace, { recursive: true, force: true });
+  });
+  updater.downloadUpdate = () => {
+    downloads += 1;
+    return updater.updateDownloaded(
+      { info: { size: 17 }, url: new URL("https://fixture.invalid/update.zip") },
+      { version: "2.0.0", downloadedFile: zip },
+    );
+  };
+  updater.checkForUpdates = async () => { checks += 1; };
+  let state = { status: "idle" };
+  const states = [];
+  const coordinator = createUpdaterCoordinator(updater, (patch) => {
+    state = { ...state, ...patch };
+    states.push({ ...state });
+  }, { nativeStaging: true });
+  const timers = new Map();
+  const originalTimeout = globalThis.setTimeout;
+  t.mock.method(globalThis, "setTimeout", (callback, delay, ...args) => {
+    if (delay !== 120_000 && delay !== 300_000) return originalTimeout(callback, delay, ...args);
+    const timer = { unref() {} };
+    timers.set(delay, { callback, timer });
+    return timer;
+  });
+  const originalClear = globalThis.clearTimeout;
+  t.mock.method(globalThis, "clearTimeout", (timer) => {
+    for (const [delay, pending] of timers) {
+      if (pending.timer === timer) { timers.delete(delay); return; }
+    }
+    originalClear(timer);
+  });
+  return {
+    native, updater, coordinator, states, timers, nativeCalled, transferred, warnings,
+    state: () => state,
+    calls: () => ({ downloads, checks, quitCalls }),
+  };
+}
+
+test("real Mac ZIP transfer stays preparing until native ready; restart is single-flight", async (t) => {
+  const h = harness(t);
+  const download = h.coordinator.download();
+  await h.transferred.promise;
+  assert.equal(h.state().status, "preparing");
+  assert.equal(h.updater.squirrelDownloadedUpdate, false);
+  h.coordinator.install();
+  await h.coordinator.download();
+  await h.coordinator.check(true);
+  assert.deepEqual(h.calls(), { downloads: 1, checks: 0, quitCalls: 0 });
+  const waitingListeners = h.native.listenerCount("update-downloaded");
+  assert.throws(() => h.updater.quitAndInstall(), /not ready/);
+  assert.equal(h.native.listenerCount("update-downloaded"), waitingListeners, "premature Restart never arms a future quit");
+
+  h.native.emit("update-downloaded");
+  await download;
+  assert.equal(h.state().status, "downloaded");
+  assert.equal(h.updater.squirrelDownloadedUpdate, true);
+  assert.equal(h.native.listenerCount("update-downloaded"), 1, "temporary staging listener was removed");
+  assert.equal(h.timers.has(300_000), false);
+  h.coordinator.install();
+  h.timers.get(120_000).callback();
+  assert.equal(h.state().status, "installing");
+  assert.match(h.state().message, /Quit and reopen/);
+  assert.ok(h.warnings.some((message) => /restart handoff exceeded/.test(message)));
+  h.coordinator.install();
+  await h.coordinator.download();
+  await h.coordinator.check(true);
+  h.native.emit("update-downloaded");
+  assert.deepEqual(h.calls(), { downloads: 1, checks: 0, quitCalls: 1 });
+  t.diagnostic("ZIP transferred -> preparing (0 quits) -> native ready -> downloaded -> one restart; watchdog and late ready cannot repeat it");
+});
+
+test("a native staging deadline fails visibly without retrying or reviving on late readiness", async (t) => {
+  const h = harness(t, { fetchZip: false });
+  const download = h.coordinator.download();
+  await h.nativeCalled.promise;
+  assert.equal(h.state().status, "preparing");
+  h.timers.get(300_000).callback();
+  assert.equal(h.state().status, "error");
+  assert.equal(h.state().retryable, false);
+  assert.match(h.state().message, /took too long.*Quit and reopen/);
+  assert.ok(h.warnings.some((message) => /preparation exceeded/.test(message)));
+  const failed = h.state();
+  await h.coordinator.download();
+  await h.coordinator.check(true);
+  h.coordinator.install();
+  h.native.emit("update-downloaded");
+  await download;
+  h.updater.emit("download-progress", { percent: 100 });
+  h.updater.emit("update-downloaded", { version: "9.0.0" });
+  assert.deepEqual(h.state(), failed);
+  assert.deepEqual(h.calls(), { downloads: 1, checks: 0, quitCalls: 0 });
+  assert.equal(h.native.listenerCount("update-downloaded"), 1);
+  t.diagnostic("native never fetches ZIP -> deadline/error/retryable=false; late native ready keeps error and causes zero quits");
+});
+
+test("native validation errors after ZIP transfer remain visible and clean up staging listeners", async (t) => {
+  const h = harness(t);
+  const download = h.coordinator.download();
+  await h.transferred.promise;
+  h.native.emit("error", new Error("signature validation failed"));
+  await download;
+  assert.equal(h.state().status, "error");
+  assert.equal(h.state().retryable, false);
+  assert.match(h.state().message, /signature validation failed.*Quit and reopen/);
+  assert.equal(h.states.filter((s) => s.status === "error").length, 1);
+  assert.equal(h.native.listenerCount("error"), 1);
+  assert.equal(h.native.listenerCount("update-downloaded"), 1);
+  assert.equal(h.timers.has(300_000), false);
+  const failed = h.state();
+  await h.coordinator.download();
+  await h.coordinator.check(true);
+  h.coordinator.install();
+  h.native.emit("update-downloaded");
+  assert.deepEqual(h.state(), failed);
+  assert.deepEqual(h.calls(), { downloads: 1, checks: 0, quitCalls: 0 });
+});
+
+test("a late native error after readiness is not silently routed as a background check", async (t) => {
+  const h = harness(t);
+  const download = h.coordinator.download();
+  await h.transferred.promise;
+  h.native.emit("update-downloaded");
+  await download;
+  h.native.emit("error", new Error("native stage lost"));
+  assert.equal(h.state().status, "error");
+  assert.equal(h.state().retryable, false);
+  assert.match(h.state().message, /native stage lost/);
+  h.coordinator.install();
+  assert.equal(h.calls().quitCalls, 0);
+});
+
+test("Mac vendor patch fails closed on an unknown upstream shape", () => {
+  assert.throws(() => patchMacUpdater("not the pinned MacUpdater"), /one Mac updater site to patch, found 0/);
+});

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -834,6 +834,7 @@ async function gatherDiagnostics() {
   const logPath = path.join(LOG_DIR, "server.log");
   const log = readSafeLogTail(logPath);
   const desktopLog = readSafeLogTail(DESKTOP_CRASH_LOG);
+  const updaterLog = readSafeLogTail(path.join(LOG_DIR, "updater.log"));
   return buildDiagnosticsReport({
     appInfo: {
       version: app.getVersion(),
@@ -846,6 +847,7 @@ async function gatherDiagnostics() {
     },
     configSummary: serverStatus ?? {},
     desktopLogTail: desktopLog?.tail ?? "",
+    updaterLogTail: updaterLog?.tail ?? "",
     logTail: log?.tail ?? "",
   });
 }

--- a/electron/updater-coordinator.mjs
+++ b/electron/updater-coordinator.mjs
@@ -4,27 +4,46 @@
 // chat app must not run dpkg itself. Everything before the install is shared.
 // It receives the staged paths and resolves with an optional state patch
 // describing what is left to do, which the card renders.
-export function createUpdaterCoordinator(updater, setState, { handOffInstall = null } = {}) {
+export function createUpdaterCoordinator(updater, setState, { handOffInstall = null, nativeStaging = false } = {}) {
   let checkOperation = null;
   // Set from downloadUpdate's resolution: the paths electron-updater staged.
   // Only the hand-off needs them; quitAndInstall reads its own copy.
   let downloadedFiles = null;
   let downloadOperation = null;
   let installOperation = null;
+  let nativeStagingStarted = false;
+  let nativeReady = false;
+  // Squirrel has no cancellation or attempt ID. After a staging failure a
+  // second attempt could consume the first attempt's late ready event.
+  let recoveryRequired = false;
   // A staged update, install hand-off, or failed user action remains useful
   // until the user acts again. Hourly checks must not replace its controls.
   let actionOwnsState = false;
   const routedErrors = new WeakSet();
 
   const routeError = (manual, error) => {
+    if (recoveryRequired) return;
     actionOwnsState = manual;
     if (error instanceof Error) routedErrors.add(error);
-    if (downloadOperation) downloadOperation.failed = true;
+    if (downloadOperation) {
+      downloadOperation.failed = true;
+      clearTimeout(downloadOperation.timer);
+    }
     if (checkOperation) checkOperation.failed = true;
     if (installOperation) {
       installOperation.failed = true;
       clearTimeout(installOperation.timer);
       installOperation = null;
+    }
+    if (nativeStagingStarted) {
+      recoveryRequired = true;
+      nativeReady = false;
+      setState({
+        status: "error",
+        retryable: false,
+        message: `${String(error?.message ?? error)} Quit and reopen OpenMausBot before trying the update again.`,
+      });
+      return;
     }
     if (!manual) {
       setState({ status: "idle" });
@@ -39,7 +58,7 @@ export function createUpdaterCoordinator(updater, setState, { handOffInstall = n
   }
 
   function checkOwnsState() {
-    return !actionOwnsState && !installOperation && !downloadOperation && !checkOperation?.supersededByDownload;
+    return !recoveryRequired && !actionOwnsState && !installOperation && !downloadOperation && !checkOperation?.supersededByDownload;
   }
 
   updater.on("checking-for-update", () => {
@@ -61,26 +80,39 @@ export function createUpdaterCoordinator(updater, setState, { handOffInstall = n
     // Shared error events do not identify their operation. If a download
     // overtook a check, let their individual promises route failures instead.
     if (checkOperation?.supersededByDownload && !installOperation) return;
-    const manual = Boolean(installOperation || downloadOperation || checkOperation?.manual);
+    const manual = Boolean(installOperation || downloadOperation || checkOperation?.manual || nativeStagingStarted);
     routeError(manual, error);
   });
-  updater.on("download-progress", (progress) =>
-    setState({ status: "downloading", percent: Math.round(progress?.percent ?? 0) }),
-  );
+  updater.on("download-progress", (progress) => {
+    if (recoveryRequired || installOperation || nativeStagingStarted) return;
+    setState({ status: "downloading", percent: Math.round(progress?.percent ?? 0) });
+  });
   updater.on("update-downloaded", (info) => {
+    if (recoveryRequired || installOperation) return;
     // On macOS electron-updater emits this before Squirrel.Mac has finished
-    // staging the ZIP. Keep the UI in downloading until downloadUpdate's
-    // promise resolves, which is the point the native updater is ready.
+    // staging the ZIP. Our vendor patch resolves downloadUpdate only on the
+    // native ready event, not merely when the local ZIP transfer finishes.
     if (downloadOperation) {
       downloadOperation.downloadedInfo = info;
+      if (nativeStaging && !nativeStagingStarted) {
+        nativeStagingStarted = true;
+        setState({ status: "preparing", version: info?.version, message: undefined });
+        downloadOperation.timer = setTimeout(() => {
+          updater.logger?.warn?.("Native update preparation exceeded the five-minute deadline; restart is required before retrying.");
+          routeError(true, new Error("Preparing the update took too long."));
+        }, 5 * 60 * 1000);
+        downloadOperation.timer.unref?.();
+      }
       return;
     }
+    // No native attempt may become actionable from an uncorrelated late event.
+    if (nativeStaging) return;
     actionOwnsState = true;
     setState({ status: "downloaded", version: info?.version });
   });
 
   function check(manual = false) {
-    if (installOperation || (!manual && actionOwnsState)) return Promise.resolve();
+    if (recoveryRequired || installOperation || (nativeStaging && (downloadOperation || nativeStagingStarted)) || (!manual && actionOwnsState)) return Promise.resolve();
     if (checkOperation) {
       // A manual caller upgrades the shared operation; a timer never downgrades it.
       if (manual) checkOperation.manual = true;
@@ -107,10 +139,11 @@ export function createUpdaterCoordinator(updater, setState, { handOffInstall = n
   }
 
   function download() {
+    if (recoveryRequired || installOperation || nativeStagingStarted) return Promise.resolve();
     if (checkOperation) checkOperation.supersededByDownload = true;
     if (downloadOperation) return downloadOperation.promise;
 
-    const operation = { downloadedInfo: null, failed: false, promise: null };
+    const operation = { downloadedInfo: null, failed: false, promise: null, timer: null };
     downloadOperation = operation;
     // Own the state before the request goes out: the first "download-progress"
     // can be seconds away (connection setup, redirects), and until then the
@@ -124,6 +157,7 @@ export function createUpdaterCoordinator(updater, setState, { handOffInstall = n
             downloadedFiles = Array.isArray(result) ? result.filter((file) => typeof file === "string") : null;
           }
           if (!operation.failed && operation.downloadedInfo) {
+            nativeReady = nativeStaging;
             actionOwnsState = true;
             setState({ status: "downloaded", version: operation.downloadedInfo?.version });
           }
@@ -131,6 +165,7 @@ export function createUpdaterCoordinator(updater, setState, { handOffInstall = n
         })
         .catch((error) => handleRejectedOperation(true, error))
         .finally(() => {
+          clearTimeout(operation.timer);
           if (downloadOperation === operation) downloadOperation = null;
         });
     } catch (error) {
@@ -142,7 +177,7 @@ export function createUpdaterCoordinator(updater, setState, { handOffInstall = n
   }
 
   function install() {
-    if (installOperation) return;
+    if (recoveryRequired || installOperation || downloadOperation || (nativeStaging && !nativeReady)) return;
     actionOwnsState = true;
     if (handOffInstall) {
       handOff();
@@ -157,13 +192,13 @@ export function createUpdaterCoordinator(updater, setState, { handOffInstall = n
       routeError(true, error);
       return;
     }
-    // quitAndInstall is void. If neither a quit nor an updater error arrives,
-    // recover the UI instead of spinning for the lifetime of the process.
+    // quitAndInstall is void and cannot be canceled. A slow handoff must stay
+    // busy: exposing Retry here used to arm another native quit callback.
     if (installOperation === operation) {
       operation.timer = setTimeout(() => {
         if (installOperation !== operation) return;
-        installOperation = null;
-        setState({ status: "error", message: "The update could not be staged. Quit the app and try again." });
+        updater.logger?.warn?.("Update restart handoff exceeded two minutes; keeping installation locked to prevent overlapping retries.");
+        setState({ status: "installing", message: "Restart is taking longer than expected. Quit and reopen OpenMausBot to finish the update." });
       }, 2 * 60 * 1000);
       operation.timer.unref?.();
     }

--- a/electron/updater-coordinator.node-test.mjs
+++ b/electron/updater-coordinator.node-test.mjs
@@ -145,7 +145,7 @@ test("download reports downloading before the first progress event", async () =>
   await download;
 });
 
-test("downloaded waits for native staging to finish before becoming actionable", async () => {
+test("downloaded waits for the updater download promise before becoming actionable", async () => {
   const { updater, coordinator, getState } = harness();
   const pending = deferred();
   updater.downloadUpdate = () => pending.promise;
@@ -157,6 +157,58 @@ test("downloaded waits for native staging to finish before becoming actionable",
   pending.resolve(["update.zip"]);
   await download;
   assert.deepEqual(getState(), { status: "downloaded", version: "2.0.0" });
+});
+
+test("Mac transfer failures cannot overlap a pending download and remain retryable after it settles", async () => {
+  const h = harness({ nativeStaging: true });
+  const pending = deferred();
+  let calls = 0;
+  h.updater.downloadUpdate = () => { calls += 1; return pending.promise; };
+  h.updater.checkForUpdates = () => assert.fail("a check cannot overlap a Mac download");
+  h.updater.quitAndInstall = () => assert.fail("an incomplete transfer cannot install");
+  const first = h.coordinator.download();
+  const failure = new Error("connection lost before ZIP completed");
+  h.updater.emit("error", failure);
+  assert.equal(h.getState().status, "error");
+  assert.notEqual(h.getState().retryable, false);
+  assert.strictEqual(h.coordinator.download(), first);
+  await h.coordinator.check(true);
+  h.coordinator.install();
+  assert.equal(calls, 1);
+  pending.reject(failure);
+  await first;
+
+  h.updater.downloadUpdate = async () => {
+    calls += 1;
+    h.updater.emit("update-downloaded", { version: "2.0.0" });
+    return ["update.zip"];
+  };
+  await h.coordinator.download();
+  assert.equal(calls, 2);
+  assert.equal(h.getState().status, "downloaded");
+});
+
+test("a restart watchdog keeps Windows/AppImage installs locked against overlapping retries", async (t) => {
+  const h = harness();
+  let quits = 0;
+  let watchdog;
+  t.mock.method(globalThis, "setTimeout", (callback, delay) => {
+    assert.equal(delay, 120_000);
+    watchdog = callback;
+    return { unref() {} };
+  });
+  h.updater.quitAndInstall = () => { quits += 1; };
+  h.updater.checkForUpdates = () => assert.fail("install still owns the updater");
+  await downloadInto(h);
+  h.coordinator.install();
+  watchdog();
+  h.updater.downloadUpdate = () => assert.fail("a retry must not overlap a slow installer");
+  await h.coordinator.download();
+  await h.coordinator.check(true);
+  h.coordinator.install();
+  assert.equal(h.getState().status, "installing");
+  assert.match(h.getState().message, /Quit and reopen/);
+  assert.equal(quits, 1);
 });
 
 test("an asynchronous native install error escapes the restarting spinner", () => {

--- a/electron/updater.mjs
+++ b/electron/updater.mjs
@@ -24,7 +24,7 @@ const require = createRequire(import.meta.url);
 
 let autoUpdater = null;
 let win = null;
-// status: idle | checking | available | downloading | downloaded | installing | error
+// status: idle | checking | available | downloading | preparing | downloaded | installing | handed-off | error
 let state = { status: "idle" };
 let updaterCoordinator = null;
 
@@ -117,6 +117,7 @@ export function startUpdater() {
   setState({ installMode: handOff ? "handoff" : "restart" });
   updaterCoordinator = createUpdaterCoordinator(autoUpdater, setState, {
     handOffInstall: handOff ? handOffDownloadedPackage(packageType) : null,
+    nativeStaging: process.platform === "darwin",
   });
 
   // first check ~15s after launch (let the app settle), then hourly — both

--- a/electron/updater.test.mjs
+++ b/electron/updater.test.mjs
@@ -54,7 +54,7 @@ it("sends updater progress to a reopened window without restarting the updater",
 
   expect(first.webContents.send).not.toHaveBeenCalled();
   expect(reopened.webContents.send.mock.calls.map(([, state]) => state.status))
-    .toEqual(["downloading", "downloading", "downloaded"]);
+    .toEqual(["downloading", "downloading", ...(process.platform === "darwin" ? ["preparing"] : []), "downloaded"]);
   expect(handlers.get("update:get-state")(localEvent)).toMatchObject({ status: "downloaded", version: "2.0.0" });
   expect(updater.on.mock.calls).toHaveLength(listenerCount);
   expect(vi.getTimerCount()).toBe(timerCount);

--- a/electron/vendor-updater.node-test.mjs
+++ b/electron/vendor-updater.node-test.mjs
@@ -1,10 +1,11 @@
 // The vendored electron-updater bundle is a build artifact, but it is also the
-// code that actually runs in the packaged app. These tests pin the one
-// behaviour we deliberately changed in it: an AppImage update must land on the
-// path the user launches, never a new versioned filename.
+// code that actually runs in the packaged app. An AppImage update must land on
+// the path the user launches and wait for the old desktop to exit before it
+// starts the replacement.
 //
 // See scripts/patch-appimage-updater.mjs for the reasoning.
 import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import {
   existsSync,
@@ -22,6 +23,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import { patchAppImageUpdater } from "../scripts/patch-appimage-updater.mjs";
+import { acquireDataDirLease } from "./data-dir-lease.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const bundle = readFileSync(join(root, "electron/vendor/electron-updater.cjs"), "utf8");
@@ -48,7 +50,7 @@ test("an AppImage update can never be written to a different filename", () => {
   assert.doesNotMatch(bundle, renamePattern);
 });
 
-// The shape of the three sites the patch rewrites, as esbuild emits them.
+// The shape of the sites the patch rewrites, as esbuild emits them.
 const UPSTREAM = [
   "        (0, fs_1.unlinkSync)(appImageFile);",
   "        let destination;",
@@ -60,6 +62,7 @@ const UPSTREAM = [
   "          destination = path2.join(path2.dirname(appImageFile), path2.basename(installerPath));",
   "        }",
   '        (0, child_process_1.execFileSync)("mv", ["-f", installerPath, destination]);',
+  '        this.spawnLog(destination, [], env);',
 ].join("\n");
 
 test("the patch keeps the running path and never deletes ahead of the rename", () => {
@@ -70,6 +73,8 @@ test("the patch keeps the running path and never deletes ahead of the rename", (
   assert.doesNotMatch(patched, /unlinkSync\)\(appImageFile\)/);
   assert.match(patched, /mv", \["-f", installerPath, stagedDestination\]/);
   assert.match(patched, /renameSync\)\(stagedDestination, destination\)/);
+  assert.match(patched, /app\.relaunch\(\{ execPath: destination, args: \[\] \}\)/);
+  assert.doesNotMatch(patched, /this\.spawnLog\(destination/);
 });
 
 test("the patch tolerates esbuild renaming the path import", () => {
@@ -86,14 +91,21 @@ test("the patch fails closed when upstream's shape moves", () => {
     ["no rename branch", UPSTREAM.replace(/destination = path2\.join[^;]+;/, "destination = elsewhere;")],
     ["no early unlink", UPSTREAM.replace("        (0, fs_1.unlinkSync)(appImageFile);\n", "")],
     ["no move", UPSTREAM.replace(/\(0, child_process_1\.execFileSync\)\("mv"[^;]+;/, "")],
+    ["no immediate relaunch", UPSTREAM.replace("this.spawnLog(destination, [], env);", "")],
     ["two rename branches", `${UPSTREAM}\n${UPSTREAM}`],
   ]) {
     assert.throws(() => patchAppImageUpdater(mutated), /to patch, found/, label);
   }
 });
 
-test("the shipped installer moves the update onto the running AppImage's path", (t) => {
-  const electron = { app: {}, autoUpdater: new EventEmitter() };
+test("the shipped installer replaces the AppImage and queues its original path for relaunch", (t) => {
+  let relaunched = null;
+  let relaunchEnvironment = null;
+  const electron = { app: { relaunch(options) {
+    relaunched = options;
+    relaunchEnvironment = { appImage: process.env.APPIMAGE, silent: process.env.APPIMAGE_SILENT_INSTALL };
+    return true;
+  } }, autoUpdater: new EventEmitter() };
   const load = Module._load;
   Module._load = (request, ...rest) => (request === "electron" ? electron : load(request, ...rest));
   t.after(() => {
@@ -102,7 +114,8 @@ test("the shipped installer moves the update onto the running AppImage's path", 
 
   const { AppImageUpdater } = createRequire(import.meta.url)("./vendor/electron-updater.cjs");
   const workspace = mkdtempSync(join(tmpdir(), "omb-appimage-install-"));
-  t.after(() => rmSync(workspace, { recursive: true, force: true }));
+  const lease = acquireDataDirLease(join(workspace, "data"));
+  t.after(() => { lease.release(); rmSync(workspace, { recursive: true, force: true }); });
 
   // The user launches a versioned filename — the case upstream renames.
   const launched = join(workspace, "OpenMausBot-0.1.43-x86_64.AppImage");
@@ -112,6 +125,7 @@ test("the shipped installer moves the update onto the running AppImage's path", 
   writeFileSync(staged, "new", { mode: 0o755 });
 
   const previous = process.env.APPIMAGE;
+  const previousSilent = process.env.APPIMAGE_SILENT_INSTALL;
   process.env.APPIMAGE = launched;
   t.after(() => {
     if (previous === undefined) delete process.env.APPIMAGE;
@@ -119,25 +133,65 @@ test("the shipped installer moves the update onto the running AppImage's path", 
   });
 
   const renames = [];
-  let relaunched = null;
   AppImageUpdater.prototype.doInstall.call(
     {
       installerPath: staged,
       _logger: { info() {}, warn() {}, error() {}, debug() {} },
       dispatchError: (error) => assert.fail(error),
       emit: (event, value) => renames.push([event, value]),
-      spawnLog: (target) => {
-        relaunched = target;
-      },
+      spawnLog: () => assert.fail("the replacement must not start before desktop shutdown"),
     },
     { isForceRunAfter: true },
   );
 
   assert.equal(readFileSync(launched, "utf8"), "new", "the update must land on the launched path");
   assert.equal(existsSync(staged), false, "the staged download must be consumed");
-  assert.deepEqual(readdirSync(workspace).sort(), ["OpenMausBot-0.1.43-x86_64.AppImage", "pending"]);
-  assert.equal(relaunched, launched, "the relaunch must use the path the launcher points at");
+  assert.deepEqual(readdirSync(workspace).sort(), ["OpenMausBot-0.1.43-x86_64.AppImage", "data", "pending"]);
+  assert.deepEqual(relaunched, { execPath: launched, args: [] });
+  assert.deepEqual(relaunchEnvironment, { appImage: launched, silent: "true" });
+  assert.equal(process.env.APPIMAGE_SILENT_INSTALL, previousSilent, "the old process keeps its environment");
+  assert.throws(() => acquireDataDirLease(join(workspace, "data")), /already using this data directory/);
   assert.deepEqual(renames, [], "no filename change means no appimage-filename-updated event");
+});
+
+test("a rejected AppImage relaunch is reported without quitting the desktop", (t) => {
+  const electron = { app: { relaunch: () => false }, autoUpdater: new EventEmitter() };
+  const load = Module._load;
+  Module._load = (request, ...rest) => request === "electron" ? electron : load(request, ...rest);
+  t.after(() => { Module._load = load; });
+  const { AppImageUpdater, BaseUpdater } = createRequire(import.meta.url)("./vendor/electron-updater.cjs");
+  const workspace = mkdtempSync(join(tmpdir(), "omb-appimage-relaunch-failed-"));
+  t.after(() => rmSync(workspace, { recursive: true, force: true }));
+  const launched = join(workspace, "OpenMausBot.AppImage");
+  const staged = join(workspace, "pending.AppImage");
+  writeFileSync(launched, "old");
+  writeFileSync(staged, "new");
+  const previous = process.env.APPIMAGE;
+  const previousSilent = process.env.APPIMAGE_SILENT_INSTALL;
+  process.env.APPIMAGE = launched;
+  process.env.APPIMAGE_SILENT_INSTALL = "previous";
+  t.after(() => {
+    if (previous === undefined) delete process.env.APPIMAGE;
+    else process.env.APPIMAGE = previous;
+    if (previousSilent === undefined) delete process.env.APPIMAGE_SILENT_INSTALL;
+    else process.env.APPIMAGE_SILENT_INSTALL = previousSilent;
+  });
+  const errors = [];
+  const updater = {
+    installerPath: staged,
+    downloadedUpdateHelper: { downloadedFileInfo: {} },
+    _logger: { info() {}, warn() {}, error() {} },
+    dispatchError: (error) => errors.push(error.message),
+    emit() {},
+    doInstall: AppImageUpdater.prototype.doInstall,
+    install: BaseUpdater.prototype.install,
+    app: { quit: () => assert.fail("a failed relaunch must not quit the desktop") },
+  };
+  BaseUpdater.prototype.quitAndInstall.call(updater, true, true);
+  assert.deepEqual(errors, ["Could not schedule the updated AppImage to restart"]);
+  assert.equal(updater.quitAndInstallCalled, false);
+  assert.equal(process.env.APPIMAGE_SILENT_INSTALL, "previous");
+  assert.equal(readFileSync(launched, "utf8"), "new", "the installed replacement remains available for a manual restart");
 });
 
 test("the running AppImage is never removed before its replacement is in place", (t) => {
@@ -183,4 +237,94 @@ test("the running AppImage is never removed before its replacement is in place",
 
   assert.equal(readFileSync(launched, "utf8"), "the app the user has", "a failed update cost the user their app");
   assert.deepEqual(readdirSync(workspace), [basename(launched)], "a partial download was left behind");
+});
+
+const xvfb = process.platform === "linux" && !process.env.DISPLAY
+  ? spawnSync("which", ["xvfb-run"], { encoding: "utf8" }).stdout?.trim()
+  : "";
+
+test("Electron relaunch waits for deferred cleanup and the replacement acquires the same data directory", {
+  skip: process.platform === "win32" || (process.platform === "linux" && !process.env.DISPLAY && !xvfb),
+  timeout: 20_000,
+}, async (t) => {
+  const workspace = mkdtempSync(join(tmpdir(), "omb-appimage-relaunch-"));
+  t.after(() => rmSync(workspace, { recursive: true, force: true }));
+  const launched = join(workspace, "OpenMausBot-1.0.0.AppImage");
+  const staged = join(workspace, "OpenMausBot-2.0.0.AppImage");
+  const receipt = join(workspace, "restarted.json");
+  const fixture = join(workspace, "main.cjs");
+  mkdirSync(join(workspace, "user-data"));
+  const leaseModule = new URL("./data-dir-lease.mjs", import.meta.url).href;
+  const replacement = `
+    const { writeFileSync } = require("node:fs");
+    (async () => {
+      let parentAlive = true;
+      try { process.kill(Number(process.env.OMB_UPDATER_TEST_PARENT), 0); }
+      catch (error) { if (error.code === "ESRCH") parentAlive = false; else throw error; }
+      const { acquireDataDirLease } = await import(${JSON.stringify(leaseModule)});
+      const lease = acquireDataDirLease(${JSON.stringify(join(workspace, "data"))});
+      lease.release();
+      writeFileSync(${JSON.stringify(receipt)}, JSON.stringify({ parentAlive,
+        acquired: true, appImage: process.env.APPIMAGE, silent: process.env.APPIMAGE_SILENT_INSTALL }));
+    })().catch(error => { writeFileSync(${JSON.stringify(receipt)}, JSON.stringify({ error: error.message })); process.exitCode = 1; });
+  `;
+  writeFileSync(launched, "old AppImage", { mode: 0o755 });
+  // A disposable executable substitutes for the AppImage payload, not for
+  // Electron's native relauncher or the vendored install/quit methods.
+  writeFileSync(staged, `#!${process.execPath}\n${replacement}`, { mode: 0o755 });
+  writeFileSync(fixture, `
+    const { app, autoUpdater } = require("electron");
+    const { existsSync } = require("node:fs");
+    app.setPath("userData", ${JSON.stringify(join(workspace, "user-data"))});
+    app.whenReady().then(async () => {
+      if (!app.requestSingleInstanceLock()) throw new Error("fixture lock unavailable");
+      const { acquireDataDirLease } = await import(${JSON.stringify(leaseModule)});
+      const lease = acquireDataDirLease(${JSON.stringify(join(workspace, "data"))});
+      process.env.APPIMAGE = ${JSON.stringify(launched)};
+      process.env.OMB_UPDATER_TEST_PARENT = String(process.pid);
+      autoUpdater.on("before-quit-for-update", () => app.releaseSingleInstanceLock());
+      let cleaned = false;
+      app.on("before-quit", event => {
+        if (cleaned) return;
+        event.preventDefault();
+        setTimeout(() => {
+          if (existsSync(${JSON.stringify(receipt)})) throw new Error("replacement started during cleanup");
+          cleaned = true;
+          app.quit();
+        }, 250);
+      });
+      app.on("will-quit", () => lease.release());
+      const { AppImageUpdater, BaseUpdater } = require(${JSON.stringify(join(root, "electron/vendor/electron-updater.cjs"))});
+      const updater = {
+        installerPath: ${JSON.stringify(staged)}, downloadedUpdateHelper: { downloadedFileInfo: {} },
+        _logger: { info() {}, warn() {}, error() {} }, emit() {},
+        dispatchError(error) { throw error; }, app,
+        doInstall: AppImageUpdater.prototype.doInstall, install: BaseUpdater.prototype.install,
+        spawnLog() { throw new Error("immediate relaunch bypassed cleanup"); }
+      };
+      BaseUpdater.prototype.quitAndInstall.call(updater, true, true);
+    }).catch(error => { console.error(error); app.exit(1); });
+  `);
+  const electron = createRequire(import.meta.url)("electron");
+  const args = ["--no-sandbox", fixture];
+  const env = { ...process.env };
+  delete env.ELECTRON_RUN_AS_NODE;
+  const child = spawn(xvfb || electron, xvfb ? ["-a", electron, ...args] : args, { env, stdio: ["ignore", "pipe", "pipe"] });
+  let output = "";
+  child.stdout.on("data", chunk => { output += chunk; });
+  child.stderr.on("data", chunk => { output += chunk; });
+  const timeout = setTimeout(() => child.kill("SIGKILL"), 10_000);
+  const code = await new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", resolve);
+  }).finally(() => clearTimeout(timeout));
+  assert.equal(code, 0, output);
+  for (let attempt = 0; !existsSync(receipt) && attempt < 100; attempt++) {
+    await new Promise(resolve => setTimeout(resolve, 25));
+  }
+  assert.equal(existsSync(receipt), true, `replacement never started: ${output}`);
+  assert.deepEqual(JSON.parse(readFileSync(receipt, "utf8")), {
+    parentAlive: false, acquired: true, appImage: launched, silent: "true",
+  });
+  assert.equal(readFileSync(launched, "utf8"), `#!${process.execPath}\n${replacement}`);
 });

--- a/electron/vendor/electron-updater.cjs
+++ b/electron/vendor/electron-updater.cjs
@@ -14962,7 +14962,16 @@ var require_AppImageUpdater = __commonJS({
           APPIMAGE_SILENT_INSTALL: "true"
         };
         if (options.isForceRunAfter) {
-          this.spawnLog(destination, [], env);
+          const previousSilentInstall = process.env.APPIMAGE_SILENT_INSTALL;
+          try {
+            process.env.APPIMAGE_SILENT_INSTALL = env.APPIMAGE_SILENT_INSTALL;
+            if (require("electron").app.relaunch({ execPath: destination, args: [] }) === false) {
+              throw new Error("Could not schedule the updated AppImage to restart");
+            }
+          } finally {
+            if (previousSilentInstall === undefined) delete process.env.APPIMAGE_SILENT_INSTALL;
+            else process.env.APPIMAGE_SILENT_INSTALL = previousSilentInstall;
+          }
         } else {
           env.APPIMAGE_EXIT_AFTER_INSTALL = "true";
           (0, child_process_1.execFileSync)(destination, [], { env });
@@ -15447,7 +15456,16 @@ var require_MacUpdater = __commonJS({
           }
           return `http://127.0.0.1:${address === null || address === void 0 ? void 0 : address.port}`;
         };
+        this.squirrelDownloadedUpdate = false;
         return await new Promise((resolve, reject) => {
+          const cleanup = () => {
+            this.nativeUpdater.removeListener("error", fail);
+            this.nativeUpdater.removeListener("update-downloaded", ready);
+            this.server?.removeListener("error", fail);
+          };
+          const fail = (error) => { cleanup(); reject(error); };
+          const ready = () => { cleanup(); resolve([]); };
+          this.server.once("error", fail);
           const pass = (0, crypto_1.randomBytes)(64).toString("base64").replace(/\//g, "_").replace(/\+/g, "-");
           const authInfo = Buffer.from(`autoupdater:${pass}`, "ascii");
           const fileUrl = `/${(0, crypto_1.randomBytes)(64).toString("hex")}.zip`;
@@ -15484,13 +15502,6 @@ var require_MacUpdater = __commonJS({
               return;
             }
             log.info(`${fileUrl} requested by Squirrel.Mac, pipe ${downloadedFile}`);
-            let errorOccurred = false;
-            response.on("finish", () => {
-              if (!errorOccurred) {
-                this.nativeUpdater.removeListener("error", reject);
-                resolve([]);
-              }
-            });
             const readStream = (0, fs_1.createReadStream)(downloadedFile);
             readStream.on("error", (error) => {
               try {
@@ -15498,9 +15509,7 @@ var require_MacUpdater = __commonJS({
               } catch (e) {
                 log.warn(`cannot end response: ${e}`);
               }
-              errorOccurred = true;
-              this.nativeUpdater.removeListener("error", reject);
-              reject(new Error(`Cannot pipe "${downloadedFile}": ${error}`));
+              fail(new Error(`Cannot pipe "${downloadedFile}": ${error}`));
             });
             response.writeHead(200, {
               "Content-Type": "application/zip",
@@ -15511,19 +15520,24 @@ var require_MacUpdater = __commonJS({
           this.debug(`Proxy server for native Squirrel.Mac is starting to listen (${logContext})`);
           this.server.listen(0, "127.0.0.1", () => {
             this.debug(`Proxy server for native Squirrel.Mac is listening (address=${getServerUrl(this.server)}, ${logContext})`);
-            this.nativeUpdater.setFeedURL({
-              url: getServerUrl(this.server),
-              headers: {
-                "Cache-Control": "no-cache",
-                Authorization: `Basic ${authInfo.toString("base64")}`
+            try {
+              this.nativeUpdater.setFeedURL({
+                url: getServerUrl(this.server),
+                headers: {
+                  "Cache-Control": "no-cache",
+                  Authorization: `Basic ${authInfo.toString("base64")}`
+                }
+              });
+              this.dispatchUpdateDownloaded(event);
+              if (this.autoInstallOnAppQuit) {
+                this.nativeUpdater.once("error", fail);
+                this.nativeUpdater.once("update-downloaded", ready);
+                this.nativeUpdater.checkForUpdates();
+              } else {
+                ready();
               }
-            });
-            this.dispatchUpdateDownloaded(event);
-            if (this.autoInstallOnAppQuit) {
-              this.nativeUpdater.once("error", reject);
-              this.nativeUpdater.checkForUpdates();
-            } else {
-              resolve([]);
+            } catch (error) {
+              fail(error);
             }
           });
         });
@@ -15540,10 +15554,7 @@ var require_MacUpdater = __commonJS({
         if (this.squirrelDownloadedUpdate) {
           this.handleUpdateDownloaded();
         } else {
-          this.nativeUpdater.on("update-downloaded", () => this.handleUpdateDownloaded());
-          if (!this.autoInstallOnAppQuit) {
-            this.nativeUpdater.checkForUpdates();
-          }
+          throw new Error("The native Mac update is not ready to install.");
         }
       }
     };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.60",
+  "version": "0.1.61",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {

--- a/scripts/bundle-updater.mjs
+++ b/scripts/bundle-updater.mjs
@@ -10,16 +10,21 @@ import { build } from "esbuild";
 import { createRequire } from "node:module";
 import { readFile, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { dirname, join, sep } from "node:path";
 
 import { patchAppImageUpdater } from "./patch-appimage-updater.mjs";
+import { patchMacUpdater } from "./patch-mac-updater.mjs";
 
 const require = createRequire(import.meta.url);
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const outfile = join(root, "electron/vendor/electron-updater.cjs");
+const entryPoint = require.resolve("electron-updater");
 
 await build({
-  entryPoints: [require.resolve("electron-updater")],
+  entryPoints: [entryPoint],
+  // Keep source labels reproducible when an isolated worktree reuses the
+  // identical node_modules tree through a symlink.
+  absWorkingDir: entryPoint.split(`${sep}node_modules${sep}`)[0],
   bundle: true,
   platform: "node",
   target: "node20",
@@ -31,5 +36,5 @@ await build({
 
 // Throws when upstream's shape moved, so a bundle that would silently break
 // AppImage launchers never reaches a release.
-await writeFile(outfile, patchAppImageUpdater(await readFile(outfile, "utf8")));
-console.log("patched AppImage install to overwrite in place");
+await writeFile(outfile, patchMacUpdater(patchAppImageUpdater(await readFile(outfile, "utf8"))));
+console.log("patched AppImage replacement and native Mac staging readiness");

--- a/scripts/patch-appimage-updater.mjs
+++ b/scripts/patch-appimage-updater.mjs
@@ -49,15 +49,35 @@ const ATOMIC_MOVE = [
   "(0, fs_1.renameSync)(stagedDestination, destination);",
 ].join("\n        ");
 
+// BaseUpdater starts doInstall before it asks Electron to quit. An immediate
+// spawn can reach the data-directory lease while the old desktop is still
+// cleaning up. Electron's relauncher waits for this process to exit instead;
+// keep the original AppImage path, not the executable inside its old mount.
+const IMMEDIATE_RELAUNCH = /this\.spawnLog\(destination, \[\], env\);/g;
+const QUEUED_RELAUNCH = [
+  'const previousSilentInstall = process.env.APPIMAGE_SILENT_INSTALL;',
+  'try {',
+  '  process.env.APPIMAGE_SILENT_INSTALL = env.APPIMAGE_SILENT_INSTALL;',
+  '  if (require("electron").app.relaunch({ execPath: destination, args: [] }) === false) {',
+  '    throw new Error("Could not schedule the updated AppImage to restart");',
+  '  }',
+  '} finally {',
+  '  if (previousSilentInstall === undefined) delete process.env.APPIMAGE_SILENT_INSTALL;',
+  '  else process.env.APPIMAGE_SILENT_INSTALL = previousSilentInstall;',
+  '}',
+].join("\n          ");
+
 const REPLACEMENTS = [
   ["rename branch", RENAME_ASSIGNMENT, IN_PLACE_ASSIGNMENT],
   ["unlink before install", UNLINK_BEFORE_INSTALL, ""],
   ["move into place", MOVE_INTO_PLACE, ATOMIC_MOVE],
+  ["immediate relaunch", IMMEDIATE_RELAUNCH, QUEUED_RELAUNCH],
 ];
 
 /**
  * Keep an AppImage update on the running file's path, and never remove that
- * file until the replacement is in place.
+ * file until the replacement is in place. Queue its restart after the old
+ * process exits, without weakening the desktop's data-directory lease.
  *
  * Throws when any step's upstream shape moved: a silently unpatched bundle
  * would ship the launcher-breaking behaviour again.

--- a/scripts/patch-mac-updater.mjs
+++ b/scripts/patch-mac-updater.mjs
@@ -1,0 +1,86 @@
+// electron-updater 6.8.9 resolves the Mac download when its local HTTP response
+// finishes, before Squirrel validates/extracts the ZIP. Wait for native ready
+// instead, and never arm a future quit from a premature Restart request.
+// Exact, single-site replacements deliberately fail closed on upstream changes.
+export function patchMacUpdater(source) {
+  function replace(before, after) {
+    const count = source.split(before).length - 1;
+    if (count !== 1) throw new Error(`Expected one Mac updater site to patch, found ${count}: ${before.slice(0, 80)}`);
+    source = source.replace(before, after);
+  }
+
+  replace(
+    '        return await new Promise((resolve, reject) => {\n          const pass =',
+    `        this.squirrelDownloadedUpdate = false;
+        return await new Promise((resolve, reject) => {
+          const cleanup = () => {
+            this.nativeUpdater.removeListener("error", fail);
+            this.nativeUpdater.removeListener("update-downloaded", ready);
+            this.server?.removeListener("error", fail);
+          };
+          const fail = (error) => { cleanup(); reject(error); };
+          const ready = () => { cleanup(); resolve([]); };
+          this.server.once("error", fail);
+          const pass =`,
+  );
+  replace(
+    `            let errorOccurred = false;
+            response.on("finish", () => {
+              if (!errorOccurred) {
+                this.nativeUpdater.removeListener("error", reject);
+                resolve([]);
+              }
+            });
+`,
+    "",
+  );
+  replace(
+    `              errorOccurred = true;
+              this.nativeUpdater.removeListener("error", reject);
+              reject(new Error(\`Cannot pipe "\${downloadedFile}": \${error}\`));`,
+    '              fail(new Error(`Cannot pipe "${downloadedFile}": ${error}`));',
+  );
+  replace(
+    `            this.nativeUpdater.setFeedURL({
+              url: getServerUrl(this.server),
+              headers: {
+                "Cache-Control": "no-cache",
+                Authorization: \`Basic \${authInfo.toString("base64")}\`
+              }
+            });
+            this.dispatchUpdateDownloaded(event);
+            if (this.autoInstallOnAppQuit) {
+              this.nativeUpdater.once("error", reject);
+              this.nativeUpdater.checkForUpdates();
+            } else {
+              resolve([]);
+            }`,
+    `            try {
+              this.nativeUpdater.setFeedURL({
+                url: getServerUrl(this.server),
+                headers: {
+                  "Cache-Control": "no-cache",
+                  Authorization: \`Basic \${authInfo.toString("base64")}\`
+                }
+              });
+              this.dispatchUpdateDownloaded(event);
+              if (this.autoInstallOnAppQuit) {
+                this.nativeUpdater.once("error", fail);
+                this.nativeUpdater.once("update-downloaded", ready);
+                this.nativeUpdater.checkForUpdates();
+              } else {
+                ready();
+              }
+            } catch (error) {
+              fail(error);
+            }`,
+  );
+  replace(
+    `          this.nativeUpdater.on("update-downloaded", () => this.handleUpdateDownloaded());
+          if (!this.autoInstallOnAppQuit) {
+            this.nativeUpdater.checkForUpdates();
+          }`,
+    '          throw new Error("The native Mac update is not ready to install.");',
+  );
+  return source;
+}

--- a/scripts/smoke-linux-update.mjs
+++ b/scripts/smoke-linux-update.mjs
@@ -131,12 +131,14 @@ async function main() {
   console.log("[smoke-linux-update] downloading…");
   await updater.downloadUpdate(result.cancellationToken);
 
-  // Record the relaunch instead of starting a second app; the file placement
-  // is what this proves, and the target it would launch is part of that.
+  // Record the queued relaunch instead of starting a second app. The native
+  // relauncher would otherwise run it when this fixture exits.
   let relaunched = null;
-  updater.spawnLog = (target) => {
-    relaunched = target;
+  app.relaunch = (options) => {
+    relaunched = options.execPath;
+    return true;
   };
+  updater.spawnLog = () => { throw new Error("AppImage relaunch bypassed Electron's exit ordering"); };
   updater.quitAndInstall(true, true);
 
   const survivors = readdirSync(installDir);

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -93,12 +93,20 @@ function UpdatesRow() {
       : s?.status === "available"
         ? `${s.version} available`
         : s?.status === "downloading"
-          ? `Downloading ${Math.round(s.percent ?? 0)}%`
-          : s?.status === "downloaded"
-            ? `${s.version} ready — restart to apply`
-            : s?.status === "error"
-              ? `Check failed: ${s.message ?? "unknown error"}`
-              : "You're on the latest version we know of.";
+          ? s.percent == null
+            ? "Starting download…"
+            : `Downloading ${Math.round(s.percent)}%`
+          : s?.status === "preparing"
+            ? "Download complete. macOS is preparing the update."
+            : s?.status === "downloaded"
+              ? `${s.version} ready — ${s.installMode === "handoff" ? "install in a terminal" : "restart to apply"}`
+              : s?.status === "installing"
+                ? s.message || (s.installMode === "handoff" ? "Opening a terminal…" : "Restarting to update…")
+                : s?.status === "handed-off"
+                  ? "Command copied — finish the update in your terminal."
+                  : s?.status === "error"
+                    ? `Update failed: ${s.message ?? "unknown error"}`
+                    : "You're on the latest version we know of.";
   return (
     <Card title="Updates" subtitle={label}>
       <button
@@ -107,14 +115,23 @@ function UpdatesRow() {
           if (s?.status === "downloaded") return void updater.install();
           void updater.check();
         }}
-        disabled={s?.status === "checking" || s?.status === "downloading"}
+        disabled={
+          s?.status === "checking" || s?.status === "downloading" || s?.status === "preparing" ||
+          s?.status === "installing" || s?.retryable === false
+        }
         className="rounded-lg border border-hairline/40 px-3 py-1.5 text-[13px] text-ink hover:bg-control disabled:opacity-40"
       >
-        {s?.status === "available"
-          ? "Download"
-          : s?.status === "downloaded"
-            ? "Restart and install"
-            : "Check for updates"}
+        {s?.retryable === false
+          ? "Quit and reopen the app"
+          : s?.status === "available"
+            ? "Download"
+            : s?.status === "downloaded"
+              ? s.installMode === "handoff" ? "Install" : "Restart and install"
+              : s?.status === "preparing"
+                ? "Preparing…"
+                : s?.status === "installing"
+                  ? s.installMode === "handoff" ? "Opening…" : "Restarting…"
+                  : "Check for updates"}
       </button>
     </Card>
   );
@@ -482,7 +499,7 @@ function DiagnosticsRow() {
   return (
     <Card
       title="Diagnostics"
-      subtitle="Versions, configuration on/off state and a redacted server log tail. Review the file before sharing it."
+      subtitle="Versions, configuration on/off state and redacted server, desktop and updater log tails. Review the file before sharing it."
     >
       <div className="flex min-w-0 flex-col items-end gap-2">
         <button

--- a/src/components/SidebarProfileMenu.test.ts
+++ b/src/components/SidebarProfileMenu.test.ts
@@ -42,6 +42,7 @@ describe("updatePhase", () => {
   it("reports the bridge's own in-flight states", () => {
     expect(updatePhase(state({ status: "checking" }), false)).toBe("checking");
     expect(updatePhase(state({ status: "downloading" }), false)).toBe("downloading");
+    expect(updatePhase(state({ status: "preparing" }), false)).toBe("preparing");
     expect(updatePhase(state({ status: "installing" }), false)).toBe("installing");
   });
 
@@ -72,6 +73,16 @@ describe("updateLabel", () => {
     expect(updateLabel("downloading", state({ status: "downloading", percent: 41.6 }))).toBe("Downloading… 42%");
   });
 
+  it("distinguishes native preparation from restart readiness", () => {
+    expect(updateLabel("preparing", state({ status: "preparing", percent: 100 }))).toBe("Preparing update…");
+    expect(updateLabel("installing", state({ status: "installing", message: "Restart is taking longer than expected." })))
+      .toBe("Restart is taking longer than expected.");
+    expect(updateLabel("downloaded", state({ status: "downloaded", version: "0.2.0", installMode: "handoff" })))
+      .toBe("Version 0.2.0 ready — install");
+    expect(updateLabel("installing", state({ status: "installing", installMode: "handoff" })))
+      .toBe("Opening a terminal…");
+  });
+
   it("carries the updater's own message when something failed", () => {
     expect(updateLabel("error", state({ status: "error", message: "Network unreachable" }))).toBe(
       "Network unreachable",
@@ -95,6 +106,7 @@ describe("updateBusy", () => {
   it("blocks clicks while something is in flight", () => {
     expect(updateBusy("checking")).toBe(true);
     expect(updateBusy("downloading")).toBe(true);
+    expect(updateBusy("preparing")).toBe(true);
     expect(updateBusy("installing")).toBe(true);
     expect(updateBusy("available")).toBe(false);
     expect(updateBusy("downloaded")).toBe(false);
@@ -123,6 +135,7 @@ describe("updateNoteworthy", () => {
   it("puts a real update on the profile row", () => {
     expect(updateNoteworthy("available")).toBe(true);
     expect(updateNoteworthy("downloading")).toBe(true);
+    expect(updateNoteworthy("preparing")).toBe(true);
     expect(updateNoteworthy("downloaded")).toBe(true);
     expect(updateNoteworthy("installing")).toBe(true);
     expect(updateNoteworthy("error")).toBe(true);

--- a/src/components/SidebarProfileMenu.tsx
+++ b/src/components/SidebarProfileMenu.tsx
@@ -70,10 +70,12 @@ export function updateLabel(phase: UpdatePhase, state: UpdaterState | null): str
       return `Version ${state?.version ?? ""} available — download`.replace("  ", " ");
     case "downloading":
       return state?.percent == null ? "Starting download…" : `Downloading… ${Math.round(state.percent)}%`;
+    case "preparing":
+      return "Preparing update…";
     case "downloaded":
-      return `Version ${state?.version ?? ""} ready — restart`.replace("  ", " ");
+      return `Version ${state?.version ?? ""} ready — ${state?.installMode === "handoff" ? "install" : "restart"}`.replace("  ", " ");
     case "installing":
-      return "Restarting to update…";
+      return state?.message || (state?.installMode === "handoff" ? "Opening a terminal…" : "Restarting to update…");
     case "checking":
       return "Checking for updates…";
     case "handed-off":
@@ -92,7 +94,7 @@ export function updateLabel(phase: UpdatePhase, state: UpdaterState | null): str
  * download and install round-trip through main first, and without this the
  * row would sit there looking clickable. */
 export function updateBusy(phase: UpdatePhase, pending = false): boolean {
-  return pending || phase === "checking" || phase === "downloading" || phase === "installing";
+  return pending || phase === "checking" || phase === "downloading" || phase === "preparing" || phase === "installing";
 }
 
 function UpdateIcon({ phase, pending, size = 18 }: { phase: UpdatePhase; pending: boolean; size?: number }) {
@@ -149,7 +151,7 @@ function useUpdateItem(): UpdateEntry | null {
       key: "update",
       label,
       icon: <UpdateIcon phase={phase} pending={pending} />,
-      disabled: updateBusy(phase, pending),
+      disabled: updateBusy(phase, pending) || state?.retryable === false,
       // progress is reported on the row itself, so the menu stays put
       keepOpen: true,
       attention: phase === "downloaded" || phase === "error",

--- a/src/components/UpdateBanner.test.ts
+++ b/src/components/UpdateBanner.test.ts
@@ -1,0 +1,61 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { UpdaterState } from "@/lib/updater";
+
+const fixture = vi.hoisted(() => ({ state: { status: "idle" } as UpdaterState }));
+vi.mock("@/lib/updater", () => ({ useUpdaterState: () => fixture.state }));
+vi.mock("../lib/brand", () => ({ brand: () => ({ name: "OpenMausBot" }) }));
+import { UpdateBanner } from "./UpdateBanner";
+
+afterEach(() => vi.unstubAllGlobals());
+function render(state: UpdaterState) {
+  fixture.state = state;
+  vi.stubGlobal("window", { ogb: { updater: {} } });
+  return renderToStaticMarkup(createElement(UpdateBanner));
+}
+
+describe("UpdateBanner", () => {
+  it("cannot restart or retry while macOS is preparing the downloaded bytes", () => {
+    const html = render({ status: "preparing", version: "0.2.0", percent: 100 });
+    expect(html).toContain("Preparing update…");
+    expect(html).toContain("macOS is preparing the update.");
+    expect(html).toContain("disabled=\"\"");
+    expect(html).not.toContain("Restart to update");
+    expect(html).not.toContain("Try again");
+    expect(html).not.toContain("Dismiss");
+  });
+
+  it("offers restart only after native preparation is complete", () => {
+    const html = render({ status: "downloaded", version: "0.2.0" });
+    expect(html).toContain("0.2.0 is ready");
+    expect(html).toContain("Restart to update");
+  });
+
+  it("keeps restart busy and displays the recovery instruction", () => {
+    const html = render({ status: "installing", message: "Restart is taking longer than expected. Quit the app completely." });
+    expect(html).toContain("Quit the app completely.");
+    expect(html).toContain("disabled=\"\"");
+    expect(html).not.toContain("Try again");
+  });
+
+  it("shows a preparation failure with a recovery action", () => {
+    const html = render({ status: "error", message: "Native staging failed" });
+    expect(html).toContain("Update failed");
+    expect(html).toContain("Native staging failed");
+    expect(html).toContain("Try again");
+  });
+
+  it.each(["ETIMEDOUT while staging", "native error ".repeat(30)])("preserves restart recovery for a nonretryable error: %s", (message) => {
+    const html = render({ status: "error", retryable: false, message });
+    expect(html).toContain("Quit and reopen OpenMausBot before trying the update again.");
+    expect(html).not.toContain("Try again");
+    expect(html).toContain("Dismiss");
+  });
+
+  it("preserves system package hand-off without promising restart", () => {
+    const html = render({ status: "downloaded", version: "0.2.0", installMode: "handoff" });
+    expect(html).toContain("Copy the install command and open a terminal.");
+    expect(html).not.toContain("Restart to update");
+  });
+});

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -46,7 +46,8 @@ export function UpdateBanner() {
 
   // while busy the card owns the moment: no dismissing, no second click
   const installing = s.status === "installing";
-  const busy = s.status === "downloading" || installing;
+  const preparing = s.status === "preparing";
+  const busy = s.status === "downloading" || preparing || installing;
   // Ubuntu system packages can't be swapped under a running app, so the
   // command is copied and a terminal opens; the user finishes there.
   // Nothing restarts, and the card has to stop promising that it will.
@@ -57,15 +58,17 @@ export function UpdateBanner() {
       ? `${brand().name} ${s.version} is available`
       : s.status === "downloading"
         ? `Downloading ${s.version ?? "update"}…`
-        : s.status === "downloaded"
-          ? `${s.version} is ready`
-          : installing
-            ? handoff
-              ? "Opening a terminal…"
-              : "Restarting to update…"
-            : s.status === "handed-off"
-              ? "Finish in a terminal"
-              : "Update check failed";
+        : preparing
+          ? "Preparing update…"
+          : s.status === "downloaded"
+            ? `${s.version} is ready`
+            : installing
+              ? handoff
+                ? "Opening a terminal…"
+                : "Restarting to update…"
+              : s.status === "handed-off"
+                ? "Finish in a terminal"
+                : "Update failed";
   const subtitle =
     s.status === "available"
       ? "A newer version is ready to download."
@@ -74,19 +77,23 @@ export function UpdateBanner() {
           s.percent == null
           ? "Starting download…"
           : `${Math.round(s.percent)}%`
-        : s.status === "downloaded"
-          ? handoff
-            ? "Copy the install command and open a terminal."
-            : "Restart to finish updating."
-          : installing
+        : preparing
+          ? "Download complete. macOS is preparing the update."
+          : s.status === "downloaded"
             ? handoff
-              ? "Copying the command…"
-              : `${brand().name} will reopen in a moment.`
-            : s.status === "handed-off"
-              ? s.terminalOpened
-                ? "Command copied — paste it in the terminal that opened."
-                : "Command copied — paste it in a terminal to finish."
-              : friendlyError(s.message);
+              ? "Copy the install command and open a terminal."
+              : "Restart to finish updating."
+            : installing
+              ? handoff
+                ? "Copying the command…"
+                : s.message || `${brand().name} will reopen in a moment.`
+              : s.status === "handed-off"
+                ? s.terminalOpened
+                  ? "Command copied — paste it in the terminal that opened."
+                  : "Command copied — paste it in a terminal to finish."
+                : s.retryable === false
+                  ? `Quit and reopen ${brand().name} before trying the update again.`
+                  : friendlyError(s.message);
 
   return (
     <div className="animate-panel-in fixed bottom-4 left-4 z-50 w-[300px] rounded-xl border border-hairline/40 bg-panel p-3.5 shadow-2xl shadow-black/50">
@@ -96,7 +103,7 @@ export function UpdateBanner() {
         </span>
         <div className="min-w-0 flex-1">
           <div className="text-[13.5px] font-semibold text-ink">{title}</div>
-          <div className="mt-0.5 truncate text-[12.5px] text-ink-secondary" title={subtitle}>
+          <div className="mt-0.5 text-[12.5px] text-ink-secondary" title={subtitle}>
             {subtitle}
           </div>
         </div>
@@ -131,13 +138,13 @@ export function UpdateBanner() {
         </div>
       )}
 
-      {installing && (
+      {(preparing || installing) && (
         <div className="mt-2.5 flex gap-2">
           <button
             disabled
             className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-control py-1.5 text-[13px] font-medium text-ink-secondary"
           >
-            <Loader2 size={13} className="animate-spin" /> {handoff ? "Opening…" : "Restarting…"}
+            <Loader2 size={13} className="animate-spin" /> {preparing ? "Preparing…" : handoff ? "Opening…" : "Restarting…"}
           </button>
         </div>
       )}
@@ -188,7 +195,7 @@ export function UpdateBanner() {
               )}
             </button>
           )}
-          {s.status === "error" && (
+          {s.status === "error" && s.retryable !== false && (
             <button
               onClick={() => {
                 setPending("check");
@@ -212,7 +219,7 @@ export function UpdateBanner() {
             className="rounded-lg px-3 py-1.5 text-[13px] text-ink-secondary hover:bg-control hover:text-ink disabled:opacity-50 disabled:hover:bg-transparent"
           >
             {/* after a hand-off there is nothing left to postpone */}
-            {s.status === "handed-off" ? "Done" : "Later"}
+            {s.status === "handed-off" || s.retryable === false ? "Dismiss" : "Later"}
           </button>
         </div>
       )}

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -306,6 +306,8 @@ export interface UpdaterState {
     | "checking"
     | "available"
     | "downloading"
+    /** downloaded bytes are being staged by the native macOS updater */
+    | "preparing"
     | "downloaded"
     | "installing"
     /** the command is on the clipboard; the user finishes in a terminal */
@@ -314,6 +316,8 @@ export interface UpdaterState {
   version?: string;
   percent?: number;
   message?: string;
+  /** native work may still be running; recovery requires an app restart */
+  retryable?: boolean;
   /**
    * How the download gets applied. "restart" quits and installs in place;
    * "handoff" copies the install command and opens a terminal so the user


### PR DESCRIPTION
## Summary

Fix two reproduced updater loops and prepare patch release **0.1.61**.

- **macOS:** wait for native Squirrel readiness, not completion of the local ZIP response, before offering Restart. Show a separate Preparing update state. A five-minute native staging timeout or native error stays visible and requires quitting/reopening; retry cannot overlap uncancellable native work or consume a stale ready event. Premature restart never registers a deferred quit callback, and a slow restart stays single-flight.
- **Linux AppImage:** queue the original AppImage path through Electron's native relauncher so the replacement starts after the old process and its data-directory lease are gone. Preserve atomic same-path replacement. A rejected relaunch reports an error without quitting the running desktop.
- **Diagnostics:** include a safe, bounded updater-log tail. Redact signed URL parameters, URL credentials, authorization headers and cookies.
- Keep banner, sidebar and Settings consistent during preparation/restart/recovery, and document the one-time manual-install fallback for older stuck clients.

The pinned updater bundle is regenerated through fail-closed patches. No changes to signing, feed locations, release mirrors, Windows installer semantics, or the system-package terminal handoff.

## Verification

- Real shipped MacUpdater + coordinator fixture: authenticated loopback ZIP completes while status stays Preparing; native readiness unlocks one Restart; native error/deadline + late completion never revives controls or unexpectedly quits.
- Real Electron relaunch fixture: delayed cleanup retains the production data lease; replacement runs only after parent exit and reacquires the same data directory at the original launcher path.
- Diagnostics regression fixtures, updater UI tests, typecheck, Electron syntax checks and production renderer build.
- Isolated browser interaction check of the actual UpdateBanner: preparation, error recovery, one restart, and no retry during a slow restart.
- Full cross-platform CI required before merge.
- Full local suite passed: 3,906 app tests, 8 broker tests, 144 Electron tests, and packaged-server smoke. Final targeted core/vendor (30), updater IPC (1), and UI/diagnostics (71) regressions also passed after review edits.

No mutations against the installed application or user data. The release pipeline validates artifact signing, notarization and packaging; these local tests do not claim an end-to-end signed macOS upgrade or reproduce an unidentified customer's OS crash.

## Release note

The **installed** app performs an update. A user stuck on an older updater may need to install 0.1.61 over their existing application once; they should not delete their data directory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - macOS updates now show a distinct “Preparing update…” stage before restart.
  - Update controls reflect preparation, installation, handoff, and recovery states.
  - Diagnostics now include a bounded, redacted updater log.
  - Added guidance for reporting update failures, including update stages and versions.

- **Bug Fixes**
  - Failed updates retain their error state and avoid unsafe retries.
  - Install and restart flows now prevent overlapping operations and provide clearer recovery instructions.
  - AppImage and macOS updates now relaunch and complete more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->