### PR TITLE
feat(cli): guided onboarding and phone QR pairing (0.1.62)

### DIFF
--- a/.github/workflows/sync-published-release.yml
+++ b/.github/workflows/sync-published-release.yml
@@ -39,7 +39,10 @@ jobs:
             --json isDraft,isPrerelease --jq 'select(.isDraft == false and .isPrerelease == false) | true' | grep -q true || {
               echo "::error::$TAG is not a published stable release in $GITHUB_REPOSITORY"; exit 1; }
           mkdir assets
-          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir assets
+          # npm attaches its lowercase tarball independently after publishing.
+          # The legacy updater bridge mirrors only the desktop/feed assets.
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir assets \
+            --pattern '*.yml' --pattern 'OpenMausBot*' --pattern 'SHA256SUMS-ubuntu-x64.txt'
           required=(
             latest-linux.yml latest-mac.yml latest.yml
             "OpenMausBot-$version-amd64.deb"
@@ -120,7 +123,10 @@ jobs:
             name,
             `sha256:${createHash("sha256").update(readFileSync(join("assets", name))).digest("hex")}`,
           ]));
-          const remote = JSON.parse(execFileSync("gh", ["release", "view", tag, "--repo", process.env.GITHUB_REPOSITORY, "--json", "assets"], { encoding: "utf8" })).assets;
+          const inventory = JSON.parse(execFileSync("gh", ["release", "view", tag, "--repo", process.env.GITHUB_REPOSITORY, "--json", "assets"], { encoding: "utf8" })).assets;
+          const npmTarball = `openmausbot-${tag.slice(1)}.tgz`;
+          const remote = inventory.filter((asset) => asset.name !== npmTarball);
+          if (inventory.length - remote.length > 1) throw new Error(`duplicate canonical npm asset: ${npmTarball}`);
           if (remote.length !== expected.size) throw new Error(`canonical release has ${remote.length} assets but ${expected.size} downloaded`);
           for (const asset of remote) {
             if (expected.get(asset.name) !== asset.digest) throw new Error(`canonical digest mismatch for ${asset.name}`);
@@ -161,6 +167,9 @@ jobs:
             { encoding: "utf8", env: { ...process.env, GH_TOKEN: token } },
           )).assets.map((asset) => [asset.name, asset.digest]));
           const canonical = assets(process.env.GITHUB_REPOSITORY, process.env.CANONICAL_TOKEN);
+          // The npm job may attach this optional asset between our download
+          // and comparison. It is canonical-only, never an updater artifact.
+          canonical.delete(`openmausbot-${tag.slice(1)}.tgz`);
           const legacy = assets("milind-soni/openmausbot-releases", process.env.LEGACY_TOKEN);
           if (canonical.size !== legacy.size) throw new Error(`legacy mirror has ${legacy.size} assets; canonical has ${canonical.size}`);
           for (const [name, digest] of canonical) {

--- a/README.md
+++ b/README.md
@@ -344,19 +344,41 @@ OpenMausBot is free and open source. If it does real work for you, you can
 one-time any amount, or monthly. Payments are handled by [Polar](https://polar.sh/supamaus),
 which takes care of receipts and taxes; nothing about the app ever sits behind a paywall.
 
-## Run it on a server
+## Run from a terminal or on a server
 
-Bots keep working with every laptop closed when the server runs on a VPS or
-a Mac mini. With Node 24, run `npx openmausbot start`: first launch guides
-you through choosing AI access, signing in or entering a hidden API key,
-and choosing a default model. Repeat `npx openmausbot setup` to change the
-default or add a connection without replacing your bots or conversations.
-See the [short setup guide](docs/cli-onboarding.md).
+With Node 24 or newer, install once and run:
 
-For an already configured server or a service, use `npx openmausbot serve` (add
-`--tunnel` for a public address with no domain or open port, or
-`--tailscale` for your tailnet), or the Docker stack for your own domain.
-Devices pair once with a short code. The step-by-step guide is
+```sh
+npm install -g openmausbot
+openmausbot
+```
+
+Or use `npx openmausbot` without a global install. First launch guides you with
+arrow-key choices: choose AI access, sign in or paste a hidden API key, choose
+a model, and optionally connect a phone. Next time, the same command reuses your
+saved setup and opens the local workspace. Keep the terminal open; Ctrl-C stops
+the server, not your saved work. Use `--no-open` to skip opening the browser.
+
+Phone access is optional and defaults to skipping. Choose an explicitly
+approved managed public HTTPS endpoint protected by pairing, an existing
+Tailscale connection, or your own HTTPS reverse proxy. Use Safari or an installed
+iOS app on iPhone/iPad; Android uses the web browser for this CLI flow. A phone
+cannot use a localhost link. `--local` ignores saved remote access for one launch;
+`--no-pair` suppresses phone prompts and invitations but does not disable a saved
+remote connection.
+
+Run `openmausbot setup` to reconfigure without resetting bots or conversations;
+the saved model default applies only to new bots. Native setup confirms provider
+sign-in; API setup asks before a potentially billable test message. API keys are
+saved as plaintext, not encrypted, in private `config.json` (`0600` on Unix).
+See the [short setup guide](docs/cli-onboarding.md) for account differences,
+phone choices, credential storage, and cancellation.
+
+For a background service on a VPS or an always-on computer, use
+`npx openmausbot serve` with explicit remote options: `--tunnel` after
+`npx openmausbot login` for a managed public address, `--tailscale` for your
+tailnet, or the Docker stack for your own domain. These are separate from
+AI-provider sign-in. Devices pair once with a short code. The deployment guide is
 [docs/deploy-vps.md](docs/deploy-vps.md); the reference is
 [docs/self-hosting.md](docs/self-hosting.md).
 

--- a/README.md
+++ b/README.md
@@ -347,7 +347,13 @@ which takes care of receipts and taxes; nothing about the app ever sits behind a
 ## Run it on a server
 
 Bots keep working with every laptop closed when the server runs on a VPS or
-a Mac mini. One command with Node 24: `npx openmausbot serve` (add
+a Mac mini. With Node 24, run `npx openmausbot start`: first launch guides
+you through choosing AI access, signing in or entering a hidden API key,
+and choosing a default model. Repeat `npx openmausbot setup` to change the
+default or add a connection without replacing your bots or conversations.
+See the [short setup guide](docs/cli-onboarding.md).
+
+For an already configured server or a service, use `npx openmausbot serve` (add
 `--tunnel` for a public address with no domain or open port, or
 `--tailscale` for your tailnet), or the Docker stack for your own domain.
 Devices pair once with a short code. The step-by-step guide is

--- a/docs/cli-onboarding.md
+++ b/docs/cli-onboarding.md
@@ -1,0 +1,43 @@
+# Terminal setup
+
+With Node 24 or newer installed, run:
+
+```sh
+npx openmausbot start
+```
+
+The first start guides you through three choices:
+
+1. Choose ChatGPT/Codex, Claude Code, or an API service. Existing supported connections are also listed.
+2. Connect your account, or paste an API key into the hidden prompt. Setup offers to install a missing Codex or Claude CLI. Codex also supports device-code sign-in for a remote terminal. API services include OpenAI, OpenRouter, Groq, and other OpenAI-compatible endpoints.
+3. Choose a model, then save. API connections ask before sending a short test message, which your provider may charge for. The selected provider and model become the default for new bots.
+
+The server starts and prints its local address and a pairing link. Open the local address to chat, or use the pairing link to connect another device. Later, run the same `npx openmausbot start` command; your saved setup is reused. Stop the server with Ctrl-C.
+
+Codex and Claude Code support agent tools. API-key connections currently support chat only. A ChatGPT or Claude subscription does not include separately billed API usage. Native account sign-in is confirmed during setup; access to the selected model is checked when you send a message.
+
+## Commands
+
+| Command | Use |
+| --- | --- |
+| `npx openmausbot setup` | Run or change setup, then exit without starting the server. |
+| `npx openmausbot start` | Run setup if needed, then start the server with saved settings. |
+| `npx openmausbot serve` | Start without interactive prompts; useful for existing configurations and unattended services. |
+| `npx openmausbot login` | Sign in to an OpenMausBot account to reserve a public address for `--tunnel`. This is separate from AI-provider sign-in. |
+
+`start` accepts the same server options as `serve`, including `--port`, `--data-dir`, `--no-pair`, `--tailscale`, and `--tunnel`. If you set a custom data directory during setup, pass that same `--data-dir` when starting. For example:
+
+```sh
+npx openmausbot setup --data-dir /path/to/omb-data
+npx openmausbot start --data-dir /path/to/omb-data --port 8799
+```
+
+Setup requires an interactive terminal. `start` can run without a terminal once setup is complete. Existing bots and conversations retain their settings; the saved default applies to new bots. Stop a running server before changing its setup.
+
+## Credentials and cancellation
+
+API keys are hidden while typed or pasted. New API connections save the key in the selected data directory's `config.json` as plaintext, with owner-only permissions (`0600`) on Unix. Keep that file private; it is not encrypted. Account sign-in credentials are managed by the provider's own CLI.
+
+Ctrl-C cancels a prompt without saving OMB settings. Installations or provider sign-ins already completed remain available for the next attempt.
+
+For remote access and deployment options, see [self-hosting](self-hosting.md) and [the VPS guide](deploy-vps.md).

--- a/docs/cli-onboarding.md
+++ b/docs/cli-onboarding.md
@@ -1,43 +1,84 @@
 # Terminal setup
 
-With Node 24 or newer installed, run:
+Install [Node.js](https://nodejs.org/) 24 or newer, then choose either way to run OpenMausBot:
 
 ```sh
-npx openmausbot start
+# Install once, then use the short command:
+npm install -g openmausbot
+openmausbot
 ```
 
-The first start guides you through three choices:
+Or, without a global install:
+
+```sh
+npx openmausbot
+```
+
+Use the same command next time. The first launch guides you through setup; later launches reuse your saved AI connection and phone-access choice. `openmausbot start` is the same as the bare command. If that workspace is already running, OpenMausBot opens it instead of starting a second server.
+
+## First launch
+
+The setup wizard uses Clack. Use ↑/↓ and Enter to select an option. Plain terminals show numbered choices instead.
 
 1. Choose ChatGPT/Codex, Claude Code, or an API service. Existing supported connections are also listed.
-2. Connect your account, or paste an API key into the hidden prompt. Setup offers to install a missing Codex or Claude CLI. Codex also supports device-code sign-in for a remote terminal. API services include OpenAI, OpenRouter, Groq, and other OpenAI-compatible endpoints.
-3. Choose a model, then save. API connections ask before sending a short test message, which your provider may charge for. The selected provider and model become the default for new bots.
+2. Sign in with the provider, or paste an API key into the hidden prompt. Setup asks before installing a missing Codex or Claude CLI. Codex also offers device-code sign-in for a remote terminal. API choices include OpenAI, OpenRouter, Groq, and other OpenAI-compatible endpoints.
+3. Choose a model and save. An API connection asks permission to send a short test message, which the provider may charge for. Native CLI setup confirms sign-in; it does not test the chosen model with a message. Model access is checked when you send one.
+4. Optionally connect a phone, or choose **Skip for now**. Your AI setup is already saved before this step.
 
-The server starts and prints its local address and a pairing link. Open the local address to chat, or use the pairing link to connect another device. Later, run the same `npx openmausbot start` command; your saved setup is reused. Stop the server with Ctrl-C.
+The workspace then starts and opens its local address in a browser on this computer. On SSH or a computer without a graphical desktop, open the printed address using an appropriate connection instead. Automatic browser opening only uses the local address; `--no-open` disables it.
 
-Codex and Claude Code support agent tools. API-key connections currently support chat only. A ChatGPT or Claude subscription does not include separately billed API usage. Native account sign-in is confirmed during setup; access to the selected model is checked when you send a message.
+Keep the terminal open while using your bots. This runs a foreground server, not an installed background service. Ctrl-C stops the server without deleting saved work; closing the browser alone does not stop it. Bots keep working only while the computer and server are running.
+
+Codex and Claude Code support agent tools. API-key connections currently support chat only. A ChatGPT or Claude subscription does not include separately billed API usage. Changing the saved default affects **new bots only**; existing bots and conversations keep their settings.
+
+## Optional phone access
+
+A phone cannot connect to this computer's `localhost` address. The harness also does not listen on your LAN address. The guide does not create a phone QR until a configured HTTPS address has been checked against this workspace.
+
+Choose one connection method:
+
+- **Managed HTTPS address:** setup asks explicit permission for a public endpoint through Cloudflare and a possible connector download. Device pairing protects chat and settings; the pairing page and basic server identity remain publicly reachable. Sign in to an **OpenMausBot account** using an emailed code, or reuse this machine's saved account. This account is separate from ChatGPT, Claude, or an API-provider account. The connection stays active while OpenMausBot runs.
+- **Existing Tailscale:** both computer and phone must already be signed in to the same tailnet, with HTTPS certificates enabled. Setup asks before enabling HTTPS serving to that tailnet; it does not install or sign in to Tailscale for you.
+- **Existing HTTPS address (advanced):** supply the origin of a reverse proxy you already configured, such as `https://maus.example.com`. Do not paste a password, path, query, or pairing code. Entering an address does not create the proxy or open a LAN listener.
+
+After the connection is ready:
+
+- **iPhone/iPad:** scan the QR with Camera to open Safari. If you already have the OpenMausBot iOS app, use its pairing scanner or paste the full link there.
+- **Android:** scan with Camera and open the link in your web browser. This CLI link does **not** work with the current Android native app's companion-pairing scanner.
+
+Choose **Connect** on the phone. Scanning alone is not a successful pairing. The code is private, single-use, and expires after five minutes. Guided phone pairing grants client access for chat and approvals, not settings or pairing administration.
+
+If the workspace starts but its HTTPS check fails, the local workspace remains usable and no phone code is created. Fix the connection and run `openmausbot pair` in another terminal to try again. A missing account, connector, or Tailscale prerequisite can prevent startup; follow the printed error, or use `openmausbot --local`. To add phone access after skipping it, stop the server, run `openmausbot setup`, then start it again.
 
 ## Commands
 
+The examples below assume a global install; prefix them with `npx` otherwise.
+
 | Command | Use |
 | --- | --- |
-| `npx openmausbot setup` | Run or change setup, then exit without starting the server. |
-| `npx openmausbot start` | Run setup if needed, then start the server with saved settings. |
-| `npx openmausbot serve` | Start without interactive prompts; useful for existing configurations and unattended services. |
-| `npx openmausbot login` | Sign in to an OpenMausBot account to reserve a public address for `--tunnel`. This is separate from AI-provider sign-in. |
+| `openmausbot` | Set up once, then start with saved settings. |
+| `openmausbot setup` | Revisit AI and optional phone setup, save, and exit without starting. This is not a reset. |
+| `openmausbot --no-open` | Start without opening a browser. |
+| `openmausbot --local` | Ignore saved remote access for this launch; keep the saved choice for next time. |
+| `openmausbot --no-pair` | Suppress phone setup prompts and pairing invitations. This does **not** turn off saved remote access; use `--local` for that. |
+| `openmausbot pair` | Create another phone invitation while the configured workspace and HTTPS connection are running. |
+| `openmausbot sessions` | List paired devices; `openmausbot sessions revoke ID` signs one out. |
+| `openmausbot serve` | Start without onboarding prompts or automatic browser opening; specify remote-access flags explicitly for a service. |
+| `openmausbot login` | Sign in to an OpenMausBot account for `--tunnel`; this does not sign in to an AI provider or start the tunnel. |
 
-`start` accepts the same server options as `serve`, including `--port`, `--data-dir`, `--no-pair`, `--tailscale`, and `--tunnel`. If you set a custom data directory during setup, pass that same `--data-dir` when starting. For example:
+`start` accepts the same server options as `serve`, including `--port`, `--data-dir`, `--tailscale`, `--tunnel`, and `--public-url`. Keep using your custom data directory and port when starting or pairing:
 
 ```sh
-npx openmausbot setup --data-dir /path/to/omb-data
-npx openmausbot start --data-dir /path/to/omb-data --port 8799
+openmausbot setup --data-dir /path/to/omb-data --port 8799
+openmausbot --data-dir /path/to/omb-data --port 8799
 ```
 
-Setup requires an interactive terminal. `start` can run without a terminal once setup is complete. Existing bots and conversations retain their settings; the saved default applies to new bots. Stop a running server before changing its setup.
+Setup needs an interactive terminal. Later starts can run without one once setup is complete. Stop a running server before changing its setup or access mode: `--local` does not turn off a remote connection belonging to a server that is already running. You do not need to delete configuration, bots, or conversations to reconfigure it.
 
 ## Credentials and cancellation
 
-API keys are hidden while typed or pasted. New API connections save the key in the selected data directory's `config.json` as plaintext, with owner-only permissions (`0600`) on Unix. Keep that file private; it is not encrypted. Account sign-in credentials are managed by the provider's own CLI.
+API keys are hidden while typed or pasted. New API connections save their key in the data directory's `config.json` as **plaintext, not encrypted**, with owner-only permissions (`0600`) on Unix. Managed-access account credentials in `tunnel-account.json` are also plaintext with `0600` permissions on Unix. Keep these files and backups private. Native provider sign-in credentials are managed by the provider's own CLI.
 
-Ctrl-C cancels a prompt without saving OMB settings. Installations or provider sign-ins already completed remain available for the next attempt.
+Ctrl-C during AI setup leaves unsaved OMB changes unapplied. Installations and provider sign-ins already completed remain available. Ctrl-C during the later phone step keeps the AI setup you already saved, exits without starting a server, and does not undo an account sign-in already completed. Run `openmausbot setup` to continue; no destructive reset is needed.
 
-For remote access and deployment options, see [self-hosting](self-hosting.md) and [the VPS guide](deploy-vps.md).
+For remote access and background deployment options, see [self-hosting](self-hosting.md) and [the VPS guide](deploy-vps.md).

--- a/docs/deploy-vps.md
+++ b/docs/deploy-vps.md
@@ -41,9 +41,14 @@ ssh root@YOUR_SERVER_IP
 No domain, no proxy, no open port. The server gets an address like `https://c-7f3a9c.openmausbot.com` through a Cloudflare tunnel; only traffic through the tunnel reaches it, and that traffic still has to pair.
 
 ```sh
+npx openmausbot setup          # once: choose AI access, connect, and choose a model
 npx openmausbot login          # once: an emailed code signs this machine in and reserves its address
 npx openmausbot serve --tunnel # runs the server there and prints the pairing link with a QR code
 ```
+
+`setup` connects an AI provider; it is separate from the OpenMausBot account.
+Use Codex's device-code option over SSH, or enter a hidden API key for a
+chat-only connection. More engines can be added later. See [CLI setup](cli-onboarding.md).
 
 `login` asks for your email, sends an 8-digit code, and prints the address it reserved for this machine. `serve --tunnel` downloads `cloudflared` on the first run (a pinned version with a verified digest, into `~/.openmausbot`), starts the server, connects the tunnel, and after a few seconds prints `tunnel: live at https://…`. Leave it running; see "Keep it running" for a service.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -47,6 +47,11 @@ refreshes it.
 3. README and docs downloads point at the canonical repo, while the legacy
    mirror exists only for installed updater clients and historical releases.
 
+The npm package is published separately and its versioned `.tgz` is attached
+only to the canonical release. It is not a desktop updater artifact; the
+mirror checks permit that one extra file while still verifying the complete,
+byte-identical desktop asset set.
+
 ## Why the gates exist
 
 Each verification step in `release.yml` maps to a real incident from the

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -45,13 +45,20 @@ Desktop-only for now (needs the Mac/Linux app):
 On any machine with Node 24 or newer (a VPS, a Mac mini, a Raspberry Pi):
 
 ```sh
-npx openmausbot serve
+npx openmausbot start
 ```
 
-It starts the server, keeps your data in `~/.openmausbot`, and prints a
+First launch asks you to choose AI access, connect an account or API key,
+and choose the default model for new bots. Existing sign-ins can be reused;
+Codex also offers device-code login for SSH. API-key connections currently
+support chat, not agent tools or computer use. The [setup guide](cli-onboarding.md)
+explains the choices, key storage, and how to run setup again safely.
+
+It then starts the server, keeps your data in `~/.openmausbot`, and prints a
 pairing link with a QR code: scan it with the phone, or open it on the
-laptop. Sign the engine CLIs in on the same machine as usual (`claude`,
-`codex`, …). Two ways to make it reachable from elsewhere:
+laptop. Use `npx openmausbot setup` to configure without starting, or
+`npx openmausbot serve` to start non-interactively with your existing config
+(for services and scripts). Two ways to make it reachable from elsewhere:
 
 - **On your Tailscale network, no domain needed:**
   `npx openmausbot serve --tailscale`. Tailscale terminates HTTPS with its

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.61",
+  "version": "0.1.62",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {
@@ -79,6 +79,7 @@
     "control-plane:dry-run": "pnpm --filter @openmausbot/control-plane dry-run"
   },
   "dependencies": {
+    "@clack/prompts": "1.7.0",
     "@hpke/core": "1.9.0",
     "@trycua/cua-driver": "0.22.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@clack/prompts':
+        specifier: 1.7.0
+        version: 1.7.0
       '@hpke/core':
         specifier: 1.9.0
         version: 1.9.0
@@ -396,6 +399,14 @@ packages:
 
   '@better-fetch/fetch@1.3.1':
     resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
+
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
+    engines: {node: '>= 20.12.0'}
 
   '@cloudflare/kv-asset-handler@0.5.0':
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
@@ -2622,8 +2633,17 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.5:
     resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3822,6 +3842,9 @@ packages:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -4495,6 +4518,18 @@ snapshots:
       '@noble/hashes': 2.3.0
 
   '@better-fetch/fetch@1.3.1': {}
+
+  '@clack/core@1.4.3':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.7.0':
+    dependencies:
+      '@clack/core': 1.4.3
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
@@ -6410,7 +6445,17 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.5: {}
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -8053,6 +8098,8 @@ snapshots:
   simple-update-notifier@2.0.0:
     dependencies:
       semver: 7.8.5
+
+  sisteransi@1.0.5: {}
 
   source-map-js@1.2.1: {}
 

--- a/scripts/build-npm-package.mjs
+++ b/scripts/build-npm-package.mjs
@@ -58,14 +58,28 @@ Run the OpenMausBot server on any machine with Node 24+, then pair your
 devices to it.
 
 \`\`\`sh
+npx openmausbot start                # choose AI access once, then start with saved settings
+npx openmausbot setup                # run or change setup without starting
 npx openmausbot serve                 # starts the server, prints a pairing link + QR
 npx openmausbot serve --tailscale     # HTTPS over your tailnet, no domain needed
 npx openmausbot pair --label "Phone"  # another device later
 npx openmausbot sessions              # who is paired; "sessions revoke <id>" signs one out
 \`\`\`
 
-Engines (Claude Code, Codex, …) are separate CLIs signed in on the same
-machine. Full guide: https://github.com/milind-soni/OpenMausBot/blob/main/docs/self-hosting.md
+First start: choose ChatGPT/Codex, Claude Code, or an API service; sign in
+or paste a hidden API key; choose a model and save. Setup can install a
+missing Codex or Claude CLI. Later starts reuse your saved settings.
+
+API services include OpenAI, OpenRouter, Groq, and compatible endpoints.
+API connections currently support chat only; API billing is separate from
+ChatGPT/Claude subscriptions. New API keys are saved as plaintext in the
+private config.json (0600 on Unix). Keep this file private.
+
+Use \`serve\` for starts without prompts. \`login\` signs into an OpenMausBot
+account for remote access with \`--tunnel\`; AI-provider sign-in is in setup.
+
+Setup guide: https://github.com/milind-soni/OpenMausBot/blob/main/docs/cli-onboarding.md
+Hosting guide: https://github.com/milind-soni/OpenMausBot/blob/main/docs/self-hosting.md
 `,
 );
 console.log(`npm package assembled at ${out} (openmausbot@${app.version})`);

--- a/scripts/build-npm-package.mjs
+++ b/scripts/build-npm-package.mjs
@@ -54,32 +54,81 @@ writeFileSync(
   join(out, "README.md"),
   `# openmausbot
 
-Run the OpenMausBot server on any machine with Node 24+, then pair your
-devices to it.
+Your own team of AI bots, with guided terminal setup. Requires Node 24+.
 
 \`\`\`sh
-npx openmausbot start                # choose AI access once, then start with saved settings
-npx openmausbot setup                # run or change setup without starting
-npx openmausbot serve                 # starts the server, prints a pairing link + QR
-npx openmausbot serve --tailscale     # HTTPS over your tailnet, no domain needed
-npx openmausbot pair --label "Phone"  # another device later
-npx openmausbot sessions              # who is paired; "sessions revoke <id>" signs one out
+npm install -g openmausbot
+openmausbot
 \`\`\`
 
-First start: choose ChatGPT/Codex, Claude Code, or an API service; sign in
-or paste a hidden API key; choose a model and save. Setup can install a
-missing Codex or Claude CLI. Later starts reuse your saved settings.
+Or run \`npx openmausbot\` without a global install. Use the same command next
+time; \`openmausbot start\` is an alias for the bare command.
+
+First launch: use arrow keys and Enter (numbered choices in plain terminals) to choose
+ChatGPT/Codex, Claude Code, or an API service; sign in or paste a hidden API
+key; choose a model and save. Setup asks before installing a missing Codex
+or Claude CLI. The saved model applies only to new bots; existing bots and
+conversations keep their settings.
+
+One optional step connects your phone, defaulting to Skip for now. Choose
+an explicitly approved managed public HTTPS endpoint protected by pairing,
+existing Tailscale, or an HTTPS reverse proxy you already configured.
+Managed access uses a separate OpenMausBot account and asks permission for
+the public endpoint and possible connector download. The pairing page and
+basic server identity are public; chat and settings require pairing.
+Tailscale must already be installed and signed in on both devices.
+
+After the HTTPS connection is checked, scan the QR with your phone's
+Camera: use Safari on iPhone/iPad or a web browser on Android. An installed
+OpenMausBot iOS app can also scan or accept the full link. This CLI link
+does not work with the current Android native pairing scanner. Choose
+Connect on the phone; scanning alone is not a completed pairing. Codes
+are private, single-use, and expire after five minutes. Guided phone
+access permits chat and approvals, not settings or pairing administration.
+Localhost and a bare LAN address cannot connect your phone to this server.
+
+Later launches reuse your saved choices and open the local workspace.
+Keep the terminal open: this is a foreground server, not a background
+service. Ctrl-C stops the server without deleting saved work. Automatic
+browser opening uses only the local address; it is skipped for SSH and
+headless sessions, and can be disabled with \`--no-open\`.
+
+\`\`\`sh
+openmausbot setup          # reconfigure AI and optional phone access; not a reset
+openmausbot --no-open      # do not open a browser
+openmausbot --local        # ignore saved remote access for this launch
+openmausbot --no-pair      # suppress phone prompts and invitations
+openmausbot pair           # another phone while the HTTPS workspace is running
+openmausbot sessions       # list devices; sessions revoke ID signs one out
+openmausbot serve          # no onboarding prompts; explicit remote flags for services
+\`\`\`
+
+Stop an existing server before reconfiguring or changing access mode.
+\`--local\` preserves your saved choice for next time. \`--no-pair\` does not
+turn off saved remote access; use \`--local\` for that on a new launch.
+With a custom \`--data-dir\` or \`--port\`, keep using those options when
+starting and pairing.
 
 API services include OpenAI, OpenRouter, Groq, and compatible endpoints.
-API connections currently support chat only; API billing is separate from
-ChatGPT/Claude subscriptions. New API keys are saved as plaintext in the
-private config.json (0600 on Unix). Keep this file private.
+API connections currently support chat only. Setup asks before a short,
+potentially billable API test; native setup confirms sign-in, with model
+access checked when you send a message. API billing is separate from
+ChatGPT/Claude subscriptions. New API keys in config.json and managed
+account credentials in tunnel-account.json are plaintext, not encrypted,
+with owner-only permissions (0600 on Unix). Keep these files private.
 
-Use \`serve\` for starts without prompts. \`login\` signs into an OpenMausBot
-account for remote access with \`--tunnel\`; AI-provider sign-in is in setup.
+Ctrl-C before saving AI setup leaves its pending OMB changes unapplied.
+During the later phone step, it keeps the AI setup already saved and exits
+without starting a server. Completed installs and sign-ins remain; run
+\`openmausbot setup\` to continue without deleting your data.
 
-Setup guide: https://github.com/milind-soni/OpenMausBot/blob/main/docs/cli-onboarding.md
-Hosting guide: https://github.com/milind-soni/OpenMausBot/blob/main/docs/self-hosting.md
+For a service, use \`serve --tunnel\` after \`login\` for managed HTTPS,
+\`serve --tailscale\` for your tailnet, or your own reverse proxy. The
+\`login\` command signs in to an OpenMausBot account, not an AI provider;
+it does not start the tunnel itself.
+
+[Setup guide](https://github.com/milind-soni/OpenMausBot/blob/main/docs/cli-onboarding.md)
+· [Hosting guide](https://github.com/milind-soni/OpenMausBot/blob/main/docs/self-hosting.md)
 `,
 );
 console.log(`npm package assembled at ${out} (openmausbot@${app.version})`);

--- a/server/cli-api-setup.test.ts
+++ b/server/cli-api-setup.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { API_ENDPOINTS, fetchSetupModels, normalizeApiUrl, verifySetupCompletion } from "./cli-api-setup.ts";
+
+const key = "sk-setup-fixture-secret";
+const base = "https://provider.example/v1";
+const reply = { choices: [{ message: { role: "assistant", content: "OK" } }] };
+const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status });
+const mockFetch = (response: Response) => {
+  const fn = vi.fn<typeof fetch>().mockResolvedValue(response);
+  vi.stubGlobal("fetch", fn);
+  return fn;
+};
+afterEach(() => { vi.useRealTimers(); vi.restoreAllMocks(); vi.unstubAllGlobals(); vi.unstubAllEnvs(); });
+
+describe("API setup endpoint validation", () => {
+  it("offers provider API URLs and key pages, not a stale model catalog", () => {
+    expect(API_ENDPOINTS.map(({ id, url }) => [id, url])).toEqual([
+      ["openai", "https://api.openai.com/v1"],
+      ["openrouter", "https://openrouter.ai/api/v1"],
+      ["groq", "https://api.groq.com/openai/v1"],
+    ]);
+    for (const endpoint of API_ENDPOINTS) expect(endpoint.keyUrl).toMatch(/^https:\/\//u);
+  });
+
+  it("normalizes HTTPS prefixes and permits only loopback HTTP", () => {
+    expect(normalizeApiUrl("  https://PROVIDER.example:443/v1///  ")).toBe(base);
+    expect(normalizeApiUrl("https://provider.example")).toBe("https://provider.example");
+    for (const host of ["localhost", "127.0.0.1", "[::1]"]) expect(normalizeApiUrl(`http://${host}:1234/v1/`)).toBe(`http://${host}:1234/v1`);
+  });
+
+  it.each([
+    "not a URL", "file:///tmp/provider", "ftp://provider.example/v1", "http://provider.example/v1",
+    "http://localhost.example/v1", "http://192.168.1.1/v1", "http://0.0.0.0/v1",
+    `https://user:${key}@provider.example/v1`, "https://@provider.example/v1",
+    `https://provider.example/v1?key=${key}`, "https://provider.example/v1?", "https://provider.example/v1#",
+    "https://provider.example/v1#fragment", "https://provider.example\\v1", "https://provi\nder.example/v1",
+  ])("rejects an unsafe URL without echoing it: case %#", (url) => {
+    expect(() => normalizeApiUrl(url)).toThrow(/HTTPS API base URL/u);
+    try { normalizeApiUrl(url); } catch (error) { expect(String(error)).not.toContain(key); }
+  });
+});
+
+describe("API setup models", () => {
+  it("authenticates only the direct /models GET and parses a live catalog", async () => {
+    const fetch = mockFetch(json({ data: [
+      { id: "provider/model-b", name: "Model B" },
+      { id: "provider/model-a" }, { id: "provider/model-b", name: "Duplicate" },
+      null, { id: 5 }, { id: "  " }, { id: "bad\u001bmodel" },
+    ] }));
+    await expect(fetchSetupModels(`${base}/`, key)).resolves.toEqual([
+      { id: "provider/model-b", label: "Model B" }, { id: "provider/model-a", label: "provider/model-a" },
+    ]);
+    expect(fetch).toHaveBeenCalledExactlyOnceWith(`${base}/models`, {
+      method: "GET", headers: { authorization: `Bearer ${key}` }, signal: expect.any(AbortSignal), redirect: "error",
+    });
+  });
+
+  it.each([{}, null, [], { models: ["wrong contract"] }, { data: [] }, { data: [{ id: "" }] }])("rejects unusable catalogs without persisting a fallback: case %#", async (body) => {
+    mockFetch(json(body));
+    await expect(fetchSetupModels(base, key)).rejects.toThrow(/no usable models.*manually/u);
+  });
+
+  it("does not expose malformed JSON or credentials", async () => {
+    mockFetch(new Response(`provider echoed ${key}`));
+    const failure = await fetchSetupModels(base, key).catch((error: Error) => error);
+    expect(failure).toBeInstanceOf(Error);
+    expect(String(failure)).toContain("invalid JSON");
+    expect(String(failure)).not.toContain(key);
+  });
+
+  it("stops after eight seconds and aborts the request, even if fetch never settles", async () => {
+    vi.useFakeTimers();
+    const fetch = vi.fn<typeof globalThis.fetch>(() => new Promise(() => {}));
+    vi.stubGlobal("fetch", fetch);
+    const failure = expect(fetchSetupModels(base, key)).rejects.toThrow(/timed out after 8 seconds/u);
+    await vi.advanceTimersByTimeAsync(8_000);
+    await failure;
+    expect(fetch.mock.calls[0][1]?.signal?.aborted).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("includes reading the model-list body in the timeout", async () => {
+    vi.useFakeTimers();
+    const response = json({});
+    vi.spyOn(response, "json").mockImplementation(() => new Promise(() => {}));
+    mockFetch(response);
+    const failure = expect(fetchSetupModels(base, key)).rejects.toThrow(/timed out after 8 seconds/u);
+    await vi.advanceTimersByTimeAsync(8_000);
+    await failure;
+  });
+});
+
+describe("consented API setup completion", () => {
+  it("sends one tiny non-streaming message without model-specific tuning flags", async () => {
+    const fetch = mockFetch(json(reply));
+    await expect(verifySetupCompletion(base, key, "chosen/model")).resolves.toBeUndefined();
+    expect(fetch).toHaveBeenCalledOnce();
+    const [url, init] = fetch.mock.calls[0];
+    expect(url).toBe(`${base}/chat/completions`);
+    expect(init).toMatchObject({ method: "POST", headers: { authorization: `Bearer ${key}`, "content-type": "application/json" }, redirect: "error" });
+    expect(JSON.parse(String(init?.body))).toEqual({ model: "chosen/model", messages: [{ role: "user", content: "Reply with exactly OK." }], stream: false });
+    expect(init?.signal?.aborted).toBe(false);
+  });
+
+  it.each(["https://openrouter.ai/api/v1", "https://API.openrouter.ai/v1"])("mirrors the selected OpenRouter upstream without allowing fallback: %s", async (url) => {
+    const fetch = mockFetch(json(reply));
+    await verifySetupCompletion(url, key, "chosen/model", "Selected upstream");
+    expect(JSON.parse(String(fetch.mock.calls[0][1]?.body))).toMatchObject({
+      model: "chosen/model", provider: { order: ["Selected upstream"], allow_fallbacks: false },
+    });
+  });
+
+  it.each([base, "https://api.groq.com/openai/v1", "https://openrouter.ai.other.example/api/v1", "http://localhost:1234/v1"])("does not send OpenRouter routing to other endpoints: %s", async (url) => {
+    const fetch = mockFetch(json(reply));
+    await verifySetupCompletion(url, key, "chosen/model", "Selected upstream");
+    expect(JSON.parse(String(fetch.mock.calls[0][1]?.body))).not.toHaveProperty("provider");
+  });
+
+  it.each([undefined, ""])("does not inherit environment routing when the effective instance has none: case %#", async (provider) => {
+    vi.stubEnv("OPENAI_COMPAT_PROVIDER", "Unrelated environment upstream");
+    const fetch = mockFetch(json(reply));
+    await verifySetupCompletion("https://openrouter.ai/api/v1", key, "chosen/model", provider);
+    expect(JSON.parse(String(fetch.mock.calls[0][1]?.body))).not.toHaveProperty("provider");
+  });
+
+  it.each([
+    {}, { choices: [] }, { choices: [{ message: { role: "assistant", content: " " } }] },
+    { choices: [{ message: { role: "user", content: "OK" } }] },
+    { choices: [{ message: { role: "assistant", reasoning_content: "thinking" } }] },
+    { choices: [{ message: { role: "assistant", content: [{ text: "wrong contract" }] } }] },
+  ])("requires an actual nonempty assistant reply: case %#", async (body) => {
+    mockFetch(json(body));
+    await expect(verifySetupCompletion(base, key, "model")).rejects.toThrow(/did not return an assistant text reply/u);
+  });
+
+  it("aborts after thirty seconds without claiming the billable test succeeded", async () => {
+    vi.useFakeTimers();
+    const fetch = vi.fn<typeof globalThis.fetch>(() => new Promise(() => {}));
+    vi.stubGlobal("fetch", fetch);
+    const failure = expect(verifySetupCompletion(base, key, "model")).rejects.toThrow(/timed out after 30 seconds/u);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await failure;
+    expect(fetch.mock.calls[0][1]?.signal?.aborted).toBe(true);
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+});
+
+describe("safe API setup failures", () => {
+  it.each([
+    [401, /key.*permissions/u], [403, /key.*permissions/u], [402, /credits.*billing/u],
+    [429, /rate or quota limit/u], [400, /model ID.*Chat Completions/u],
+    [404, /model ID.*Chat Completions/u], [422, /model ID.*Chat Completions/u],
+    [503, /provider is unavailable/u], [302, /Redirects are not followed/u],
+  ])("distinguishes HTTP %i without reading the provider's error body", async (status, expected) => {
+    const response = json({ error: { message: `raw-secret ${key}` } }, status);
+    const text = vi.spyOn(response, "text");
+    const parse = vi.spyOn(response, "json");
+    mockFetch(response);
+    const failure = await verifySetupCompletion(base, key, "model").catch((error: Error) => error);
+    expect(String(failure)).toContain(`HTTP ${status}`);
+    expect(String(failure)).toMatch(expected);
+    expect(String(failure)).not.toContain(key);
+    expect(text).not.toHaveBeenCalled();
+    expect(parse).not.toHaveBeenCalled();
+  });
+
+  it("explains a missing models route instead of suggesting a model change", async () => {
+    mockFetch(json({ error: key }, 404));
+    await expect(fetchSetupModels(base, key)).rejects.toThrow(/HTTP 404.*\/models endpoint/u);
+  });
+
+  it.each(["network", "redirect"]) ("redacts raw %s fetch errors and their causes", async (kind) => {
+    const fetch = vi.fn<typeof globalThis.fetch>().mockRejectedValue(new TypeError(`${kind}: ${key}`, { cause: new Error(`https://${key}@provider.example`) }));
+    vi.stubGlobal("fetch", fetch);
+    const failure = await fetchSetupModels(base, key).catch((error: Error) => error);
+    expect(String(failure)).toMatch(/network.*direct API URL.*redirects are not followed/u);
+    expect(String(failure)).not.toContain(key);
+    expect((failure as Error).cause).toBeUndefined();
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it("rejects missing or newline-containing inputs before any request", async () => {
+    const fetch = vi.fn(); vi.stubGlobal("fetch", fetch);
+    await expect(fetchSetupModels(base, " ")).rejects.toThrow(/API key/u);
+    await expect(fetchSetupModels(base, `${key}\nInjected: value`)).rejects.toThrow(/API key/u);
+    await expect(verifySetupCompletion(base, key, " ")).rejects.toThrow(/model ID/u);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not validate a trimmed replacement for an existing runtime credential", async () => {
+    const fetch = vi.fn(); vi.stubGlobal("fetch", fetch);
+    await expect(fetchSetupModels(base, ` ${key} `)).rejects.toThrow(/API key/u);
+    await expect(verifySetupCompletion(base, `${key}\n`, "model")).rejects.toThrow(/API key/u);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/server/cli-api-setup.ts
+++ b/server/cli-api-setup.ts
@@ -1,0 +1,128 @@
+// Small, stateless probes for CLI onboarding. The caller owns consent for the
+// metered completion and persistence; neither credentials nor replies are logged.
+export const API_ENDPOINTS = [
+  { id: "openai", label: "OpenAI API", url: "https://api.openai.com/v1", keyUrl: "https://platform.openai.com/api-keys" },
+  { id: "openrouter", label: "OpenRouter", url: "https://openrouter.ai/api/v1", keyUrl: "https://openrouter.ai/settings/keys" },
+  { id: "groq", label: "Groq", url: "https://api.groq.com/openai/v1", keyUrl: "https://console.groq.com/keys" },
+] as const;
+
+export function normalizeApiUrl(value: string): string {
+  const input = value.trim();
+  const invalid = () => new Error("Enter an HTTPS API base URL without credentials, a query, or a fragment. HTTP is allowed only for localhost.");
+  let url: URL;
+  try { url = new URL(input); } catch { throw invalid(); }
+  const local = ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
+  if (
+    // Reject invisible URL characters and ambiguous authority/path separators.
+    // eslint-disable-next-line no-control-regex
+    /[\u0000-\u0020\u007f\\?#]/u.test(input) || url.username || url.password ||
+    input.slice(input.indexOf("://") + 3).split("/")[0]?.includes("@") ||
+    (url.protocol !== "https:" && !(url.protocol === "http:" && local))
+  ) throw invalid();
+  return url.href.replace(/\/+$/u, "");
+}
+
+class SetupApiError extends Error {}
+
+function httpFailure(status: number, completion: boolean): SetupApiError {
+  const prefix = `API returned HTTP ${status}.`;
+  if (status === 401 || status === 403) return new SetupApiError(`${prefix} Check the API key and its access permissions.`);
+  if (status === 402) return new SetupApiError(`${prefix} Check the provider's credits and billing settings.`);
+  if (status === 429) return new SetupApiError(`${prefix} A rate or quota limit was reached. Check credits and limits, then try again later.`);
+  if (status >= 300 && status < 400) return new SetupApiError(`${prefix} Redirects are not followed. Use the provider's direct API base URL.`);
+  if (completion && [400, 404, 422].includes(status)) return new SetupApiError(`${prefix} Check the model ID and access, or choose a model that supports Chat Completions at this API URL.`);
+  if (status === 404) return new SetupApiError(`${prefix} Check the API base URL: it must provide a /models endpoint.`);
+  if (status >= 500) return new SetupApiError(`${prefix} The provider is unavailable. Try again later.`);
+  return new SetupApiError(`${prefix} Check the API URL and provider settings, then try again.`);
+}
+
+async function setupJson(url: string, key: string, body?: Record<string, unknown>): Promise<unknown> {
+  const base = normalizeApiUrl(url);
+  // The wizard trims newly pasted keys. Existing credentials must be tested
+  // exactly as the runtime will send them, not silently repaired only here.
+  const token = key;
+  // Header credentials must not contain control characters or whitespace.
+  // eslint-disable-next-line no-control-regex
+  if (!token || /[\u0000-\u0020\u007f]/u.test(token)) throw new SetupApiError("Enter a non-empty API key without spaces or line breaks.");
+  const completion = body !== undefined;
+  const operation = completion ? "The test reply" : "The model list";
+  const timeoutMs = completion ? 30_000 : 8_000;
+  const abort = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    // Include reading the response body in the deadline, not only headers.
+    return await Promise.race([
+      (async () => {
+        const response = await fetch(`${base}${completion ? "/chat/completions" : "/models"}`, {
+          method: completion ? "POST" : "GET",
+          headers: { authorization: `Bearer ${token}`, ...(completion ? { "content-type": "application/json" } : {}) },
+          ...(completion ? { body: JSON.stringify(body) } : {}),
+          signal: abort.signal,
+          redirect: "error",
+        });
+        if (!response.ok) {
+          void response.body?.cancel().catch(() => {});
+          throw httpFailure(response.status, completion);
+        }
+        try { return await response.json(); }
+        catch { throw new SetupApiError(`${operation} returned invalid JSON. Check that the API URL supports the OpenAI-compatible API.`); }
+      })(),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          abort.abort();
+          reject(new SetupApiError(`${operation} timed out after ${timeoutMs / 1000} seconds. Check the connection and try again.`));
+        }, timeoutMs);
+      }),
+    ]);
+  } catch (error) {
+    if (error instanceof SetupApiError) throw error;
+    // fetch errors can contain a URL, echoed credentials, or provider content.
+    // Deliberately expose neither their message nor their cause.
+    throw new SetupApiError("Could not reach the API. Check the network and direct API URL; redirects are not followed.");
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const record = (value: unknown): Record<string, unknown> | undefined =>
+  value !== null && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
+
+export async function fetchSetupModels(url: string, key: string): Promise<Array<{ id: string; label: string }>> {
+  const json = record(await setupJson(url, key));
+  const models = new Map<string, { id: string; label: string }>();
+  for (const entry of Array.isArray(json?.data) ? json.data : []) {
+    const item = record(entry);
+    const id = typeof item?.id === "string" ? item.id.trim() : "";
+    // Model IDs and display labels reach the terminal; block control sequences.
+    // eslint-disable-next-line no-control-regex
+    if (!id || /[\u0000-\u001f\u007f]/u.test(id) || models.has(id)) continue;
+    // eslint-disable-next-line no-control-regex
+    const name = typeof item?.name === "string" ? item.name.replace(/[\u0000-\u001f\u007f]/gu, "").trim() : "";
+    models.set(id, { id, label: name || id });
+  }
+  if (!models.size) throw new SetupApiError("The API returned no usable models. Check the API URL and model access, or enter a model ID from your provider manually.");
+  return [...models.values()];
+}
+
+/** Call only after consent, passing the effective instance's provider routing. */
+export async function verifySetupCompletion(url: string, key: string, model: string, provider?: string): Promise<void> {
+  const id = model.trim();
+  // Keep manually entered IDs safe to show in the terminal and saved setup.
+  // eslint-disable-next-line no-control-regex
+  if (!id || /[\u0000-\u001f\u007f]/u.test(id)) throw new SetupApiError("Choose a non-empty model ID without control characters.");
+  const host = new URL(normalizeApiUrl(url)).hostname.toLowerCase();
+  // Mirror OpenAICompatDriver's OpenRouter-only routing, without inheriting
+  // environment overrides that the caller may have deliberately disabled.
+  const pinProvider = provider && (host === "openrouter.ai" || host.endsWith(".openrouter.ai"));
+  const json = record(await setupJson(url, key, {
+    model: id,
+    messages: [{ role: "user", content: "Reply with exactly OK." }],
+    stream: false,
+    ...(pinProvider ? { provider: { order: [provider], allow_fallbacks: false } } : {}),
+  }));
+  const choice = record(Array.isArray(json?.choices) ? json.choices[0] : undefined);
+  const message = record(choice?.message);
+  if (message?.role !== "assistant" || typeof message.content !== "string" || !message.content.trim()) {
+    throw new SetupApiError("The API did not return an assistant text reply. Choose a model that supports Chat Completions, then try again.");
+  }
+}

--- a/server/cli-lifecycle.test.ts
+++ b/server/cli-lifecycle.test.ts
@@ -1,0 +1,255 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { hostname } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { isWorkspaceRunning, runOnboardingCommand, runServe, type CliOptions } from "./cli.ts";
+
+const mocks = vi.hoisted(() => ({
+  denyLogOpen: false,
+  spawn: vi.fn(),
+  tailscaleStatus: vi.fn(), tailscaleServe: vi.fn(), tailscaleServeOff: vi.fn(),
+  createTunnelAccount: vi.fn(), createTunnelOrigin: vi.fn(), cleanupTunnelOrigin: vi.fn(),
+  describeTunnelAccount: vi.fn(), tunnelAccess: vi.fn(), ensureCloudflared: vi.fn(),
+  guardianEntry: vi.fn(), startTunnel: vi.fn(),
+}));
+vi.mock("node:child_process", async (original) => ({
+  ...await original<typeof import("node:child_process")>(), spawn: mocks.spawn,
+}));
+vi.mock("node:fs", async (original) => {
+  const fs = await original<typeof import("node:fs")>();
+  return {
+    ...fs,
+    openSync: (...args: Parameters<typeof fs.openSync>) => {
+      if (mocks.denyLogOpen && String(args[0]).endsWith(".log")) {
+        throw Object.assign(new Error("Fixture log permission denied"), { code: "EACCES" });
+      }
+      return fs.openSync(...args);
+    },
+  };
+});
+vi.mock("./tailscale.ts", () => ({
+  tailscaleStatus: mocks.tailscaleStatus, tailscaleServe: mocks.tailscaleServe,
+  tailscaleServeOff: mocks.tailscaleServeOff, explainTailscaleFailure: (failure: string) => failure,
+}));
+vi.mock("./tunnel.ts", () => ({ ...mocks, describeTunnelState: () => "Fixture tunnel" }));
+vi.mock("./browser-engine.ts", () => ({
+  browserEngineStatus: () => ({ kind: "ready" }), describeBrowserEngine: () => "Fixture browser ready",
+}));
+vi.mock("./cli-setup.ts", () => ({
+  runSetup: () => { throw new Error("An existing workspace must not rerun setup"); },
+}));
+
+const workspaceId = "4e406646-1030-4613-8878-e227ab722ffc";
+const childPid = process.pid + 1;
+const ttyDescriptors = [process.stdin, process.stdout].map((stream) => Object.getOwnPropertyDescriptor(stream, "isTTY"));
+let dataDir: string;
+let options: CliOptions;
+let signalListeners: Map<NodeJS.Signals, Set<unknown>>;
+const children: ChildProcess[] = [];
+
+function childProcess(): ChildProcess {
+  const child = Object.assign(new EventEmitter(), {
+    pid: childPid,
+    kill: vi.fn((signal: NodeJS.Signals) => {
+      queueMicrotask(() => child.emit("exit", null, signal));
+      return true;
+    }),
+  }) as unknown as ChildProcess;
+  children.push(child);
+  return child;
+}
+
+// Invoke only the handler installed by runServe, never signal the test runner
+// or another process. The child is an EventEmitter, not a real subprocess.
+function interrupt(): void {
+  const handlers = process.listeners("SIGINT").filter((handler) => !signalListeners.get("SIGINT")?.has(handler));
+  expect(handlers).toHaveLength(1);
+  handlers[0]!("SIGINT");
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mocks.denyLogOpen = false;
+  dataDir = mkdtempSync(join(process.env.HOME!, "cli-lifecycle-"));
+  options = { command: "serve", port: 18451, dataDir, tailscale: false, tunnel: false, client: false, pair: false, json: false, guided: true, open: false };
+  signalListeners = new Map(["SIGINT", "SIGTERM"].map((signal) => [signal as NodeJS.Signals, new Set(process.listeners(signal))]));
+  mocks.spawn.mockImplementation(() => childProcess());
+  mocks.tailscaleStatus.mockResolvedValue({ status: { cli: "/fixture/tailscale", dnsName: "fixture.tail.test", addresses: [], backendState: "Running" } });
+  mocks.tailscaleServe.mockResolvedValue({ origin: "https://fixture.tail.test" });
+  mocks.tailscaleServeOff.mockResolvedValue(undefined);
+  mocks.createTunnelAccount.mockReturnValue({ credentials: { status: "available", read: () => ({}) }, service: { retry: async () => ({}) } });
+  mocks.describeTunnelAccount.mockReturnValue({ email: "fixture@example.test" });
+  mocks.tunnelAccess.mockReturnValue({ endpoint: "https://fixture.openmausbot.test" });
+  mocks.ensureCloudflared.mockResolvedValue("/fixture/cloudflared");
+  mocks.guardianEntry.mockReturnValue("/fixture/guardian");
+  mocks.createTunnelOrigin.mockReturnValue({ socketPath: join(dataDir, "fixture.sock") });
+  mocks.startTunnel.mockReturnValue({ started: Promise.resolve(), stop: vi.fn().mockResolvedValue(undefined) });
+  vi.stubGlobal("fetch", vi.fn(() => { throw new Error("Unexpected fixture request"); }));
+});
+
+afterEach(() => {
+  for (const child of children.splice(0)) child.emit("exit", 0, null);
+  for (const [signal, before] of signalListeners) {
+    for (const listener of process.listeners(signal)) if (!before.has(listener)) process.removeListener(signal, listener);
+  }
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  for (const [index, stream] of [process.stdin, process.stdout].entries()) {
+    const descriptor = ttyDescriptors[index];
+    if (descriptor) Object.defineProperty(stream, "isTTY", descriptor);
+    else Reflect.deleteProperty(stream, "isTTY");
+  }
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("CLI startup lifecycle", () => {
+  it("does not enable Tailscale or spawn a server when guided logs cannot be opened", async () => {
+    mocks.denyLogOpen = true;
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json({}, { status: 503 })));
+    await expect(runServe({ ...options, tailscale: true }, vi.fn())).rejects.toMatchObject({ code: "EACCES" });
+    expect(mocks.tailscaleServe).not.toHaveBeenCalled();
+    expect(mocks.tailscaleServeOff).not.toHaveBeenCalled();
+    expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+
+  it("turns Tailscale back off if spawning the server fails after enabling serve", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json({}, { status: 503 })));
+    mocks.spawn.mockImplementation(() => { throw new Error("Fixture spawn failure"); });
+    await expect(runServe({ ...options, tailscale: true }, vi.fn())).rejects.toThrow("Fixture spawn failure");
+    expect(mocks.tailscaleServe).toHaveBeenCalledOnce();
+    expect(mocks.tailscaleServeOff).toHaveBeenCalledOnce();
+    expect(mocks.tailscaleServeOff).toHaveBeenCalledWith(expect.objectContaining({ dnsName: "fixture.tail.test" }));
+  });
+
+  it.each([
+    { outcome: "success", result: { origin: "https://fixture.tail.test" } },
+    { outcome: "failure", result: { failure: "unknown" } },
+  ])("cleans up and never spawns when Tailscale returns $outcome after startup cancellation", async ({ result }) => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json({}, { status: 503 })));
+    mocks.tailscaleServe.mockImplementation(async () => {
+      await Promise.resolve();
+      interrupt();
+      return result;
+    });
+    expect(await runServe({ ...options, tailscale: true }, vi.fn())).toBe(130);
+    expect(mocks.tailscaleServe).toHaveBeenCalledOnce();
+    expect(mocks.tailscaleServeOff).toHaveBeenCalledOnce();
+    expect(mocks.tailscaleServeOff).toHaveBeenCalledWith(expect.objectContaining({ dnsName: "fixture.tail.test" }));
+    expect(mocks.spawn).not.toHaveBeenCalled();
+    for (const [signal, before] of signalListeners) {
+      expect(process.listeners(signal).filter((handler) => !before.has(handler))).toEqual([]);
+    }
+  });
+
+  it("does not start a tunnel after SIGINT during the final readiness response", async () => {
+    let healthRequests = 0;
+    vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request) => {
+      expect(String(url)).toBe(`http://127.0.0.1:${options.port}/api/health`);
+      healthRequests++;
+      if (healthRequests === 1) return Response.json({}, { status: 503 });
+      if (healthRequests === 3) interrupt();
+      return Response.json({ app: "openmausbot", pid: childPid });
+    }));
+    expect(await runServe({ ...options, tunnel: true }, vi.fn())).toBe(0);
+    expect(healthRequests).toBe(3);
+    expect(mocks.startTunnel).not.toHaveBeenCalled();
+    expect(children[0]!.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(mocks.cleanupTunnelOrigin).toHaveBeenCalledOnce();
+  });
+
+  it("reopens a matching desktop workspace even when its server PID differs from the lease owner", async () => {
+    writeFileSync(join(dataDir, "environment-id"), workspaceId);
+    writeFileSync(join(dataDir, "openmausbot-server.lease"), JSON.stringify({
+      version: 1, pid: process.pid, host: hostname(), token: workspaceId, createdAt: Date.now(),
+    }));
+    vi.stubEnv("OMB_DATA_DIR", process.env.OMB_DATA_DIR);
+    for (const stream of [process.stdin, process.stdout]) Object.defineProperty(stream, "isTTY", { value: true, configurable: true });
+    vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request) => String(url).endsWith("/api/health")
+      ? Response.json({ app: "openmausbot", pid: childPid })
+      : Response.json({ environmentId: workspaceId })));
+    const start = vi.fn();
+    const open = vi.fn().mockResolvedValue(true);
+    const io = { log: vi.fn(), error: vi.fn(), ask: vi.fn() };
+    expect(await runOnboardingCommand({ ...options, command: "start", open: true }, io, start, { open })).toBe(0);
+    expect(open).toHaveBeenCalledWith(options.port);
+    expect(start).not.toHaveBeenCalled();
+    expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+
+  it("does not mistake another workspace on the same port for this one", async () => {
+    writeFileSync(join(dataDir, "environment-id"), workspaceId);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(Response.json({ app: "openmausbot", pid: childPid }))
+      .mockResolvedValueOnce(Response.json({ environmentId: "different-workspace" })));
+    expect(await isWorkspaceRunning(options)).toBe(false);
+  });
+
+  it.each(["mismatched", "unreachable"])("never mints a phone code for a %s public endpoint", async (failure) => {
+    let healthRequests = 0;
+    const requests: string[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const address = String(url);
+      requests.push(address);
+      expect(init?.method).not.toBe("POST");
+      if (address.endsWith("/api/health")) {
+        return ++healthRequests === 1 ? Response.json({}, { status: 503 }) : Response.json({ app: "openmausbot", pid: childPid });
+      }
+      if (address.startsWith("https://")) {
+        if (failure === "unreachable") throw new Error("Fixture endpoint offline");
+        return Response.json({ environmentId: "another-workspace" });
+      }
+      return Response.json({ environmentId: workspaceId });
+    }));
+    const log = vi.fn((line: string) => { if (line.includes("Keep this terminal open")) interrupt(); });
+    expect(await runServe({ ...options, pair: true, phone: "android", publicUrl: "https://fixture.example.test" }, log)).toBe(0);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("no phone pairing code was created"));
+    expect(requests.some((url) => url.includes("/api/auth/pairing"))).toBe(false);
+    expect(requests).toContain("https://fixture.example.test/.well-known/openmausbot/environment");
+  });
+
+  it("offers Android client pairing only after verifying the same workspace, without claiming it is connected", async () => {
+    const origin = "https://fixture.example.test";
+    const code = "ABCD-EFGH-JKLM";
+    const expiresAt = Date.now() + 300_000;
+    const pairingUrl = `${origin}/pair#code=${code}`;
+    let healthRequests = 0;
+    const fetcher = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const address = String(url);
+      if (address.endsWith("/api/health")) {
+        return ++healthRequests === 1 ? Response.json({}, { status: 503 }) : Response.json({ app: "openmausbot", pid: childPid });
+      }
+      if (address === `http://127.0.0.1:${options.port}/api/auth/pairing`) {
+        expect(init?.method).toBe("POST");
+        expect(JSON.parse(String(init?.body))).toEqual({ label: "Android", scopes: ["client"] });
+        return Response.json({ code, url: pairingUrl, expiresAt });
+      }
+      expect(address).toMatch(/\/\.well-known\/openmausbot\/environment$/);
+      expect(init?.method).not.toBe("POST");
+      expect(init?.body).toBeUndefined();
+      return Response.json({ environmentId: workspaceId });
+    });
+    vi.stubGlobal("fetch", fetcher);
+    const log = vi.fn((line: string) => { if (line.includes("Keep this terminal open")) interrupt(); });
+    expect(await runServe({ ...options, pair: true, phone: "android", publicUrl: origin }, log)).toBe(0);
+    const requests = fetcher.mock.calls.map(([url]) => String(url));
+    const pairingRequest = `http://127.0.0.1:${options.port}/api/auth/pairing`;
+    expect(requests.filter((url) => url === pairingRequest)).toHaveLength(1);
+    expect(requests).toContain(`http://127.0.0.1:${options.port}/.well-known/openmausbot/environment`);
+    expect(requests).toContain(`${origin}/.well-known/openmausbot/environment`);
+    expect(requests.indexOf(`${origin}/.well-known/openmausbot/environment`)).toBeLessThan(requests.indexOf(pairingRequest));
+    const output = log.mock.calls.map(([line]) => line).join("\n");
+    expect(output).toContain(`pairing code:  ${code}`);
+    expect(output).toContain(`expires:       ${new Date(expiresAt).toLocaleTimeString()} (single use)`);
+    expect(output).toContain(`open or scan:  ${pairingUrl}`);
+    expect(output).toMatch(/[▀▄█]/);
+    expect(output).toContain(`Or open ${origin}/pair on your phone and enter the code.`);
+    expect(output).toContain("On Android, scan the QR with Camera and open it in your web browser.");
+    expect(output).toContain("not the Android native pairing scanner");
+    expect(output).toContain("client access: chat and approvals, not settings or pairing administration");
+    expect(output).toContain("Scanning a QR does not mean the phone is paired.");
+    expect(output).toContain("Waiting for you to connect on the phone.");
+    expect(output).not.toMatch(/pairing complete|phone (?:is |successfully )?connected|paired successfully/i);
+  });
+});

--- a/server/cli-pair.test.ts
+++ b/server/cli-pair.test.ts
@@ -1,0 +1,150 @@
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runPair, type CliOptions } from "./cli.ts";
+import { SetupCancelled } from "./cli-prompts.ts";
+import { removeTempDir } from "./testing/cleanup.ts";
+
+const mocks = vi.hoisted(() => ({
+  readCliStartup: vi.fn(),
+  createTunnelAccount: vi.fn(), describeTunnelAccount: vi.fn(), tailscaleStatus: vi.fn(),
+  ui: { log: vi.fn(), choose: vi.fn(), ask: vi.fn(), secret: vi.fn(), confirm: vi.fn() },
+}));
+vi.mock("./cli-setup.ts", () => ({ readCliStartup: mocks.readCliStartup }));
+vi.mock("./cli-prompts.ts", async (original) => ({
+  ...await original<typeof import("./cli-prompts.ts")>(), defaultSetupIo: () => mocks.ui,
+}));
+vi.mock("./tailscale.ts", () => ({
+  tailscaleStatus: mocks.tailscaleStatus,
+  tailscaleServe: vi.fn(), tailscaleServeOff: vi.fn(), explainTailscaleFailure: vi.fn(),
+}));
+vi.mock("./tunnel.ts", () => ({
+  createTunnelAccount: mocks.createTunnelAccount, describeTunnelAccount: mocks.describeTunnelAccount,
+  cleanupTunnelOrigin: vi.fn(), createTunnelOrigin: vi.fn(), describeTunnelState: vi.fn(),
+  ensureCloudflared: vi.fn(), guardianEntry: vi.fn(), startTunnel: vi.fn(), tunnelAccess: vi.fn(),
+}));
+
+const advertisedOrigin = "https://current.example.test";
+const explicitOrigin = "https://override.example.test";
+const workspaceId = "4e406646-1030-4613-8878-e227ab722ffc";
+const code = "ABCD-EFGH-JKLM";
+const ttyDescriptors = [process.stdin, process.stdout].map((stream) => Object.getOwnPropertyDescriptor(stream, "isTTY"));
+let dataDir: string;
+let options: CliOptions;
+let publicUrl: string | null;
+let remoteWorkspaceId: string;
+const fetchMock = vi.fn<typeof fetch>();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  // The shared test setup supplies a throwaway HOME before module imports.
+  dataDir = mkdtempSync(join(process.env.HOME!, "cli-pair-"));
+  vi.stubEnv("OMB_DATA_DIR", dataDir);
+  options = { command: "pair", port: 18451, dataDir, tailscale: false, tunnel: false, client: false, pair: true, json: false };
+  publicUrl = advertisedOrigin;
+  remoteWorkspaceId = workspaceId;
+  for (const stream of [process.stdin, process.stdout]) Object.defineProperty(stream, "isTTY", { value: true, configurable: true });
+  mocks.ui.choose.mockResolvedValue(0);
+  mocks.createTunnelAccount.mockReturnValue({ credentials: { read: () => ({}) } });
+  mocks.describeTunnelAccount.mockReturnValue({ address: "https://old-tunnel.example.test", email: "fixture@example.test" });
+  mocks.tailscaleStatus.mockResolvedValue({ status: { dnsName: "old-tailnet.example.test" } });
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  fetchMock.mockImplementation(async (input, init) => {
+    const url = String(input);
+    const local = `http://127.0.0.1:${options.port}`;
+    if (url === `${local}/api/health`) return Response.json({ app: "openmausbot", pid: 12345 });
+    if (url === `${local}/api/auth/pairing`) {
+      if (init?.method === "POST") return Response.json({ code, expiresAt: Date.now() + 300_000, url: `${advertisedOrigin}/pair#code=${code}` });
+      return Response.json({ pairings: [], publicUrl });
+    }
+    if (url === `${local}/.well-known/openmausbot/environment`) return Response.json({ environmentId: workspaceId });
+    if ([advertisedOrigin, explicitOrigin].some((origin) => url === `${origin}/.well-known/openmausbot/environment`)) {
+      return Response.json({ environmentId: remoteWorkspaceId });
+    }
+    // No real network fallback is allowed, including stale saved addresses.
+    throw new Error(`Unexpected fixture request: ${url}`);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  for (const [index, stream] of [process.stdin, process.stdout].entries()) {
+    const descriptor = ttyDescriptors[index];
+    if (descriptor) Object.defineProperty(stream, "isTTY", descriptor);
+    else Reflect.deleteProperty(stream, "isTTY");
+  }
+  await removeTempDir(dataDir);
+});
+
+function expectPhonePairing(origin: string): void {
+  const probes = fetchMock.mock.calls.filter(([url]) => String(url).startsWith("https://"));
+  expect(probes).toHaveLength(1);
+  expect(String(probes[0]![0])).toBe(`${origin}/.well-known/openmausbot/environment`);
+  expect(probes[0]![1]).not.toHaveProperty("body");
+  expect(probes[0]![1]).not.toHaveProperty("headers");
+  const invitations = fetchMock.mock.calls.filter(([, init]) => init?.method === "POST");
+  expect(invitations).toHaveLength(1);
+  expect(String(invitations[0]![0])).toBe(`http://127.0.0.1:${options.port}/api/auth/pairing`);
+  expect(JSON.parse(String(invitations[0]![1]?.body))).toMatchObject({ scopes: ["client"] });
+  const transcript = mocks.ui.log.mock.calls.map(([line]) => line).join("\n");
+  expect(transcript).toContain(`pairing code:  ${code}`);
+  expect(transcript).toContain(`${origin}/pair#code=${code}`);
+  expect(transcript).toMatch(/[▀▄█]/);
+  expect(mocks.createTunnelAccount).not.toHaveBeenCalled();
+  expect(mocks.tailscaleStatus).not.toHaveBeenCalled();
+}
+
+describe("guided phone pairing address discovery", () => {
+  it.each([
+    { access: "tunnel", phone: "ios" },
+    { access: "tailscale", phone: "android" },
+    { access: "public-url", publicUrl: "https://old-proxy.example.test", phone: "ios" },
+  ])("uses the running server's advertised origin instead of saved $access access", async (saved) => {
+    mocks.readCliStartup.mockReturnValue(saved);
+    expect(await runPair(options)).toBe(0);
+    expectPhonePairing(advertisedOrigin);
+  });
+
+  it("allows an explicit --public-url to override the advertised and saved addresses", async () => {
+    mocks.readCliStartup.mockReturnValue({ access: "tunnel", phone: "ios" });
+    expect(await runPair({ ...options, publicUrl: explicitOrigin })).toBe(0);
+    expectPhonePairing(explicitOrigin);
+  });
+
+  it.each([
+    "https://localhost",
+    "https://user:stale-secret@example.test",
+    "https://old.example.test/pair#code=stale-code",
+    undefined,
+  ])("ignores an invalid saved public URL (%s) when the server advertises a valid origin", async (savedUrl) => {
+    mocks.readCliStartup.mockReturnValue({ access: "public-url", publicUrl: savedUrl, phone: "ios" });
+    expect(await runPair(options)).toBe(0);
+    expectPhonePairing(advertisedOrigin);
+  });
+
+  it("does not read stale or unreadable setup settings before using the running origin", async () => {
+    mocks.readCliStartup.mockImplementation(() => { throw new Error("Fixture config is stale or unreadable"); });
+    expect(await runPair(options)).toBe(0);
+    expect(mocks.readCliStartup).not.toHaveBeenCalled();
+    expectPhonePairing(advertisedOrigin);
+  });
+
+  it("does not mint a code when the advertised endpoint identifies another workspace", async () => {
+    remoteWorkspaceId = "another-workspace";
+    expect(await runPair(options)).toBe(1);
+    expect(fetchMock.mock.calls.filter(([, init]) => init?.method === "POST")).toHaveLength(0);
+    expect(mocks.ui.log).toHaveBeenCalledWith(expect.stringContaining("no phone pairing code was created"));
+  });
+
+  it.each([2, new SetupCancelled()])("does not mint a code when phone selection is cancelled (%s)", async (cancel) => {
+    if (cancel instanceof Error) mocks.ui.choose.mockRejectedValue(cancel);
+    else mocks.ui.choose.mockResolvedValue(cancel);
+    expect(await runPair(options)).toBe(cancel instanceof Error ? 130 : 0);
+    expect(fetchMock.mock.calls.filter(([, init]) => init?.method === "POST")).toHaveLength(0);
+    expect(fetchMock.mock.calls.filter(([url]) => String(url).startsWith("https://"))).toHaveLength(0);
+  });
+});

--- a/server/cli-phone-setup.test.ts
+++ b/server/cli-phone-setup.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CliOptions } from "./cli.ts";
+import { SetupCancelled, type SetupIo } from "./cli-prompts.ts";
+import { normalizePhoneOrigin, phonePairingInstructions, runPhoneSetup, type PhoneSetupDependencies } from "./cli-phone-setup.ts";
+
+const options: CliOptions = {
+  command: "start", port: 18799, dataDir: "/fixture/phone-home", tailscale: false,
+  tunnel: false, pair: false, client: false, json: false,
+};
+
+function prompts(script: { choices?: Array<number | Error>; confirms?: boolean[]; answers?: Array<string | Error> } = {}) {
+  const choices = [...script.choices ?? []];
+  const confirms = [...script.confirms ?? []];
+  const answers = [...script.answers ?? []];
+  const lines: string[] = [];
+  const take = <T>(values: Array<T | Error>, question: string): T => {
+    if (!values.length) throw new Error(`Unexpected fixture prompt: ${question}`);
+    const next = values.shift()!;
+    if (next instanceof Error) throw next;
+    return next;
+  };
+  const io: SetupIo = {
+    log: vi.fn((line: string) => { lines.push(line); }),
+    choose: vi.fn(async (question: string, choicesOffered: readonly string[]) => {
+      lines.push(question, ...choicesOffered);
+      return take(choices, question);
+    }),
+    ask: vi.fn(async (question: string) => take(answers, question)),
+    secret: vi.fn(async () => { throw new Error("The fixture must inject account sign-in"); }),
+    confirm: vi.fn(async (question: string) => { lines.push(question); return take(confirms, question); }),
+  };
+  return { io, lines, consumed: () => expect([choices, confirms, answers]).toEqual([[], [], []]) };
+}
+
+function dependencies() {
+  return {
+    accountReady: vi.fn<NonNullable<PhoneSetupDependencies["accountReady"]>>().mockReturnValue(false),
+    login: vi.fn<PhoneSetupDependencies["login"]>().mockResolvedValue(0),
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn(() => { throw new Error("Phone setup fixtures must not use the network"); }));
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe("phone origin validation", () => {
+  it.each([
+    ["https://maus.example", "https://maus.example"],
+    ["  https://MAUS.example:443/  ", "https://maus.example"],
+    ["https://mini.tail1234.ts.net:8443", "https://mini.tail1234.ts.net:8443"],
+    ["https://[2001:db8::1]:8443/", "https://[2001:db8::1]:8443"],
+  ])("normalizes an HTTPS origin without claiming reachability: %s", (input, expected) => {
+    expect(normalizePhoneOrigin(input)).toBe(expected);
+  });
+
+  it.each([
+    "", "not a url", "http://maus.example", "https:maus.example", "https:///maus.example", "https://@maus.example",
+    "https://localhost", "https://localhost.",
+    "https://mini.localhost", "https://127.0.0.1:8799", "https://127.1", "https://2130706433",
+    "https://0.0.0.0", "https://[::]", "https://[::1]", "https://[::ffff:127.0.0.1]",
+    "https://[::ffff:0.0.0.0]", "https://user:password@maus.example", "https://maus.example/pair",
+    "https://maus.example/?token=secret", "https://maus.example/#code=ABCD-EFGH-JKLM",
+    "https://maus.example/?", "https://maus.example/#", "https://maus.\nexample",
+    "https://maus.example\\private", "openmausbot://pair?token=secret",
+  ])("rejects a local, credential-bearing or non-origin input: %s", (input) => {
+    expect(normalizePhoneOrigin(input)).toBeNull();
+  });
+});
+
+describe("optional phone setup", () => {
+  it("defaults to skipping without account access or changes", async () => {
+    const deps = dependencies();
+    const ui = prompts({ choices: [0] });
+    const result = await runPhoneSetup(options, ui.io, deps);
+    expect(result).toEqual({ options });
+    expect(result.options).toBe(options);
+    expect(ui.io.choose).toHaveBeenCalledWith("Use OpenMausBot on your phone?", expect.any(Array), 0);
+    expect(deps.accountReady).not.toHaveBeenCalled();
+    expect(deps.login).not.toHaveBeenCalled();
+    ui.consumed();
+  });
+
+  it("requires explicit public exposure/download consent before managed sign-in", async () => {
+    const deps = dependencies();
+    const ui = prompts({ choices: [1, 0], confirms: [true] });
+    const original = { ...options };
+    expect(await runPhoneSetup(options, ui.io, deps)).toEqual({
+      phone: "ios", options: { ...options, tunnel: true, publicUrl: undefined, client: true, pair: true },
+    });
+    expect(options).toEqual(original);
+    expect(deps.login).toHaveBeenCalledWith(options, ui.io);
+    expect(ui.io.confirm).toHaveBeenCalledWith(expect.stringContaining("public endpoint"), false);
+    expect(vi.mocked(ui.io.confirm).mock.invocationCallOrder[0]).toBeLessThan(deps.accountReady.mock.invocationCallOrder[0]!);
+    expect(ui.lines.join("\n")).toContain("basic server identity are public");
+    expect(ui.lines.join("\n")).toContain("download the Cloudflare connector");
+    ui.consumed();
+  });
+
+  it("declining exposure returns to routes and may skip without sign-in", async () => {
+    const deps = dependencies();
+    const ui = prompts({ choices: [2, 0, 4], confirms: [false] });
+    expect(await runPhoneSetup(options, ui.io, deps)).toEqual({ options });
+    expect(deps.accountReady).not.toHaveBeenCalled();
+    expect(deps.login).not.toHaveBeenCalled();
+    ui.consumed();
+  });
+
+  it("reuses an existing account after consent without another email", async () => {
+    const deps = dependencies();
+    deps.accountReady.mockReturnValue(true);
+    const ui = prompts({ choices: [2, 0], confirms: [true] });
+    expect((await runPhoneSetup(options, ui.io, deps)).phone).toBe("android");
+    expect(deps.login).not.toHaveBeenCalled();
+    expect(ui.lines.join("\n")).toContain("saved OpenMausBot account");
+    ui.consumed();
+  });
+
+  it.each([1, new Error("secret-token-never-print")])("does not select managed access after failed sign-in: %s", async (failure) => {
+    const deps = dependencies();
+    if (failure instanceof Error) deps.login.mockRejectedValue(failure);
+    else deps.login.mockResolvedValue(failure);
+    const ui = prompts({ choices: [1, 0], confirms: [true] });
+    expect(await runPhoneSetup(options, ui.io, deps)).toEqual({ options });
+    expect(ui.lines.join("\n")).not.toContain("secret-token-never-print");
+    expect(ui.lines.join("\n")).toContain("provider setup is still saved");
+    ui.consumed();
+  });
+
+  it("does not attempt sign-in if saved-account inspection fails", async () => {
+    const deps = dependencies();
+    deps.accountReady.mockRejectedValue(new Error("credential-document-secret"));
+    const ui = prompts({ choices: [1, 0], confirms: [true] });
+    expect(await runPhoneSetup(options, ui.io, deps)).toEqual({ options });
+    expect(deps.login).not.toHaveBeenCalled();
+    expect(ui.lines.join("\n")).not.toContain("credential-document-secret");
+  });
+
+  it("supports existing Tailscale only after consent, without installing it or signing in", async () => {
+    const deps = dependencies();
+    const ui = prompts({ choices: [2, 1], confirms: [true] });
+    expect(await runPhoneSetup(options, ui.io, deps)).toEqual({
+      phone: "android", options: { ...options, tailscale: true, publicUrl: undefined, client: true, pair: true },
+    });
+    expect(ui.io.confirm).toHaveBeenCalledWith(expect.stringContaining("tailnet"), false);
+    expect(deps.login).not.toHaveBeenCalled();
+    expect(ui.lines.join("\n")).toContain("already be installed");
+    ui.consumed();
+  });
+
+  it("rejects a pasted secret without echoing it, then accepts an advanced HTTPS origin", async () => {
+    const deps = dependencies();
+    const ui = prompts({ choices: [2, 2, 2], answers: ["https://user:secret@example.com/#code=credential", "https://maus.example/"] });
+    expect(await runPhoneSetup(options, ui.io, deps)).toEqual({
+      phone: "android", options: { ...options, publicUrl: "https://maus.example", client: true, pair: true },
+    });
+    expect(ui.lines.join("\n")).not.toContain("user:secret");
+    expect(ui.lines.join("\n")).not.toContain("code=credential");
+    expect(deps.login).not.toHaveBeenCalled();
+    ui.consumed();
+  });
+
+  it("offers back and skip without enabling any route", async () => {
+    const deps = dependencies();
+    const ui = prompts({ choices: [1, 2, 3, 0], answers: [""] });
+    expect(await runPhoneSetup(options, ui.io, deps)).toEqual({ options });
+    expect(deps.login).not.toHaveBeenCalled();
+    ui.consumed();
+  });
+
+  it.each([
+    { publicUrl: "https://maus.example/" }, { tailscale: true }, { tunnel: true },
+  ])("reuses explicit existing route options without a nested chooser: %j", async (route) => {
+    const deps = dependencies();
+    deps.accountReady.mockReturnValue(true);
+    const ui = prompts({ choices: [1] });
+    const input = { ...options, ...route };
+    const result = await runPhoneSetup(input, ui.io, deps);
+    expect(result.phone).toBe("ios");
+    expect(result.options.client).toBe(true);
+    expect(ui.io.choose).toHaveBeenCalledTimes(1);
+    expect(ui.io.confirm).not.toHaveBeenCalled();
+    expect(deps.login).not.toHaveBeenCalled();
+    ui.consumed();
+  });
+
+  it("does not mistake a localhost publicUrl for phone connectivity", async () => {
+    const deps = dependencies();
+    const ui = prompts({ choices: [1, 4] });
+    const input = { ...options, publicUrl: "http://127.0.0.1:18799" };
+    expect(await runPhoneSetup(input, ui.io, deps)).toEqual({ options: input });
+    expect(ui.lines.join("\n")).toContain("localhost or LAN-IP link will not connect");
+    ui.consumed();
+  });
+
+  it("propagates Ctrl-C before route selection without changing options", async () => {
+    const deps = dependencies();
+    const ui = prompts({ choices: [new SetupCancelled()] });
+    await expect(runPhoneSetup(options, ui.io, deps)).rejects.toBeInstanceOf(SetupCancelled);
+    expect(deps.login).not.toHaveBeenCalled();
+    expect(options.tunnel).toBe(false);
+  });
+
+  it("propagates Ctrl-C during account sign-in without selecting or saving a route", async () => {
+    const deps = dependencies();
+    deps.login.mockRejectedValue(new SetupCancelled());
+    const ui = prompts({ choices: [1, 0], confirms: [true] });
+    await expect(runPhoneSetup(options, ui.io, deps)).rejects.toBeInstanceOf(SetupCancelled);
+    expect(options.tunnel).toBe(false);
+  });
+});
+
+describe("phone pairing instructions", () => {
+  it.each(["ios", "android"] as const)("refuses phone instructions for an unready %s route", (phone) => {
+    const text = phonePairingInstructions(phone, { origin: "https://maus.example", ready: false }).join("\n");
+    expect(text).toContain("not ready");
+    expect(text).not.toContain("https://maus.example");
+    expect(text).not.toContain("already connected");
+  });
+
+  it.each(["https://localhost", "https://maus.example/#code=secret", null])("never repeats a local or credential-bearing origin: %s", (origin) => {
+    const text = phonePairingInstructions("ios", { origin, ready: true }).join("\n");
+    expect(text).toContain("not ready");
+    expect(text).not.toContain("secret");
+    expect(text).not.toContain("localhost");
+  });
+
+  it("describes iOS browser/native options without claiming an app-store release", () => {
+    const text = phonePairingInstructions("ios", { origin: "https://maus.example", ready: true }).join("\n");
+    expect(text).toContain("Safari");
+    expect(text).toContain("already have");
+    expect(text).toContain("https://maus.example/pair");
+    expect(text).toContain("does not mean the phone is paired");
+    expect(text).toContain("not settings or pairing administration");
+    expect(text).not.toMatch(/apps\.apple|testflight|play\.google/);
+  });
+
+  it("describes Android web pairing, not native app compatibility", () => {
+    const text = phonePairingInstructions("android", { origin: "https://maus.example", ready: true }).join("\n");
+    expect(text).toContain("web browser");
+    expect(text).toContain("not the Android native pairing scanner");
+    expect(text).toContain("five minutes");
+  });
+});

--- a/server/cli-phone-setup.ts
+++ b/server/cli-phone-setup.ts
@@ -1,0 +1,137 @@
+// Optional phone onboarding only chooses a route. The caller owns starting,
+// verifying and stopping that route, and minting/cancelling its pairing code.
+import type { CliOptions } from "./cli.ts";
+import { SetupCancelled, type SetupIo } from "./cli-prompts.ts";
+
+export type PhoneKind = "ios" | "android";
+export interface PhoneSetupResult {
+  options: CliOptions;
+  phone?: PhoneKind;
+}
+export interface PhoneSetupDependencies {
+  /** May read saved tunnel credentials, but must not sign in or start a tunnel. */
+  accountReady?(options: CliOptions): boolean | Promise<boolean>;
+  /** The caller supplies account sign-in; email uses ask, the emailed code secret. */
+  login(options: CliOptions, io: SetupIo): Promise<number>;
+}
+
+/** A configured HTTPS origin, not proof that a phone can reach it. Never accept
+ * a pasted invitation, password, query token, localhost or unspecified bind. */
+export function normalizePhoneOrigin(raw: string): string | null {
+  const value = raw.trim();
+  // Reject control characters before URL parsing can silently remove them.
+  // eslint-disable-next-line no-control-regex
+  if (!/^https:\/\/[^/]/i.test(value) || /[\s\u0000-\u001f\u007f\\?#@]/.test(value)) return null;
+  try {
+    const url = new URL(value);
+    const host = url.hostname.toLowerCase().replace(/\.$/, "");
+    if (url.protocol !== "https:" || url.username || url.password || url.pathname !== "/") return null;
+    if (!host || host === "localhost" || host.endsWith(".localhost") || host === "0.0.0.0" || host.startsWith("127.")) return null;
+    if (host === "[::]" || host === "[::1]" || /^\[::ffff:(?:0:0|7f[0-9a-f]{2}:[0-9a-f]+)\]$/.test(host)) return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+export async function runPhoneSetup(
+  options: CliOptions,
+  io: SetupIo,
+  deps: PhoneSetupDependencies,
+): Promise<PhoneSetupResult> {
+  const skip = (): PhoneSetupResult => ({ options });
+  const selected = (phone: PhoneKind, route: Partial<CliOptions> = {}): PhoneSetupResult => ({
+    options: { ...options, ...route, client: true, pair: true }, phone,
+  });
+  const signIn = async (): Promise<boolean> => {
+    try {
+      if (await deps.accountReady?.(options)) {
+        io.log("Your saved OpenMausBot account can be reused. The connection will be checked when the server starts.");
+        return true;
+      }
+      io.log("Sign in to an OpenMausBot account using an emailed code. This is separate from your AI provider account.");
+      if (await deps.login(options, io) === 0) return true;
+    } catch (error) {
+      if (error instanceof SetupCancelled) throw error;
+      // Account errors can contain credentials or URLs. Leave details to the
+      // account UI rather than echoing an arbitrary error into terminal logs.
+    }
+    io.log("Phone access could not be prepared. Your AI provider setup is still saved; you can try phone setup later.");
+    return false;
+  };
+  for (;;) {
+    const device = await io.choose("Use OpenMausBot on your phone?", [
+      "Skip for now",
+      "iPhone / iPad — native app or Safari",
+      "Android — web browser",
+    ], 0);
+    if (device === 0) return skip();
+    const phone: PhoneKind = device === 1 ? "ios" : "android";
+    if (options.tunnel) return await signIn() ? selected(phone) : skip();
+    if (options.tailscale) {
+      io.log("Keep Tailscale connected on both this computer and your phone, on the same tailnet.");
+      return selected(phone);
+    }
+    const existing = options.publicUrl ? normalizePhoneOrigin(options.publicUrl) : null;
+    if (existing) {
+      io.log("Your configured HTTPS address will be checked before a phone pairing link is shown.");
+      return selected(phone, { publicUrl: existing });
+    }
+    io.log("This server listens only on this computer. A localhost or LAN-IP link will not connect your phone.");
+    let back = false;
+    while (!back) {
+      const route = await io.choose("How should your phone reach this computer?", [
+        "Managed HTTPS address — protected by pairing",
+        "Existing Tailscale — only your tailnet",
+        "Existing HTTPS address — advanced",
+        "Back to phone choice",
+        "Skip for now",
+      ], 4);
+      if (route === 4) return skip();
+      if (route === 3) { back = true; continue; }
+      if (route === 0) {
+        io.log("This creates a public HTTPS endpoint through Cloudflare. Chat and settings require device pairing; the sign-in page and basic server identity are public.");
+        io.log("Starting it may download the Cloudflare connector. It stays active while OpenMausBot runs; stop OpenMausBot to close the connection.");
+        if (!await io.confirm("Allow this managed public endpoint and connector download?", false)) continue;
+        if (!await signIn()) return skip();
+        return selected(phone, { tunnel: true, tailscale: false, publicUrl: undefined });
+      }
+      if (route === 1) {
+        io.log("Tailscale must already be installed and signed in on this computer and phone, with HTTPS certificates enabled for the tailnet.");
+        if (!await io.confirm("Allow OpenMausBot to serve HTTPS to your tailnet while it runs?", false)) continue;
+        return selected(phone, { tailscale: true, tunnel: false, publicUrl: undefined });
+      }
+      io.log("Use an HTTPS reverse proxy you already configured for this server. Enter only its origin, without a password, pairing code, path, query or fragment.");
+      const answer = await io.ask("Existing HTTPS address (Enter goes back): ");
+      if (!answer.trim()) continue;
+      const origin = normalizePhoneOrigin(answer);
+      if (!origin) {
+        io.log("Enter a non-localhost HTTPS origin, such as https://maus.example.com. The address was not saved.");
+        continue;
+      }
+      io.log("This does not create a proxy or open a LAN listener. Its connection will be checked before pairing.");
+      return selected(phone, { publicUrl: origin, tunnel: false, tailscale: false });
+    }
+  }
+}
+
+/** Call after route verification, beside the separately minted QR. The URL
+ * here is an origin, never the invitation containing its one-time credential. */
+export function phonePairingInstructions(
+  phone: PhoneKind,
+  input: { origin: string | null; ready: boolean },
+): string[] {
+  const origin = input.origin ? normalizePhoneOrigin(input.origin) : null;
+  if (!input.ready || !origin) {
+    return ["Phone access is not ready yet. No phone QR should be shown until the HTTPS connection is verified.",
+      "Your local OpenMausBot can still be used on this computer."];
+  }
+  return [
+    phone === "ios"
+      ? "On iPhone or iPad, scan the QR with Camera to open Safari. If you already have the OpenMausBot iOS app, use its pairing scanner or paste the full pairing link there."
+      : "On Android, scan the QR with Camera and open it in your web browser. This link is for the web app, not the Android native pairing scanner.",
+    `Or open ${origin}/pair on your phone and enter the code.`,
+    "Choose Connect on the phone. Scanning a QR does not mean the phone is paired.",
+    "The code works once and expires after five minutes. This phone receives client access: chat and approvals, not settings or pairing administration.",
+  ];
+}

--- a/server/cli-prompts.test.ts
+++ b/server/cli-prompts.test.ts
@@ -1,0 +1,134 @@
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import { defaultSetupIo, SetupCancelled } from "./cli-prompts.ts";
+
+function terminal(raw = false) {
+  const input = Object.assign(new PassThrough(), {
+    isTTY: true,
+    isRaw: raw,
+    setRawMode: vi.fn((enabled: boolean) => { input.isRaw = enabled; }),
+  });
+  input.pause();
+  const output = new PassThrough();
+  let text = "";
+  output.on("data", (chunk) => { text += String(chunk); });
+  return { input, io: defaultSetupIo(input, output), text: () => text };
+}
+
+describe("terminal setup prompts", () => {
+  it("numbers choices, retries invalid input, and returns the selected index", async () => {
+    const { input, io, text } = terminal();
+    const selected = io.choose("Provider", ["Claude", "Codex"], 0);
+    expect(text()).toContain("1. Claude (default)");
+    expect(text()).toContain("2. Codex");
+    input.write("9\r");
+    await vi.waitFor(() => expect(text()).toContain("Enter a number from 1 to 2."));
+    input.write("2\r");
+    expect(await selected).toBe(1);
+    expect(input.isRaw).toBe(false);
+    expect(input.isPaused()).toBe(true);
+  });
+
+  it("accepts an empty answer for the default choice and confirmation", async () => {
+    const { input, io } = terminal();
+    const selected = io.choose("Model", ["First", "Second"], 1);
+    input.write("\r");
+    expect(await selected).toBe(1);
+    const confirmed = io.confirm("Save?", true);
+    input.write("\r");
+    expect(await confirmed).toBe(true);
+    const declined = io.confirm("Replace?");
+    input.write("\r");
+    expect(await declined).toBe(false);
+  });
+
+  it("does not execute terminal escapes from provider labels or prompt text", async () => {
+    const { input, io, text } = terminal();
+    io.log("Provider \u001b[31mred\u001b[0m\u0007");
+    expect(text()).toBe("Provider red \n");
+    const selected = io.choose("Model\u001b[2J", ["Untrusted\u001b[2J\nlabel"], 0);
+    expect(text()).toContain("1. Untrusted label");
+    input.write("\r");
+    expect(await selected).toBe(0);
+    const secret = io.secret("Key \u001b[2J\u0007: ");
+    input.write("secret\r");
+    await secret;
+    // Readline emits its own cursor sequences, so inspect the labels and
+    // secret prompt specifically rather than forbidding all terminal output.
+    expect(text()).not.toContain("\u001b[2J");
+    expect(text()).not.toContain("\u0007");
+    expect(text()).not.toContain("secret");
+  });
+
+  it("never echoes a pasted key, including bracketed-paste markers split across chunks", async () => {
+    const { input, io, text } = terminal();
+    const secret = io.secret("API key: ");
+    expect(input.isRaw).toBe(true);
+    input.write("\u001b[20");
+    input.write("0~sk-private-pasted-key\u001b[201~\r");
+    expect(await secret).toBe("sk-private-pasted-key");
+    expect(text()).toBe("API key: \n");
+    expect(input.isRaw).toBe(false);
+    expect(input.isPaused()).toBe(true);
+    expect(input.listenerCount("data")).toBe(0);
+  });
+
+  it("supports corrections without echo and restores a terminal that was already raw", async () => {
+    const { input, io, text } = terminal(true);
+    const secret = io.secret("Key: ");
+    input.write("mistake\u0015sk-secrex\u007ft\r");
+    expect(await secret).toBe("sk-secret");
+    expect(text()).toBe("Key: \n");
+    expect(input.isRaw).toBe(true);
+  });
+
+  it.each(["\u0003", "\u0004"])("cancels hidden input on control character %j and restores the terminal", async (key) => {
+    const { input, io, text } = terminal();
+    const rejected = expect(io.secret("Key: ")).rejects.toBeInstanceOf(SetupCancelled);
+    input.write(`sk-do-not-display${key}`);
+    await rejected;
+    expect(text()).toBe("Key: \n");
+    expect(input.isRaw).toBe(false);
+    expect(input.isPaused()).toBe(true);
+    expect(input.listenerCount("data")).toBe(0);
+  });
+
+  it.each(["\u0003", "\u0004"])("cancels ordinary questions on control character %j", async (key) => {
+    const { input, io } = terminal();
+    const rejected = expect(io.ask("Account: ")).rejects.toBeInstanceOf(SetupCancelled);
+    input.write(`partial${key}`);
+    await rejected;
+    expect(input.isRaw).toBe(false);
+    expect(input.isPaused()).toBe(true);
+  });
+
+  it("restores raw mode and signal handlers when a secret read fails", async () => {
+    const { input, io, text } = terminal();
+    const sigint = process.listenerCount("SIGINT");
+    const sigterm = process.listenerCount("SIGTERM");
+    const rejected = expect(io.secret("Key: ")).rejects.toThrow("input disconnected");
+    input.write("sk-private");
+    input.emit("error", new Error("input disconnected"));
+    await rejected;
+    expect(input.isRaw).toBe(false);
+    expect(process.listenerCount("SIGINT")).toBe(sigint);
+    expect(process.listenerCount("SIGTERM")).toBe(sigterm);
+    expect(text()).not.toContain("sk-private");
+  });
+
+  it("cancels a secret at end of input without accepting a partial key", async () => {
+    const { input, io } = terminal();
+    const rejected = expect(io.secret("Key: ")).rejects.toBeInstanceOf(SetupCancelled);
+    input.end("partial");
+    await rejected;
+    expect(input.isRaw).toBe(false);
+  });
+
+  it("refuses secret entry without a terminal", () => {
+    const { input, io, text } = terminal();
+    input.isTTY = false;
+    expect(() => io.secret("Key: ")).toThrow("interactive terminal");
+    expect(text()).toBe("");
+    expect(input.setRawMode).not.toHaveBeenCalled();
+  });
+});

--- a/server/cli-prompts.test.ts
+++ b/server/cli-prompts.test.ts
@@ -1,134 +1,271 @@
 import { PassThrough } from "node:stream";
-import { describe, expect, it, vi } from "vitest";
+import { stripVTControlCharacters } from "node:util";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { defaultSetupIo, SetupCancelled } from "./cli-prompts.ts";
 
-function terminal(raw = false) {
+function terminal(raw = false, display: { isTTY?: boolean; columns?: number; rows?: number } = {}) {
   const input = Object.assign(new PassThrough(), {
     isTTY: true,
     isRaw: raw,
     setRawMode: vi.fn((enabled: boolean) => { input.isRaw = enabled; }),
   });
   input.pause();
-  const output = new PassThrough();
-  let text = "";
-  output.on("data", (chunk) => { text += String(chunk); });
-  return { input, io: defaultSetupIo(input, output), text: () => text };
+  const output = Object.assign(new PassThrough(), { isTTY: true, columns: 80, rows: 24 }, display);
+  let transcript = "";
+  output.on("data", (chunk) => { transcript += String(chunk); });
+  return { input, output, io: defaultSetupIo(input, output), text: () => transcript };
 }
 
-describe("terminal setup prompts", () => {
-  it("numbers choices, retries invalid input, and returns the selected index", async () => {
-    const { input, io, text } = terminal();
-    const selected = io.choose("Provider", ["Claude", "Codex"], 0);
-    expect(text()).toContain("1. Claude (default)");
-    expect(text()).toContain("2. Codex");
-    input.write("9\r");
-    await vi.waitFor(() => expect(text()).toContain("Enter a number from 1 to 2."));
-    input.write("2\r");
-    expect(await selected).toBe(1);
-    expect(input.isRaw).toBe(false);
-    expect(input.isPaused()).toBe(true);
+const signals = ["SIGINT", "SIGTERM", "exit"] as const;
+const signalCounts = () => signals.map((signal) => process.listenerCount(signal));
+function expectClean(fixture: ReturnType<typeof terminal>, raw = false) {
+  expect(fixture.input.isRaw).toBe(raw);
+  if (!fixture.input.readableEnded) expect(fixture.input.isPaused()).toBe(true);
+  expect(fixture.input.listenerCount("data")).toBe(0);
+  expect(fixture.input.listenerCount("keypress")).toBe(0);
+  expect(fixture.output.listenerCount("resize")).toBe(0);
+}
+
+describe("Clack setup adapter", () => {
+  beforeEach(() => {
+    vi.stubEnv("TERM", "xterm-256color");
+    vi.stubEnv("NO_COLOR", undefined);
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("uses the default index and Clack arrow navigation, including split sequences", async () => {
+    const fixture = terminal();
+    const answer = fixture.io.choose("Provider", ["First", "Second", "Third"], 1);
+    expect(stripVTControlCharacters(fixture.text())).toContain("↑/↓");
+    fixture.input.write("\u001b");
+    fixture.input.write("[");
+    fixture.input.write("B");
+    fixture.input.write("\r");
+    expect(await answer).toBe(2);
+    expectClean(fixture);
   });
 
-  it("accepts an empty answer for the default choice and confirmation", async () => {
-    const { input, io } = terminal();
-    const selected = io.choose("Model", ["First", "Second"], 1);
-    input.write("\r");
-    expect(await selected).toBe(1);
-    const confirmed = io.confirm("Save?", true);
-    input.write("\r");
-    expect(await confirmed).toBe(true);
-    const declined = io.confirm("Replace?");
-    input.write("\r");
+  it("selects the first item by default and preserves explicit defaults", async () => {
+    const fixture = terminal();
+    const first = fixture.io.choose("Model", ["First", "Second"]);
+    fixture.input.write("\r");
+    expect(await first).toBe(0);
+    const second = fixture.io.choose("Model", ["First", "Second"], 1);
+    fixture.input.write("\r");
+    expect(await second).toBe(1);
+    expectClean(fixture);
+  });
+
+  it("rejects unavailable choices and invalid defaults before entering raw mode", async () => {
+    const fixture = terminal();
+    await expect(fixture.io.choose("Model", [])).rejects.toThrow("no choices");
+    for (const invalid of [-1, 2, 0.5, NaN]) {
+      await expect(fixture.io.choose("Model", ["First", "Second"], invalid)).rejects.toThrow("default choice");
+    }
+    expect(fixture.input.setRawMode).not.toHaveBeenCalled();
+    expect(fixture.text()).toBe("");
+  });
+
+  it("lets Clack bound long lists and render narrow terminal labels", async () => {
+    const fixture = terminal(false, { columns: 38, rows: 12 });
+    const answer = fixture.io.choose("Choose a model", Array.from({ length: 50 }, (_, i) => `Model ${i + 1}: ${"long label ".repeat(6)}`));
+    expect(fixture.text()).not.toContain("Model 8:");
+    fixture.input.write("\u001b[A\r");
+    expect(await answer).toBe(49); // Clack wraps at the end of the option list.
+    expect(stripVTControlCharacters(fixture.text())).toContain("Model 50:");
+    expectClean(fixture);
+  });
+
+  it("uses Clack text input without changing whitespace or empty answers", async () => {
+    const fixture = terminal();
+    const entered = fixture.io.ask("Account: ");
+    fixture.input.write("  name@example.com  \r");
+    expect(await entered).toBe("  name@example.com  ");
+    const empty = fixture.io.ask("Optional: ");
+    fixture.input.write("\r");
+    expect(await empty).toBe("");
+    expectClean(fixture);
+  });
+
+  it("keeps confirmation default-negative and supports defaults, arrows and y/n", async () => {
+    const fixture = terminal();
+    const declined = fixture.io.confirm("Replace?");
+    fixture.input.write("\r");
     expect(await declined).toBe(false);
+    const accepted = fixture.io.confirm("Save?", true);
+    fixture.input.write("\r");
+    expect(await accepted).toBe(true);
+    const arrow = fixture.io.confirm("Continue?");
+    fixture.input.write("\u001b[A\r");
+    expect(await arrow).toBe(true);
+    const yes = fixture.io.confirm("Continue?");
+    fixture.input.write("y");
+    expect(await yes).toBe(true);
+    const no = fixture.io.confirm("Replace?", true);
+    fixture.input.write("n");
+    expect(await no).toBe(false);
+    expectClean(fixture);
   });
 
-  it("does not execute terminal escapes from provider labels or prompt text", async () => {
-    const { input, io, text } = terminal();
-    io.log("Provider \u001b[31mred\u001b[0m\u0007");
-    expect(text()).toBe("Provider red \n");
-    const selected = io.choose("Model\u001b[2J", ["Untrusted\u001b[2J\nlabel"], 0);
-    expect(text()).toContain("1. Untrusted label");
-    input.write("\r");
-    expect(await selected).toBe(0);
-    const secret = io.secret("Key \u001b[2J\u0007: ");
-    input.write("secret\r");
-    await secret;
-    // Readline emits its own cursor sequences, so inspect the labels and
-    // secret prompt specifically rather than forbidding all terminal output.
-    expect(text()).not.toContain("\u001b[2J");
-    expect(text()).not.toContain("\u0007");
-    expect(text()).not.toContain("secret");
+  it.each([true, false])("never echoes pasted secrets with rich output=%s", async (rich) => {
+    const fixture = terminal(false, { isTTY: rich });
+    const answer = fixture.io.secret("API key: ");
+    expect(fixture.input.isRaw).toBe(true);
+    fixture.input.write("\u001b[20");
+    fixture.input.write("0~sk-private-pasted-key\u001b[201~\r");
+    expect(await answer).toBe("sk-private-pasted-key");
+    expect(fixture.text()).not.toContain("sk-private");
+    expect(fixture.text()).not.toContain("pasted-key");
+    if (rich) expect(fixture.text()).toContain("*");
+    else expect(fixture.text()).toBe("API key: \n");
+    expectClean(fixture);
   });
 
-  it("never echoes a pasted key, including bracketed-paste markers split across chunks", async () => {
-    const { input, io, text } = terminal();
-    const secret = io.secret("API key: ");
-    expect(input.isRaw).toBe(true);
-    input.write("\u001b[20");
-    input.write("0~sk-private-pasted-key\u001b[201~\r");
-    expect(await secret).toBe("sk-private-pasted-key");
-    expect(text()).toBe("API key: \n");
-    expect(input.isRaw).toBe(false);
-    expect(input.isPaused()).toBe(true);
-    expect(input.listenerCount("data")).toBe(0);
+  it.each([true, false])("supports hidden corrections and split UTF-8 with rich output=%s", async (rich) => {
+    const fixture = terminal(true, { isTTY: rich });
+    const answer = fixture.io.secret("Key: ");
+    fixture.input.write("mistake\u0015sk-secrex\u007ft");
+    const encoded = Buffer.from("é");
+    fixture.input.write(encoded.subarray(0, 1));
+    fixture.input.write(encoded.subarray(1));
+    fixture.input.write("\r");
+    expect(await answer).toBe("sk-secreté");
+    expect(fixture.text()).not.toContain("sk-secret");
+    expectClean(fixture, true);
   });
 
-  it("supports corrections without echo and restores a terminal that was already raw", async () => {
-    const { input, io, text } = terminal(true);
-    const secret = io.secret("Key: ");
-    input.write("mistake\u0015sk-secrex\u007ft\r");
-    expect(await secret).toBe("sk-secret");
-    expect(text()).toBe("Key: \n");
-    expect(input.isRaw).toBe(true);
+  it.each(["ask", "secret", "choose", "confirm"] as const)("cancels %s on Ctrl-C/D and restores all prompt resources", async (kind) => {
+    for (const rich of [true, false]) for (const key of ["\u0003", "\u0004"]) {
+      const fixture = terminal(true, { isTTY: rich });
+      const before = signalCounts();
+      const pending = kind === "choose" ? fixture.io.choose("Provider", ["First", "Second"]) : fixture.io[kind]("Question");
+      const rejected = expect(pending).rejects.toBeInstanceOf(SetupCancelled);
+      fixture.input.write("\u001b[");
+      fixture.input.write(key);
+      await rejected;
+      expectClean(fixture, true);
+      expect(signalCounts()).toEqual(before);
+    }
   });
 
-  it.each(["\u0003", "\u0004"])("cancels hidden input on control character %j and restores the terminal", async (key) => {
-    const { input, io, text } = terminal();
-    const rejected = expect(io.secret("Key: ")).rejects.toBeInstanceOf(SetupCancelled);
-    input.write(`sk-do-not-display${key}`);
+  it("translates Clack's Escape cancellation into SetupCancelled", async () => {
+    const fixture = terminal();
+    const pending = fixture.io.choose("Provider", ["First"]);
+    const rejected = expect(pending).rejects.toBeInstanceOf(SetupCancelled);
+    fixture.input.write("\u001b");
     await rejected;
-    expect(text()).toBe("Key: \n");
-    expect(input.isRaw).toBe(false);
-    expect(input.isPaused()).toBe(true);
-    expect(input.listenerCount("data")).toBe(0);
+    expectClean(fixture);
   });
 
-  it.each(["\u0003", "\u0004"])("cancels ordinary questions on control character %j", async (key) => {
-    const { input, io } = terminal();
-    const rejected = expect(io.ask("Account: ")).rejects.toBeInstanceOf(SetupCancelled);
-    input.write(`partial${key}`);
-    await rejected;
-    expect(input.isRaw).toBe(false);
-    expect(input.isPaused()).toBe(true);
+  it.each(["end", "close", "error", "output-error", "SIGINT", "SIGTERM"])("cleans up a hidden prompt on %s", async (kind) => {
+    for (const rich of [true, false]) {
+      const fixture = terminal(false, { isTTY: rich });
+      const previous = new Set(process.listeners(kind));
+      const before = signalCounts();
+      const pending = fixture.io.secret("Key: ");
+      const rejected = expect(pending).rejects.toThrow(kind.includes("error") ? "disconnected" : "Setup cancelled");
+      fixture.input.write("sk-do-not-print");
+      if (kind === "end") fixture.input.end();
+      else if (kind === "close") fixture.input.emit("close");
+      else if (kind === "error") fixture.input.emit("error", new Error("input disconnected"));
+      else if (kind === "output-error") fixture.output.emit("error", new Error("output disconnected"));
+      else process.listeners(kind).find((listener) => !previous.has(listener))!();
+      await rejected;
+      expect(fixture.text()).not.toContain("sk-do-not-print");
+      expectClean(fixture);
+      expect(signalCounts()).toEqual(before);
+    }
   });
 
-  it("restores raw mode and signal handlers when a secret read fails", async () => {
-    const { input, io, text } = terminal();
-    const sigint = process.listenerCount("SIGINT");
-    const sigterm = process.listenerCount("SIGTERM");
-    const rejected = expect(io.secret("Key: ")).rejects.toThrow("input disconnected");
-    input.write("sk-private");
-    input.emit("error", new Error("input disconnected"));
-    await rejected;
-    expect(input.isRaw).toBe(false);
-    expect(process.listenerCount("SIGINT")).toBe(sigint);
-    expect(process.listenerCount("SIGTERM")).toBe(sigterm);
-    expect(text()).not.toContain("sk-private");
+  it("preserves an already-flowing input stream", async () => {
+    const fixture = terminal();
+    fixture.input.resume();
+    const pending = fixture.io.choose("Provider", ["First"]);
+    fixture.input.write("\r");
+    await pending;
+    expect(fixture.input.readableFlowing).toBe(true);
+    expect(fixture.input.isRaw).toBe(false);
   });
 
-  it("cancels a secret at end of input without accepting a partial key", async () => {
-    const { input, io } = terminal();
-    const rejected = expect(io.secret("Key: ")).rejects.toBeInstanceOf(SetupCancelled);
-    input.end("partial");
-    await rejected;
-    expect(input.isRaw).toBe(false);
+  it("does not retain a text decoder that could echo the following secret", async () => {
+    const fixture = terminal();
+    const selected = fixture.io.choose("Provider", ["API key"]);
+    fixture.input.write("\r");
+    await selected;
+    const account = fixture.io.ask("Name: ");
+    fixture.input.write("My account\r");
+    await account;
+    const secret = fixture.io.secret("Key: ");
+    fixture.input.write("sk-never-echo-this\r");
+    expect(await secret).toBe("sk-never-echo-this");
+    expect(fixture.text()).not.toContain("sk-never-echo-this");
+    expectClean(fixture);
   });
 
-  it("refuses secret entry without a terminal", () => {
-    const { input, io, text } = terminal();
-    input.isTTY = false;
-    expect(() => io.secret("Key: ")).toThrow("interactive terminal");
-    expect(text()).toBe("");
-    expect(input.setRawMode).not.toHaveBeenCalled();
+  it("sanitizes provider labels, log output and questions before rendering", async () => {
+    const fixture = terminal();
+    fixture.io.log("Provider \u001b[31mred\u001b[0m\u0007");
+    expect(fixture.text()).toBe("Provider red\n");
+    const selected = fixture.io.choose("Model\u001b[2J", ["Untrusted\u001b[2J\nlabel"]);
+    fixture.input.write("\r");
+    await selected;
+    const answer = fixture.io.ask("Account\u001b[2J\u0007: ");
+    fixture.input.write("name\r");
+    await answer;
+    expect(fixture.text()).not.toContain("\u001b[2J");
+    expect(fixture.text()).not.toContain("\u0007");
+    expect(stripVTControlCharacters(fixture.text())).toContain("Untrusted label");
+  });
+
+  it("refuses hidden input without a terminal before printing or changing raw mode", () => {
+    const fixture = terminal();
+    fixture.input.isTTY = false;
+    expect(() => fixture.io.secret("Key: ")).toThrow("interactive terminal");
+    expect(fixture.text()).toBe("");
+    expect(fixture.input.setRawMode).not.toHaveBeenCalled();
+  });
+
+  it.each(["dumb", "NO_COLOR", "redirected", "narrow", "short"])("uses an escape-free numeric fallback for %s output", async (mode) => {
+    if (mode === "dumb") vi.stubEnv("TERM", "dumb");
+    if (mode === "NO_COLOR") vi.stubEnv("NO_COLOR", "");
+    const fixture = terminal(false, { isTTY: mode !== "redirected", columns: mode === "narrow" ? 16 : 80, rows: mode === "short" ? 5 : 24 });
+    const pending = fixture.io.choose("Provider", ["First", "Second"], 0);
+    expect(fixture.text()).toContain("1. First (default)");
+    fixture.input.write("9\r");
+    await vi.waitFor(() => expect(fixture.text()).toContain("Enter a number from 1 to 2."));
+    fixture.input.write("2\r");
+    expect(await pending).toBe(1);
+    expect(fixture.text()).not.toContain("\u001b");
+    expectClean(fixture);
+  });
+
+  it("pages plain long lists and accepts multi-digit numeric choices", async () => {
+    const fixture = terminal(false, { isTTY: false });
+    const pending = fixture.io.choose("Model", Array.from({ length: 50 }, (_, index) => `Model ${index + 1}`));
+    expect(fixture.text()).not.toContain("21. Model");
+    fixture.input.write("n\r");
+    await vi.waitFor(() => expect(fixture.text()).toContain("21. Model"));
+    fixture.input.write("42\r");
+    expect(await pending).toBe(41);
+    expectClean(fixture);
+  });
+
+  it("preserves choice and consent defaults in plain mode and retries invalid confirmations", async () => {
+    const fixture = terminal(false, { isTTY: false });
+    const select = fixture.io.choose("Model", ["First", "Second"], 1);
+    fixture.input.write("\r");
+    expect(await select).toBe(1);
+    const confirmed = fixture.io.confirm("Save?", true);
+    fixture.input.write("\r");
+    expect(await confirmed).toBe(true);
+    const declined = fixture.io.confirm("Replace?");
+    fixture.input.write("\r");
+    expect(await declined).toBe(false);
+    const retried = fixture.io.confirm("Continue?");
+    fixture.input.write("maybe\r");
+    await vi.waitFor(() => expect(fixture.text()).toContain("Enter yes or no."));
+    fixture.input.write("yes\r");
+    expect(await retried).toBe(true);
+    expectClean(fixture);
   });
 });

--- a/server/cli-prompts.ts
+++ b/server/cli-prompts.ts
@@ -1,0 +1,176 @@
+import { createInterface } from "node:readline";
+import type { Readable, Writable } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
+
+export interface SetupIo {
+  log(line: string): void;
+  ask(question: string): Promise<string>;
+  secret(question: string): Promise<string>;
+  choose(question: string, options: readonly string[], defaultIndex?: number): Promise<number>;
+  confirm(question: string, defaultYes?: boolean): Promise<boolean>;
+}
+
+export class SetupCancelled extends Error {
+  constructor() {
+    super("Setup cancelled.");
+    this.name = "SetupCancelled";
+  }
+}
+
+type TerminalInput = Readable & {
+  isTTY?: boolean;
+  isRaw?: boolean;
+  setRawMode?: (mode: boolean) => unknown;
+};
+
+function displayText(text: string, multiline = false): string {
+  // These expressions deliberately remove terminal control characters.
+  // eslint-disable-next-line no-control-regex
+  const plain = text.replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, "");
+  // eslint-disable-next-line no-control-regex
+  return plain.replace(/[\u0000-\u001f\u007f-\u009f]/g, (character) => character === "\n" && multiline ? "\n" : " ");
+}
+
+/** Streams are injectable so prompt tests never read the user's terminal. */
+export function defaultSetupIo(input: TerminalInput = process.stdin, output: Writable = process.stdout): SetupIo {
+  const log = (line: string) => { output.write(`${displayText(line, true)}\n`); };
+  const requireTerminal = () => {
+    if (!input.isTTY || !input.setRawMode) throw new Error("Setup needs an interactive terminal.");
+  };
+  const restoreInput = (raw: boolean, flowing: boolean) => {
+    input.setRawMode?.(raw);
+    if (flowing) input.resume();
+    else input.pause();
+  };
+
+  const ask = (question: string): Promise<string> => {
+    requireTerminal();
+    const raw = input.isRaw === true;
+    const flowing = input.readableFlowing === true;
+    return new Promise((resolve, reject) => {
+      const rl = createInterface({ input, output, terminal: true });
+      let finished = false;
+      const restore = () => restoreInput(raw, flowing);
+      const finish = (answer?: string, error?: Error) => {
+        if (finished) return;
+        finished = true;
+        process.removeListener("SIGINT", cancel);
+        process.removeListener("SIGTERM", cancel);
+        process.removeListener("exit", restore);
+        input.removeListener("error", fail);
+        input.removeListener("keypress", onKeypress);
+        rl.close();
+        restore();
+        if (error) reject(error);
+        else resolve(answer ?? "");
+      };
+      const cancel = () => finish(undefined, new SetupCancelled());
+      const fail = (error: Error) => finish(undefined, error);
+      const onKeypress = (_text: string, key: { sequence?: string }) => {
+        if (key.sequence === "\u0004") cancel();
+      };
+      rl.once("SIGINT", cancel);
+      rl.once("close", cancel);
+      input.once("error", fail);
+      input.on("keypress", onKeypress);
+      process.once("SIGINT", cancel);
+      process.once("SIGTERM", cancel);
+      process.once("exit", restore);
+      rl.question(displayText(question), (answer) => finish(answer));
+    });
+  };
+
+  const secret = (question: string): Promise<string> => {
+    requireTerminal();
+    const raw = input.isRaw === true;
+    const flowing = input.readableFlowing === true;
+    return new Promise((resolve, reject) => {
+      let value = "";
+      let escape = "";
+      let finished = false;
+      const decoder = new StringDecoder("utf8");
+      const restore = () => restoreInput(raw, flowing);
+      const finish = (error?: Error) => {
+        if (finished) return;
+        finished = true;
+        input.removeListener("data", onData);
+        input.removeListener("end", cancel);
+        input.removeListener("close", cancel);
+        input.removeListener("error", fail);
+        process.removeListener("SIGINT", cancel);
+        process.removeListener("SIGTERM", cancel);
+        process.removeListener("exit", restore);
+        restore();
+        output.write("\n");
+        if (error) reject(error);
+        else resolve(value);
+        value = "";
+      };
+      const cancel = () => finish(new SetupCancelled());
+      const fail = (error: Error) => finish(error);
+      const onData = (chunk: Buffer | string) => {
+        const text = typeof chunk === "string" ? chunk : decoder.write(chunk);
+        for (const character of text) {
+          if (character === "\u0003" || character === "\u0004") return cancel();
+          // Ignore cursor keys and bracketed-paste markers, including markers
+          // split across chunks. No input bytes are ever written to output.
+          if (escape === "\u001b") {
+            escape = character === "[" || character === "O" ? escape + character : "";
+            continue;
+          }
+          if (escape) {
+            if (/[@-~]/.test(character)) escape = "";
+            continue;
+          }
+          if (character === "\u001b") escape = character;
+          else if (character === "\r" || character === "\n") return finish();
+          else if (character === "\u007f" || character === "\b") value = Array.from(value).slice(0, -1).join("");
+          else if (character === "\u0015") value = "";
+          else if (character >= " " && character !== "\u007f") value += character;
+        }
+      };
+      input.on("data", onData);
+      input.once("end", cancel);
+      input.once("close", cancel);
+      input.once("error", fail);
+      process.once("SIGINT", cancel);
+      process.once("SIGTERM", cancel);
+      process.once("exit", restore);
+      try {
+        input.setRawMode!(true);
+        output.write(displayText(question));
+        input.resume();
+      } catch (error) {
+        finish(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  };
+
+  const choose: SetupIo["choose"] = async (question, options, defaultIndex) => {
+    if (!options.length) throw new Error("There are no choices available.");
+    if (defaultIndex !== undefined && (!Number.isInteger(defaultIndex) || defaultIndex < 0 || defaultIndex >= options.length)) {
+      throw new Error("The default choice is not available.");
+    }
+    log(displayText(question));
+    options.forEach((option, index) => log(`  ${index + 1}. ${displayText(option)}${index === defaultIndex ? " (default)" : ""}`));
+    while (true) {
+      const answer = (await ask(`Choose 1–${options.length}${defaultIndex === undefined ? "" : ` [${defaultIndex + 1}]`}: `)).trim();
+      if (!answer && defaultIndex !== undefined) return defaultIndex;
+      const selected = /^\d+$/.test(answer) ? Number(answer) - 1 : -1;
+      if (selected >= 0 && selected < options.length) return selected;
+      log(`Enter a number from 1 to ${options.length}.`);
+    }
+  };
+
+  const confirm: SetupIo["confirm"] = async (question, defaultYes = false) => {
+    while (true) {
+      const answer = (await ask(`${question} ${defaultYes ? "[Y/n]" : "[y/N]"}: `)).trim().toLowerCase();
+      if (!answer) return defaultYes;
+      if (answer === "y" || answer === "yes") return true;
+      if (answer === "n" || answer === "no") return false;
+      log("Enter yes or no.");
+    }
+  };
+
+  return { log, ask, secret, choose, confirm };
+}

--- a/server/cli-prompts.ts
+++ b/server/cli-prompts.ts
@@ -1,6 +1,7 @@
+import { confirm as clackConfirm, isCancel, password, select, text } from "@clack/prompts";
 import { createInterface } from "node:readline";
-import type { Readable, Writable } from "node:stream";
-import { StringDecoder } from "node:string_decoder";
+import { PassThrough, type Readable, type Writable } from "node:stream";
+import { stripVTControlCharacters } from "node:util";
 
 export interface SetupIo {
   log(line: string): void;
@@ -22,155 +23,164 @@ type TerminalInput = Readable & {
   isRaw?: boolean;
   setRawMode?: (mode: boolean) => unknown;
 };
+type TerminalOutput = Writable & { isTTY?: boolean; columns?: number; rows?: number };
+type PromptContext = { input: TerminalInput; output: TerminalOutput; signal: AbortSignal };
 
-function displayText(text: string, multiline = false): string {
-  // These expressions deliberately remove terminal control characters.
-  // eslint-disable-next-line no-control-regex
-  const plain = text.replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, "");
+function displayText(value: string, multiline = false): string {
+  const plain = stripVTControlCharacters(value);
+  // Provider-supplied labels must not issue terminal control commands.
   // eslint-disable-next-line no-control-regex
   return plain.replace(/[\u0000-\u001f\u007f-\u009f]/g, (character) => character === "\n" && multiline ? "\n" : " ");
 }
 
-/** Streams are injectable so prompt tests never read the user's terminal. */
-export function defaultSetupIo(input: TerminalInput = process.stdin, output: Writable = process.stdout): SetupIo {
+/** A line-based fallback with no cursor/color output. Readline has no output
+ * stream for secrets, so even pasted input cannot be echoed. */
+function plainText(question: string, hidden: boolean, context: PromptContext): Promise<string> {
+  const { input, output, signal } = context;
+  return new Promise((resolve, reject) => {
+    input.setRawMode?.(hidden);
+    const rl = createInterface({ input, terminal: hidden });
+    let finished = false;
+    const finish = (answer?: string, error?: unknown) => {
+      if (finished) return;
+      finished = true;
+      signal.removeEventListener("abort", cancel);
+      rl.close();
+      output.write("\n");
+      if (error) reject(error);
+      else resolve(answer ?? "");
+    };
+    const cancel = () => finish(undefined, signal.reason ?? new SetupCancelled());
+    signal.addEventListener("abort", cancel, { once: true });
+    rl.once("line", (answer) => finish(answer));
+    rl.once("close", () => finish(undefined, new SetupCancelled()));
+    output.write(question);
+  });
+}
+
+/** Streams are injectable; fixtures never read the user's real terminal. */
+export function defaultSetupIo(input: TerminalInput = process.stdin, output: TerminalOutput = process.stdout): SetupIo {
   const log = (line: string) => { output.write(`${displayText(line, true)}\n`); };
-  const requireTerminal = () => {
+  const rich = () => output.isTTY === true && process.env.TERM !== "dumb" && process.env.NO_COLOR === undefined
+    && (output.columns ?? 80) >= 30 && (output.rows ?? 24) >= 8;
+
+  const run = <T>(prompt: (context: PromptContext) => Promise<T | symbol>): Promise<T> => {
     if (!input.isTTY || !input.setRawMode) throw new Error("Setup needs an interactive terminal.");
-  };
-  const restoreInput = (raw: boolean, flowing: boolean) => {
-    input.setRawMode?.(raw);
-    if (flowing) input.resume();
-    else input.pause();
-  };
-
-  const ask = (question: string): Promise<string> => {
-    requireTerminal();
     const raw = input.isRaw === true;
     const flowing = input.readableFlowing === true;
-    return new Promise((resolve, reject) => {
-      const rl = createInterface({ input, output, terminal: true });
-      let finished = false;
-      const restore = () => restoreInput(raw, flowing);
-      const finish = (answer?: string, error?: Error) => {
-        if (finished) return;
-        finished = true;
-        process.removeListener("SIGINT", cancel);
-        process.removeListener("SIGTERM", cancel);
-        process.removeListener("exit", restore);
-        input.removeListener("error", fail);
-        input.removeListener("keypress", onKeypress);
-        rl.close();
-        restore();
-        if (error) reject(error);
-        else resolve(answer ?? "");
-      };
-      const cancel = () => finish(undefined, new SetupCancelled());
-      const fail = (error: Error) => finish(undefined, error);
-      const onKeypress = (_text: string, key: { sequence?: string }) => {
-        if (key.sequence === "\u0004") cancel();
-      };
-      rl.once("SIGINT", cancel);
-      rl.once("close", cancel);
-      input.once("error", fail);
-      input.on("keypress", onKeypress);
-      process.once("SIGINT", cancel);
-      process.once("SIGTERM", cancel);
-      process.once("exit", restore);
-      rl.question(displayText(question), (answer) => finish(answer));
+    const controller = new AbortController();
+    // Clack owns this prompt's readline/key decoder, not the shared stdin.
+    // Discarding this stream also discards unfinished escape/paste sequences.
+    const promptInput = Object.assign(new PassThrough(), {
+      isTTY: true,
+      setRawMode: (mode: boolean) => input.setRawMode!(mode),
     });
-  };
-
-  const secret = (question: string): Promise<string> => {
-    requireTerminal();
-    const raw = input.isRaw === true;
-    const flowing = input.readableFlowing === true;
-    return new Promise((resolve, reject) => {
-      let value = "";
-      let escape = "";
-      let finished = false;
-      const decoder = new StringDecoder("utf8");
-      const restore = () => restoreInput(raw, flowing);
-      const finish = (error?: Error) => {
-        if (finished) return;
-        finished = true;
-        input.removeListener("data", onData);
-        input.removeListener("end", cancel);
-        input.removeListener("close", cancel);
-        input.removeListener("error", fail);
-        process.removeListener("SIGINT", cancel);
-        process.removeListener("SIGTERM", cancel);
-        process.removeListener("exit", restore);
-        restore();
-        output.write("\n");
-        if (error) reject(error);
-        else resolve(value);
-        value = "";
-      };
-      const cancel = () => finish(new SetupCancelled());
-      const fail = (error: Error) => finish(error);
-      const onData = (chunk: Buffer | string) => {
-        const text = typeof chunk === "string" ? chunk : decoder.write(chunk);
-        for (const character of text) {
-          if (character === "\u0003" || character === "\u0004") return cancel();
-          // Ignore cursor keys and bracketed-paste markers, including markers
-          // split across chunks. No input bytes are ever written to output.
-          if (escape === "\u001b") {
-            escape = character === "[" || character === "O" ? escape + character : "";
-            continue;
-          }
-          if (escape) {
-            if (/[@-~]/.test(character)) escape = "";
-            continue;
-          }
-          if (character === "\u001b") escape = character;
-          else if (character === "\r" || character === "\n") return finish();
-          else if (character === "\u007f" || character === "\b") value = Array.from(value).slice(0, -1).join("");
-          else if (character === "\u0015") value = "";
-          else if (character >= " " && character !== "\u007f") value += character;
-        }
-      };
-      input.on("data", onData);
+    let failure: Error | undefined;
+    let settled = false;
+    const fail = (error: Error) => {
+      failure ??= error;
+      controller.abort(failure);
+    };
+    const cancel = () => fail(new SetupCancelled());
+    const forward = (chunk: Buffer | string) => {
+      // Ctrl-D and cancellation during an incomplete escape must not wait
+      // for a key decoder. No prompt input is ever copied to its output.
+      const interrupted = typeof chunk === "string"
+        ? chunk.includes("\u0003") || chunk.includes("\u0004")
+        : chunk.includes(3) || chunk.includes(4);
+      if (interrupted) cancel();
+      else if (!controller.signal.aborted) promptInput.write(chunk);
+    };
+    const restore = () => {
+      input.setRawMode!(raw);
+      if (flowing) input.resume();
+      else input.pause();
+    };
+    return (async () => {
+      input.on("data", forward);
       input.once("end", cancel);
       input.once("close", cancel);
       input.once("error", fail);
+      output.once("error", fail);
       process.once("SIGINT", cancel);
       process.once("SIGTERM", cancel);
       process.once("exit", restore);
       try {
-        input.setRawMode!(true);
-        output.write(displayText(question));
+        if (input.readableEnded || input.destroyed) throw new SetupCancelled();
+        const pending = prompt({ input: promptInput, output, signal: controller.signal });
         input.resume();
+        const value = await pending;
+        settled = true;
+        if (failure) throw failure;
+        if (isCancel(value)) throw new SetupCancelled();
+        return value as T;
       } catch (error) {
-        finish(error instanceof Error ? error : new Error(String(error)));
+        if (!settled) controller.abort(error);
+        throw failure ?? error;
+      } finally {
+        input.removeListener("data", forward);
+        input.removeListener("end", cancel);
+        input.removeListener("close", cancel);
+        input.removeListener("error", fail);
+        output.removeListener("error", fail);
+        process.removeListener("SIGINT", cancel);
+        process.removeListener("SIGTERM", cancel);
+        process.removeListener("exit", restore);
+        promptInput.destroy();
+        restore();
       }
-    });
+    })();
   };
 
-  const choose: SetupIo["choose"] = async (question, options, defaultIndex) => {
+  const ask: SetupIo["ask"] = (question) => run((context) => rich()
+    ? text({ ...context, message: displayText(question) })
+    : plainText(displayText(question), false, context));
+  const secret: SetupIo["secret"] = (question) => run((context) => rich()
+    ? password({ ...context, message: displayText(question), mask: "*" })
+    : plainText(displayText(question), true, context));
+
+  const choose: SetupIo["choose"] = async (question, options, defaultIndex = 0) => {
     if (!options.length) throw new Error("There are no choices available.");
-    if (defaultIndex !== undefined && (!Number.isInteger(defaultIndex) || defaultIndex < 0 || defaultIndex >= options.length)) {
+    if (!Number.isInteger(defaultIndex) || defaultIndex < 0 || defaultIndex >= options.length) {
       throw new Error("The default choice is not available.");
     }
-    log(displayText(question));
-    options.forEach((option, index) => log(`  ${index + 1}. ${displayText(option)}${index === defaultIndex ? " (default)" : ""}`));
-    while (true) {
-      const answer = (await ask(`Choose 1–${options.length}${defaultIndex === undefined ? "" : ` [${defaultIndex + 1}]`}: `)).trim();
-      if (!answer && defaultIndex !== undefined) return defaultIndex;
-      const selected = /^\d+$/.test(answer) ? Number(answer) - 1 : -1;
-      if (selected >= 0 && selected < options.length) return selected;
+    if (rich()) return run((context) => select({
+      ...context,
+      message: displayText(question),
+      options: options.map((label, value) => ({ value, label: displayText(label) })),
+      initialValue: defaultIndex,
+      maxItems: 7,
+    }));
+
+    const pageSize = 20;
+    let start = Math.floor(defaultIndex / pageSize) * pageSize;
+    for (;;) {
+      log(question);
+      options.slice(start, start + pageSize).forEach((label, offset) => {
+        const index = start + offset;
+        log(`  ${index + 1}. ${label}${index === defaultIndex ? " (default)" : ""}`);
+      });
+      const paged = options.length > pageSize;
+      if (paged) log(`Showing ${start + 1}–${Math.min(start + pageSize, options.length)} of ${options.length}. Type n/p for next/previous page.`);
+      const answer = (await ask(`Choose 1–${options.length} [${defaultIndex + 1}]: `)).trim();
+      if (!answer) return defaultIndex;
+      if (paged && /^[np]$/i.test(answer)) {
+        start = Math.max(0, Math.min(Math.floor((options.length - 1) / pageSize) * pageSize, start + (answer.toLowerCase() === "n" ? pageSize : -pageSize)));
+        continue;
+      }
+      if (/^\d+$/.test(answer) && Number(answer) >= 1 && Number(answer) <= options.length) return Number(answer) - 1;
       log(`Enter a number from 1 to ${options.length}.`);
     }
   };
-
   const confirm: SetupIo["confirm"] = async (question, defaultYes = false) => {
-    while (true) {
-      const answer = (await ask(`${question} ${defaultYes ? "[Y/n]" : "[y/N]"}: `)).trim().toLowerCase();
+    if (rich()) return run((context) => clackConfirm({ ...context, message: displayText(question), initialValue: defaultYes }));
+    for (;;) {
+      const answer = (await ask(`${question} ${defaultYes ? "[Y/n]" : "[y/N]"}: `)).trim();
       if (!answer) return defaultYes;
-      if (answer === "y" || answer === "yes") return true;
-      if (answer === "n" || answer === "no") return false;
+      if (/^y(es)?$/i.test(answer)) return true;
+      if (/^n(o)?$/i.test(answer)) return false;
       log("Enter yes or no.");
     }
   };
-
   return { log, ask, secret, choose, confirm };
 }

--- a/server/cli-setup.test.ts
+++ b/server/cli-setup.test.ts
@@ -1,0 +1,508 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DATA_DIR, instanceConfigs, loadConfig, PROVIDER_CREDENTIAL_ENV, WORKSPACE_CREDENTIAL_ENV, type AppConfig } from "./config.ts";
+import { acquireDataDirLease } from "./data-dir-lease.ts";
+import { SetupCancelled, type SetupIo } from "./cli-prompts.ts";
+import { isSetupComplete, runSetup } from "./cli-setup.ts";
+import { OpenAICompatDriver } from "./drivers/openai-compat.ts";
+
+const options = { dataDir: DATA_DIR, port: 8799 };
+const configPath = join(DATA_DIR, "config.json");
+const models = {
+  default: "fixture-default",
+  options: [
+    { id: "fixture-default", label: "Fixture default" },
+    { id: "fixture-selected", label: "Fixture selected" },
+  ],
+};
+type Dependencies = NonNullable<Parameters<typeof runSetup>[2]>;
+
+function dependencies() {
+  return {
+    inspect: vi.fn<Dependencies["inspect"]>().mockResolvedValue({
+      snapshot: { state: "available", authenticated: true }, models,
+    }),
+    runCli: vi.fn<Dependencies["runCli"]>().mockResolvedValue(undefined),
+    models: vi.fn<Dependencies["models"]>().mockResolvedValue(models.options),
+    verify: vi.fn<Dependencies["verify"]>().mockResolvedValue(undefined),
+  };
+}
+
+function prompts(script: { choices?: number[]; confirms?: boolean[]; secrets?: Array<string | Error>; answers?: string[] } = {}) {
+  const choices = [...(script.choices ?? [])];
+  const confirms = [...(script.confirms ?? [])];
+  const secrets = [...(script.secrets ?? [])];
+  const answers = [...(script.answers ?? [])];
+  const lines: string[] = [];
+  const take = <T>(values: T[], question: string): T => {
+    if (!values.length) throw new Error(`Unexpected fixture prompt: ${question}`);
+    return values.shift()!;
+  };
+  const io = {
+    log: vi.fn((line: string) => { lines.push(line); }),
+    choose: vi.fn<SetupIo["choose"]>(async (question, available) => {
+      lines.push(question, ...available);
+      const selected = take(choices, question);
+      if (selected < 0 || selected >= available.length) throw new Error("Fixture selected an unavailable option");
+      return selected;
+    }),
+    confirm: vi.fn<SetupIo["confirm"]>(async (question) => { lines.push(question); return take(confirms, question); }),
+    secret: vi.fn<SetupIo["secret"]>(async (question) => {
+      lines.push(question);
+      const value = take(secrets, question);
+      if (value instanceof Error) throw value;
+      return value;
+    }),
+    ask: vi.fn<SetupIo["ask"]>(async (question) => { lines.push(question); return take(answers, question); }),
+  };
+  return { io, lines, assertConsumed: () => expect([choices, confirms, secrets, answers]).toEqual([[], [], [], []]) };
+}
+
+function persist(config: AppConfig & Record<string, unknown>): string {
+  const raw = JSON.stringify(config, null, 2);
+  writeFileSync(configPath, raw, { mode: 0o600 });
+  return raw;
+}
+
+function expectLeaseReleased() {
+  const lease = acquireDataDirLease(DATA_DIR);
+  expect(lease.release()).toBe(true);
+}
+
+beforeEach(() => {
+  // testing/setup.ts assigns a throwaway HOME before this module loads.
+  rmSync(DATA_DIR, { recursive: true, force: true });
+  mkdirSync(DATA_DIR, { recursive: true });
+  for (const name of [...WORKSPACE_CREDENTIAL_ENV, ...PROVIDER_CREDENTIAL_ENV, "OPENAI_COMPAT_MODEL", "OPENAI_COMPAT_PROVIDER"])
+    vi.stubEnv(name, undefined);
+  vi.stubGlobal("fetch", vi.fn(() => { throw new Error("Wizard fixtures must never make network requests"); }));
+});
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("native provider onboarding", () => {
+  it.each([{ choice: 0, id: "codex", driver: "codex" }, { choice: 1, id: "claude", driver: "claudeAgent" }])(
+    "uses an existing $id login and saves the selected model without starting an auth process",
+    async ({ choice, id, driver }) => {
+      const deps = dependencies();
+      const ui = prompts({ choices: [choice, 1], confirms: [true] });
+      expect(await runSetup(options, ui.io, deps)).toBe(true);
+      expect(deps.inspect).toHaveBeenCalledWith(id, { driver, enabled: true });
+      expect(deps.runCli).not.toHaveBeenCalled();
+      expect(deps.models).not.toHaveBeenCalled();
+      expect(deps.verify).not.toHaveBeenCalled();
+      expect(loadConfig().defaultModelSelection).toEqual({ instanceId: id, model: "fixture-selected" });
+      expect(loadConfig().instances?.[id]).toEqual({ driver, enabled: true });
+      expect(loadConfig().instances?.openaiCompat.driver).toBe("openai-compat");
+      expect(ui.lines.join("\n")).toContain("Existing sign-in found");
+      expect(await isSetupComplete(DATA_DIR)).toBe(true);
+      ui.assertConsumed();
+      expectLeaseReleased();
+    },
+  );
+
+  it("installs Codex only after confirmation and supports remote device sign-in", async () => {
+    const deps = dependencies();
+    deps.inspect
+      .mockResolvedValueOnce({ snapshot: { state: "unavailable", reason: "missing fixture CLI" }, models })
+      .mockResolvedValueOnce({ snapshot: { state: "available", authenticated: false }, models });
+    const ui = prompts({ choices: [0, 1, 0], confirms: [true, true] });
+    expect(await runSetup(options, ui.io, deps)).toBe(true);
+    expect(deps.runCli.mock.calls).toEqual([
+      ["npm", ["install", "-g", "@openai/codex"]],
+      ["codex", ["login", "--device-auth"], undefined],
+    ]);
+    expect(ui.io.confirm.mock.invocationCallOrder[0]).toBeLessThan(deps.runCli.mock.invocationCallOrder[0]!);
+    expect(deps.inspect).toHaveBeenCalledTimes(3);
+    ui.assertConsumed();
+  });
+
+  it("runs Claude's account login and retains a custom CLI path and environment", async () => {
+    const original = { driver: "claudeAgent", config: { cli: "/fixture/bin/claude" }, environment: { CLAUDE_CONFIG_DIR: "/fixture/account" } };
+    persist({ instances: { workClaude: original } });
+    const deps = dependencies();
+    deps.inspect.mockResolvedValueOnce({ snapshot: { state: "available", authenticated: false }, models });
+    const ui = prompts({ choices: [3, 0], confirms: [true] });
+    expect(await runSetup(options, ui.io, deps)).toBe(true);
+    expect(deps.runCli).toHaveBeenCalledWith("/fixture/bin/claude", ["auth", "login"], original.environment);
+    expect(loadConfig().instances?.workClaude).toEqual({ ...original, enabled: true });
+    expect(loadConfig().defaultModelSelection?.instanceId).toBe("workClaude");
+    ui.assertConsumed();
+  });
+
+  it("does not save after a CLI exits successfully without confirming sign-in", async () => {
+    const original = persist({ profile: { name: "Existing user" } });
+    const deps = dependencies();
+    deps.inspect.mockResolvedValue({ snapshot: { state: "available", authenticated: false }, models });
+    const ui = prompts({ choices: [0, 0] });
+    await expect(runSetup(options, ui.io, deps)).rejects.toThrow("Sign-in was not confirmed");
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expectLeaseReleased();
+  });
+
+  it("keeps settings after sign-in cancellation", async () => {
+    const original = persist({ profile: { name: "Existing user" } });
+    const deps = dependencies();
+    deps.inspect.mockResolvedValueOnce({ snapshot: { state: "available", authenticated: false }, models });
+    deps.runCli.mockRejectedValue(new SetupCancelled());
+    const ui = prompts({ choices: [0, 0] });
+    expect(await runSetup(options, ui.io, deps)).toBe(false);
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expectLeaseReleased();
+  });
+
+  it("cancels a declined install before running any command", async () => {
+    const deps = dependencies();
+    deps.inspect.mockResolvedValue({ snapshot: { state: "unavailable" }, models });
+    const ui = prompts({ choices: [0], confirms: [false] });
+    expect(await runSetup(options, ui.io, deps)).toBe(false);
+    expect(deps.runCli).not.toHaveBeenCalled();
+    expect(existsSync(configPath)).toBe(false);
+    expectLeaseReleased();
+  });
+
+  it("keeps the saved native model selected when setup is run again", async () => {
+    persist({ instances: { codex: { driver: "codex" } }, defaultModelSelection: { instanceId: "codex", model: "fixture-selected" } });
+    const ui = prompts({ choices: [3, 1], confirms: [true] });
+    expect(await runSetup(options, ui.io, dependencies())).toBe(true);
+    expect(ui.io.choose.mock.calls[0]?.[2]).toBe(3);
+    expect(ui.io.choose.mock.calls[1]?.[2]).toBe(1);
+    expect(loadConfig().defaultModelSelection).toEqual({ instanceId: "codex", model: "fixture-selected" });
+  });
+
+  it("does not change a saved setup when the final native save is declined", async () => {
+    const original = persist({ profile: { name: "Keep" }, defaultModelSelection: { instanceId: "claude", model: "previous" } });
+    const ui = prompts({ choices: [0, 1], confirms: [false] });
+    expect(await runSetup(options, ui.io, dependencies())).toBe(false);
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expectLeaseReleased();
+  });
+
+  it("does not install over an unavailable custom CLI path", async () => {
+    const original = persist({ instances: { codex: { driver: "codex", config: { cli: "/fixture/custom-codex" } } } });
+    const deps = dependencies();
+    deps.inspect.mockResolvedValue({ snapshot: { state: "unavailable" }, models });
+    const ui = prompts({ choices: [0] });
+    await expect(runSetup(options, ui.io, deps)).rejects.toThrow("custom CLI path is unavailable");
+    expect(deps.runCli).not.toHaveBeenCalled();
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expectLeaseReleased();
+  });
+
+  it("does not overwrite an instance that repurposed a native provider ID", async () => {
+    const existing = { driver: "customAcp", displayName: "Keep this connection", config: { cli: "/fixture/other" } };
+    persist({ instances: { codex: existing } });
+    const ui = prompts({ choices: [0, 0], confirms: [true] });
+    expect(await runSetup(options, ui.io, dependencies())).toBe(true);
+    const saved = loadConfig();
+    expect(saved.instances?.codex).toEqual(existing);
+    expect(saved.defaultModelSelection?.instanceId).toMatch(/^codex-[\da-f]{8}$/);
+    expect(saved.instances?.[saved.defaultModelSelection!.instanceId]?.driver).toBe("codex");
+  });
+});
+
+describe("API onboarding", () => {
+  it.each<{
+    label: string;
+    configKey?: string;
+    environment?: Record<string, string>;
+    processEnvironment: Record<string, string>;
+    expected: string;
+  }>([
+    {
+      label: "explicit config key", configKey: "config-key",
+      environment: { OMB_SETUP_TEST_CUSTOM_KEY: "instance-custom-key", OPENAI_COMPAT_API_KEY: "instance-default-key" },
+      processEnvironment: { OMB_SETUP_TEST_CUSTOM_KEY: "process-custom-key", OPENAI_COMPAT_API_KEY: "process-default-key" },
+      expected: "config-key",
+    },
+    {
+      label: "custom instance environment key",
+      environment: { OMB_SETUP_TEST_CUSTOM_KEY: "instance-custom-key", OPENAI_COMPAT_API_KEY: "instance-default-key" },
+      processEnvironment: { OMB_SETUP_TEST_CUSTOM_KEY: "process-custom-key", OPENAI_COMPAT_API_KEY: "process-default-key" },
+      expected: "instance-custom-key",
+    },
+    {
+      label: "standard instance environment fallback",
+      environment: { OPENAI_COMPAT_API_KEY: "instance-default-key" },
+      processEnvironment: { OMB_SETUP_TEST_CUSTOM_KEY: "process-custom-key" },
+      expected: "instance-default-key",
+    },
+    {
+      label: "custom process environment fallback",
+      processEnvironment: { OMB_SETUP_TEST_CUSTOM_KEY: "process-custom-key" }, expected: "process-custom-key",
+    },
+    {
+      label: "standard process environment fallback",
+      processEnvironment: { OPENAI_COMPAT_API_KEY: "process-default-key" }, expected: "process-default-key",
+    },
+  ])("uses the driver's $label precedence for existing API setup", async ({ configKey, environment, processEnvironment, expected }) => {
+    for (const [name, value] of Object.entries(processEnvironment)) vi.stubEnv(name, value);
+    const original = {
+      driver: "openai-compat", ...(environment ? { environment } : {}),
+      config: { url: "https://api.example.test/v1", apiKeyEnv: "OMB_SETUP_TEST_CUSTOM_KEY", ...(configKey ? { key: configKey } : {}) },
+    };
+    persist({ instances: { existing: original } });
+    const deps = dependencies();
+    const ui = prompts({ choices: [3, 0], confirms: [true, true] });
+    expect(await runSetup(options, ui.io, deps)).toBe(true);
+    expect(deps.models).toHaveBeenCalledWith("https://api.example.test/v1", expected);
+    expect(deps.verify).toHaveBeenCalledWith("https://api.example.test/v1", expected, "fixture-default");
+    expect(ui.io.secret).not.toHaveBeenCalled();
+    expect(loadConfig().instances?.existing).toEqual({ ...original, config: { ...original.config, model: "fixture-default" } });
+    ui.assertConsumed();
+  });
+
+  it("verifies an existing connection using its effective workspace routing provider", async () => {
+    persist({
+      openaiCompat: { provider: "fireworks" },
+      instances: { routed: { driver: "openai-compat", config: { url: "https://openrouter.ai/api/v1", key: "fixture-key" } } },
+    });
+    const deps = dependencies();
+    const ui = prompts({ choices: [3, 0], confirms: [true, true] });
+    expect(await runSetup(options, ui.io, deps)).toBe(true);
+    expect(deps.verify).toHaveBeenCalledWith("https://openrouter.ai/api/v1", "fixture-key", "fixture-default", "fireworks");
+    expect(loadConfig().instances?.routed.config).toEqual({ url: "https://openrouter.ai/api/v1", key: "fixture-key", model: "fixture-default" });
+    ui.assertConsumed();
+  });
+
+  it("does not inherit an old workspace or environment routing pin for a new standalone API connection", async () => {
+    persist({ openaiCompat: { provider: "workspace-provider" } });
+    vi.stubEnv("OPENAI_COMPAT_PROVIDER", "environment-provider");
+    const deps = dependencies();
+    const ui = prompts({ choices: [2, 1, 0], secrets: ["fixture-new-key"], confirms: [true, true] });
+    expect(await runSetup(options, ui.io, deps)).toBe(true);
+    expect(deps.verify).toHaveBeenCalledWith("https://openrouter.ai/api/v1", "fixture-new-key", "fixture-default");
+    const saved = loadConfig();
+    const id = saved.defaultModelSelection!.instanceId;
+    const liveEntry = instanceConfigs(saved)[id]!;
+    expect(liveEntry.config).toMatchObject({ provider: "" });
+    expect(OpenAICompatDriver.decodeConfig(liveEntry.config).provider).toBeUndefined();
+    ui.assertConsumed();
+  });
+
+  it("keeps verified routing when a missing-key connection is saved as a new additive instance", async () => {
+    const original = {
+      driver: "openai-compat", displayName: "Pinned OpenRouter",
+      config: { url: "https://openrouter.ai/api/v1", provider: "fireworks", model: "old-model" },
+    };
+    persist({ instances: { pinned: original } });
+    const deps = dependencies();
+    const ui = prompts({ choices: [3, 0], secrets: ["fixture-new-key"], confirms: [true, true] });
+    expect(await runSetup(options, ui.io, deps)).toBe(true);
+    expect(ui.io.secret).toHaveBeenCalledTimes(1);
+    expect(deps.verify).toHaveBeenCalledWith("https://openrouter.ai/api/v1", "fixture-new-key", "fixture-default", "fireworks");
+    const saved = loadConfig();
+    const id = saved.defaultModelSelection!.instanceId;
+    expect(id).toMatch(/^api-[\da-f]{8}$/);
+    expect(saved.instances?.pinned).toEqual(original);
+    expect(saved.instances?.[id]?.config).toEqual({
+      url: "https://openrouter.ai/api/v1", key: "fixture-new-key", model: "fixture-default", provider: "fireworks",
+    });
+    expect(OpenAICompatDriver.decodeConfig(instanceConfigs(saved)[id]!.config).provider).toBe("fireworks");
+    ui.assertConsumed();
+  });
+
+  it("adds a verified connection without changing existing credentials, bots or conversations", async () => {
+    const existing = {
+      defaultModelSelection: { instanceId: "oldApi", model: "old-model" },
+      instances: { oldApi: { driver: "openai-compat", config: { url: "https://old.example.test/v1", key: "old-secret", model: "old-model" } } },
+      openaiCompat: { key: "workspace-secret", url: "https://workspace.example.test/v1" },
+      xai: { key: "xai-secret" }, profile: { name: "Ada" }, futureSetting: { keep: true },
+    };
+    persist(existing);
+    const sentinel = '[{"id":"existing-bot","modelSelection":{"instanceId":"oldApi","model":"old-model"}}]';
+    const transcript = '[{"role":"user","text":"Existing conversation"}]';
+    writeFileSync(join(DATA_DIR, "bots.json"), sentinel);
+    writeFileSync(join(DATA_DIR, "messages-existing-thread.json"), transcript);
+    const deps = dependencies();
+    const ui = prompts({ choices: [2, 0, 1], secrets: ["  new-fixture-secret  "], confirms: [true, true] });
+    expect(await runSetup(options, ui.io, deps)).toBe(true);
+
+    expect(deps.models).toHaveBeenCalledWith("https://api.openai.com/v1", "new-fixture-secret");
+    expect(deps.verify).toHaveBeenCalledWith("https://api.openai.com/v1", "new-fixture-secret", "fixture-selected");
+    expect(ui.io.confirm.mock.calls[0]?.[0]).toMatch(/may charge/);
+    expect(ui.io.confirm.mock.invocationCallOrder[0]).toBeLessThan(deps.verify.mock.invocationCallOrder[0]!);
+    expect(deps.verify.mock.invocationCallOrder[0]).toBeLessThan(ui.io.confirm.mock.invocationCallOrder[1]!);
+    const saved = JSON.parse(readFileSync(configPath, "utf8"));
+    const id = saved.defaultModelSelection.instanceId;
+    expect(id).toMatch(/^api-[\da-f]{8}$/);
+    expect(saved.defaultModelSelection).toEqual({ instanceId: id, model: "fixture-selected" });
+    expect(saved.instances.oldApi).toEqual(existing.instances.oldApi);
+    expect(saved.instances[id]).toMatchObject({ driver: "openai-compat", config: { url: "https://api.openai.com/v1", key: "new-fixture-secret", model: "fixture-selected" } });
+    expect(saved).toMatchObject({ openaiCompat: existing.openaiCompat, xai: existing.xai, profile: existing.profile, futureSetting: existing.futureSetting });
+    expect(readFileSync(join(DATA_DIR, "bots.json"), "utf8")).toBe(sentinel);
+    expect(readFileSync(join(DATA_DIR, "messages-existing-thread.json"), "utf8")).toBe(transcript);
+    expect(ui.lines.join("\n")).toMatch(/billed separately/);
+    expect(ui.lines.join("\n")).toMatch(/plaintext/);
+    expect(ui.lines.join("\n")).not.toContain("new-fixture-secret");
+    if (process.platform !== "win32") expect(statSync(configPath).mode & 0o777).toBe(0o600);
+    ui.assertConsumed();
+  });
+
+  it.each([{ confirms: [false], verified: false }, { confirms: [true, false], verified: true }])(
+    "does not save when API confirmation is declined: $confirms",
+    async ({ confirms, verified }) => {
+      const original = persist({ profile: { name: "Keep" } });
+      const deps = dependencies();
+      const ui = prompts({ choices: [2, 1, 0], secrets: ["fixture-key"], confirms });
+      expect(await runSetup(options, ui.io, deps)).toBe(false);
+      expect(deps.verify).toHaveBeenCalledTimes(verified ? 1 : 0);
+      expect(readFileSync(configPath, "utf8")).toBe(original);
+      expectLeaseReleased();
+    },
+  );
+
+  it("keeps existing settings after a failed completion check", async () => {
+    const original = persist({ profile: { name: "Keep" }, defaultModelSelection: { instanceId: "codex", model: "original" } });
+    const deps = dependencies();
+    deps.verify.mockRejectedValue(new Error("API returned HTTP 401. Check the API key."));
+    const ui = prompts({ choices: [2, 2, 0], secrets: ["fixture-key"], confirms: [true] });
+    await expect(runSetup(options, ui.io, deps)).rejects.toThrow("HTTP 401");
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expectLeaseReleased();
+  });
+
+  it("cancels hidden key entry without saving or contacting the provider", async () => {
+    const deps = dependencies();
+    const ui = prompts({ choices: [2, 0], secrets: [new SetupCancelled()] });
+    expect(await runSetup(options, ui.io, deps)).toBe(false);
+    expect(deps.models).not.toHaveBeenCalled();
+    expect(deps.verify).not.toHaveBeenCalled();
+    expect(existsSync(configPath)).toBe(false);
+    expectLeaseReleased();
+  });
+
+  it("allows an exact model ID after a catalog failure and verifies it before saving", async () => {
+    const deps = dependencies();
+    deps.models.mockRejectedValue(new Error("The catalog is unavailable"));
+    const ui = prompts({ choices: [2, 0, 0], secrets: ["fixture-key"], answers: [" manual-chat-model "], confirms: [true, true, true] });
+    expect(await runSetup(options, ui.io, deps)).toBe(true);
+    expect(deps.verify).toHaveBeenCalledWith("https://api.openai.com/v1", "fixture-key", "manual-chat-model");
+    expect(loadConfig().defaultModelSelection?.model).toBe("manual-chat-model");
+    ui.assertConsumed();
+  });
+
+  it("reuses an API connection without changing its endpoint or key and preselects the saved model", async () => {
+    const deps = dependencies();
+    const first = prompts({ choices: [2, 0, 1], secrets: ["fixture-first-key"], confirms: [true, true] });
+    expect(await runSetup(options, first.io, deps)).toBe(true);
+    const before = loadConfig();
+    const priorId = before.defaultModelSelection!.instanceId;
+    const prior = before.instances![priorId]!;
+    // The explicit saved fleet has Codex, Claude, OpenAI-compatible, then
+    // this newly added API connection in the existing-connections list.
+    const existingIds = Object.entries(before.instances!).filter(([, entry]) =>
+      ["codex", "claudeAgent", "openai-compat"].includes(entry.driver) && entry.enabled !== false).map(([id]) => id);
+    const chosen = existingIds.indexOf(priorId) + 3;
+    const second = prompts({ choices: [chosen, 0], confirms: [true, true] });
+    expect(await runSetup(options, second.io, deps)).toBe(true);
+    expect(second.io.choose.mock.calls[0]?.[2]).toBe(chosen);
+    expect(second.io.choose.mock.calls[1]?.[2]).toBe(1);
+    expect(second.io.secret).not.toHaveBeenCalled();
+    expect(loadConfig().instances?.[priorId]).toEqual({
+      ...prior, config: { ...(prior.config as Record<string, unknown>), model: "fixture-default" },
+    });
+    expect(Object.keys(loadConfig().instances!)).toEqual(Object.keys(before.instances!));
+    expect(loadConfig().defaultModelSelection?.instanceId).toBe(priorId);
+    expect(loadConfig().defaultModelSelection?.model).toBe("fixture-default");
+    expect(deps.verify).toHaveBeenLastCalledWith("https://api.openai.com/v1", "fixture-first-key", "fixture-default");
+    second.assertConsumed();
+  });
+
+  it("searches beyond the first model page and saves an exact selected ID", async () => {
+    const deps = dependencies();
+    const catalog = Array.from({ length: 25 }, (_, index) => ({ id: `fixture-model-${index}`, label: `Model ${index}` }));
+    deps.models.mockResolvedValue(catalog);
+    const ui = prompts({ choices: [2, 0, 20, 0], secrets: ["fixture-key"], answers: ["fixture-model-24"], confirms: [true, true] });
+    expect(await runSetup(options, ui.io, deps)).toBe(true);
+    expect(deps.verify).toHaveBeenCalledWith("https://api.openai.com/v1", "fixture-key", "fixture-model-24");
+    expect(loadConfig().defaultModelSelection?.model).toBe("fixture-model-24");
+    ui.assertConsumed();
+  });
+
+  it("keeps a saved model beyond the first page selected when accepting the default", async () => {
+    persist({
+      instances: { api: { driver: "openai-compat", config: { url: "https://api.example.test/v1", key: "fixture-key", model: "fixture-model-24" } } },
+      defaultModelSelection: { instanceId: "api", model: "fixture-model-24" },
+    });
+    const deps = dependencies();
+    deps.models.mockResolvedValue(Array.from({ length: 25 }, (_, index) => ({ id: `fixture-model-${index}`, label: `Model ${index}` })));
+    const ui = prompts({ confirms: [true, true] });
+    ui.io.choose.mockImplementation(async (question, available, defaultIndex) => {
+      if (question.startsWith("1/3")) return 3;
+      expect(defaultIndex).toBeDefined();
+      expect(available[defaultIndex!]).toContain("fixture-model-24");
+      return defaultIndex!;
+    });
+    expect(await runSetup(options, ui.io, deps)).toBe(true);
+    expect(loadConfig().defaultModelSelection).toEqual({ instanceId: "api", model: "fixture-model-24" });
+    expect(deps.verify).toHaveBeenCalledWith("https://api.example.test/v1", "fixture-key", "fixture-model-24");
+    ui.assertConsumed();
+  });
+
+  it("does not borrow another API connection's selected default model", async () => {
+    persist({
+      instances: {
+        primary: { driver: "openai-compat", config: { url: "https://primary.example.test/v1", key: "primary-key", model: "fixture-selected" } },
+        secondary: { driver: "openai-compat", config: { url: "https://secondary.example.test/v1", key: "secondary-key", model: "fixture-default" } },
+      },
+      defaultModelSelection: { instanceId: "primary", model: "fixture-selected" },
+    });
+    const deps = dependencies();
+    const ui = prompts({ choices: [4, 0], confirms: [true, true] });
+    expect(await runSetup(options, ui.io, deps)).toBe(true);
+    expect(ui.io.choose.mock.calls[1]?.[2]).toBe(0);
+    expect(deps.verify).toHaveBeenCalledWith("https://secondary.example.test/v1", "secondary-key", "fixture-default");
+    expect(loadConfig().defaultModelSelection).toEqual({ instanceId: "secondary", model: "fixture-default" });
+    ui.assertConsumed();
+  });
+});
+
+describe("setup state and write boundaries", () => {
+  it("requires a saved selection belonging to an enabled configured or built-in instance", async () => {
+    expect(await isSetupComplete(DATA_DIR)).toBe(false);
+    persist({ defaultModelSelection: { instanceId: "codex", model: "fixture" } });
+    expect(await isSetupComplete(DATA_DIR)).toBe(true);
+    persist({ defaultModelSelection: { instanceId: "missing", model: "fixture" } });
+    expect(await isSetupComplete(DATA_DIR)).toBe(false);
+    persist({ instances: { codex: { driver: "codex", enabled: false } }, defaultModelSelection: { instanceId: "codex", model: "fixture" } });
+    expect(await isSetupComplete(DATA_DIR)).toBe(false);
+    persist({ instances: { custom: { driver: "openai-compat" } }, defaultModelSelection: { instanceId: "custom", model: "fixture" } });
+    expect(await isSetupComplete(DATA_DIR)).toBe(true);
+  });
+
+  it.each(["toString", "constructor", "__proto__"])("does not count inherited object property %s as a saved instance", async (instanceId) => {
+    persist({ defaultModelSelection: { instanceId, model: "fixture" } });
+    expect(await isSetupComplete(DATA_DIR)).toBe(false);
+  });
+
+  it.each(["{broken JSON", '{"instances":{"codex":{"driver":42}}}'])("refuses an unreadable existing configuration: %s", async (raw) => {
+    writeFileSync(configPath, raw);
+    const ui = prompts();
+    const deps = dependencies();
+    await expect(runSetup(options, ui.io, deps)).rejects.toThrow("Existing config.json");
+    await expect(isSetupComplete(DATA_DIR)).rejects.toThrow("Existing config.json");
+    expect(readFileSync(configPath, "utf8")).toBe(raw);
+    expect(ui.io.choose).not.toHaveBeenCalled();
+    expect(deps.inspect).not.toHaveBeenCalled();
+    expectLeaseReleased();
+  });
+
+  it("refuses setup while another owner holds the data directory", async () => {
+    const original = persist({ profile: { name: "Active app" } });
+    const held = acquireDataDirLease(DATA_DIR);
+    try {
+      const ui = prompts();
+      const deps = dependencies();
+      await expect(runSetup(options, ui.io, deps)).rejects.toThrow(/already using this data directory/);
+      expect(ui.io.choose).not.toHaveBeenCalled();
+      expect(deps.inspect).not.toHaveBeenCalled();
+      expect(readFileSync(configPath, "utf8")).toBe(original);
+    } finally { held.release(); }
+    expectLeaseReleased();
+  });
+});

--- a/server/cli-setup.test.ts
+++ b/server/cli-setup.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DATA_DIR, instanceConfigs, loadConfig, PROVIDER_CREDENTIAL_ENV, WORKSPACE_CREDENTIAL_ENV, type AppConfig } from "./config.ts";
 import { acquireDataDirLease } from "./data-dir-lease.ts";
 import { SetupCancelled, type SetupIo } from "./cli-prompts.ts";
-import { isSetupComplete, runSetup } from "./cli-setup.ts";
+import { isSetupComplete, readCliStartup, runSetup, saveCliStartup } from "./cli-setup.ts";
 import { OpenAICompatDriver } from "./drivers/openai-compat.ts";
 
 const options = { dataDir: DATA_DIR, port: 8799 };
@@ -30,7 +30,7 @@ function dependencies() {
   };
 }
 
-function prompts(script: { choices?: number[]; confirms?: boolean[]; secrets?: Array<string | Error>; answers?: string[] } = {}) {
+function prompts(script: { choices?: Array<number | Error>; confirms?: boolean[]; secrets?: Array<string | Error>; answers?: string[] } = {}) {
   const choices = [...(script.choices ?? [])];
   const confirms = [...(script.confirms ?? [])];
   const secrets = [...(script.secrets ?? [])];
@@ -45,6 +45,7 @@ function prompts(script: { choices?: number[]; confirms?: boolean[]; secrets?: A
     choose: vi.fn<SetupIo["choose"]>(async (question, available) => {
       lines.push(question, ...available);
       const selected = take(choices, question);
+      if (selected instanceof Error) throw selected;
       if (selected < 0 || selected >= available.length) throw new Error("Fixture selected an unavailable option");
       return selected;
     }),
@@ -95,6 +96,7 @@ describe("native provider onboarding", () => {
       expect(deps.runCli).not.toHaveBeenCalled();
       expect(deps.models).not.toHaveBeenCalled();
       expect(deps.verify).not.toHaveBeenCalled();
+      expect(ui.io.choose.mock.calls[1]?.[1]).toEqual(["Fixture default", "Fixture selected", "Search models…"]);
       expect(loadConfig().defaultModelSelection).toEqual({ instanceId: id, model: "fixture-selected" });
       expect(loadConfig().instances?.[id]).toEqual({ driver, enabled: true });
       expect(loadConfig().instances?.openaiCompat.driver).toBe("openai-compat");
@@ -138,8 +140,10 @@ describe("native provider onboarding", () => {
     const original = persist({ profile: { name: "Existing user" } });
     const deps = dependencies();
     deps.inspect.mockResolvedValue({ snapshot: { state: "available", authenticated: false }, models });
-    const ui = prompts({ choices: [0, 0] });
-    await expect(runSetup(options, ui.io, deps)).rejects.toThrow("Sign-in was not confirmed");
+    const ui = prompts({ choices: [0, 0, 2] });
+    expect(await runSetup(options, ui.io, deps)).toBe(false);
+    expect(ui.lines.join("\n")).toContain("Sign-in was not confirmed");
+    expect(ui.lines.join("\n")).not.toContain("Test reply received");
     expect(readFileSync(configPath, "utf8")).toBe(original);
     expectLeaseReleased();
   });
@@ -167,11 +171,25 @@ describe("native provider onboarding", () => {
 
   it("keeps the saved native model selected when setup is run again", async () => {
     persist({ instances: { codex: { driver: "codex" } }, defaultModelSelection: { instanceId: "codex", model: "fixture-selected" } });
-    const ui = prompts({ choices: [3, 1], confirms: [true] });
+    const ui = prompts({ choices: [3, 0], confirms: [true] });
     expect(await runSetup(options, ui.io, dependencies())).toBe(true);
     expect(ui.io.choose.mock.calls[0]?.[2]).toBe(3);
-    expect(ui.io.choose.mock.calls[1]?.[2]).toBe(1);
+    expect(ui.io.choose.mock.calls[1]?.[2]).toBe(0);
+    expect(ui.io.choose.mock.calls[1]?.[1][0]).toBe("Fixture selected");
     expect(loadConfig().defaultModelSelection).toEqual({ instanceId: "codex", model: "fixture-selected" });
+  });
+
+  it("uses the model ID when the catalog has no human-readable name", async () => {
+    const deps = dependencies();
+    deps.inspect.mockResolvedValue({
+      snapshot: { state: "available", authenticated: true },
+      models: { default: "id-only", options: [{ id: "id-only", label: "id-only" }, { id: "unnamed", label: " " }] },
+    });
+    const ui = prompts({ choices: [0, 1], confirms: [true] });
+    expect(await runSetup(options, ui.io, deps)).toBe(true);
+    expect(ui.io.choose.mock.calls[1]?.[1]).toEqual(["id-only", "unnamed", "Search models…"]);
+    expect(loadConfig().defaultModelSelection?.model).toBe("unnamed");
+    ui.assertConsumed();
   });
 
   it("does not change a saved setup when the final native save is declined", async () => {
@@ -186,8 +204,9 @@ describe("native provider onboarding", () => {
     const original = persist({ instances: { codex: { driver: "codex", config: { cli: "/fixture/custom-codex" } } } });
     const deps = dependencies();
     deps.inspect.mockResolvedValue({ snapshot: { state: "unavailable" }, models });
-    const ui = prompts({ choices: [0] });
-    await expect(runSetup(options, ui.io, deps)).rejects.toThrow("custom CLI path is unavailable");
+    const ui = prompts({ choices: [0, 2] });
+    expect(await runSetup(options, ui.io, deps)).toBe(false);
+    expect(ui.lines.join("\n")).toContain("custom CLI path is unavailable");
     expect(deps.runCli).not.toHaveBeenCalled();
     expect(readFileSync(configPath, "utf8")).toBe(original);
     expectLeaseReleased();
@@ -360,8 +379,9 @@ describe("API onboarding", () => {
     const original = persist({ profile: { name: "Keep" }, defaultModelSelection: { instanceId: "codex", model: "original" } });
     const deps = dependencies();
     deps.verify.mockRejectedValue(new Error("API returned HTTP 401. Check the API key."));
-    const ui = prompts({ choices: [2, 2, 0], secrets: ["fixture-key"], confirms: [true] });
-    await expect(runSetup(options, ui.io, deps)).rejects.toThrow("HTTP 401");
+    const ui = prompts({ choices: [2, 2, 0, 2], secrets: ["fixture-key"], confirms: [true] });
+    expect(await runSetup(options, ui.io, deps)).toBe(false);
+    expect(ui.lines.join("\n")).toContain("HTTP 401");
     expect(readFileSync(configPath, "utf8")).toBe(original);
     expectLeaseReleased();
   });
@@ -398,10 +418,10 @@ describe("API onboarding", () => {
     const existingIds = Object.entries(before.instances!).filter(([, entry]) =>
       ["codex", "claudeAgent", "openai-compat"].includes(entry.driver) && entry.enabled !== false).map(([id]) => id);
     const chosen = existingIds.indexOf(priorId) + 3;
-    const second = prompts({ choices: [chosen, 0], confirms: [true, true] });
+    const second = prompts({ choices: [chosen, 1], confirms: [true, true] });
     expect(await runSetup(options, second.io, deps)).toBe(true);
     expect(second.io.choose.mock.calls[0]?.[2]).toBe(chosen);
-    expect(second.io.choose.mock.calls[1]?.[2]).toBe(1);
+    expect(second.io.choose.mock.calls[1]?.[2]).toBe(0);
     expect(second.io.secret).not.toHaveBeenCalled();
     expect(loadConfig().instances?.[priorId]).toEqual({
       ...prior, config: { ...(prior.config as Record<string, unknown>), model: "fixture-default" },
@@ -421,6 +441,7 @@ describe("API onboarding", () => {
     expect(await runSetup(options, ui.io, deps)).toBe(true);
     expect(deps.verify).toHaveBeenCalledWith("https://api.openai.com/v1", "fixture-key", "fixture-model-24");
     expect(loadConfig().defaultModelSelection?.model).toBe("fixture-model-24");
+    expect(ui.io.choose.mock.calls[3]?.[1]).toEqual(["Model 24", "Search models…"]);
     ui.assertConsumed();
   });
 
@@ -433,9 +454,9 @@ describe("API onboarding", () => {
     deps.models.mockResolvedValue(Array.from({ length: 25 }, (_, index) => ({ id: `fixture-model-${index}`, label: `Model ${index}` })));
     const ui = prompts({ confirms: [true, true] });
     ui.io.choose.mockImplementation(async (question, available, defaultIndex) => {
-      if (question.startsWith("1/3")) return 3;
+      if (question === "Choose your AI connection") return 3;
       expect(defaultIndex).toBeDefined();
-      expect(available[defaultIndex!]).toContain("fixture-model-24");
+      expect(available[defaultIndex!]).toBe("Model 24");
       return defaultIndex!;
     });
     expect(await runSetup(options, ui.io, deps)).toBe(true);
@@ -459,6 +480,155 @@ describe("API onboarding", () => {
     expect(deps.verify).toHaveBeenCalledWith("https://secondary.example.test/v1", "secondary-key", "fixture-default");
     expect(loadConfig().defaultModelSelection).toEqual({ instanceId: "secondary", model: "fixture-default" });
     ui.assertConsumed();
+  });
+});
+
+describe("connection recovery", () => {
+  it("retries a native connection without changing the saved setup during the failed attempt", async () => {
+    const original = persist({
+      profile: { name: "Keep" },
+      defaultModelSelection: { instanceId: "claude", model: "previous" },
+    });
+    const deps = dependencies();
+    deps.inspect.mockRejectedValueOnce(new Error("Could not read sign-in status. Try again."));
+    const ui = prompts({ choices: [0, 0, 0], confirms: [true] });
+    const choose = ui.io.choose.getMockImplementation()!;
+    ui.io.choose.mockImplementation(async (...args) => {
+      if (args[0] === "What would you like to do?") expect(readFileSync(configPath, "utf8")).toBe(original);
+      return choose(...args);
+    });
+    expect(await runSetup(options, ui.io, deps)).toBe(true);
+    expect(deps.inspect).toHaveBeenCalledTimes(2);
+    expect(deps.runCli).not.toHaveBeenCalled();
+    expect(deps.verify).not.toHaveBeenCalled();
+    expect(loadConfig().defaultModelSelection).toEqual({ instanceId: "codex", model: "fixture-default" });
+    expect(ui.lines.join("\n")).toContain("Model access is checked by the provider when you send your first message");
+    expect(ui.lines.join("\n")).not.toContain("Test reply received");
+    ui.assertConsumed();
+    expectLeaseReleased();
+  });
+
+  it("changes provider only after an explicit recovery choice", async () => {
+    const original = { driver: "codex", config: { cli: "/fixture/old-codex" } };
+    persist({ instances: { codex: original }, defaultModelSelection: { instanceId: "codex", model: "previous" } });
+    const deps = dependencies();
+    deps.inspect.mockRejectedValueOnce(new Error("This sign-in could not be checked."));
+    const ui = prompts({ choices: [0, 1, 1, 0], confirms: [true] });
+    expect(await runSetup(options, ui.io, deps)).toBe(true);
+    expect(deps.inspect.mock.calls.map(([id]) => id)).toEqual(["codex", "claude"]);
+    expect(loadConfig().instances?.codex).toEqual(original);
+    expect(loadConfig().defaultModelSelection).toEqual({ instanceId: "claude", model: "fixture-default" });
+    ui.assertConsumed();
+  });
+
+  it("cancels at recovery without altering config, bots or conversations", async () => {
+    const original = persist({ profile: { name: "Existing user" }, defaultModelSelection: { instanceId: "claude", model: "previous" } });
+    const botsPath = join(DATA_DIR, "bots.json");
+    const messagesPath = join(DATA_DIR, "messages-fixture.json");
+    writeFileSync(botsPath, '[{"id":"keep"}]');
+    writeFileSync(messagesPath, '[{"text":"keep conversation"}]');
+    const deps = dependencies();
+    deps.inspect.mockRejectedValue(new Error("Sign-in service unavailable."));
+    const ui = prompts({ choices: [0, new SetupCancelled()] });
+    expect(await runSetup(options, ui.io, deps)).toBe(false);
+    expect(deps.inspect).toHaveBeenCalledTimes(1);
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expect(readFileSync(botsPath, "utf8")).toBe('[{"id":"keep"}]');
+    expect(readFileSync(messagesPath, "utf8")).toBe('[{"text":"keep conversation"}]');
+    expect(ui.lines.join("\n")).not.toContain("Setup saved");
+    ui.assertConsumed();
+    expectLeaseReleased();
+  });
+
+  it("allows a replacement API key on retry and asks again before each metered check", async () => {
+    const original = persist({ defaultModelSelection: { instanceId: "claude", model: "previous" } });
+    const deps = dependencies();
+    deps.verify.mockImplementationOnce(async () => {
+      expect(readFileSync(configPath, "utf8")).toBe(original);
+      throw new Error("API returned HTTP 401. Check the API key.");
+    });
+    const ui = prompts({
+      choices: [2, 2, 0, 0, 2, 0],
+      secrets: ["fixture-wrong-key", "fixture-replacement-key"], confirms: [true, true, true],
+    });
+    expect(await runSetup(options, ui.io, deps)).toBe(true);
+    expect(deps.verify.mock.calls).toEqual([
+      ["https://api.groq.com/openai/v1", "fixture-wrong-key", "fixture-default"],
+      ["https://api.groq.com/openai/v1", "fixture-replacement-key", "fixture-default"],
+    ]);
+    expect(ui.io.confirm.mock.calls.slice(0, 2).every(([question]) => question.includes("may charge"))).toBe(true);
+    for (let i = 0; i < 2; i++) {
+      expect(ui.io.confirm.mock.invocationCallOrder[i]).toBeLessThan(deps.verify.mock.invocationCallOrder[i]!);
+    }
+    const saved = loadConfig();
+    expect(saved.instances?.[saved.defaultModelSelection!.instanceId]?.config).toMatchObject({ key: "fixture-replacement-key" });
+    expect(readFileSync(configPath, "utf8")).not.toContain("fixture-wrong-key");
+    expect(ui.lines.join("\n")).not.toContain("fixture-replacement-key");
+    ui.assertConsumed();
+  });
+
+  it("can leave a failing API route for a native account without saving the key", async () => {
+    const deps = dependencies();
+    deps.verify.mockRejectedValue(new Error("API returned HTTP 429. Check limits."));
+    const ui = prompts({ choices: [2, 0, 0, 1, 1, 0], secrets: ["fixture-unused-key"], confirms: [true, true] });
+    expect(await runSetup(options, ui.io, deps)).toBe(true);
+    expect(loadConfig().defaultModelSelection).toEqual({ instanceId: "claude", model: "fixture-default" });
+    expect(readFileSync(configPath, "utf8")).not.toContain("fixture-unused-key");
+    expect(deps.verify).toHaveBeenCalledTimes(1);
+    expect(deps.inspect).toHaveBeenCalledTimes(1);
+    ui.assertConsumed();
+  });
+
+  it("offers recovery after a catalog failure when the user does not know a manual model ID", async () => {
+    const deps = dependencies();
+    deps.models.mockRejectedValueOnce(new Error("The model list timed out."));
+    const ui = prompts({
+      choices: [2, 0, 0, 0, 0], secrets: ["fixture-key", "fixture-key"], confirms: [false, true, true],
+    });
+    expect(await runSetup(options, ui.io, deps)).toBe(true);
+    expect(deps.models).toHaveBeenCalledTimes(2);
+    expect(deps.verify).toHaveBeenCalledTimes(1);
+    expect(ui.io.ask).not.toHaveBeenCalled();
+    ui.assertConsumed();
+  });
+});
+
+describe("CLI startup preferences", () => {
+  it("reads and saves preferences without changing existing provider settings", () => {
+    expect(readCliStartup(DATA_DIR)).toBeUndefined();
+    const existing = {
+      profile: { name: "Keep" }, defaultModelSelection: { instanceId: "codex", model: "previous" },
+      instances: { codex: { driver: "codex", config: { cli: "/fixture/codex" } } }, futureSetting: { keep: true },
+    };
+    persist(existing);
+    saveCliStartup(DATA_DIR, { access: "tailscale", phone: "ios" });
+    expect(readCliStartup(DATA_DIR)).toEqual({ access: "tailscale", phone: "ios" });
+    expect(JSON.parse(readFileSync(configPath, "utf8"))).toMatchObject(existing);
+    expectLeaseReleased();
+  });
+
+  it("refuses to save while the server owns the data directory", () => {
+    const original = persist({ cliStartup: { access: "local" } });
+    const lease = acquireDataDirLease(DATA_DIR);
+    try {
+      expect(() => saveCliStartup(DATA_DIR, { access: "tunnel", phone: "android" })).toThrow(/already using this data directory/);
+      expect(readFileSync(configPath, "utf8")).toBe(original);
+    } finally { lease.release(); }
+  });
+
+  it("refuses corrupt configuration on both read and save", () => {
+    const original = "{broken config";
+    writeFileSync(configPath, original);
+    expect(() => readCliStartup(DATA_DIR)).toThrow("Existing config.json");
+    expect(() => saveCliStartup(DATA_DIR, { access: "local" })).toThrow("Existing config.json");
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expectLeaseReleased();
+  });
+
+  it("refuses a different data directory without reading or writing it", () => {
+    expect(() => readCliStartup(join(DATA_DIR, "wrong"))).toThrow("data directory mismatch");
+    expect(() => saveCliStartup(join(DATA_DIR, "wrong"), { access: "local" })).toThrow("data directory mismatch");
+    expect(existsSync(join(DATA_DIR, "wrong"))).toBe(false);
   });
 });
 

--- a/server/cli-setup.ts
+++ b/server/cli-setup.ts
@@ -6,7 +6,7 @@ import { join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
 import {
   DATA_DIR, instanceConfigs, loadConfig, parseStoredConfig, saveConfig,
-  stripWorkspaceCredentialEnv, PROVIDER_CREDENTIAL_ENV,
+  stripWorkspaceCredentialEnv, PROVIDER_CREDENTIAL_ENV, type AppConfig,
 } from "./config.ts";
 import type { InstanceConfig, ModelCatalog, ProviderSnapshot } from "./contracts.ts";
 import { acquireDataDirLease } from "./data-dir-lease.ts";
@@ -52,7 +52,7 @@ export async function runSetupCli(cli: string, args: string[], environment: Reco
     child.once("exit", (code, signal) => {
       if (code === 0) done();
       else if (signal === "SIGINT" || code === 130) reject(new SetupCancelled());
-      else reject(new Error(`${cli} did not finish successfully. Fix the error shown above, then run setup again.`));
+      else reject(new Error(`${cli} did not finish successfully. Fix the error shown above, then try again.`));
     });
   });
   resetPathCache();
@@ -84,24 +84,37 @@ export async function isSetupComplete(dataDir: string): Promise<boolean> {
   return !!(saved && Object.hasOwn(instances, saved.instanceId) && instances[saved.instanceId]?.enabled !== false);
 }
 
+export function readCliStartup(dataDir: string): AppConfig["cliStartup"] {
+  assertDataDir(dataDir);
+  checkStoredConfig(dataDir);
+  return loadConfig().cliStartup;
+}
+
+export function saveCliStartup(dataDir: string, settings: NonNullable<AppConfig["cliStartup"]>): void {
+  assertDataDir(dataDir);
+  const lease = acquireDataDirLease(dataDir);
+  try {
+    checkStoredConfig(dataDir);
+    saveConfig({ cliStartup: settings });
+  } finally {
+    lease.release();
+  }
+}
+
 function rawObject(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
 }
 
 async function chooseModel(io: SetupIo, models: ModelCatalog): Promise<string> {
-  if (!models.options.length) throw new Error("This connection returned no models. Check the provider and run setup again.");
+  if (!models.options.length) throw new Error("This connection returned no models. Check the provider and try again.");
   let query = "";
   for (;;) {
     const matches = models.options.filter((m) => `${m.label} ${m.id}`.toLowerCase().includes(query.toLowerCase()));
-    const visible = matches.slice(0, 20);
     const preferred = matches.find((m) => m.id === models.default);
-    if (preferred && !visible.includes(preferred)) {
-      visible.pop();
-      visible.unshift(preferred);
-    }
+    const visible = (preferred ? [preferred, ...matches.filter((m) => m !== preferred)] : matches).slice(0, 20);
     const defaultIndex = visible.findIndex((m) => m.id === models.default);
-    const selected = await io.choose("3/3 · Choose a model", [
-      ...visible.map((m) => `${m.label}${m.label !== m.id ? ` (${m.id})` : ""}${m.id === models.default ? " — current default" : ""}`),
+    const selected = await io.choose("Choose your model", [
+      ...visible.map((m) => m.label.trim() || m.id),
       "Search models…",
     ], defaultIndex < 0 ? undefined : defaultIndex);
     if (selected < visible.length) return visible[selected]!.id;
@@ -118,15 +131,15 @@ async function connectNative(
   choice: typeof NATIVE[number], id: string, entry: InstanceConfig, io: SetupIo, deps: SetupDependencies,
 ): Promise<ModelCatalog> {
   const cli = typeof rawObject(entry.config).cli === "string" ? rawObject(entry.config).cli as string : choice.cli;
-  io.log("2/3 · Connect your account");
-  io.log("Your provider handles sign-in. Its account limits and billing apply; OMB does not need your password.");
+  io.log("Connecting your account…");
+  io.log("Sign-in stays with your provider. Its account limits apply; OMB never asks for your password.");
   let state = await deps.inspect(id, entry);
   if (state.snapshot.state !== "available") {
     if (cli !== choice.cli) throw new Error("Your custom CLI path is unavailable. Fix that path in Settings before running setup again.");
     if (!await io.confirm(`Install ${choice.cli} with npm install -g ${choice.pkg}?`, true)) throw new SetupCancelled();
     await deps.runCli("npm", ["install", "-g", choice.pkg]);
     state = await deps.inspect(id, entry);
-    if (state.snapshot.state !== "available") throw new Error(`${choice.cli} is still unavailable. Check the installation output and run setup again.`);
+    if (state.snapshot.state !== "available") throw new Error(`${choice.cli} is still unavailable. Check the installation output and try again.`);
   }
   if (!state.snapshot.authenticated) {
     let args = ["auth", "login"];
@@ -140,7 +153,7 @@ async function connectNative(
     await deps.runCli(cli, args, entry.environment);
     state = await deps.inspect(id, entry);
     if (state.snapshot.state !== "available" || !state.snapshot.authenticated) {
-      throw new Error("Sign-in was not confirmed. Your OMB settings are unchanged; complete provider sign-in and run setup again.");
+      throw new Error("Sign-in was not confirmed. Your OMB settings are unchanged; complete provider sign-in and try again.");
     }
   } else {
     io.log("Existing sign-in found — you do not need to sign in again.");
@@ -164,88 +177,105 @@ export async function runSetup(
     const existing = Object.entries(runtime).filter(([id, entry]) =>
       !!cfg.instances?.[id] && ["codex", "claudeAgent", "openai-compat"].includes(entry.driver) && entry.enabled !== false);
     io.log("\nWelcome to OpenMausBot\n");
-    io.log("Choose AI access → connect → choose a model. Ctrl-C cancels.");
-    io.log("Existing bots, conversations and connections stay as they are.");
-    io.log("Other engines, integrations and remote access can be configured in app Settings later.\n");
+    io.log("Let's connect your AI. Choose a provider, then a model.");
+    io.log("Existing bots and conversations stay untouched. Ctrl-C cancels.");
+    io.log("You can add integrations and change settings later.\n");
     const existingDefault = existing.findIndex(([id]) => id === cfg.defaultModelSelection?.instanceId);
-    const pick = await io.choose("1/3 · How do you want to connect?", [
+    const providerOptions = [
       ...NATIVE.map((n) => n.label),
       "API key — OpenAI, OpenRouter, Groq or a compatible service (chat only)",
       ...existing.map(([id, entry]) => `Use existing: ${entry.displayName ?? id}${id === cfg.defaultModelSelection?.instanceId ? " — current" : ""}`),
-    ], existingDefault < 0 ? 0 : existingDefault + 3);
+    ];
+    let pick: number | undefined;
 
-    const prior = pick >= 3 ? existing[pick - 3] : undefined;
-    const native = pick < 2 ? NATIVE[pick] : NATIVE.find((n) => n.driver === prior?.[1].driver);
     let id: string;
     let entry: InstanceConfig;
     let model: string;
-    if (native) {
-      // Reuse native provider settings, including custom CLI paths. If a user
-      // repurposed the familiar ID, do not overwrite their connection.
-      id = prior?.[0] ?? native.id;
-      if (!prior && runtime[id] && runtime[id]!.driver !== native.driver) id = `${native.id}-${randomUUID().slice(0, 8)}`;
-      entry = { ...(cfg.instances?.[id] ?? { driver: native.driver }), enabled: true };
-      const models = await connectNative(native, id, entry, io, deps);
-      const saved = cfg.defaultModelSelection;
-      model = await chooseModel(io, {
-        ...models,
-        default: saved?.instanceId === id ? saved.model : models.default,
-      });
-    } else {
-      io.log("2/3 · Connect an API key");
-      io.log("API usage is billed separately from ChatGPT/Claude subscriptions.");
-      io.log("This connection supports chat, not agent tools or computer use. Choose Codex or Claude for those.");
-      let url: string;
-      let key: string;
-      let label: string;
-      let reuse = false;
-      let routingProvider: string | undefined;
-      if (prior) {
-        const config = rawObject(prior[1].config);
-        const decoded = BUILT_IN_DRIVERS.find((d) => d.driverKind === "openai-compat")!.decodeConfig(config);
-        url = normalizeApiUrl(decoded.url);
-        key = decoded.key ?? prior[1].environment?.[decoded.apiKeyEnv]
-          ?? prior[1].environment?.OPENAI_COMPAT_API_KEY
-          ?? process.env[decoded.apiKeyEnv] ?? process.env.OPENAI_COMPAT_API_KEY ?? "";
-        routingProvider = decoded.provider;
-        label = prior[1].displayName ?? prior[0];
-        reuse = !!key;
-        if (!key) key = (await io.secret(`API key for ${url} (hidden): `)).trim();
-      } else {
-        const endpoint = await io.choose("Which API service?", [...API_ENDPOINTS.map((e) => e.label), "Other OpenAI-compatible endpoint"]);
-        const preset = API_ENDPOINTS[endpoint];
-        url = preset ? preset.url : normalizeApiUrl((await io.ask("API base URL (including /v1): ")).trim());
-        label = preset?.label ?? new URL(url).hostname;
-        if (preset) io.log(`Create a key: ${preset.keyUrl}`);
-        key = (await io.secret(`API key for ${url} (hidden): `)).trim();
+    for (;;) {
+      pick ??= await io.choose("Choose your AI connection", providerOptions, existingDefault < 0 ? 0 : existingDefault + 3);
+      const prior = pick >= 3 ? existing[pick - 3] : undefined;
+      const native = pick < 2 ? NATIVE[pick] : NATIVE.find((n) => n.driver === prior?.[1].driver);
+      try {
+        if (native) {
+          // Reuse native provider settings, including custom CLI paths. If a user
+          // repurposed the familiar ID, do not overwrite their connection.
+          id = prior?.[0] ?? native.id;
+          if (!prior && runtime[id] && runtime[id]!.driver !== native.driver) id = `${native.id}-${randomUUID().slice(0, 8)}`;
+          entry = { ...(cfg.instances?.[id] ?? { driver: native.driver }), enabled: true };
+          const models = await connectNative(native, id, entry, io, deps);
+          const saved = cfg.defaultModelSelection;
+          model = await chooseModel(io, {
+            ...models,
+            default: saved?.instanceId === id ? saved.model : models.default,
+          });
+        } else {
+          io.log("Connect an API key");
+          io.log("API usage is billed separately from ChatGPT/Claude subscriptions.");
+          io.log("This connection supports chat, not agent tools or computer use. Choose Codex or Claude for those.");
+          let url: string;
+          let key: string;
+          let label: string;
+          let reuse = false;
+          let routingProvider: string | undefined;
+          if (prior) {
+            const config = rawObject(prior[1].config);
+            const decoded = BUILT_IN_DRIVERS.find((d) => d.driverKind === "openai-compat")!.decodeConfig(config);
+            url = normalizeApiUrl(decoded.url);
+            key = decoded.key ?? prior[1].environment?.[decoded.apiKeyEnv]
+              ?? prior[1].environment?.OPENAI_COMPAT_API_KEY
+              ?? process.env[decoded.apiKeyEnv] ?? process.env.OPENAI_COMPAT_API_KEY ?? "";
+            routingProvider = decoded.provider;
+            label = prior[1].displayName ?? prior[0];
+            reuse = !!key;
+            if (!key) key = (await io.secret(`API key for ${url} (hidden): `)).trim();
+          } else {
+            const endpoint = await io.choose("Which API service?", [...API_ENDPOINTS.map((e) => e.label), "Other OpenAI-compatible endpoint"]);
+            const preset = API_ENDPOINTS[endpoint];
+            url = preset ? preset.url : normalizeApiUrl((await io.ask("API base URL (including /v1): ")).trim());
+            label = preset?.label ?? new URL(url).hostname;
+            if (preset) io.log(`Create a key: ${preset.keyUrl}`);
+            key = (await io.secret(`API key for ${url} (hidden): `)).trim();
+          }
+          if (!key) throw new Error("An API key is required. Nothing was saved.");
+          io.log("Checking the model catalog…");
+          let models: ModelCatalog["options"];
+          try { models = await deps.models(url, key); }
+          catch (error) {
+            if (error instanceof SetupCancelled) throw error;
+            io.log(error instanceof Error ? error.message : "Could not load this model catalog.");
+            if (!await io.confirm("Enter an exact chat model ID and check it directly instead?", false)) throw error;
+            const manual = (await io.ask("Chat model ID: ")).trim();
+            if (!manual) throw new Error("A model ID is required. Nothing was saved.");
+            models = [{ id: manual, label: manual }];
+          }
+          const previousModel = prior ? rawObject(prior[1].config).model : undefined;
+          const preferredModel = cfg.defaultModelSelection?.instanceId === prior?.[0]
+            ? cfg.defaultModelSelection?.model : previousModel;
+          io.log("Choose a chat model; image, audio and embedding-only models cannot reply here.");
+          model = await chooseModel(io, { default: typeof preferredModel === "string" ? preferredModel : "", options: models });
+          if (!await io.confirm("Send one short test message? Your API provider may charge for this request.", true)) throw new SetupCancelled();
+          if (routingProvider) await deps.verify(url, key, model, routingProvider);
+          else await deps.verify(url, key, model);
+          io.log("Test reply received.");
+          // API additions never change the URL/key behind an existing bot. A new
+          // isolated instance also avoids inherited global URL/key overrides.
+          id = reuse && prior ? prior[0] : `api-${randomUUID().slice(0, 8)}`;
+          entry = reuse && prior
+            ? { ...cfg.instances![id]!, config: { ...rawObject(cfg.instances![id]!.config), model } }
+            : { driver: "openai-compat", displayName: label, config: { url, key, model, provider: routingProvider ?? "" } };
+          if (!reuse) io.log("The key will be stored in your private config.json (plaintext, owner-only permissions on Unix). Never share this file.");
+        }
+        break;
+      } catch (error) {
+        if (error instanceof SetupCancelled) throw error;
+        io.log(error instanceof Error ? error.message : "This connection could not be set up.");
+        io.log("Your saved connection and model have not changed.");
+        const recovery = await io.choose("What would you like to do?", [
+          "Try this connection again", "Choose another connection or API key", "Cancel setup",
+        ], 0);
+        if (recovery === 2) throw new SetupCancelled();
+        if (recovery === 1) pick = undefined;
       }
-      if (!key) throw new Error("An API key is required. Nothing was saved.");
-      io.log("Checking the model catalog…");
-      let models: ModelCatalog["options"];
-      try { models = await deps.models(url, key); }
-      catch (error) {
-        io.log(error instanceof Error ? error.message : "Could not load this model catalog.");
-        if (!await io.confirm("Enter an exact chat model ID and check it directly instead?", false)) throw new SetupCancelled();
-        const manual = (await io.ask("Chat model ID: ")).trim();
-        if (!manual) throw new Error("A model ID is required. Nothing was saved.");
-        models = [{ id: manual, label: manual }];
-      }
-      const previousModel = prior ? rawObject(prior[1].config).model : undefined;
-      const preferredModel = cfg.defaultModelSelection?.instanceId === prior?.[0]
-        ? cfg.defaultModelSelection?.model : previousModel;
-      io.log("Choose a chat model; image, audio and embedding-only models cannot reply here.");
-      model = await chooseModel(io, { default: typeof preferredModel === "string" ? preferredModel : "", options: models });
-      if (!await io.confirm("Send one short test message? Your API provider may charge for this request.", true)) throw new SetupCancelled();
-      if (routingProvider) await deps.verify(url, key, model, routingProvider);
-      else await deps.verify(url, key, model);
-      io.log("Test reply received.");
-      // API additions never change the URL/key behind an existing bot. A new
-      // isolated instance also avoids inherited global URL/key overrides.
-      id = reuse && prior ? prior[0] : `api-${randomUUID().slice(0, 8)}`;
-      entry = reuse && prior
-        ? { ...cfg.instances![id]!, config: { ...rawObject(cfg.instances![id]!.config), model } }
-        : { driver: "openai-compat", displayName: label, config: { url, key, model, provider: routingProvider ?? "" } };
-      if (!reuse) io.log("The key will be stored in your private config.json (plaintext, owner-only permissions on Unix). Never share this file.");
     }
 
     io.log(`\nDefault for new bots: ${entry.displayName ?? id} / ${model}`);

--- a/server/cli-setup.ts
+++ b/server/cli-setup.ts
@@ -1,0 +1,266 @@
+// Guided setup stays outside server/index: no server, store, or bot is started
+// until the user has saved a connection and explicitly starts the application.
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+  DATA_DIR, instanceConfigs, loadConfig, parseStoredConfig, saveConfig,
+  stripWorkspaceCredentialEnv, PROVIDER_CREDENTIAL_ENV,
+} from "./config.ts";
+import type { InstanceConfig, ModelCatalog, ProviderSnapshot } from "./contracts.ts";
+import { acquireDataDirLease } from "./data-dir-lease.ts";
+import { augmentedPath, resetPathCache } from "./env-path.ts";
+import { resolveCli } from "./procs.ts";
+import { ProviderRegistry } from "./harness/registry.ts";
+import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
+import { defaultSetupIo, SetupCancelled, type SetupIo } from "./cli-prompts.ts";
+import { API_ENDPOINTS, fetchSetupModels, normalizeApiUrl, verifySetupCompletion } from "./cli-api-setup.ts";
+
+type Inspection = { snapshot: ProviderSnapshot; models: ModelCatalog };
+interface SetupDependencies {
+  inspect(id: string, entry: InstanceConfig): Promise<Inspection>;
+  runCli(cli: string, args: string[], environment?: Record<string, string>): Promise<void>;
+  models: typeof fetchSetupModels;
+  verify: typeof verifySetupCompletion;
+}
+
+async function inspect(id: string, entry: InstanceConfig): Promise<Inspection> {
+  const registry = new ProviderRegistry(BUILT_IN_DRIVERS);
+  try {
+    await registry.load({ [id]: entry });
+    const provider = registry.get(id);
+    if (!provider) throw new Error("This provider configuration could not be loaded. Check it in app Settings.");
+    const snapshot = await provider.snapshot();
+    return { snapshot, models: provider.models };
+  } finally {
+    await registry.disposeAll();
+  }
+}
+
+/** Native CLIs own their OAuth flow; no tokens pass through our prompts. */
+export async function runSetupCli(cli: string, args: string[], environment: Record<string, string> = {}): Promise<void> {
+  const env: NodeJS.ProcessEnv = { ...process.env, ...environment, PATH: augmentedPath() };
+  stripWorkspaceCredentialEnv(env);
+  for (const key of PROVIDER_CREDENTIAL_ENV) delete env[key];
+  delete env.CLAUDECODE;
+  delete env.CLAUDE_CODE_ENTRYPOINT;
+  const command = resolveCli(cli, args);
+  await new Promise<void>((done, reject) => {
+    const child = spawn(command.command, command.args, { env, stdio: "inherit" });
+    child.once("error", () => reject(new Error(`Could not start ${cli}. Check that it is installed and on PATH.`)));
+    child.once("exit", (code, signal) => {
+      if (code === 0) done();
+      else if (signal === "SIGINT" || code === 130) reject(new SetupCancelled());
+      else reject(new Error(`${cli} did not finish successfully. Fix the error shown above, then run setup again.`));
+    });
+  });
+  resetPathCache();
+}
+
+const dependencies: SetupDependencies = { inspect, runCli: runSetupCli, models: fetchSetupModels, verify: verifySetupCompletion };
+
+function assertDataDir(dataDir: string): void {
+  if (resolve(dataDir) !== resolve(DATA_DIR)) throw new Error("Setup data directory mismatch. Restart the CLI with --data-dir.");
+}
+
+// loadConfig deliberately tolerates broken files at server boot. An onboarding
+// write must instead refuse a broken existing file, never replace its contents.
+function checkStoredConfig(dataDir: string): void {
+  try {
+    parseStoredConfig(JSON.parse(readFileSync(join(dataDir, "config.json"), "utf8")));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw new Error("Existing config.json could not be read or validated. Setup has not changed it; repair it before continuing.");
+  }
+}
+
+export async function isSetupComplete(dataDir: string): Promise<boolean> {
+  assertDataDir(dataDir);
+  checkStoredConfig(dataDir);
+  const cfg = loadConfig();
+  const saved = cfg.defaultModelSelection;
+  const instances = instanceConfigs(cfg);
+  return !!(saved && Object.hasOwn(instances, saved.instanceId) && instances[saved.instanceId]?.enabled !== false);
+}
+
+function rawObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+async function chooseModel(io: SetupIo, models: ModelCatalog): Promise<string> {
+  if (!models.options.length) throw new Error("This connection returned no models. Check the provider and run setup again.");
+  let query = "";
+  for (;;) {
+    const matches = models.options.filter((m) => `${m.label} ${m.id}`.toLowerCase().includes(query.toLowerCase()));
+    const visible = matches.slice(0, 20);
+    const preferred = matches.find((m) => m.id === models.default);
+    if (preferred && !visible.includes(preferred)) {
+      visible.pop();
+      visible.unshift(preferred);
+    }
+    const defaultIndex = visible.findIndex((m) => m.id === models.default);
+    const selected = await io.choose("3/3 · Choose a model", [
+      ...visible.map((m) => `${m.label}${m.label !== m.id ? ` (${m.id})` : ""}${m.id === models.default ? " — current default" : ""}`),
+      "Search models…",
+    ], defaultIndex < 0 ? undefined : defaultIndex);
+    if (selected < visible.length) return visible[selected]!.id;
+    query = (await io.ask("Model name or part of its ID (Enter shows all): ")).trim();
+  }
+}
+
+const NATIVE = [
+  { id: "codex", driver: "codex", label: "ChatGPT / Codex — sign in with your account", cli: "codex", pkg: "@openai/codex" },
+  { id: "claude", driver: "claudeAgent", label: "Claude Code — sign in with your account", cli: "claude", pkg: "@anthropic-ai/claude-code" },
+] as const;
+
+async function connectNative(
+  choice: typeof NATIVE[number], id: string, entry: InstanceConfig, io: SetupIo, deps: SetupDependencies,
+): Promise<ModelCatalog> {
+  const cli = typeof rawObject(entry.config).cli === "string" ? rawObject(entry.config).cli as string : choice.cli;
+  io.log("2/3 · Connect your account");
+  io.log("Your provider handles sign-in. Its account limits and billing apply; OMB does not need your password.");
+  let state = await deps.inspect(id, entry);
+  if (state.snapshot.state !== "available") {
+    if (cli !== choice.cli) throw new Error("Your custom CLI path is unavailable. Fix that path in Settings before running setup again.");
+    if (!await io.confirm(`Install ${choice.cli} with npm install -g ${choice.pkg}?`, true)) throw new SetupCancelled();
+    await deps.runCli("npm", ["install", "-g", choice.pkg]);
+    state = await deps.inspect(id, entry);
+    if (state.snapshot.state !== "available") throw new Error(`${choice.cli} is still unavailable. Check the installation output and run setup again.`);
+  }
+  if (!state.snapshot.authenticated) {
+    let args = ["auth", "login"];
+    if (choice.id === "codex") {
+      const method = await io.choose("How would you like to sign in?", [
+        "Open a browser on this computer", "Use a device code (SSH / remote server)",
+      ], process.env.SSH_CONNECTION ? 1 : 0);
+      args = method === 1 ? ["login", "--device-auth"] : ["login"];
+    }
+    if (args.includes("--device-auth")) io.log("Enable device-code login in ChatGPT security settings if your account requests it.");
+    await deps.runCli(cli, args, entry.environment);
+    state = await deps.inspect(id, entry);
+    if (state.snapshot.state !== "available" || !state.snapshot.authenticated) {
+      throw new Error("Sign-in was not confirmed. Your OMB settings are unchanged; complete provider sign-in and run setup again.");
+    }
+  } else {
+    io.log("Existing sign-in found — you do not need to sign in again.");
+  }
+  if (state.snapshot.update) io.log(`${state.snapshot.update.title}: ${state.snapshot.update.command}`);
+  io.log("Sign-in confirmed. Model access is checked by the provider when you send your first message.");
+  return state.models;
+}
+
+export async function runSetup(
+  options: { dataDir: string; port: number },
+  io: SetupIo = defaultSetupIo(),
+  deps: SetupDependencies = dependencies,
+): Promise<boolean> {
+  assertDataDir(options.dataDir);
+  const lease = acquireDataDirLease(options.dataDir);
+  try {
+    checkStoredConfig(options.dataDir);
+    const cfg = loadConfig();
+    const runtime = instanceConfigs(cfg);
+    const existing = Object.entries(runtime).filter(([id, entry]) =>
+      !!cfg.instances?.[id] && ["codex", "claudeAgent", "openai-compat"].includes(entry.driver) && entry.enabled !== false);
+    io.log("\nWelcome to OpenMausBot\n");
+    io.log("Choose AI access → connect → choose a model. Ctrl-C cancels.");
+    io.log("Existing bots, conversations and connections stay as they are.");
+    io.log("Other engines, integrations and remote access can be configured in app Settings later.\n");
+    const existingDefault = existing.findIndex(([id]) => id === cfg.defaultModelSelection?.instanceId);
+    const pick = await io.choose("1/3 · How do you want to connect?", [
+      ...NATIVE.map((n) => n.label),
+      "API key — OpenAI, OpenRouter, Groq or a compatible service (chat only)",
+      ...existing.map(([id, entry]) => `Use existing: ${entry.displayName ?? id}${id === cfg.defaultModelSelection?.instanceId ? " — current" : ""}`),
+    ], existingDefault < 0 ? 0 : existingDefault + 3);
+
+    const prior = pick >= 3 ? existing[pick - 3] : undefined;
+    const native = pick < 2 ? NATIVE[pick] : NATIVE.find((n) => n.driver === prior?.[1].driver);
+    let id: string;
+    let entry: InstanceConfig;
+    let model: string;
+    if (native) {
+      // Reuse native provider settings, including custom CLI paths. If a user
+      // repurposed the familiar ID, do not overwrite their connection.
+      id = prior?.[0] ?? native.id;
+      if (!prior && runtime[id] && runtime[id]!.driver !== native.driver) id = `${native.id}-${randomUUID().slice(0, 8)}`;
+      entry = { ...(cfg.instances?.[id] ?? { driver: native.driver }), enabled: true };
+      const models = await connectNative(native, id, entry, io, deps);
+      const saved = cfg.defaultModelSelection;
+      model = await chooseModel(io, {
+        ...models,
+        default: saved?.instanceId === id ? saved.model : models.default,
+      });
+    } else {
+      io.log("2/3 · Connect an API key");
+      io.log("API usage is billed separately from ChatGPT/Claude subscriptions.");
+      io.log("This connection supports chat, not agent tools or computer use. Choose Codex or Claude for those.");
+      let url: string;
+      let key: string;
+      let label: string;
+      let reuse = false;
+      let routingProvider: string | undefined;
+      if (prior) {
+        const config = rawObject(prior[1].config);
+        const decoded = BUILT_IN_DRIVERS.find((d) => d.driverKind === "openai-compat")!.decodeConfig(config);
+        url = normalizeApiUrl(decoded.url);
+        key = decoded.key ?? prior[1].environment?.[decoded.apiKeyEnv]
+          ?? prior[1].environment?.OPENAI_COMPAT_API_KEY
+          ?? process.env[decoded.apiKeyEnv] ?? process.env.OPENAI_COMPAT_API_KEY ?? "";
+        routingProvider = decoded.provider;
+        label = prior[1].displayName ?? prior[0];
+        reuse = !!key;
+        if (!key) key = (await io.secret(`API key for ${url} (hidden): `)).trim();
+      } else {
+        const endpoint = await io.choose("Which API service?", [...API_ENDPOINTS.map((e) => e.label), "Other OpenAI-compatible endpoint"]);
+        const preset = API_ENDPOINTS[endpoint];
+        url = preset ? preset.url : normalizeApiUrl((await io.ask("API base URL (including /v1): ")).trim());
+        label = preset?.label ?? new URL(url).hostname;
+        if (preset) io.log(`Create a key: ${preset.keyUrl}`);
+        key = (await io.secret(`API key for ${url} (hidden): `)).trim();
+      }
+      if (!key) throw new Error("An API key is required. Nothing was saved.");
+      io.log("Checking the model catalog…");
+      let models: ModelCatalog["options"];
+      try { models = await deps.models(url, key); }
+      catch (error) {
+        io.log(error instanceof Error ? error.message : "Could not load this model catalog.");
+        if (!await io.confirm("Enter an exact chat model ID and check it directly instead?", false)) throw new SetupCancelled();
+        const manual = (await io.ask("Chat model ID: ")).trim();
+        if (!manual) throw new Error("A model ID is required. Nothing was saved.");
+        models = [{ id: manual, label: manual }];
+      }
+      const previousModel = prior ? rawObject(prior[1].config).model : undefined;
+      const preferredModel = cfg.defaultModelSelection?.instanceId === prior?.[0]
+        ? cfg.defaultModelSelection?.model : previousModel;
+      io.log("Choose a chat model; image, audio and embedding-only models cannot reply here.");
+      model = await chooseModel(io, { default: typeof preferredModel === "string" ? preferredModel : "", options: models });
+      if (!await io.confirm("Send one short test message? Your API provider may charge for this request.", true)) throw new SetupCancelled();
+      if (routingProvider) await deps.verify(url, key, model, routingProvider);
+      else await deps.verify(url, key, model);
+      io.log("Test reply received.");
+      // API additions never change the URL/key behind an existing bot. A new
+      // isolated instance also avoids inherited global URL/key overrides.
+      id = reuse && prior ? prior[0] : `api-${randomUUID().slice(0, 8)}`;
+      entry = reuse && prior
+        ? { ...cfg.instances![id]!, config: { ...rawObject(cfg.instances![id]!.config), model } }
+        : { driver: "openai-compat", displayName: label, config: { url, key, model, provider: routingProvider ?? "" } };
+      if (!reuse) io.log("The key will be stored in your private config.json (plaintext, owner-only permissions on Unix). Never share this file.");
+    }
+
+    io.log(`\nDefault for new bots: ${entry.displayName ?? id} / ${model}`);
+    if (!await io.confirm("Save this setup?", true)) throw new SetupCancelled();
+    // An explicit fleet replaces the implicit fleet. Start from an EMPTY
+    // config's defaults, not instanceConfigs(cfg), whose env contains secrets.
+    const instances = { ...(cfg.instances && Object.keys(cfg.instances).length ? cfg.instances : instanceConfigs({})), [id]: entry };
+    saveConfig({ instances, defaultModelSelection: { instanceId: id, model } });
+    io.log("\nSetup saved. Existing bots and conversations were not changed.");
+    return true;
+  } catch (error) {
+    if (!(error instanceof SetupCancelled)) throw error;
+    io.log("\nSetup cancelled. No OMB settings were changed. Provider sign-ins or installs already completed are kept.");
+    return false;
+  } finally {
+    lease.release();
+  }
+}

--- a/server/cli.test.ts
+++ b/server/cli.test.ts
@@ -3,13 +3,16 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { formatSessions, pairingBlock, parseArgs, qrToString, runLogin, serverEntry } from "./cli.ts";
+import { formatSessions, pairingBlock, parseArgs, qrToString, runLogin, runOnboardingCommand, serverEntry, type CliOptions } from "./cli.ts";
+import { SetupCancelled } from "./cli-prompts.ts";
 import { removeTempDir, waitForExit } from "./testing/cleanup.ts";
 import { startControlPlaneStub } from "./testing/control-plane-stub.ts";
 
 const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
+const setup = vi.hoisted(() => ({ runSetup: vi.fn(), isSetupComplete: vi.fn() }));
+vi.mock("./cli-setup.ts", () => setup);
 
 describe("openmausbot command line", () => {
   it("parses commands and flags, and explains mistakes", () => {
@@ -25,6 +28,8 @@ describe("openmausbot command line", () => {
     expect(parseArgs(["pair", "--public-url", "mini.example"], {})).toEqual({ error: "--public-url must start with http:// or https://" });
     expect(parseArgs(["serve", "--bogus"], {})).toEqual({ error: 'unknown argument "--bogus"' });
     expect(parseArgs(["serve", "--tunnel"], {})).toMatchObject({ command: "serve", tunnel: true });
+    expect(parseArgs(["setup", "--data-dir", "/tmp/cli-setup"], {})).toMatchObject({ command: "setup", dataDir: resolve("/tmp/cli-setup") });
+    expect(parseArgs(["start", "--port", "8125", "--no-pair"], {})).toMatchObject({ command: "start", port: 8125, pair: false });
     expect(parseArgs(["login", "--email", "a@b.test"], {})).toMatchObject({ command: "login", email: "a@b.test" });
     expect(parseArgs(["logout"], {})).toMatchObject({ command: "logout" });
     expect(parseArgs(["browser", "install", "--with-deps"], {})).toMatchObject({ command: "browser", browserAction: "install", withDeps: true });
@@ -99,6 +104,88 @@ describe("openmausbot command line", () => {
     }
     expect(dead).toBe(true);
   }, 90_000);
+});
+
+describe("terminal onboarding commands", () => {
+  const inputTty = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+  const outputTty = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+  const terminal = (enabled: boolean) => {
+    Object.defineProperty(process.stdin, "isTTY", { value: enabled, configurable: true });
+    Object.defineProperty(process.stdout, "isTTY", { value: enabled, configurable: true });
+  };
+  afterEach(() => {
+    if (inputTty) Object.defineProperty(process.stdin, "isTTY", inputTty);
+    else Reflect.deleteProperty(process.stdin, "isTTY");
+    if (outputTty) Object.defineProperty(process.stdout, "isTTY", outputTty);
+    else Reflect.deleteProperty(process.stdout, "isTTY");
+    vi.unstubAllEnvs();
+    vi.resetAllMocks();
+  });
+  const command = (name: "setup" | "start") => parseArgs([name, "--data-dir", join(process.env.HOME!, "onboarding"), "--port", "18451"], {}) as CliOptions;
+  const io = () => ({ log: vi.fn(), error: vi.fn(), ask: vi.fn() });
+  const preserveEnv = () => vi.stubEnv("OMB_DATA_DIR", process.env.OMB_DATA_DIR);
+
+  it("runs explicit setup once and explains how to start without launching a server", async () => {
+    terminal(true);
+    preserveEnv();
+    const options = command("setup");
+    const output = io();
+    const serve = vi.fn();
+    setup.runSetup.mockImplementation(async () => {
+      expect(process.env.OMB_DATA_DIR).toBe(options.dataDir);
+      return true;
+    });
+    expect(await runOnboardingCommand(options, output, serve)).toBe(0);
+    expect(setup.runSetup).toHaveBeenCalledWith({ dataDir: options.dataDir, port: options.port });
+    expect(setup.isSetupComplete).not.toHaveBeenCalled();
+    expect(serve).not.toHaveBeenCalled();
+    expect(output.log).toHaveBeenCalledWith("Start with: npx openmausbot start");
+  });
+
+  it("starts after first-time setup and passes through the requested serve options", async () => {
+    terminal(true);
+    preserveEnv();
+    const options = command("start");
+    setup.isSetupComplete.mockResolvedValue(false);
+    setup.runSetup.mockResolvedValue(true);
+    const serve = vi.fn().mockResolvedValue(0);
+    expect(await runOnboardingCommand(options, io(), serve)).toBe(0);
+    expect(setup.runSetup).toHaveBeenCalledOnce();
+    expect(serve).toHaveBeenCalledWith(options);
+  });
+
+  it("uses completed setup without prompting even when start has no terminal", async () => {
+    terminal(false);
+    preserveEnv();
+    setup.isSetupComplete.mockResolvedValue(true);
+    const serve = vi.fn().mockResolvedValue(7);
+    expect(await runOnboardingCommand(command("start"), io(), serve)).toBe(7);
+    expect(setup.runSetup).not.toHaveBeenCalled();
+    expect(serve).toHaveBeenCalledOnce();
+  });
+
+  it.each(["setup", "start"] as const)("refuses an unconfigured %s without a terminal", async (name) => {
+    terminal(false);
+    preserveEnv();
+    setup.isSetupComplete.mockResolvedValue(false);
+    const output = io();
+    const serve = vi.fn();
+    expect(await runOnboardingCommand(command(name), output, serve)).toBe(1);
+    expect(setup.runSetup).not.toHaveBeenCalled();
+    expect(serve).not.toHaveBeenCalled();
+    expect(output.error).toHaveBeenCalledWith(expect.stringContaining("interactive terminal"));
+  });
+
+  it.each([false, new SetupCancelled()])("does not start after setup is cancelled (%s)", async (result) => {
+    terminal(true);
+    preserveEnv();
+    setup.isSetupComplete.mockResolvedValue(false);
+    if (result instanceof Error) setup.runSetup.mockRejectedValue(result);
+    else setup.runSetup.mockResolvedValue(result);
+    const serve = vi.fn();
+    expect(await runOnboardingCommand(command("start"), io(), serve)).toBe(130);
+    expect(serve).not.toHaveBeenCalled();
+  });
 });
 
 const exited = (child: ChildProcess) => (child.exitCode !== null ? Promise.resolve(child.exitCode) : new Promise<number | null>((done) => child.once("exit", (code) => done(code))));

--- a/server/cli.test.ts
+++ b/server/cli.test.ts
@@ -3,15 +3,15 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { formatSessions, pairingBlock, parseArgs, qrToString, runLogin, runOnboardingCommand, serverEntry, type CliOptions } from "./cli.ts";
+import { applyStartupPreferences, formatSessions, pairingBlock, parseArgs, qrToString, runLogin, runOnboardingCommand, serverEntry, verifyPhoneEndpoint, type CliOptions } from "./cli.ts";
 import { SetupCancelled } from "./cli-prompts.ts";
 import { removeTempDir, waitForExit } from "./testing/cleanup.ts";
 import { startControlPlaneStub } from "./testing/control-plane-stub.ts";
 
 const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
-const setup = vi.hoisted(() => ({ runSetup: vi.fn(), isSetupComplete: vi.fn() }));
+const setup = vi.hoisted(() => ({ runSetup: vi.fn(), isSetupComplete: vi.fn(), readCliStartup: vi.fn(), saveCliStartup: vi.fn() }));
 vi.mock("./cli-setup.ts", () => setup);
 
 describe("openmausbot command line", () => {
@@ -21,7 +21,11 @@ describe("openmausbot command line", () => {
     expect(serve).toMatchObject({ command: "serve", port: 9001, dataDir: resolve("/tmp/x"), label: "cab mini", tailscale: true, pair: false });
     expect(parseArgs(["pair", "--client", "--public-url", "https://h/"], {})).toMatchObject({ command: "pair", client: true, publicUrl: "https://h" });
     expect(parseArgs(["sessions", "revoke", "abc"], {})).toMatchObject({ command: "sessions", revoke: "abc" });
-    expect(parseArgs([], { OMB_PORT: "8123" })).toMatchObject({ command: "help", port: 8123 });
+    expect(parseArgs([], { OMB_PORT: "8123" })).toMatchObject({ command: "start", port: 8123 });
+    expect(parseArgs(["--port", "8125", "--no-open", "--local"], {})).toMatchObject({ command: "start", port: 8125, open: false, local: true });
+    expect(parseArgs(["--help"], {})).toMatchObject({ command: "help" });
+    expect(parseArgs(["-h"], {})).toMatchObject({ command: "help" });
+    expect(parseArgs(["--local", "--tunnel"], {})).toHaveProperty("error");
     expect(parseArgs(["dance"], {})).toEqual({ error: 'unknown command "dance"' });
     expect(parseArgs(["serve", "--port"], {})).toEqual({ error: "--port needs a value" });
     expect(parseArgs(["serve", "--port", "70000"], {})).toEqual({ error: "--port must be 1-65535" });
@@ -124,6 +128,15 @@ describe("terminal onboarding commands", () => {
   const command = (name: "setup" | "start") => parseArgs([name, "--data-dir", join(process.env.HOME!, "onboarding"), "--port", "18451"], {}) as CliOptions;
   const io = () => ({ log: vi.fn(), error: vi.fn(), ask: vi.fn() });
   const preserveEnv = () => vi.stubEnv("OMB_DATA_DIR", process.env.OMB_DATA_DIR);
+  const phoneSetup = vi.fn<NonNullable<NonNullable<Parameters<typeof runOnboardingCommand>[3]>["phoneSetup"]>>();
+  const running = vi.fn().mockResolvedValue(false);
+  const open = vi.fn().mockResolvedValue(true);
+  const flow = { phoneSetup, running, open };
+  beforeEach(() => {
+    phoneSetup.mockImplementation(async (options) => ({ options }));
+    running.mockResolvedValue(false);
+    open.mockResolvedValue(true);
+  });
 
   it("runs explicit setup once and explains how to start without launching a server", async () => {
     terminal(true);
@@ -135,11 +148,13 @@ describe("terminal onboarding commands", () => {
       expect(process.env.OMB_DATA_DIR).toBe(options.dataDir);
       return true;
     });
-    expect(await runOnboardingCommand(options, output, serve)).toBe(0);
+    expect(await runOnboardingCommand(options, output, serve, flow)).toBe(0);
     expect(setup.runSetup).toHaveBeenCalledWith({ dataDir: options.dataDir, port: options.port });
     expect(setup.isSetupComplete).not.toHaveBeenCalled();
     expect(serve).not.toHaveBeenCalled();
-    expect(output.log).toHaveBeenCalledWith("Start with: npx openmausbot start");
+    expect(output.log).toHaveBeenCalledWith(expect.stringContaining("Start with: openmausbot"));
+    expect(phoneSetup).toHaveBeenCalledOnce();
+    expect(setup.saveCliStartup).toHaveBeenCalledWith(options.dataDir, { access: "local" });
   });
 
   it("starts after first-time setup and passes through the requested serve options", async () => {
@@ -149,9 +164,9 @@ describe("terminal onboarding commands", () => {
     setup.isSetupComplete.mockResolvedValue(false);
     setup.runSetup.mockResolvedValue(true);
     const serve = vi.fn().mockResolvedValue(0);
-    expect(await runOnboardingCommand(options, io(), serve)).toBe(0);
+    expect(await runOnboardingCommand(options, io(), serve, flow)).toBe(0);
     expect(setup.runSetup).toHaveBeenCalledOnce();
-    expect(serve).toHaveBeenCalledWith(options);
+    expect(serve).toHaveBeenCalledWith({ ...options, guided: true });
   });
 
   it("uses completed setup without prompting even when start has no terminal", async () => {
@@ -159,7 +174,7 @@ describe("terminal onboarding commands", () => {
     preserveEnv();
     setup.isSetupComplete.mockResolvedValue(true);
     const serve = vi.fn().mockResolvedValue(7);
-    expect(await runOnboardingCommand(command("start"), io(), serve)).toBe(7);
+    expect(await runOnboardingCommand(command("start"), io(), serve, flow)).toBe(7);
     expect(setup.runSetup).not.toHaveBeenCalled();
     expect(serve).toHaveBeenCalledOnce();
   });
@@ -170,7 +185,7 @@ describe("terminal onboarding commands", () => {
     setup.isSetupComplete.mockResolvedValue(false);
     const output = io();
     const serve = vi.fn();
-    expect(await runOnboardingCommand(command(name), output, serve)).toBe(1);
+    expect(await runOnboardingCommand(command(name), output, serve, flow)).toBe(1);
     expect(setup.runSetup).not.toHaveBeenCalled();
     expect(serve).not.toHaveBeenCalled();
     expect(output.error).toHaveBeenCalledWith(expect.stringContaining("interactive terminal"));
@@ -183,8 +198,119 @@ describe("terminal onboarding commands", () => {
     if (result instanceof Error) setup.runSetup.mockRejectedValue(result);
     else setup.runSetup.mockResolvedValue(result);
     const serve = vi.fn();
-    expect(await runOnboardingCommand(command("start"), io(), serve)).toBe(130);
+    expect(await runOnboardingCommand(command("start"), io(), serve, flow)).toBe(130);
     expect(serve).not.toHaveBeenCalled();
+  });
+
+  it("persists an explicitly chosen phone route and uses it on later starts without prompts", async () => {
+    terminal(true);
+    preserveEnv();
+    const options = command("start");
+    setup.isSetupComplete.mockResolvedValue(true);
+    phoneSetup.mockResolvedValue({ options: { ...options, tunnel: true, client: true }, phone: "android" });
+    const serve = vi.fn().mockResolvedValue(0);
+    await runOnboardingCommand(options, io(), serve, flow);
+    expect(setup.saveCliStartup).toHaveBeenCalledWith(options.dataDir, { access: "tunnel", phone: "android" });
+    expect(serve).toHaveBeenLastCalledWith(expect.objectContaining({ tunnel: true, phone: "android", guided: true }));
+    phoneSetup.mockClear();
+    setup.readCliStartup.mockReturnValue({ access: "tunnel", phone: "android" });
+    await runOnboardingCommand(options, io(), serve, flow);
+    expect(phoneSetup).not.toHaveBeenCalled();
+    expect(serve).toHaveBeenLastCalledWith(expect.objectContaining({ tunnel: true, phone: "android" }));
+  });
+
+  it("keeps the provider setup but does not start if phone setup is cancelled", async () => {
+    terminal(true);
+    preserveEnv();
+    setup.runSetup.mockResolvedValue(true);
+    phoneSetup.mockRejectedValue(new SetupCancelled());
+    const serve = vi.fn();
+    const output = io();
+    expect(await runOnboardingCommand(command("start"), output, serve, flow)).toBe(130);
+    expect(serve).not.toHaveBeenCalled();
+    expect(setup.saveCliStartup).not.toHaveBeenCalled();
+    expect(output.log).toHaveBeenCalledWith(expect.stringContaining("already saved is kept"));
+  });
+
+  it("reopens an already-running workspace without setup, pairing, or a second server", async () => {
+    terminal(true);
+    preserveEnv();
+    running.mockResolvedValue(true);
+    const serve = vi.fn();
+    expect(await runOnboardingCommand(command("start"), io(), serve, flow)).toBe(0);
+    expect(open).toHaveBeenCalledWith(18451);
+    expect(setup.runSetup).not.toHaveBeenCalled();
+    expect(phoneSetup).not.toHaveBeenCalled();
+    expect(serve).not.toHaveBeenCalled();
+  });
+
+  it("honors --no-pair and --no-open without saving an access choice", async () => {
+    terminal(true);
+    preserveEnv();
+    setup.isSetupComplete.mockResolvedValue(true);
+    const serve = vi.fn().mockResolvedValue(0);
+    await runOnboardingCommand({ ...command("start"), pair: false, open: false }, io(), serve, flow);
+    expect(phoneSetup).not.toHaveBeenCalled();
+    expect(setup.saveCliStartup).not.toHaveBeenCalled();
+    expect(serve).toHaveBeenCalledWith(expect.objectContaining({ pair: false, open: false }));
+  });
+
+  it("does not claim --local changed an already-running public workspace", async () => {
+    terminal(true);
+    preserveEnv();
+    running.mockResolvedValue(true);
+    const output = io();
+    const serve = vi.fn();
+    expect(await runOnboardingCommand({ ...command("start"), local: true }, output, serve, flow)).toBe(1);
+    expect(output.error).toHaveBeenCalledWith(expect.stringContaining("current connection was not changed"));
+    expect(open).not.toHaveBeenCalled();
+    expect(serve).not.toHaveBeenCalled();
+  });
+
+  it("does not persist a credential-bearing explicit URL even when phone setup is skipped", async () => {
+    terminal(true);
+    preserveEnv();
+    setup.isSetupComplete.mockResolvedValue(true);
+    const options = { ...command("start"), publicUrl: "https://user:secret@example.com" };
+    const serve = vi.fn();
+    await expect(runOnboardingCommand(options, io(), serve, flow)).rejects.toThrow("address was not saved");
+    expect(setup.saveCliStartup).not.toHaveBeenCalled();
+    expect(serve).not.toHaveBeenCalled();
+  });
+});
+
+describe("saved startup access", () => {
+  const options = () => parseArgs([], {}) as CliOptions;
+  it("keeps local launches local and supports a one-time local override", () => {
+    expect(applyStartupPreferences(options(), { access: "local" })).toMatchObject({ tunnel: false, tailscale: false, publicUrl: undefined });
+    expect(applyStartupPreferences({ ...options(), local: true }, { access: "tunnel", phone: "ios" })).toMatchObject({ tunnel: false, phone: undefined });
+  });
+  it("explicit route flags take priority over saved settings", () => {
+    expect(applyStartupPreferences({ ...options(), tailscale: true }, { access: "tunnel" })).toMatchObject({ tailscale: true, tunnel: false });
+  });
+  it("refuses a saved URL that embeds a credential or points to localhost", () => {
+    for (const publicUrl of ["https://localhost", "https://user:secret@example.com", "https://example.com/pair#code=secret"])
+      expect(() => applyStartupPreferences(options(), { access: "public-url", publicUrl })).toThrow("not a valid HTTPS origin");
+  });
+});
+
+describe("phone endpoint identity", () => {
+  afterEach(() => vi.unstubAllGlobals());
+  it("checks the public endpoint matches this server without sending credentials", async () => {
+    const fetcher = vi.fn().mockResolvedValueOnce(Response.json({ environmentId: "fixture" }))
+      .mockResolvedValueOnce(Response.json({ environmentId: "fixture" }));
+    vi.stubGlobal("fetch", fetcher);
+    expect(await verifyPhoneEndpoint(18451, "https://maus.example.com")).toBe(true);
+    expect(fetcher.mock.calls[1]![1]).toMatchObject({ redirect: "error" });
+    expect(fetcher.mock.calls[1]![1]).not.toHaveProperty("headers");
+  });
+  it("refuses another server or unreachable origin", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(Response.json({ environmentId: "ours" }))
+      .mockResolvedValueOnce(Response.json({ environmentId: "other" })));
+    expect(await verifyPhoneEndpoint(18451, "https://maus.example.com")).toBe(false);
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    expect(await verifyPhoneEndpoint(18451, "https://maus.example.com")).toBe(false);
+    expect(await verifyPhoneEndpoint(18451, "https://localhost")).toBe(false);
   });
 });
 

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -4,6 +4,8 @@
 // `pnpm omb` (a checkout) — because scripts/bundle-server.mjs bundles this
 // file next to the server.
 //
+//   openmausbot setup [--data-dir ~/.openmausbot]
+//   openmausbot start [serve options]
 //   openmausbot serve [--port 8799] [--data-dir ~/.openmausbot] [--label "cab mini"]
 //                     [--public-url https://host] [--tailscale | --tunnel] [--no-pair]
 //   openmausbot pair  [--label "My MacBook"] [--client] [--public-url https://host]
@@ -29,13 +31,7 @@ import { fileURLToPath } from "node:url";
 import qrcode from "qrcode-terminal";
 
 import { explainTailscaleFailure, tailscaleServe, tailscaleServeOff, tailscaleStatus, type TailscaleStatus } from "./tailscale.ts";
-import {
-  browserEngineStatus,
-  describeBrowserEngine,
-  ensureChrome,
-  installAgentBrowserBinary,
-  resolveAgentBrowserBinary,
-} from "./browser-engine.ts";
+import { SetupCancelled } from "./cli-prompts.ts";
 import {
   cleanupTunnelOrigin,
   createTunnelAccount,
@@ -54,7 +50,7 @@ import {
 const HERE = dirname(fileURLToPath(import.meta.url));
 
 export interface CliOptions {
-  command: "serve" | "pair" | "sessions" | "status" | "login" | "logout" | "browser" | "help";
+  command: "setup" | "start" | "serve" | "pair" | "sessions" | "status" | "login" | "logout" | "browser" | "help";
   port: number;
   dataDir: string;
   label?: string;
@@ -71,7 +67,7 @@ export interface CliOptions {
   json: boolean;
 }
 
-const COMMANDS = ["serve", "pair", "sessions", "status", "login", "logout", "browser", "help", "--help", "-h"];
+const COMMANDS = ["setup", "start", "serve", "pair", "sessions", "status", "login", "logout", "browser", "help", "--help", "-h"];
 
 export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): CliOptions | { error: string } {
   const [command = "help", ...rest] = argv;
@@ -125,6 +121,8 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
 
 export const USAGE = `openmausbot — run the server anywhere, pair devices to it
 
+  openmausbot setup [--data-dir DIR]
+  openmausbot start [the same options as serve]
   openmausbot serve [--port 8799] [--data-dir DIR] [--label NAME]
                     [--public-url https://host] [--tailscale | --tunnel] [--no-pair]
   openmausbot pair  [--label NAME] [--client] [--public-url https://host]
@@ -134,7 +132,9 @@ export const USAGE = `openmausbot — run the server anywhere, pair devices to i
   openmausbot logout
   openmausbot browser install [--with-deps] | status
 
-serve   starts the server and prints a pairing link + QR code
+setup   choose an AI provider, sign in or enter an API key, then pick a model
+start   run setup once if needed, then start with your saved settings
+serve   starts the server without prompts and prints a pairing link + QR code
 pair    mints a pairing code against a running server (--client: chat only)
 sessions lists paired devices; "sessions revoke ID" signs one out
 status  what the server says about itself
@@ -372,6 +372,7 @@ export async function runLogout(options: CliOptions, io: CliIo = defaultIo()): P
 }
 
 export async function runBrowser(options: CliOptions, io: CliIo = defaultIo()): Promise<number> {
+  const { browserEngineStatus, describeBrowserEngine, ensureChrome, installAgentBrowserBinary, resolveAgentBrowserBinary } = await import("./browser-engine.ts");
   const status = browserEngineStatus({ dataDir: options.dataDir });
   if (options.browserAction === "status") {
     io.log(describeBrowserEngine(status));
@@ -457,6 +458,7 @@ async function planTunnel(options: CliOptions, log: (line: string) => void): Pro
 }
 
 export async function runServe(options: CliOptions, log: (line: string) => void = console.log): Promise<number> {
+  const { browserEngineStatus, describeBrowserEngine } = await import("./browser-engine.ts");
   if (await serverUp(options.port)) {
     console.error(`something already answers on http://127.0.0.1:${options.port}; use \`openmausbot pair\` against it, or --port for a second server`);
     return 1;
@@ -568,13 +570,57 @@ export async function runServe(options: CliOptions, log: (line: string) => void 
   });
 }
 
+/** Keep setup imports behind the data-dir override: config binds its paths
+ * when first imported. `serve` remains usable with stdin closed. */
+export async function runOnboardingCommand(
+  options: CliOptions,
+  io: CliIo = defaultIo(),
+  startServer: (options: CliOptions) => Promise<number> = runServe,
+): Promise<number> {
+  const interactive = process.stdin.isTTY === true && process.stdout.isTTY === true;
+  if (options.command === "setup" && !interactive) {
+    io.error("Setup needs an interactive terminal. Run `npx openmausbot setup` in a terminal, then use `npx openmausbot serve` for unattended starts.");
+    return 1;
+  }
+  process.env.OMB_DATA_DIR = options.dataDir;
+  const { runSetup, isSetupComplete } = await import("./cli-setup.ts");
+  if (options.command === "setup" || !(await isSetupComplete(options.dataDir))) {
+    if (!interactive) {
+      io.error("No completed setup was found. Run `npx openmausbot setup` in an interactive terminal first, or use `npx openmausbot serve` with an existing configuration.");
+      return 1;
+    }
+    try {
+      if (!(await runSetup({ dataDir: options.dataDir, port: options.port }))) {
+        io.log("Setup cancelled. Run `npx openmausbot setup` when you're ready.");
+        return 130;
+      }
+    } catch (error) {
+      if (!(error instanceof SetupCancelled)) throw error;
+      io.log("Setup cancelled. Run `npx openmausbot setup` when you're ready.");
+      return 130;
+    }
+  }
+  if (options.command === "setup") {
+    io.log("Start with: npx openmausbot start");
+    if (options.dataDir !== join(homedir(), ".openmausbot") || options.port !== 8799) {
+      io.log(`Use the same --data-dir (${options.dataDir}) and --port (${options.port}) options when starting.`);
+    }
+    return 0;
+  }
+  return startServer(options);
+}
+
 export async function main(argv = process.argv.slice(2)): Promise<number> {
   const options = parseArgs(argv);
   if ("error" in options) {
     console.error(`${options.error}\n\n${USAGE}`);
     return 2;
   }
+  process.env.OMB_DATA_DIR = options.dataDir;
   switch (options.command) {
+    case "setup":
+    case "start":
+      return runOnboardingCommand(options);
     case "serve":
       return runServe(options);
     case "pair":

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -23,7 +23,7 @@
 // This module only exports; openmausbot.ts is the entry that runs main(), so
 // bundling this file into other entries (pair-cli.ts) never runs it twice.
 import { spawn, type ChildProcess } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
@@ -31,7 +31,9 @@ import { fileURLToPath } from "node:url";
 import qrcode from "qrcode-terminal";
 
 import { explainTailscaleFailure, tailscaleServe, tailscaleServeOff, tailscaleStatus, type TailscaleStatus } from "./tailscale.ts";
-import { SetupCancelled } from "./cli-prompts.ts";
+import { defaultSetupIo, SetupCancelled, type SetupIo } from "./cli-prompts.ts";
+import { normalizePhoneOrigin, phonePairingInstructions, runPhoneSetup } from "./cli-phone-setup.ts";
+import type { AppConfig } from "./config.ts";
 import {
   cleanupTunnelOrigin,
   createTunnelAccount,
@@ -65,12 +67,19 @@ export interface CliOptions {
   browserAction?: "install" | "status";
   withDeps?: boolean;
   json: boolean;
+  /** Explicitly ignore saved remote access for this launch. */
+  local?: boolean;
+  open?: boolean;
+  /** Internal guided-start presentation; serve remains script-friendly. */
+  guided?: boolean;
+  phone?: "ios" | "android";
 }
 
 const COMMANDS = ["setup", "start", "serve", "pair", "sessions", "status", "login", "logout", "browser", "help", "--help", "-h"];
 
 export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): CliOptions | { error: string } {
-  const [command = "help", ...rest] = argv;
+  const implicitStart = !argv.length || (argv[0]!.startsWith("--") && argv[0] !== "--help");
+  const [command = "start", ...rest] = implicitStart ? ["start", ...argv] : argv;
   if (!COMMANDS.includes(command)) {
     return { error: `unknown command "${command}"` };
   }
@@ -102,6 +111,8 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
       else if (arg === "--tunnel") options.tunnel = true;
       else if (arg === "--client") options.client = true;
       else if (arg === "--no-pair") options.pair = false;
+      else if (arg === "--no-open") options.open = false;
+      else if (arg === "--local") options.local = true;
       else if (arg === "--json") options.json = true;
       else if (arg === "--email") options.email = value();
       else if (options.command === "sessions" && arg === "revoke") options.revoke = value();
@@ -115,12 +126,14 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
   if (!Number.isInteger(options.port) || options.port < 1 || options.port > 65_535) return { error: "--port must be 1-65535" };
   if (options.publicUrl && !/^https?:\/\//.test(options.publicUrl)) return { error: "--public-url must start with http:// or https://" };
   if (options.tailscale && options.tunnel) return { error: "choose one of --tailscale (your tailnet) and --tunnel (a public address)" };
+  if (options.local && (options.tailscale || options.tunnel || options.publicUrl)) return { error: "--local cannot be combined with a remote-access option" };
   if (options.command === "browser" && !options.browserAction) return { error: "browser needs an action: install or status" };
   return options;
 }
 
-export const USAGE = `openmausbot — run the server anywhere, pair devices to it
+export const USAGE = `openmausbot — your team of AI bots, ready in a few steps
 
+  openmausbot                         set up once, then open your workspace
   openmausbot setup [--data-dir DIR]
   openmausbot start [the same options as serve]
   openmausbot serve [--port 8799] [--data-dir DIR] [--label NAME]
@@ -132,8 +145,8 @@ export const USAGE = `openmausbot — run the server anywhere, pair devices to i
   openmausbot logout
   openmausbot browser install [--with-deps] | status
 
-setup   choose an AI provider, sign in or enter an API key, then pick a model
-start   run setup once if needed, then start with your saved settings
+setup   choose AI access and optional phone access; keep existing bots and chats
+start   same as openmausbot: use your saved settings and open the workspace
 serve   starts the server without prompts and prints a pairing link + QR code
 pair    mints a pairing code against a running server (--client: chat only)
 sessions lists paired devices; "sessions revoke ID" signs one out
@@ -152,6 +165,13 @@ browser install: the bots' browser engine (agent-browser, pinned) and a
 --tunnel     serve at a public https://….openmausbot.com address through a
              Cloudflare tunnel: no domain, no proxy, no open port. Run
              \`openmausbot login\` once on this machine first.
+
+--no-open   do not open a browser window
+--no-pair   skip phone setup and do not print a pairing code
+--local     start locally this time, ignoring saved remote-access settings
+
+Install once with \`npm install -g openmausbot\`, then type \`openmausbot\`.
+Or run without a global install: \`npx openmausbot\`. Node 24+ is required.
 `;
 
 /** Terminal in, terminal out; tests substitute all three. */
@@ -192,18 +212,96 @@ const message = (error: unknown) => (error instanceof Error ? error.message : St
 
 // ── talking to a running server (loopback = owner) ────────────────────
 async function api(port: number, path: string, init: { method?: string; body?: string } = {}): Promise<{ status: number; body: any }> {
-  const res = await fetch(`http://127.0.0.1:${port}${path}`, { method: init.method, body: init.body, headers: { "content-type": "application/json" } });
+  const res = await fetch(`http://127.0.0.1:${port}${path}`, { method: init.method, body: init.body, headers: { "content-type": "application/json" }, signal: AbortSignal.timeout(3000) });
   const body: unknown = await res.json().catch(() => ({}));
   return { status: res.status, body };
 }
 
-async function serverUp(port: number): Promise<boolean> {
+async function serverUp(port: number, pid?: number): Promise<boolean> {
   try {
-    const { status } = await api(port, "/api/health");
-    return status === 200;
+    const { status, body } = await api(port, "/api/health");
+    return status === 200 && body?.app === "openmausbot" && (pid === undefined || body.pid === pid);
   } catch {
     return false;
   }
+}
+
+/** Check identity before reusing a running process. Never attach to another
+ * workspace just because it happens to be listening on the requested port. */
+export async function isWorkspaceRunning(options: CliOptions): Promise<boolean> {
+  try {
+    const { status, body } = await api(options.port, "/api/health");
+    if (status !== 200 || body?.app !== "openmausbot") return false;
+    const expected = readFileSync(join(options.dataDir, "environment-id"), "utf8").trim();
+    const descriptor = await api(options.port, "/.well-known/openmausbot/environment");
+    return /^[0-9a-f-]{36}$/i.test(expected) && descriptor.status === 200 && descriptor.body?.environmentId === expected;
+  } catch { return false; }
+}
+
+/** No shell commands, credentials or remote URLs go to the OS URL opener. */
+export async function openDashboard(port: number, env = process.env): Promise<boolean> {
+  if (env.SSH_CONNECTION || env.SSH_TTY || (process.platform === "linux" && !env.DISPLAY && !env.WAYLAND_DISPLAY)) return false;
+  const url = `http://127.0.0.1:${port}`;
+  const command = process.platform === "darwin" ? "open" : process.platform === "win32" ? "rundll32.exe" : "xdg-open";
+  const args = process.platform === "win32" ? ["url.dll,FileProtocolHandler", url] : [url];
+  return new Promise((done) => {
+    const child = spawn(command, args, { stdio: "ignore", windowsHide: true });
+    const timer = setTimeout(() => { child.kill(); done(false); }, 3000);
+    child.once("error", () => { clearTimeout(timer); done(false); });
+    child.once("exit", (code) => { clearTimeout(timer); done(code === 0); });
+  });
+}
+
+/** A valid URL alone is not enough: its public descriptor must identify this
+ * exact server. This probe never sends a pairing code or an auth credential. */
+export async function verifyPhoneEndpoint(port: number, origin: string): Promise<boolean> {
+  if (!normalizePhoneOrigin(origin)) return false;
+  try {
+    const local = await api(port, "/.well-known/openmausbot/environment");
+    const remote = await fetch(`${origin}/.well-known/openmausbot/environment`, { signal: AbortSignal.timeout(5000), redirect: "error" });
+    if (local.status !== 200 || !remote.ok) return false;
+    const descriptor = await remote.json() as { environmentId?: unknown };
+    return typeof local.body?.environmentId === "string" && local.body.environmentId.length > 0
+      && descriptor.environmentId === local.body.environmentId;
+  } catch { return false; }
+}
+
+export function applyStartupPreferences(options: CliOptions, saved: AppConfig["cliStartup"]): CliOptions {
+  if (options.local) return { ...options, tunnel: false, tailscale: false, publicUrl: undefined, phone: undefined };
+  if (!saved || options.tunnel || options.tailscale || options.publicUrl) return options;
+  if (saved.access === "public-url" && (!saved.publicUrl || !normalizePhoneOrigin(saved.publicUrl))) {
+    throw new Error("The saved phone address is not a valid HTTPS origin. Run openmausbot setup to correct it, or openmausbot --local to start only on this computer.");
+  }
+  return {
+    ...options,
+    tunnel: saved.access === "tunnel", tailscale: saved.access === "tailscale",
+    publicUrl: saved.access === "public-url" ? saved.publicUrl : undefined,
+    phone: saved.access === "local" ? undefined : saved.phone,
+  };
+}
+
+function startupPreferences(options: CliOptions): NonNullable<AppConfig["cliStartup"]> {
+  const access = options.local ? "local" : options.tunnel ? "tunnel" : options.tailscale ? "tailscale" : options.publicUrl ? "public-url" : "local";
+  const publicUrl = access === "public-url" ? normalizePhoneOrigin(options.publicUrl!) : null;
+  if (access === "public-url" && !publicUrl) throw new Error("Use an HTTPS origin without a password, path or query for saved phone access. The address was not saved.");
+  return {
+    access,
+    ...(publicUrl ? { publicUrl } : {}),
+    ...(!options.local && options.phone ? { phone: options.phone } : {}),
+  };
+}
+
+async function showPhonePairing(options: CliOptions, origin: string | undefined, log: (line: string) => void): Promise<boolean> {
+  const ready = !!origin && await verifyPhoneEndpoint(options.port, origin);
+  if (!ready) {
+    log("Phone access is not reachable yet. Your local workspace is ready; no phone pairing code was created.");
+    log("Check the HTTPS connection, then run openmausbot pair again with the same --data-dir and --port.");
+    return false;
+  }
+  for (const line of phonePairingInstructions(options.phone ?? "ios", { origin: origin!, ready })) log(line);
+  log(await mintPairing(options.port, { client: true, label: options.label ?? (options.phone === "android" ? "Android" : "iPhone / iPad"), publicUrl: origin }));
+  log("Waiting for you to connect on the phone. Keep this terminal and the code private.");
+  return true;
 }
 
 /** The pairing link a device opens, rendered as text and a QR code. */
@@ -243,6 +341,39 @@ export async function runPair(options: CliOptions): Promise<number> {
   if (!(await serverUp(options.port))) {
     console.error(`no OpenMausBot server on http://127.0.0.1:${options.port}; start one with \`openmausbot serve\` or set OMB_PORT`);
     return 1;
+  }
+  if (process.stdin.isTTY && process.stdout.isTTY && !options.label && !options.client) {
+    const advertised = await api(options.port, "/api/auth/pairing");
+    let launch = options;
+    // The running server may use a one-time route override. Saved preferences
+    // describe the next launch, not necessarily the address working now.
+    let origin = options.publicUrl ?? (typeof advertised.body?.publicUrl === "string" ? advertised.body.publicUrl : undefined);
+    if (!origin) {
+      const { readCliStartup } = await import("./cli-setup.ts");
+      launch = applyStartupPreferences(options, readCliStartup(options.dataDir));
+      origin = launch.publicUrl;
+      if (launch.tunnel) origin = describeTunnelAccount(createTunnelAccount({ dataDir: options.dataDir, version: serverVersion() }).credentials.read()).address ?? undefined;
+      if (launch.tailscale) {
+        const status = await tailscaleStatus();
+        if (!("failure" in status)) origin = `https://${status.status.dnsName}`;
+      }
+    }
+    if (!origin || !normalizePhoneOrigin(origin)) {
+      console.log("Your workspace is running only on this computer. A phone cannot use its localhost address.");
+      console.log("Stop the server, run openmausbot setup and choose phone access, then start openmausbot again.");
+      return 1;
+    }
+    const ui = defaultSetupIo();
+    try {
+      const selected = await ui.choose("Which phone are you connecting?", ["iPhone / iPad — app or Safari", "Android — web browser", "Cancel"], 0);
+      if (selected === 2) return 0;
+      launch = { ...launch, phone: selected === 0 ? "ios" : "android" };
+      return await showPhonePairing(launch, origin, ui.log) ? 0 : 1;
+    } catch (error) {
+      if (!(error instanceof SetupCancelled)) throw error;
+      console.log("Pairing cancelled. Existing devices are unchanged.");
+      return 130;
+    }
   }
   console.log(await mintPairing(options.port, { label: options.label, client: options.client, publicUrl: options.publicUrl }));
   if (options.client) console.log("(client scope: chat and approvals only; cannot change settings or pair others)");
@@ -492,25 +623,59 @@ export async function runServe(options: CliOptions, log: (line: string) => void 
     OMB_PORT: String(options.port),
     OMB_WEBHOOK_PORT: process.env.OMB_WEBHOOK_PORT || String(options.port + 1),
   };
+  if (options.local) delete env.OMB_PUBLIC_URL;
   if (entry.staticDir) env.OMB_STATIC_DIR = entry.staticDir;
   if (entry.skillsDir && !process.env.OMB_SKILLS_DIR) env.OMB_SKILLS_DIR = entry.skillsDir;
   if (options.label && !process.env.OMB_ENVIRONMENT_LABEL) env.OMB_ENVIRONMENT_LABEL = options.label;
   if (plan) env.OMB_TUNNEL_SOCKET = plan.origin.socketPath;
-  if (tailscale) {
-    const served = await tailscaleServe(tailscale, options.port);
-    if ("failure" in served) {
-      console.error(`--tailscale: ${explainTailscaleFailure(served.failure)}`);
-      return 1;
+  let logPath: string | undefined;
+  let logFd: number | undefined;
+  let tailscaleServing = false;
+  let tailscaleAttempted = false;
+  let startupCancelled = false;
+  const cancelStartup = () => { startupCancelled = true; };
+  process.on("SIGINT", cancelStartup);
+  process.on("SIGTERM", cancelStartup);
+  let child: ChildProcess;
+  try {
+    if (options.guided) {
+      const logsDir = join(options.dataDir, "logs");
+      mkdirSync(logsDir, { recursive: true, mode: 0o700 });
+      logPath = join(logsDir, `server-${Date.now()}-${process.pid}.log`);
+      logFd = openSync(logPath, "wx", 0o600);
+      log("\nStarting your workspace…");
     }
-    publicUrl = served.origin;
-    log(`tailscale: serving https://${tailscale.dnsName} → http://127.0.0.1:${options.port} (only your tailnet can reach it)`);
+    if (tailscale) {
+      tailscaleAttempted = true;
+      const served = await tailscaleServe(tailscale, options.port);
+      // The CLI can finish enabling background serving while cancellation is
+      // arriving. Wait for that bounded command, then undo it before exiting.
+      if (startupCancelled) throw new SetupCancelled();
+      if ("failure" in served) throw new Error(`--tailscale: ${explainTailscaleFailure(served.failure)}`);
+      tailscaleServing = true;
+      publicUrl = served.origin;
+      log(`tailscale: serving https://${tailscale.dnsName} → http://127.0.0.1:${options.port} (only your tailnet can reach it)`);
+    }
+    if (startupCancelled) throw new SetupCancelled();
+    if (publicUrl) env.OMB_PUBLIC_URL = publicUrl;
+    child = spawn(entry.command, entry.args, { env, stdio: ["ignore", logFd ?? "inherit", logFd ?? "inherit"] });
+  } catch (error) {
+    if ((tailscaleServing || (startupCancelled && tailscaleAttempted)) && tailscale) await tailscaleServeOff(tailscale).catch(() => undefined);
+    if (plan) cleanupTunnelOrigin(plan.origin);
+    if (error instanceof SetupCancelled) {
+      log("Startup cancelled. No server was started; your saved work is unchanged.");
+      return 130;
+    }
+    throw error;
+  } finally {
+    if (logFd !== undefined) closeSync(logFd);
+    process.removeListener("SIGINT", cancelStartup);
+    process.removeListener("SIGTERM", cancelStartup);
   }
-  if (publicUrl) env.OMB_PUBLIC_URL = publicUrl;
-
-  const child: ChildProcess = spawn(entry.command, entry.args, { env, stdio: ["ignore", "inherit", "inherit"] });
   let exited: number | null = null;
-  child.on("exit", (code) => {
-    exited = code ?? 1;
+  const childExit = new Promise<number>((done) => {
+    child.once("error", () => { exited = 1; done(1); });
+    child.once("exit", (code, signal) => { exited = code ?? (signal === "SIGTERM" || signal === "SIGINT" ? 0 : 1); done(exited); });
   });
   let tunnel: RunningTunnel | null = null;
   let stopping: Promise<void> | null = null;
@@ -518,56 +683,86 @@ export async function runServe(options: CliOptions, log: (line: string) => void 
     stopping ??= (async () => {
       // The gateway stops accepting before the server it forwards to goes away.
       if (tunnel) await tunnel.stop().catch(() => undefined);
-      if (tailscale) await tailscaleServeOff(tailscale).catch(() => undefined);
-      if (exited === null) child.kill("SIGTERM");
+      if (tailscaleServing && tailscale) await tailscaleServeOff(tailscale).catch(() => undefined);
+      if (exited === null) {
+        child.kill("SIGTERM");
+        const timer = setTimeout(() => child.kill("SIGKILL"), 10_000);
+        timer.unref();
+        await childExit;
+        clearTimeout(timer);
+      }
       if (plan) cleanupTunnelOrigin(plan.origin);
     })();
     return stopping;
   };
-  process.on("SIGINT", () => void stop());
-  process.on("SIGTERM", () => void stop());
+  const onSignal = () => { void stop(); };
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
 
-  const deadline = Date.now() + 60_000;
-  while (Date.now() < deadline && exited === null) {
-    if (await serverUp(options.port)) break;
-    await new Promise((r) => setTimeout(r, 250));
-  }
-  if (exited !== null) {
-    if (plan) cleanupTunnelOrigin(plan.origin);
-    return exited;
-  }
-  if (!(await serverUp(options.port))) {
-    console.error("the server did not answer within a minute; see its output above");
+  try {
+    const deadline = Date.now() + 60_000;
+    while (Date.now() < deadline && exited === null && !stopping) {
+      if (await serverUp(options.port, child.pid)) break;
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    if (exited !== null) {
+      if (exited !== 0) log(`OpenMausBot could not start.${logPath ? ` Details: ${logPath}` : " See the output above."}`);
+      return exited;
+    }
+    if (stopping) return await childExit;
+    if (!(await serverUp(options.port, child.pid))) {
+      console.error(`OpenMausBot did not become ready within a minute.${logPath ? ` Details: ${logPath}` : " See its output above."}`);
+      await stop();
+      return 1;
+    }
+    if (stopping || exited !== null) return await childExit;
+    if (plan && child.pid) {
+      tunnel = startTunnel({
+        dataDir: options.dataDir,
+        access: plan.access,
+        originTarget: { pid: child.pid, socketPath: plan.origin.socketPath },
+        binaryPath: plan.binary,
+        guardian: plan.guardian,
+        onState: (state) => log(describeTunnelState(state, plan.access.endpoint)),
+      });
+      tunnel.started.catch((error: unknown) => log(`tunnel: ${message(error)}`));
+    }
+    log("");
+    log(`OpenMausBot is running on http://127.0.0.1:${options.port}${publicUrl ? `, reachable at ${publicUrl}` : ""}`);
+    if (options.guided) {
+      log("Your bots and conversations are saved automatically.");
+      log(`Details if you need help: ${logPath}`);
+      if (options.open !== false && !await openDashboard(options.port)) log("Open the local address above in a browser on this computer.");
+    } else {
+      log(`data: ${options.dataDir}`);
+      log(describeBrowserEngine(browserEngineStatus({ dataDir: options.dataDir })));
+    }
+    if (options.pair && options.phone) {
+      log("");
+      if (tunnel) {
+        // A connector may take a moment to become reachable; no pairing secret
+        // is created or sent to the public address until identity is verified.
+        log("Preparing the phone connection…");
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        await Promise.race([tunnel.started.catch(() => undefined), childExit,
+          new Promise((done) => { timer = setTimeout(done, 15_000); })]);
+        if (timer) clearTimeout(timer);
+      }
+      if (!stopping && exited === null) await showPhonePairing(options, publicUrl, log);
+    } else if (options.pair && !options.guided) {
+      log("");
+      log(await mintPairing(options.port, { label: options.label ? `${options.label} owner` : undefined, client: options.client, publicUrl: publicUrl ?? undefined }));
+      log("");
+      log("another device later:  openmausbot pair --label \"Kitchen iPad\"");
+    }
+    log(options.guided ? "\nKeep this terminal open while using your bots. Ctrl+C stops the server, not your saved work." : "stop with Ctrl+C");
+    if (options.guided) log("Next time: openmausbot · Change AI or phone setup: openmausbot setup · Pair another phone: openmausbot pair");
+    return await childExit;
+  } finally {
     await stop();
-    return 1;
+    process.removeListener("SIGINT", onSignal);
+    process.removeListener("SIGTERM", onSignal);
   }
-  if (plan && child.pid) {
-    tunnel = startTunnel({
-      dataDir: options.dataDir,
-      access: plan.access,
-      originTarget: { pid: child.pid, socketPath: plan.origin.socketPath },
-      binaryPath: plan.binary,
-      guardian: plan.guardian,
-      onState: (state) => log(describeTunnelState(state, plan.access.endpoint)),
-    });
-    tunnel.started.catch((error: unknown) => log(`tunnel: ${message(error)}`));
-  }
-  log("");
-  log(`OpenMausBot is running on http://127.0.0.1:${options.port}${publicUrl ? `, reachable at ${publicUrl}` : ""}`);
-  log(`data: ${options.dataDir}`);
-  log(describeBrowserEngine(browserEngineStatus({ dataDir: options.dataDir })));
-  if (options.pair) {
-    log("");
-    log(await mintPairing(options.port, { label: options.label ? `${options.label} owner` : undefined, publicUrl: publicUrl ?? undefined }));
-    log("");
-    log("another device later:  openmausbot pair --label \"Kitchen iPad\"");
-  }
-  log("stop with Ctrl+C");
-  return await new Promise<number>((resolveExit) => {
-    child.on("exit", (code) => {
-      void stop().finally(() => resolveExit(code ?? 0));
-    });
-  });
 }
 
 /** Keep setup imports behind the data-dir override: config binds its paths
@@ -576,6 +771,7 @@ export async function runOnboardingCommand(
   options: CliOptions,
   io: CliIo = defaultIo(),
   startServer: (options: CliOptions) => Promise<number> = runServe,
+  flow: { prompts?: SetupIo; phoneSetup?: typeof runPhoneSetup; running?: typeof isWorkspaceRunning; open?: typeof openDashboard } = {},
 ): Promise<number> {
   const interactive = process.stdin.isTTY === true && process.stdout.isTTY === true;
   if (options.command === "setup" && !interactive) {
@@ -583,31 +779,59 @@ export async function runOnboardingCommand(
     return 1;
   }
   process.env.OMB_DATA_DIR = options.dataDir;
-  const { runSetup, isSetupComplete } = await import("./cli-setup.ts");
-  if (options.command === "setup" || !(await isSetupComplete(options.dataDir))) {
-    if (!interactive) {
-      io.error("No completed setup was found. Run `npx openmausbot setup` in an interactive terminal first, or use `npx openmausbot serve` with an existing configuration.");
+  if (options.command !== "setup" && await (flow.running ?? isWorkspaceRunning)(options)) {
+    if (options.local || options.tunnel || options.tailscale || options.publicUrl) {
+      io.error("This workspace is already running. Stop it before changing local or remote access; the current connection was not changed.");
       return 1;
     }
-    try {
-      if (!(await runSetup({ dataDir: options.dataDir, port: options.port }))) {
-        io.log("Setup cancelled. Run `npx openmausbot setup` when you're ready.");
-        return 130;
-      }
-    } catch (error) {
-      if (!(error instanceof SetupCancelled)) throw error;
-      io.log("Setup cancelled. Run `npx openmausbot setup` when you're ready.");
-      return 130;
-    }
-  }
-  if (options.command === "setup") {
-    io.log("Start with: npx openmausbot start");
-    if (options.dataDir !== join(homedir(), ".openmausbot") || options.port !== 8799) {
-      io.log(`Use the same --data-dir (${options.dataDir}) and --port (${options.port}) options when starting.`);
-    }
+    io.log(`Your workspace is already running: http://127.0.0.1:${options.port}`);
+    io.log("No second server was started. Your existing bots and conversations are unchanged.");
+    if (interactive && options.open !== false) await (flow.open ?? openDashboard)(options.port);
     return 0;
   }
-  return startServer(options);
+  const { runSetup, isSetupComplete, readCliStartup, saveCliStartup } = await import("./cli-setup.ts");
+  const prompts = flow.prompts ?? defaultSetupIo();
+  try {
+    if (options.command === "setup" || !(await isSetupComplete(options.dataDir))) {
+      if (!interactive) {
+        io.error("No completed setup was found. Run `npx openmausbot setup` in an interactive terminal first, or use `npx openmausbot serve` with an existing configuration.");
+        return 1;
+      }
+      if (!(await runSetup({ dataDir: options.dataDir, port: options.port }))) {
+        io.log("Setup cancelled. Run openmausbot when you're ready.");
+        return 130;
+      }
+    }
+    const saved = readCliStartup(options.dataDir);
+    // An explicit setup revisits the access choice. Normal starts reuse consent
+    // instead of asking again or unexpectedly turning a local session public.
+    let launch = options.command === "setup" ? options : applyStartupPreferences(options, saved);
+    if (interactive && options.pair && !options.local && (options.command === "setup" || !saved)) {
+      io.log("\nOne optional step: connect your phone. You can skip this and start chatting here.");
+      const result = await (flow.phoneSetup ?? runPhoneSetup)(launch, prompts, {
+        accountReady: (value) => !!describeTunnelAccount(createTunnelAccount({ dataDir: value.dataDir, version: serverVersion() }).credentials.read()).email,
+        login: (value, ui) => runLogin(value, {
+          log: ui.log, error: ui.log,
+          ask: (question) => /code/i.test(question) ? ui.secret(question) : ui.ask(question),
+        }),
+      });
+      launch = { ...result.options, phone: result.phone };
+      saveCliStartup(options.dataDir, startupPreferences(launch));
+    }
+    if (options.command === "setup") {
+      io.log("\nAll set. Start with: openmausbot (or npx openmausbot without a global install).");
+      if (options.dataDir !== join(homedir(), ".openmausbot") || options.port !== 8799) {
+        io.log(`Use the same --data-dir (${options.dataDir}) and --port (${options.port}) options when starting.`);
+      }
+      return 0;
+    }
+    if (saved) io.log("\nWelcome back. Using your saved AI connection.");
+    return startServer({ ...launch, guided: interactive });
+  } catch (error) {
+    if (!(error instanceof SetupCancelled)) throw error;
+    io.log("\nSetup stopped. Any AI setup already saved is kept; no server was started. Run openmausbot setup to continue.");
+    return 130;
+  }
 }
 
 export async function main(argv = process.argv.slice(2)): Promise<number> {

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { JsonValue } from "./schema.ts";
 
 import { customMcpServers,
   DATA_DIR,
@@ -51,6 +52,27 @@ describe("configuration boundaries", () => {
     );
     expect(() => parseConfigPatch({ opencodeGo: { apiKey: 42 } })).toThrow("opencodeGo.apiKey");
     expect(() => parseConfigPatch({ profile: [] })).toThrow("profile");
+  });
+
+  it("accepts and normalizes a default model selection", () => {
+    const input = { defaultModelSelection: { instanceId: " codex ", model: " chosen-model ", effort: "high" } };
+    const expected = { defaultModelSelection: { instanceId: "codex", model: "chosen-model", effort: "high" } };
+    expect(parseStoredConfig(input)).toEqual(expected);
+    expect(parseConfigPatch(input)).toEqual(expected);
+  });
+
+  it.each<JsonValue>([
+    null,
+    "codex/model",
+    {},
+    { instanceId: "codex" },
+    { instanceId: "", model: "model" },
+    { instanceId: "codex", model: "   " },
+    { instanceId: "codex", model: 42 },
+    { instanceId: "codex", model: "model", effort: "turbo" },
+  ])("rejects an invalid default model selection: %j", (defaultModelSelection) => {
+    expect(() => parseStoredConfig({ defaultModelSelection })).toThrow("defaultModelSelection");
+    expect(() => parseConfigPatch({ defaultModelSelection })).toThrow("defaultModelSelection");
   });
 
   it("canonicalizes legacy browser profile ids without dropping other stored settings", () => {
@@ -391,6 +413,23 @@ describe("default fleet", () => {
     });
   });
 
+  it("keeps an explicit empty routing provider while other instances inherit the workspace pin", () => {
+    const config: AppConfig = {
+      openaiCompat: { provider: "workspace-provider" },
+      instances: {
+        isolated: { driver: "openai-compat", config: { provider: "" } },
+        inherited: { driver: "openai-compat" },
+        pinned: { driver: "openai-compat", config: { provider: "instance-provider" } },
+      },
+    };
+    const instances = instanceConfigs(config);
+    expect(instances.isolated.config).toEqual({ provider: "" });
+    expect(instances.inherited.config).toEqual({ provider: "workspace-provider" });
+    expect(instances.pinned.config).toEqual({ provider: "instance-provider" });
+    expect(config.instances?.isolated.config).toEqual({ provider: "" });
+    expect(config.instances?.inherited.config).toBeUndefined();
+  });
+
   it("does not retain an injected OpenAI-compatible URL across config refreshes", () => {
     const config: AppConfig = {
       openaiCompat: { url: "https://first.example.test/v1" },
@@ -607,6 +646,31 @@ describe("credential env preference", () => {
     expect(cfg.xai?.key).toBe("file-xai");
     expect(cfg.tts?.key).toBe("file-tts");
     expect(cfg.imageGen?.key).toBe("file-image");
+  });
+
+  it("persists a default selection without changing the fleet or unrelated settings", () => {
+    const path = join(DATA_DIR, "config.json");
+    const existing = {
+      profile: { name: "Ada" },
+      instances: { customCodex: { driver: "codex", config: { cli: "/opt/custom-codex" } } },
+      openaiCompat: { key: "fixture-key", url: "https://models.example.test/v1" },
+      futureSetting: { keep: true },
+    };
+    writeFileSync(path, JSON.stringify(existing));
+    const selection = { instanceId: "customCodex", model: "fixture-model", effort: "high" as const };
+
+    saveConfig({ defaultModelSelection: selection });
+    expect(loadConfig().defaultModelSelection).toEqual(selection);
+    expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({ ...existing, defaultModelSelection: selection });
+
+    saveConfig({ profile: { email: "ada@example.com" } });
+    expect(loadConfig().defaultModelSelection).toEqual(selection);
+
+    const replacement = { instanceId: "claude", model: "different-model" };
+    saveConfig({ defaultModelSelection: replacement });
+    expect(loadConfig().defaultModelSelection).toEqual(replacement);
+    expect(loadConfig().profile).toEqual({ name: "Ada", email: "ada@example.com" });
+    expect(loadConfig().instances).toEqual(existing.instances);
   });
 
   it("loads legacy browser profiles without resetting config and canonicalizes them on the next write", () => {

--- a/server/config.ts
+++ b/server/config.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 import { z } from "zod";
 
 import { writeFileAtomic } from "./atomic.ts";
-import type { InstanceConfigMap } from "./contracts.ts";
+import { EFFORT_LEVELS, type InstanceConfigMap, type ModelSelection } from "./contracts.ts";
 import { parseStoredMcpServer } from "./mcp-registry.ts";
 import { parseJson, schemaIssue, type JsonObject, type JsonValue } from "./schema.ts";
 
@@ -230,7 +230,13 @@ const instanceConfigSchema = z.object({
   config: z.json().optional(),
 });
 const instanceConfigMapSchema = z.record(z.string(), instanceConfigSchema);
+const defaultModelSelectionSchema = z.object({
+  instanceId: z.string().trim().min(1),
+  model: z.string().trim().min(1),
+  effort: z.enum(EFFORT_LEVELS).optional(),
+});
 const appConfigSchema = z.object({
+  defaultModelSelection: defaultModelSelectionSchema.optional(),
   xai: z.object({ key: optionalText, url: optionalText }).optional(),
   /** `model` seeds the default selection; `provider` pins an OpenRouter
    * upstream (e.g. "fireworks"). Both are non-secret and optional. */
@@ -273,6 +279,8 @@ const appConfigPatchSchema = appConfigSchema.omit({ instances: true, mcpServers:
 const jsonObjectSchema = z.record(z.string(), z.json());
 
 export interface AppConfig {
+  /** Preferred selection for newly created bots; existing bots keep theirs. */
+  defaultModelSelection?: ModelSelection;
   mcpServers?: Record<string, unknown>;
   language?: string;
   xai?: { key?: string; url?: string };
@@ -593,6 +601,11 @@ export function saveConfig(patch: Partial<AppConfig>): void {
   if (checkedPatch.vps !== undefined) disk.vps = normalizeVpsConfig(checkedPatch.vps);
   // scalar, not a section: the merge loop above only walks objects
   if (checkedPatch.language !== undefined) disk.language = checkedPatch.language;
+  // A selection is replaced as one value, so changing engines also clears
+  // an effort level omitted from the new selection.
+  if (checkedPatch.defaultModelSelection !== undefined) {
+    disk.defaultModelSelection = checkedPatch.defaultModelSelection;
+  }
   // Custom MCP mutations go through their own dedicated local API, but
   // saveConfig remains the single atomic persistence boundary.
   if (checkedPatch.mcpServers !== undefined) {
@@ -787,6 +800,9 @@ export function instanceConfigs(cfg: AppConfig): InstanceConfigMap {
         const merged = { ...current };
         // A per-instance value always wins over the workspace default.
         for (const [k, v] of Object.entries(defaults)) {
+          // Empty routing explicitly means "no upstream pin" for isolated
+          // API connections. Do not replace it with a workspace provider.
+          if (k === "provider" && typeof merged[k] === "string") continue;
           if (typeof merged[k] !== "string" || !(merged[k] as string).trim()) merged[k] = v;
         }
         entry.config = merged;

--- a/server/config.ts
+++ b/server/config.ts
@@ -237,6 +237,12 @@ const defaultModelSelectionSchema = z.object({
 });
 const appConfigSchema = z.object({
   defaultModelSelection: defaultModelSelectionSchema.optional(),
+  /** CLI-only launch preferences. Never enable remote access implicitly. */
+  cliStartup: z.object({
+    access: z.enum(["local", "tunnel", "tailscale", "public-url"]),
+    publicUrl: z.string().url().optional(),
+    phone: z.enum(["ios", "android"]).optional(),
+  }).optional(),
   xai: z.object({ key: optionalText, url: optionalText }).optional(),
   /** `model` seeds the default selection; `provider` pins an OpenRouter
    * upstream (e.g. "fireworks"). Both are non-secret and optional. */
@@ -275,12 +281,17 @@ const appConfigSchema = z.object({
 const storedAppConfigSchema = appConfigSchema.extend({
   browserProfiles: storedBrowserProfilesSchema.optional(),
 });
-const appConfigPatchSchema = appConfigSchema.omit({ instances: true, mcpServers: true });
+const appConfigPatchSchema = appConfigSchema.omit({ instances: true, mcpServers: true, cliStartup: true });
 const jsonObjectSchema = z.record(z.string(), z.json());
 
 export interface AppConfig {
   /** Preferred selection for newly created bots; existing bots keep theirs. */
   defaultModelSelection?: ModelSelection;
+  cliStartup?: {
+    access: "local" | "tunnel" | "tailscale" | "public-url";
+    publicUrl?: string;
+    phone?: "ios" | "android";
+  };
   mcpServers?: Record<string, unknown>;
   language?: string;
   xai?: { key?: string; url?: string };
@@ -606,6 +617,7 @@ export function saveConfig(patch: Partial<AppConfig>): void {
   if (checkedPatch.defaultModelSelection !== undefined) {
     disk.defaultModelSelection = checkedPatch.defaultModelSelection;
   }
+  if (checkedPatch.cliStartup !== undefined) disk.cliStartup = checkedPatch.cliStartup;
   // Custom MCP mutations go through their own dedicated local API, but
   // saveConfig remains the single atomic persistence boundary.
   if (checkedPatch.mcpServers !== undefined) {

--- a/server/default-model-selection.test.ts
+++ b/server/default-model-selection.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import type { ModelCatalog, ProviderSnapshot } from "./contracts.ts";
+import { selectDefaultModelSelection } from "./default-model-selection.ts";
+
+const codex = {
+  instanceId: "codex",
+  driverKind: "codex",
+  snapshot: { state: "available", authenticated: true } satisfies ProviderSnapshot,
+  models: {
+    default: "codex-default",
+    options: [{ id: "codex-default", label: "Default" }, { id: "selected-model", label: "Selected" }],
+  } satisfies ModelCatalog,
+};
+const claude = {
+  instanceId: "claude",
+  driverKind: "claudeAgent",
+  snapshot: { state: "available", authenticated: true } satisfies ProviderSnapshot,
+  models: { default: "claude-default", options: [{ id: "claude-default", label: "Claude" }] },
+};
+
+describe("new bot default model selection", () => {
+  it("honors the configured provider, model, and effort ahead of the Claude preference", () => {
+    const preferred = { instanceId: "codex", model: "selected-model", effort: "high" as const };
+    const selection = selectDefaultModelSelection([claude, codex], preferred);
+    expect(selection).toEqual(preferred);
+    expect(selection).not.toBe(preferred);
+  });
+
+  it("accepts the provider default even when it is not repeated in its options", () => {
+    expect(selectDefaultModelSelection(
+      [{ ...codex, models: { default: "codex-default", options: [] } }],
+      { instanceId: "codex", model: "codex-default" },
+    )).toEqual({ instanceId: "codex", model: "codex-default" });
+  });
+
+  it.each([
+    { label: "missing provider", instances: [claude] },
+    { label: "unavailable provider", instances: [claude, { ...codex, snapshot: { state: "unavailable" as const } }] },
+    { label: "signed-out provider", instances: [claude, { ...codex, snapshot: { state: "available" as const, authenticated: false } }] },
+    { label: "removed model", instances: [claude, { ...codex, models: { default: "new-model", options: [] } }] },
+  ])("returns setup for a saved $label without changing provider", ({ instances }) => {
+    expect(selectDefaultModelSelection(instances, { instanceId: "codex", model: "selected-model" }))
+      .toEqual({ instanceId: "", model: "" });
+  });
+
+  it("keeps the existing Claude preference when no default was saved", () => {
+    expect(selectDefaultModelSelection([codex, claude])).toEqual({ instanceId: "claude", model: "claude-default" });
+    expect(selectDefaultModelSelection([codex])).toEqual({ instanceId: "codex", model: "codex-default" });
+    expect(selectDefaultModelSelection([])).toEqual({ instanceId: "", model: "" });
+  });
+});

--- a/server/default-model-selection.ts
+++ b/server/default-model-selection.ts
@@ -1,0 +1,30 @@
+import type { ModelCatalog, ModelSelection, ProviderSnapshot } from "./contracts.ts";
+
+interface SelectableInstance {
+  instanceId: string;
+  driverKind: string;
+  snapshot: ProviderSnapshot;
+  models: ModelCatalog;
+}
+
+/** A saved choice is intentional: an unavailable provider or removed model
+ * sends new bots to setup instead of silently changing their provider. */
+export function selectDefaultModelSelection(
+  instances: readonly SelectableInstance[],
+  preferred?: ModelSelection,
+): ModelSelection {
+  if (preferred) {
+    const instance = instances.find((candidate) => candidate.instanceId === preferred.instanceId);
+    if (
+      instance?.snapshot.state !== "available" ||
+      instance.snapshot.authenticated === false ||
+      !(instance.models.default === preferred.model || instance.models.options.some((model) => model.id === preferred.model))
+    ) {
+      return { instanceId: "", model: "" };
+    }
+    return { ...preferred };
+  }
+  const available = instances.filter((instance) => instance.snapshot.state === "available");
+  const pick = available.find((instance) => instance.driverKind === "claudeAgent") ?? available[0];
+  return { instanceId: pick?.instanceId ?? "", model: pick?.models.default ?? "" };
+}

--- a/server/drivers/openai-compat.test.ts
+++ b/server/drivers/openai-compat.test.ts
@@ -40,6 +40,19 @@ describe("OpenAICompatDriver", () => {
     expect(cfg.apiKeyEnv).toBe("GROQ_KEY");
   });
 
+  it("allows an isolated connection to disable an inherited OpenRouter provider pin", () => {
+    const before = process.env.OPENAI_COMPAT_PROVIDER;
+    process.env.OPENAI_COMPAT_PROVIDER = "fixture-upstream";
+    try {
+      expect(OpenAICompatDriver.decodeConfig({}).provider).toBe("fixture-upstream");
+      expect(OpenAICompatDriver.decodeConfig({ provider: "" }).provider).toBeUndefined();
+      expect(OpenAICompatDriver.decodeConfig({ provider: "another-upstream" }).provider).toBe("another-upstream");
+    } finally {
+      if (before === undefined) delete process.env.OPENAI_COMPAT_PROVIDER;
+      else process.env.OPENAI_COMPAT_PROVIDER = before;
+    }
+  });
+
   it("reports unavailable without an API key", async () => {
     const inst = await OpenAICompatDriver.create({
       instanceId: "test-1",

--- a/server/drivers/openai-compat.ts
+++ b/server/drivers/openai-compat.ts
@@ -42,8 +42,10 @@ function decodeConfig(raw: unknown): OpenAICompatConfig {
     model: typeof config.model === "string" && config.model
       ? config.model
       : process.env.OPENAI_COMPAT_MODEL || undefined,
-    provider: typeof config.provider === "string" && config.provider
-      ? config.provider
+    // An explicit empty override disables inherited routing for an isolated
+    // connection (CLI setup uses this). Absent still inherits the global pin.
+    provider: typeof config.provider === "string"
+      ? config.provider || undefined
       : process.env.OPENAI_COMPAT_PROVIDER || undefined,
   };
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -7619,7 +7619,7 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
           : "this server has no public address to put in a link: set OMB_PUBLIC_URL, or open /pair on the address you use and type the code",
       });
     }
-    if (method === "GET" && path === "/api/auth/pairing") return json(res, 200, { pairings: sessions.openPairings() });
+    if (method === "GET" && path === "/api/auth/pairing") return json(res, 200, { pairings: sessions.openPairings(), publicUrl: PUBLIC_URL });
     m = path.match(/^\/api\/auth\/pairing\/([\w-]+)$/);
     if (m && method === "DELETE") {
       const cancelled = sessions.cancelPairing(m[1]);

--- a/server/index.ts
+++ b/server/index.ts
@@ -183,6 +183,7 @@ import {
 } from "./send-idempotency.ts";
 import { EventBus } from "./harness/bus.ts";
 import { ProviderRegistry } from "./harness/registry.ts";
+import { selectDefaultModelSelection } from "./default-model-selection.ts";
 import { cancelPeerApprovalsFor, cancelPeerApprovalsForThread, dismissStalePeerCards, requestPeerApproval, resolvePeerComms, type ApprovalBus } from "./peer-approval.ts";
 import { peerProvenanceNote, withPeerProvenance } from "./peer-provenance.ts";
 import { decideRoomPost, emptyRoomPostBudget, type RoomPostAttempt, type RoomPostBudget } from "./room-post-budget.ts";
@@ -951,17 +952,9 @@ function askBotAndWait(targetBotId: string, message: string, depth: number, from
   });
 }
 
-// default selection for new bots: first available instance, claude preferred
+// New bots honor setup's saved choice; unconfigured workspaces prefer Claude.
 async function defaultSelection() {
-  const described = await registry.describe();
-  const available = described.filter((d) => d.snapshot.state === "available");
-  // Deliberately NO fallback to described[0]. Handing a bot an engine whose
-  // CLI isn't installed makes it look ready and then fail on send with a raw
-  // spawn ENOENT — the single worst first-run experience, and the one every
-  // user with no CLIs used to get. An empty selection is honest: the UI shows
-  // the setup path instead of a bot that cannot answer.
-  const pick = available.find((d) => d.driverKind === "claudeAgent") ?? available[0];
-  return { instanceId: pick?.instanceId ?? "", model: pick?.models.default ?? "" };
+  return selectDefaultModelSelection(await registry.describe(), cfg.defaultModelSelection);
 }
 
 function checkedModelSelection(

--- a/server/remote-sessions.test.ts
+++ b/server/remote-sessions.test.ts
@@ -156,6 +156,7 @@ describe("pairing", () => {
     expect(opened.hint).toBeNull();
     const listed = await call("/api/auth/pairing");
     expect(listed.body.pairings.length).toBeGreaterThanOrEqual(1);
+    expect(listed.body.publicUrl).toBe(PUBLIC_URL);
   });
 
   it("refuses to mint or list codes from a client-only session", async () => {


### PR DESCRIPTION
## Summary

Make `openmausbot` a guided first launch and a familiar one-command startup afterward, using Clack arrow-key prompts. Prepare version 0.1.62 for the existing gated release pipeline.

- Choose ChatGPT/Codex, Claude Code, an existing connection, or a compatible API service; sign in or enter a masked key, choose a model, and save safely.
- Keep existing bots, model choices and conversations. The selected default applies to new bots only.
- Offer optional phone setup, defaulting to Skip. Ask before enabling a managed public HTTPS endpoint or Tailscale serving.
- Verify the HTTPS endpoint belongs to this workspace before minting a client-only invitation. Show a terminal QR, manual code/link and five-minute single-use expiry.
- Reuse saved launch choices, reopen an already-running matching workspace, keep foreground output readable with private logs, and clean up owned serving processes on cancellation.
- Preserve noninteractive `serve` and explicit legacy pairing commands. Document Android's current web-app pairing path and subscription/API billing differences.
- Keep the canonical-only npm tarball separate from desktop updater mirroring, eliminating the publication race while preserving every desktop asset/feed/digest gate.

## Verification

- 323 targeted tests across 9 suites passed, including secret masking, cancellation, persistence, route precedence, pairing scope and startup cleanup.
- 24 additional default-model and compatible-driver tests passed. Release mirror workflow passed YAML/shell parsing and all 19 synthetic inventory/hash/race cases.
- Full typecheck, UI build, scoped lint, server bundle and npm assembly passed.
- Packaged smoke: starts without node_modules; all 9 spawned helper paths resolve; MCP output flushes correctly.
- Real terminal in an isolated fake-engine fixture: select provider/model, save, skip phone, start, chat, stop, change default, restart. Existing bot retained its old model and transcript; new bot used the newly selected model and completed a turn.
- Packaged terminal rendered a QR/manual code/expiry, and Ctrl-C restored the cursor with the configuration byte-for-byte unchanged.

No live user data or provider accounts were used. Physical-phone/public-HTTPS end-to-end pairing has not been tested in this change; endpoint checks and pairing protocol are covered with isolated/mocked fixtures. Android native scanning uses a separate protocol, so this flow explicitly opens the web app.

## Release

Merging this version bump triggers the existing multi-platform Release workflow to assemble and verify the 0.1.62 draft. Publish only after its signing, packaged-server, updater-feed and asset gates succeed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guided first-run setup for AI provider, authentication, model selection, and optional phone access.
  * The default CLI command now starts onboarding, with support for `start`, `setup`, local access, tunnels, Tailscale, and custom public URLs.
  * Added iPhone/iPad and Android pairing guidance with endpoint verification.
  * Added support for OpenAI-compatible API connections, including model discovery and connection verification.

* **Documentation**
  * Updated installation, self-hosting, VPS, and CLI guides with the new onboarding and command flows.

* **Improvements**
  * Saved startup preferences can be reused for subsequent launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->