### PR TITLE
fix(settings): Close settings X works after editing SOUL.md

### DIFF
--- a/src/components/BotSettingsDialog.tsx
+++ b/src/components/BotSettingsDialog.tsx
@@ -190,7 +190,11 @@ export function BotSettingsDialog({ bot }: { bot: Bot }) {
       // review, the model picker's popover, a computer warning) owns Escape
       // and Tab while it is up: Escape closes only that layer, and the focus
       // trap below must not pull focus back out of it.
-      if (dialog?.querySelector('[role="dialog"], [role="alertdialog"]')) return;
+      // Only a *visible* nested dialog owns Escape/Tab. A hidden or
+      // zero-size leftover (display:none, empty hit box) must not trap
+      // the settings dialog's own dismiss paths.
+      const nested = dialog?.querySelector<HTMLElement>('[role="dialog"], [role="alertdialog"]');
+      if (nested && nested.getClientRects().length > 0) return;
       // BotInstructionsDialog portals to document.body, so it is not in this
       // subtree: a key pressed with focus outside this dialog belongs to
       // whatever holds focus, never to us.
@@ -293,21 +297,27 @@ export function BotSettingsDialog({ bot }: { bot: Bot }) {
           </div>
         </nav>
 
-        <div className="flex min-w-0 flex-1 flex-col">
-          <div className="flex items-center justify-between px-5 py-3">
+        {/* min-h-0 on the column + scroller, shrink-0 on the header: same
+            flex overflow trap the nav already documents. Soul's tall
+            textarea (and the drift banner) can otherwise shrink the
+            header's hit box to nothing while the X icon still paints —
+            clicks miss the button and only the outer backdrop dismisses. */}
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+          <div className="flex shrink-0 items-center justify-between px-5 py-3">
             <span className="text-[15px] font-semibold text-ink">
               {BOT_SECTIONS.find((s) => s.id === section)?.label}
             </span>
             <button
+              type="button"
               onClick={() => dispatch({ type: "toggleSettings", open: false })}
               aria-label="Close settings"
               className="rounded-md p-1 text-ink-secondary hover:bg-control hover:text-ink"
             >
-              <X size={18} />
+              <X size={18} className="pointer-events-none" />
             </button>
           </div>
 
-          <div className="flex flex-1 flex-col gap-4 overflow-y-auto px-5 pb-5">
+          <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-5 pb-5">
             {section === "overview" &&
               (overview === null && overviewError ? (
                 <div className="rounded-xl bg-card p-4 text-[13px] text-ink-secondary">Couldn’t load the overview.</div>


### PR DESCRIPTION
## Summary
- Fixes the Bot Settings dialog Close settings (X) button becoming unclickable after editing SOUL.md (#845).
- Root cause: the right-hand header lacked `shrink-0` and the section scroller lacked `min-h-0`, so Soul's tall textarea could flex-shrink the header hit box while the X icon still painted — clicks missed the button; the outer backdrop still dismissed.
- Also only yield Escape/Tab to *visible* nested dialogs, matching the existing focusable filter.

## Test plan
- [ ] Open a bot's Settings dialog → Soul
- [ ] Edit the SOUL.md textarea (add several lines)
- [ ] Click the dialog's top-right Close settings (X) — dialog should close
- [ ] Re-open, edit again, press Escape — dialog should close
- [ ] With a nested dialog open (e.g. skill review), Escape should still close only the nested layer

Fixes https://github.com/milind-soni/OpenMausBot/issues/845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Escape and Tab interactions now work correctly when nested dialogs are hidden or have no visible area.
  * Prevented tall text areas and notification banners from shrinking the settings header.
  * Improved close-button behavior within the settings dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->