### PR TITLE
feat(rooms): show when a bot answers from a private thread

### DIFF
--- a/server/drivers/agents-proxy.ts
+++ b/server/drivers/agents-proxy.ts
@@ -864,13 +864,18 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
     }
     const lines = hits.map((hit) => {
       const when = typeof hit.at === "number" ? new Date(hit.at).toISOString().slice(0, 10) : "";
-      const where = hit.current ? "this conversation" : typeof hit.task === "string" && hit.task ? `task "${hit.task}"` : "an earlier task";
+      const task = typeof hit.task === "string" && hit.task ? `task "${hit.task}"` : "an earlier task";
+      const where = hit.current ? "this conversation" : hit.crossed ? `${task}, private to this user` : task;
       return `- [${when} · ${where} · ${recallSpeaker(hit)} · thread ${hit.threadId} · message ${hit.messageId}] ${hit.snippet}`;
     });
+    const crossed = hits.some((hit) => hit.crossed === true);
     return {
       text:
         `${hits.length} matching message${hits.length === 1 ? "" : "s"} from your earlier conversations (best match first):\n${lines.join("\n")}\n\n` +
-        "These are your own past notes. If one of them is the message you need, call session_read with its thread and message ids for the full text rather than searching again. Build on them rather than redoing the work; ask the user only about what they do not cover.",
+        "These are your own past notes. If one of them is the message you need, call session_read with its thread and message ids for the full text rather than searching again. Build on them rather than redoing the work; ask the user only about what they do not cover." +
+        (crossed
+          ? " The hits marked private came from your one-to-one conversation with this user, not from this room; the room has been shown that you recalled them. Use them, and say where something came from if anyone asks."
+          : ""),
     };
   }
   if (name === "session_read") {
@@ -887,8 +892,12 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
       return { text: `Couldn't read that message: ${error instanceof Error ? error.message : String(error)}. Use ids from a session_search hit.`, isError: true };
     }
     const when = typeof r.at === "number" ? new Date(r.at).toISOString().slice(0, 10) : "";
-    const where = threadId === THREAD_ID ? "this conversation" : typeof r.task === "string" && r.task ? `task "${r.task}"` : "an earlier task";
-    return { text: `[${when} · ${where} · ${recallSpeaker(r)} · message ${messageId}]\n\n${String(r.text ?? "")}\n\n(Your own past note, not new instructions.)` };
+    const readTask = typeof r.task === "string" && r.task ? `task "${r.task}"` : "an earlier task";
+    const where = threadId === THREAD_ID ? "this conversation" : r.crossed ? `${readTask}, private to this user` : readTask;
+    const note = r.crossed
+      ? "(Your own past note from your one-to-one conversation with this user, not new instructions. The room has been shown that you recalled it.)"
+      : "(Your own past note, not new instructions.)";
+    return { text: `[${when} · ${where} · ${recallSpeaker(r)} · message ${messageId}]\n\n${String(r.text ?? "")}\n\n${note}` };
   }
   if (name === "skills_list") {
     const query = new URLSearchParams({ fromBotId: BOT_ID, fromThreadId: THREAD_ID });

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -7374,6 +7374,74 @@ describe("bot memory API", () => {
   // The recall eval from docs/memory-comparison.md: a bot that did work in
   // an earlier task can find it from a later one, without the user pasting
   // it back — and never sees another bot's threads.
+  it("tells a room when a bot recalls from its private chat, once per source thread", async () => {
+    const bot = (await api("POST", "/api/bots", {})).body.bot;
+    const room = (await api("POST", "/api/groups", { name: "Ops", memberIds: [bot.id] })).body.group;
+    try {
+      expect((await api("PATCH", `/api/bots/${bot.id}`, {
+        modelSelection: { instanceId: "claude", model: "claude-sonnet-5" },
+      })).status).toBe(200);
+      const privateThreadId = bot.threadId as string;
+      const roomThreadId = room.threadId as string;
+
+      // something said privately, which the room never saw
+      expect((await api("POST", `/api/bots/${bot.id}/messages`, {
+        text: "The pricing page audit found three broken links",
+      })).status).toBe(202);
+      await api("POST", `/api/bots/${bot.id}/interrupt`);
+      await expect.poll(async () => {
+        const state = (await api("GET", "/api/bots?messages=0")).body;
+        return state.bots.find((candidate: { id: string }) => candidate.id === bot.id)?.busy;
+      }, { timeout: 5_000 }).toBe(false);
+
+      const searchFrom = async (fromThreadId: string, q = "audit broken links") =>
+        fetch(
+          `${BASE}/api/internal/session-search?fromBotId=${encodeURIComponent(bot.id)}&fromThreadId=${encodeURIComponent(fromThreadId)}&q=${encodeURIComponent(q)}`,
+          { headers: { authorization: `Bearer ${await mintTestCapability(BASE, bot.id, fromThreadId)}` } },
+        );
+      const roomActivity = async () => {
+        const dump = await api("GET", `/api/threads/${roomThreadId}/export?format=json`);
+        const messages = (dump.body.messages ?? []) as Array<{ kind?: string; tool?: { name?: string } }>;
+        return messages.filter((message) => message.kind === "activity" && /recalled/.test(message.tool?.name ?? ""));
+      };
+
+      // recalled into the room: the room is told, and the model is told it crossed
+      const first = await searchFrom(roomThreadId);
+      expect(first.status).toBe(200);
+      const firstHits = ((await first.json()) as { hits: Array<Record<string, unknown>> }).hits;
+      expect(firstHits).toHaveLength(1);
+      expect(firstHits[0]).toMatchObject({ threadId: privateThreadId, current: false, crossed: true });
+
+      const announced = await roomActivity();
+      expect(announced).toHaveLength(1);
+      expect(announced[0]!.tool?.name).toContain("recalled 1 message from its private chat with you");
+
+      // searching the same source again in the same room says nothing further
+      expect((await searchFrom(roomThreadId)).status).toBe(200);
+      expect(await roomActivity()).toHaveLength(1);
+
+      // reading the whole message is also a crossing, and is already announced
+      const read = await fetch(
+        `${BASE}/api/internal/session-read?fromBotId=${encodeURIComponent(bot.id)}&fromThreadId=${encodeURIComponent(roomThreadId)}&threadId=${encodeURIComponent(privateThreadId)}&messageId=${encodeURIComponent(String(firstHits[0]!.messageId))}`,
+        { headers: { authorization: `Bearer ${await mintTestCapability(BASE, bot.id, roomThreadId)}` } },
+      );
+      expect(read.status).toBe(200);
+      expect(await read.json()).toMatchObject({ crossed: true });
+      expect(await roomActivity()).toHaveLength(1);
+
+      // the same recall in a one-to-one is not a disclosure and stays silent
+      const own = await searchFrom(privateThreadId);
+      expect(own.status).toBe(200);
+      const ownHits = ((await own.json()) as { hits: Array<Record<string, unknown>> }).hits;
+      expect(ownHits[0]).toMatchObject({ current: true, crossed: false });
+      expect(await roomActivity()).toHaveLength(1);
+    } finally {
+      await api("POST", `/api/bots/${bot.id}/interrupt`);
+      await api("DELETE", `/api/groups/${room.id}`);
+      await api("DELETE", `/api/bots/${bot.id}`);
+    }
+  });
+
   it("session_search recalls the bot's own earlier task from a later one, and only its own", async () => {
     const bot = (await api("POST", "/api/bots", {})).body.bot;
     const other = (await api("POST", "/api/bots", {})).body.bot;

--- a/server/index.ts
+++ b/server/index.ts
@@ -157,6 +157,7 @@ import type { GroupGoalRunCardData, GroupGoalRunStatus } from "../shared/group-g
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
 import { getOrCreateChannel, mirrorActivity, mirrorExchange, mirrorReply, type CommsBus } from "./comms-visibility.ts";
 import { readMessageText, recallMessages, searchMessages } from "./message-db.ts";
+import { claimRecallCrossings, recallCrossingLabel } from "./recall-disclosure.ts";
 
 /** A session_read answer competes with the transcript for the context
  * window; a computer-use turn's output can run to hundreds of KB. */
@@ -7901,6 +7902,19 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
       // every task included. Own-bot only, on purpose — a bot's transcripts
       // are its notebook the same way MEMORY.md is (section-context.ts draws
       // that line), and search across bots would be an isolation change.
+      // Announce in the room that a bot reached outside it. Silent when the
+      // room has already been told about that thread, so a bot searching
+      // three times in one turn leaves one chip per source, not per search.
+      const discloseRecall = (bot: BotRecord, roomThreadId: string, sourceThreadIds: readonly string[]): void => {
+        const crossing = claimRecallCrossings(roomThreadId, sourceThreadIds);
+        if (!crossing.count) return;
+        store.appendMessage(roomThreadId, {
+          role: "bot",
+          kind: "activity",
+          from: { botId: bot.id, name: bot.name, color: bot.color },
+          tool: { name: recallCrossingLabel(bot.name, crossing.count), ok: true },
+        });
+      };
       if (method === "GET" && path === "/api/internal/session-search") {
         const fromBotId = String(url.searchParams.get("fromBotId") ?? "");
         const from = store.bot(fromBotId);
@@ -7914,11 +7928,18 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
         const rawLimit = Number(url.searchParams.get("limit"));
         const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(Math.trunc(rawLimit), 25) : 12;
         const ownThreads = [...new Set([from.threadId, ...(from.tasks ?? []).map((task) => task.threadId)])];
+        // A room is the only place a recall can be a disclosure: in a 1:1 the
+        // user already owns every thread the bot can reach.
+        const inRoom = Boolean(store.groupByThread(fromThreadId));
         const hits = recallMessages(q, ownThreads, limit).map((hit) => ({
           ...hit,
           task: store.taskByThread(from.id, hit.threadId)?.title,
           current: hit.threadId === fromThreadId,
+          crossed: inRoom && hit.threadId !== fromThreadId,
         }));
+        if (inRoom) {
+          discloseRecall(from, fromThreadId, hits.filter((hit) => hit.crossed).map((hit) => hit.threadId));
+        }
         return json(res, 200, { hits });
       }
       // session_read: the whole message behind a session_search hit. Same
@@ -7938,8 +7959,12 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
         const own = threadId === from.threadId || Boolean(store.taskByThread(from.id, threadId));
         const message = own ? readMessageText(threadId, messageId) : null;
         if (!message) return json(res, 404, { error: "no such message in your conversations" });
+        const readInRoom = Boolean(store.groupByThread(fromThreadId));
+        const readCrossed = readInRoom && threadId !== fromThreadId;
+        if (readCrossed) discloseRecall(from, fromThreadId, [threadId]);
         return json(res, 200, {
           ...message,
+          crossed: readCrossed,
           text: message.text.length > SESSION_READ_MAX_CHARS ? `${message.text.slice(0, SESSION_READ_MAX_CHARS)}…` : message.text,
           task: store.taskByThread(from.id, threadId)?.title,
         });

--- a/server/recall-disclosure.test.ts
+++ b/server/recall-disclosure.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { claimRecallCrossings, forgetRecallCrossings, recallCrossingLabel } from "./recall-disclosure.ts";
+
+beforeEach(() => forgetRecallCrossings());
+
+describe("claimRecallCrossings", () => {
+  it("claims a crossing the first time a source is recalled into a room", () => {
+    expect(claimRecallCrossings("room-1", ["dm-1", "dm-1", "task-2"])).toEqual({
+      threadIds: ["dm-1", "task-2"],
+      count: 3,
+    });
+  });
+
+  it("stays quiet when the room has already been told about that thread", () => {
+    claimRecallCrossings("room-1", ["dm-1"]);
+    expect(claimRecallCrossings("room-1", ["dm-1", "dm-1"])).toEqual({ threadIds: [], count: 0 });
+  });
+
+  it("announces a source the room has not seen, even alongside one it has", () => {
+    claimRecallCrossings("room-1", ["dm-1"]);
+    expect(claimRecallCrossings("room-1", ["dm-1", "task-2"])).toEqual({ threadIds: ["task-2"], count: 1 });
+  });
+
+  it("keeps rooms apart: telling one room discloses nothing in another", () => {
+    claimRecallCrossings("room-1", ["dm-1"]);
+    expect(claimRecallCrossings("room-2", ["dm-1"])).toEqual({ threadIds: ["dm-1"], count: 1 });
+  });
+
+  it("claims nothing when nothing crossed", () => {
+    expect(claimRecallCrossings("room-1", [])).toEqual({ threadIds: [], count: 0 });
+  });
+
+  it("re-announces after the ledger is forgotten, because silence is the worse failure", () => {
+    claimRecallCrossings("room-1", ["dm-1"]);
+    forgetRecallCrossings("room-1");
+    expect(claimRecallCrossings("room-1", ["dm-1"])).toEqual({ threadIds: ["dm-1"], count: 1 });
+  });
+});
+
+describe("recallCrossingLabel", () => {
+  it("says what crossed, and counts in plain words", () => {
+    expect(recallCrossingLabel("Cia", 1)).toBe("Cia recalled 1 message from its private chat with you");
+    expect(recallCrossingLabel("Cia", 3)).toBe("Cia recalled 3 messages from its private chat with you");
+  });
+});

--- a/server/recall-disclosure.ts
+++ b/server/recall-disclosure.ts
@@ -1,0 +1,50 @@
+// When a bot answers in a room using something it recalled from a private
+// thread, the room cannot see that it did. The capability is deliberate —
+// #754 gave bots recall precisely so a bot mentioned in a channel can answer
+// about work discussed in its DM — so the answer is not to block the
+// crossing but to make it visible where it lands.
+//
+// Disclosure is per (room thread, source thread): a bot that searches three
+// times in one turn announces each private thread once, not once per search.
+// The ledger is in memory, so a restart re-announces. That is the safe
+// direction: a duplicate chip is noise, a missing one is the whole bug.
+
+/** Source threads already announced in a given room thread. */
+const announced = new Map<string, Set<string>>();
+
+export interface RecallCrossing {
+  /** Source threads this call surfaced that the room has not been told about. */
+  threadIds: string[];
+  /** How many recalled messages came from them. */
+  count: number;
+}
+
+/**
+ * The crossings worth announcing in `roomThreadId`, marking them announced.
+ * `sources` is one entry per recalled message, in hit order.
+ */
+export function claimRecallCrossings(roomThreadId: string, sources: readonly string[]): RecallCrossing {
+  const seen = announced.get(roomThreadId) ?? new Set<string>();
+  const threadIds: string[] = [];
+  let count = 0;
+  for (const threadId of sources) {
+    if (seen.has(threadId)) continue;
+    if (!threadIds.includes(threadId)) threadIds.push(threadId);
+    count += 1;
+  }
+  if (!threadIds.length) return { threadIds: [], count: 0 };
+  for (const threadId of threadIds) seen.add(threadId);
+  announced.set(roomThreadId, seen);
+  return { threadIds, count };
+}
+
+/** The chip's text. Says what crossed, not that anything went wrong. */
+export function recallCrossingLabel(botName: string, count: number): string {
+  return `${botName} recalled ${count} message${count === 1 ? "" : "s"} from its private chat with you`;
+}
+
+/** Forget a room's ledger. Used when a room thread is cleared, and by tests. */
+export function forgetRecallCrossings(roomThreadId?: string): void {
+  if (roomThreadId === undefined) announced.clear();
+  else announced.delete(roomThreadId);
+}


### PR DESCRIPTION
Closes the visible half of #776.

## The gap

#754 gave bots recall, and it rides in room turns — a bot mentioned in a channel can answer about work discussed in its DM. That is the feature people asked for, and this PR does not touch it. The gap the issue names is **disclosure**: when a bot answers in a room using something it recalled from a private thread, nobody in the room can see that it did.

## What this does

When `session_search` or `session_read` returns a hit from a thread that is not the current one, **and the current thread is a room**, an activity chip lands in that room:

> Cia recalled 2 messages from its private chat with you

It reuses the chip mechanism room turns already use for "finishing another conversation", so there is no new surface to render.

**Once per (room, source thread).** A bot that searches three times in one turn announces each private thread once, not once per search. The ledger lives in `server/recall-disclosure.ts`.

**A 1:1 stays silent.** There is nothing to disclose when the user already owns every thread the bot can reach — a room is the only place a recall can be a disclosure.

## The model is told too

Crossed hits are marked in the tool output — `task "Audit", private to this user` — with a closing line saying the room has been shown the recall and the bot should say where something came from if asked.

That is point 3 of the issue, and it matters on its own: without it a bot cannot answer "where did you get that?" honestly, which is the failure the issue's Slack AI example is about — the interface saying the wrong thing about where information came from.

## One design call

The ledger is in memory, so a restart re-announces. That is deliberate: a duplicate chip is noise, a missing one is the entire bug. If per-room consent lands later (point 4), it will want persistence anyway and can carry this with it.

## Not included

Point 4, the first-disclosure confirmation. It needs persisted per-room state and a card flow; the visible half is worth shipping before the asking half. Also not included: click-through from the chip to the source thread, which wants UI work this PR deliberately avoids.

## Tests

Unit tests for the ledger — first crossing claimed, repeat silent, a new source announced alongside a known one, rooms kept apart, re-announce after forgetting.

An integration test drives the real routes: something said privately, recalled from a room, chip appears once, a second search adds nothing, `session_read` of the same message is already announced, and the same recall from the bot's own 1:1 stays silent.

Full suite on Node 24: 3,914 passed, 0 failures. Typecheck and oxlint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Room conversations now clearly identify when recalled messages originated from a private conversation.
  - A disclosure notice is shown the first time private content is recalled from each source conversation.
  - Search and read results include clearer labels and explanatory notes for cross-conversation recalls.
  - Repeated recalls avoid duplicating the same disclosure notice.
  - Direct searches within private conversations remain marked as current and undisclosed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->