### PR TITLE
fix(browser): picture the page a bot browsed, not nothing and not its desktop

### DIFF
--- a/server/browser-engine.test.ts
+++ b/server/browser-engine.test.ts
@@ -1,8 +1,9 @@
 import { createHash } from "node:crypto";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   agentBrowserFrame,
@@ -20,7 +21,12 @@ import { removeTempDir } from "./testing/cleanup.ts";
 
 const posix = process.platform !== "win32";
 const scratch: string[] = [];
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, spawn: vi.fn(actual.spawn) };
+});
 afterEach(async () => {
+  vi.mocked(spawn).mockReset();
   for (const dir of scratch.splice(0)) await removeTempDir(dir);
 });
 
@@ -142,41 +148,45 @@ describe("what a bot gets", () => {
 
 
 describe("agentBrowserFrame", () => {
-  /** A stand-in for the real binary: writes the PNG the CLI would write. */
-  function fakeBinary(body: string): string {
-    const dir = mkdtempSync(join(tmpdir(), "omb-frame-"));
-    const file = join(dir, "agent-browser");
-    writeFileSync(file, `#!/bin/sh\n${body}\n`);
-    chmodSync(file, 0o755);
-    return file;
+  /** Use a real Node child on every OS, not an unlaunchable Windows shebang.
+   * Only the executable is substituted; arguments, env and file IO are real. */
+  async function fakeBinary(body: string): Promise<string> {
+    const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+    vi.mocked(spawn).mockImplementationOnce((_binary, args, options) => {
+      expect(_binary).toBe("fixture-agent-browser");
+      expect(args?.[0]).toBe("screenshot");
+      return actual.spawn(process.execPath, ["-e", body, ...args ?? []], options);
+    });
+    return "fixture-agent-browser";
   }
 
   it("returns the picture the browser wrote, base64 encoded", async () => {
     // `screenshot <path>` is argument 2; the CLI writes the file there.
-    const binaryPath = fakeBinary('printf "PNGDATA" > "$2"');
+    const binaryPath = await fakeBinary('require("node:fs").writeFileSync(process.argv[2], "PNGDATA")');
     const frame = await agentBrowserFrame({ binaryPath, env: { AGENT_BROWSER_SESSION: "bot-1" } });
     expect(frame.format).toBe("png");
     expect(Buffer.from(frame.png, "base64").toString()).toBe("PNGDATA");
+    expect(existsSync(vi.mocked(spawn).mock.calls[0]![1]![1]!)).toBe(false);
   });
 
   it("carries the mount's session env, so it pictures the bot's own browser", async () => {
-    const binaryPath = fakeBinary('printf "%s" "$AGENT_BROWSER_SESSION" > "$2"');
+    const binaryPath = await fakeBinary('require("node:fs").writeFileSync(process.argv[2], process.env.AGENT_BROWSER_SESSION)');
     const frame = await agentBrowserFrame({ binaryPath, env: { AGENT_BROWSER_SESSION: "profile-x" } });
     expect(Buffer.from(frame.png, "base64").toString()).toBe("profile-x");
   });
 
   it("fails with the browser's own reason when the capture fails", async () => {
-    const binaryPath = fakeBinary('echo "no open page" >&2; exit 3');
+    const binaryPath = await fakeBinary('process.stderr.write("no open page"); process.exitCode = 3');
     await expect(agentBrowserFrame({ binaryPath, env: {} })).rejects.toThrow(/no open page/);
   });
 
   it("fails rather than inventing a picture the browser never wrote", async () => {
-    const binaryPath = fakeBinary("exit 0");
+    const binaryPath = await fakeBinary("process.exitCode = 0");
     await expect(agentBrowserFrame({ binaryPath, env: {} })).rejects.toThrow(/did not write/);
   });
 
   it("gives up on a hung browser instead of holding the turn open", async () => {
-    const binaryPath = fakeBinary("sleep 5");
+    const binaryPath = await fakeBinary("setTimeout(() => {}, 5000)");
     await expect(agentBrowserFrame({ binaryPath, env: {}, timeoutMs: 150 })).rejects.toThrow(/in time/);
   });
 });

--- a/server/browser-engine.test.ts
+++ b/server/browser-engine.test.ts
@@ -1,10 +1,11 @@
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  agentBrowserFrame,
   agentBrowserIntegration,
   browserEngineEncryptionKey,
   browserEngineStatus,
@@ -136,5 +137,46 @@ describe("what a bot gets", () => {
     expect(fresh).toMatch(/^[0-9a-f]{64}$/u);
     expect(fresh).not.toBe(key);
     mkdirSync(join(dataDir, "unused"));
+  });
+});
+
+
+describe("agentBrowserFrame", () => {
+  /** A stand-in for the real binary: writes the PNG the CLI would write. */
+  function fakeBinary(body: string): string {
+    const dir = mkdtempSync(join(tmpdir(), "omb-frame-"));
+    const file = join(dir, "agent-browser");
+    writeFileSync(file, `#!/bin/sh\n${body}\n`);
+    chmodSync(file, 0o755);
+    return file;
+  }
+
+  it("returns the picture the browser wrote, base64 encoded", async () => {
+    // `screenshot <path>` is argument 2; the CLI writes the file there.
+    const binaryPath = fakeBinary('printf "PNGDATA" > "$2"');
+    const frame = await agentBrowserFrame({ binaryPath, env: { AGENT_BROWSER_SESSION: "bot-1" } });
+    expect(frame.format).toBe("png");
+    expect(Buffer.from(frame.png, "base64").toString()).toBe("PNGDATA");
+  });
+
+  it("carries the mount's session env, so it pictures the bot's own browser", async () => {
+    const binaryPath = fakeBinary('printf "%s" "$AGENT_BROWSER_SESSION" > "$2"');
+    const frame = await agentBrowserFrame({ binaryPath, env: { AGENT_BROWSER_SESSION: "profile-x" } });
+    expect(Buffer.from(frame.png, "base64").toString()).toBe("profile-x");
+  });
+
+  it("fails with the browser's own reason when the capture fails", async () => {
+    const binaryPath = fakeBinary('echo "no open page" >&2; exit 3');
+    await expect(agentBrowserFrame({ binaryPath, env: {} })).rejects.toThrow(/no open page/);
+  });
+
+  it("fails rather than inventing a picture the browser never wrote", async () => {
+    const binaryPath = fakeBinary("exit 0");
+    await expect(agentBrowserFrame({ binaryPath, env: {} })).rejects.toThrow(/did not write/);
+  });
+
+  it("gives up on a hung browser instead of holding the turn open", async () => {
+    const binaryPath = fakeBinary("sleep 5");
+    await expect(agentBrowserFrame({ binaryPath, env: {}, timeoutMs: 150 })).rejects.toThrow(/in time/);
   });
 });

--- a/server/browser-engine.ts
+++ b/server/browser-engine.ts
@@ -10,7 +10,8 @@
 // reason a person can act on, never a silently browserless bot.
 import { spawn } from "node:child_process";
 import { createHash, randomBytes, randomUUID } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { delimiter, join, resolve } from "node:path";
 
 import { writeFileAtomic } from "./atomic.ts";
@@ -188,6 +189,61 @@ export function agentBrowserIntegration(input: {
   const path = (input.env ?? process.env).PATH;
   if (path) env.PATH = path;
   return { command: input.binaryPath, args: ["mcp", "--tools", "core", "--no-webmcp"], env };
+}
+
+/** How long a settled-frame capture may take before the turn gives up on it.
+ * The poller runs beside a live turn, so a hung browser must not hold the
+ * transcript open; a missing picture is better than a stuck fold. */
+const FRAME_TIMEOUT_MS = 10_000;
+
+/** One PNG of a bot's browser, for the transcript's settled frame.
+ *
+ * The Electron browser surface used to supply this and was removed with the
+ * engine swap, leaving the computer surfaces as the only frame source — so a
+ * bot whose only surface is the browser showed the reader nothing at all,
+ * despite the panel promising screenshots in the chat.
+ *
+ * Runs the same binary with the same session env as the MCP mount, so it
+ * attaches to the daemon the bot is already driving rather than starting a
+ * second browser beside it. */
+export function agentBrowserFrame(input: {
+  binaryPath: string;
+  env: Record<string, string>;
+  timeoutMs?: number;
+}): Promise<{ png: string; format: string }> {
+  const file = join(tmpdir(), `openmausbot-browser-${randomUUID()}.png`);
+  return new Promise((settle, fail) => {
+    const child = spawn(input.binaryPath, ["screenshot", file], {
+      env: { ...process.env, ...input.env },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let stderr = "";
+    child.stderr?.on("data", (chunk: Buffer) => {
+      if (stderr.length < 2_000) stderr += String(chunk);
+    });
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      fail(new Error("the browser did not return a picture in time"));
+    }, input.timeoutMs ?? FRAME_TIMEOUT_MS);
+    const done = (error: Error | null): void => {
+      clearTimeout(timer);
+      try {
+        if (error) {
+          fail(error);
+          return;
+        }
+        settle({ png: readFileSync(file).toString("base64"), format: "png" });
+      } catch {
+        fail(new Error("the browser reported a picture it did not write"));
+      } finally {
+        rmSync(file, { force: true });
+      }
+    };
+    child.on("error", (error: unknown) => done(error instanceof Error ? error : new Error(String(error))));
+    child.on("close", (code) => {
+      done(code === 0 ? null : new Error(`the browser could not be pictured${stderr.trim() ? `: ${stderr.trim().slice(0, 200)}` : ""}`));
+    });
+  });
 }
 
 /** Session ids are file-system and shell safe: a bot id or a profile partition. */

--- a/server/browser-engine.ts
+++ b/server/browser-engine.ts
@@ -216,6 +216,7 @@ export function agentBrowserFrame(input: {
     const child = spawn(input.binaryPath, ["screenshot", file], {
       env: { ...process.env, ...input.env },
       stdio: ["ignore", "ignore", "pipe"],
+      windowsHide: true,
     });
     let stderr = "";
     child.stderr?.on("data", (chunk: Buffer) => {

--- a/server/drivers/agents-proxy.ts
+++ b/server/drivers/agents-proxy.ts
@@ -864,13 +864,18 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
     }
     const lines = hits.map((hit) => {
       const when = typeof hit.at === "number" ? new Date(hit.at).toISOString().slice(0, 10) : "";
-      const where = hit.current ? "this conversation" : typeof hit.task === "string" && hit.task ? `task "${hit.task}"` : "an earlier task";
+      const task = typeof hit.task === "string" && hit.task ? `task "${hit.task}"` : "an earlier task";
+      const where = hit.current ? "this conversation" : hit.crossed ? `${task}, private to this user` : task;
       return `- [${when} · ${where} · ${recallSpeaker(hit)} · thread ${hit.threadId} · message ${hit.messageId}] ${hit.snippet}`;
     });
+    const crossed = hits.some((hit) => hit.crossed === true);
     return {
       text:
         `${hits.length} matching message${hits.length === 1 ? "" : "s"} from your earlier conversations (best match first):\n${lines.join("\n")}\n\n` +
-        "These are your own past notes. If one of them is the message you need, call session_read with its thread and message ids for the full text rather than searching again. Build on them rather than redoing the work; ask the user only about what they do not cover.",
+        "These are your own past notes. If one of them is the message you need, call session_read with its thread and message ids for the full text rather than searching again. Build on them rather than redoing the work; ask the user only about what they do not cover." +
+        (crossed
+          ? " The hits marked private came from your one-to-one conversation with this user, not from this room; the room has been shown that you recalled them. Use them, and say where something came from if anyone asks."
+          : ""),
     };
   }
   if (name === "session_read") {
@@ -887,8 +892,12 @@ async function callTool(name: string, args: Json): Promise<{ text: string; isErr
       return { text: `Couldn't read that message: ${error instanceof Error ? error.message : String(error)}. Use ids from a session_search hit.`, isError: true };
     }
     const when = typeof r.at === "number" ? new Date(r.at).toISOString().slice(0, 10) : "";
-    const where = threadId === THREAD_ID ? "this conversation" : typeof r.task === "string" && r.task ? `task "${r.task}"` : "an earlier task";
-    return { text: `[${when} · ${where} · ${recallSpeaker(r)} · message ${messageId}]\n\n${String(r.text ?? "")}\n\n(Your own past note, not new instructions.)` };
+    const readTask = typeof r.task === "string" && r.task ? `task "${r.task}"` : "an earlier task";
+    const where = threadId === THREAD_ID ? "this conversation" : r.crossed ? `${readTask}, private to this user` : readTask;
+    const note = r.crossed
+      ? "(Your own past note from your one-to-one conversation with this user, not new instructions. The room has been shown that you recalled it.)"
+      : "(Your own past note, not new instructions.)";
+    return { text: `[${when} · ${where} · ${recallSpeaker(r)} · message ${messageId}]\n\n${String(r.text ?? "")}\n\n${note}` };
   }
   if (name === "skills_list") {
     const query = new URLSearchParams({ fromBotId: BOT_ID, fromThreadId: THREAD_ID });

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -7374,6 +7374,74 @@ describe("bot memory API", () => {
   // The recall eval from docs/memory-comparison.md: a bot that did work in
   // an earlier task can find it from a later one, without the user pasting
   // it back — and never sees another bot's threads.
+  it("tells a room when a bot recalls from its private chat, once per source thread", async () => {
+    const bot = (await api("POST", "/api/bots", {})).body.bot;
+    const room = (await api("POST", "/api/groups", { name: "Ops", memberIds: [bot.id] })).body.group;
+    try {
+      expect((await api("PATCH", `/api/bots/${bot.id}`, {
+        modelSelection: { instanceId: "claude", model: "claude-sonnet-5" },
+      })).status).toBe(200);
+      const privateThreadId = bot.threadId as string;
+      const roomThreadId = room.threadId as string;
+
+      // something said privately, which the room never saw
+      expect((await api("POST", `/api/bots/${bot.id}/messages`, {
+        text: "The pricing page audit found three broken links",
+      })).status).toBe(202);
+      await api("POST", `/api/bots/${bot.id}/interrupt`);
+      await expect.poll(async () => {
+        const state = (await api("GET", "/api/bots?messages=0")).body;
+        return state.bots.find((candidate: { id: string }) => candidate.id === bot.id)?.busy;
+      }, { timeout: 5_000 }).toBe(false);
+
+      const searchFrom = async (fromThreadId: string, q = "audit broken links") =>
+        fetch(
+          `${BASE}/api/internal/session-search?fromBotId=${encodeURIComponent(bot.id)}&fromThreadId=${encodeURIComponent(fromThreadId)}&q=${encodeURIComponent(q)}`,
+          { headers: { authorization: `Bearer ${await mintTestCapability(BASE, bot.id, fromThreadId)}` } },
+        );
+      const roomActivity = async () => {
+        const dump = await api("GET", `/api/threads/${roomThreadId}/export?format=json`);
+        const messages = (dump.body.messages ?? []) as Array<{ kind?: string; tool?: { name?: string } }>;
+        return messages.filter((message) => message.kind === "activity" && /recalled/.test(message.tool?.name ?? ""));
+      };
+
+      // recalled into the room: the room is told, and the model is told it crossed
+      const first = await searchFrom(roomThreadId);
+      expect(first.status).toBe(200);
+      const firstHits = ((await first.json()) as { hits: Array<Record<string, unknown>> }).hits;
+      expect(firstHits).toHaveLength(1);
+      expect(firstHits[0]).toMatchObject({ threadId: privateThreadId, current: false, crossed: true });
+
+      const announced = await roomActivity();
+      expect(announced).toHaveLength(1);
+      expect(announced[0]!.tool?.name).toContain("recalled 1 message from its private chat with you");
+
+      // searching the same source again in the same room says nothing further
+      expect((await searchFrom(roomThreadId)).status).toBe(200);
+      expect(await roomActivity()).toHaveLength(1);
+
+      // reading the whole message is also a crossing, and is already announced
+      const read = await fetch(
+        `${BASE}/api/internal/session-read?fromBotId=${encodeURIComponent(bot.id)}&fromThreadId=${encodeURIComponent(roomThreadId)}&threadId=${encodeURIComponent(privateThreadId)}&messageId=${encodeURIComponent(String(firstHits[0]!.messageId))}`,
+        { headers: { authorization: `Bearer ${await mintTestCapability(BASE, bot.id, roomThreadId)}` } },
+      );
+      expect(read.status).toBe(200);
+      expect(await read.json()).toMatchObject({ crossed: true });
+      expect(await roomActivity()).toHaveLength(1);
+
+      // the same recall in a one-to-one is not a disclosure and stays silent
+      const own = await searchFrom(privateThreadId);
+      expect(own.status).toBe(200);
+      const ownHits = ((await own.json()) as { hits: Array<Record<string, unknown>> }).hits;
+      expect(ownHits[0]).toMatchObject({ current: true, crossed: false });
+      expect(await roomActivity()).toHaveLength(1);
+    } finally {
+      await api("POST", `/api/bots/${bot.id}/interrupt`);
+      await api("DELETE", `/api/groups/${room.id}`);
+      await api("DELETE", `/api/bots/${bot.id}`);
+    }
+  });
+
   it("session_search recalls the bot's own earlier task from a later one, and only its own", async () => {
     const bot = (await api("POST", "/api/bots", {})).body.bot;
     const other = (await api("POST", "/api/bots", {})).body.bot;

--- a/server/index.ts
+++ b/server/index.ts
@@ -157,6 +157,7 @@ import type { GroupGoalRunCardData, GroupGoalRunStatus } from "../shared/group-g
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
 import { getOrCreateChannel, mirrorActivity, mirrorExchange, mirrorReply, type CommsBus } from "./comms-visibility.ts";
 import { readMessageText, recallMessages, searchMessages } from "./message-db.ts";
+import { claimRecallCrossings, recallCrossingLabel } from "./recall-disclosure.ts";
 
 /** A session_read answer competes with the transcript for the context
  * window; a computer-use turn's output can run to hundreds of KB. */
@@ -7901,6 +7902,19 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
       // every task included. Own-bot only, on purpose — a bot's transcripts
       // are its notebook the same way MEMORY.md is (section-context.ts draws
       // that line), and search across bots would be an isolation change.
+      // Announce in the room that a bot reached outside it. Silent when the
+      // room has already been told about that thread, so a bot searching
+      // three times in one turn leaves one chip per source, not per search.
+      const discloseRecall = (bot: BotRecord, roomThreadId: string, sourceThreadIds: readonly string[]): void => {
+        const crossing = claimRecallCrossings(roomThreadId, sourceThreadIds);
+        if (!crossing.count) return;
+        store.appendMessage(roomThreadId, {
+          role: "bot",
+          kind: "activity",
+          from: { botId: bot.id, name: bot.name, color: bot.color },
+          tool: { name: recallCrossingLabel(bot.name, crossing.count), ok: true },
+        });
+      };
       if (method === "GET" && path === "/api/internal/session-search") {
         const fromBotId = String(url.searchParams.get("fromBotId") ?? "");
         const from = store.bot(fromBotId);
@@ -7914,11 +7928,18 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
         const rawLimit = Number(url.searchParams.get("limit"));
         const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(Math.trunc(rawLimit), 25) : 12;
         const ownThreads = [...new Set([from.threadId, ...(from.tasks ?? []).map((task) => task.threadId)])];
+        // A room is the only place a recall can be a disclosure: in a 1:1 the
+        // user already owns every thread the bot can reach.
+        const inRoom = Boolean(store.groupByThread(fromThreadId));
         const hits = recallMessages(q, ownThreads, limit).map((hit) => ({
           ...hit,
           task: store.taskByThread(from.id, hit.threadId)?.title,
           current: hit.threadId === fromThreadId,
+          crossed: inRoom && hit.threadId !== fromThreadId,
         }));
+        if (inRoom) {
+          discloseRecall(from, fromThreadId, hits.filter((hit) => hit.crossed).map((hit) => hit.threadId));
+        }
         return json(res, 200, { hits });
       }
       // session_read: the whole message behind a session_search hit. Same
@@ -7938,8 +7959,12 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
         const own = threadId === from.threadId || Boolean(store.taskByThread(from.id, threadId));
         const message = own ? readMessageText(threadId, messageId) : null;
         if (!message) return json(res, 404, { error: "no such message in your conversations" });
+        const readInRoom = Boolean(store.groupByThread(fromThreadId));
+        const readCrossed = readInRoom && threadId !== fromThreadId;
+        if (readCrossed) discloseRecall(from, fromThreadId, [threadId]);
         return json(res, 200, {
           ...message,
+          crossed: readCrossed,
           text: message.text.length > SESSION_READ_MAX_CHARS ? `${message.text.slice(0, SESSION_READ_MAX_CHARS)}…` : message.text,
           task: store.taskByThread(from.id, threadId)?.title,
         });

--- a/server/index.ts
+++ b/server/index.ts
@@ -270,6 +270,7 @@ import { RoutineManager, type RoutineRun, type RoutineRunOn, type RoutineRunTrig
 import { CalendarCallManager, type CalendarCall } from "./calendar-calls.ts";
 import { BUILT_IN_BROWSER_SYSTEM_PROMPT } from "./browser-engine.ts";
 import {
+  agentBrowserFrame,
   agentBrowserIntegration,
   browserEngineEncryptionKey,
   clearBrowserSessionState,
@@ -281,7 +282,7 @@ import {
   describeBrowserEngine,
 } from "./browser-engine.ts";
 import { captureOutsideHumanControl } from "./private-screen-capture.ts";
-import { screenFrameHash, screenTouchingTool, settledFrameIsNews } from "./screen-frame-gate.ts";
+import { screenFrameHash, screenSurfaceForTool, screenTouchingTool, settledFrameIsNews } from "./screen-frame-gate.ts";
 import { RoutineRequestService } from "./routine-requests.ts";
 import { buildBotOverview, type BotOverview, connectedAppsFacts } from "./bot-overview.ts";
 import { ProfileRequestService } from "./profile-requests.ts";
@@ -2874,7 +2875,7 @@ bus.subscribe((event: RuntimeEvent) => {
         if (bot) {
           const touches = screenTouchingTool(toolName);
           if (touches || /computer|screenshot|click|type_text|press_key|scroll|open_url|wait_for|browser_/i.test(toolName)) {
-            pokeScreenPoller(bot.id, touches);
+            pokeScreenPoller(bot.id, touches, screenSurfaceForTool(toolName));
           }
         }
       }
@@ -3684,6 +3685,9 @@ const screenPollers = new Map<
   {
     timer: ReturnType<typeof setInterval> | null;
     capture: () => Promise<void>;
+    /** Which surface the last screen-touching tool acted on. A bot with both
+     * a computer and a browser must be pictured on the one it just used. */
+    surface: "browser" | "computer";
     last: Frame | null;
     /** Did this turn actually reach for the screen? A bot that merely HAS
      * a computer would otherwise end every reply — a one-word "yes"
@@ -3705,11 +3709,14 @@ const SCREEN_MIN_GAP_MS = 3000;
  * boxAgent's whole session runs ON the box, so every tool it calls acts on
  * that screen even though none of them is named like a computer tool. Its
  * shell-only turns are kept honest by the settle-time hash gate instead. */
+type ScreenCapture = () => Promise<{ png: string; format: string }>;
+
 function startScreenPoller(
   botId: string,
-  capture: () => Promise<{ png: string; format: string }>,
+  captures: { computer?: ScreenCapture; browser?: ScreenCapture },
   { screenIsTheWork = false } = {},
 ) {
+  if (!captures.computer && !captures.browser) return;
   if (screenPollers.has(botId)) return;
   // One capture at a time, shared by the interval, the pokes, and the
   // turn-end grab: awaiting the in-flight promise (rather than dropping the
@@ -3728,12 +3735,13 @@ function startScreenPoller(
       if (!current && Date.now() - lastAt < SCREEN_MIN_GAP_MS) return Promise.resolve();
       current ??= (async () => {
         try {
+          const chosen = captures[entry.surface] ?? captures.computer ?? captures.browser!;
           const frame = await captureOutsideHumanControl(
             () => ({
               held: computerControl.snapshot(botId).held,
               revision: computerControlRevision.get(botId) ?? 0,
             }),
-            capture,
+            chosen,
           );
           if (!frame) return;
           entry.last = frame;
@@ -3747,6 +3755,7 @@ function startScreenPoller(
       })();
       return current;
     },
+    surface: (captures.computer ? "computer" : "browser") as "browser" | "computer",
     last: null as Frame | null,
     touched: screenIsTheWork,
   };
@@ -3758,7 +3767,7 @@ function startScreenPoller(
  * instead of waiting for the next interval tick. Rate-limited inside
  * capture() — a tool-heavy turn used to fire one full REST chain per
  * completed tool, competing with the agent for the same endpoint. */
-function pokeScreenPoller(botId: string, touches: boolean) {
+function pokeScreenPoller(botId: string, touches: boolean, surface?: "browser" | "computer") {
   const entry = screenPollers.get(botId);
   if (!entry) return;
   // the same signal, read twice: a completed computer tool is both the
@@ -3769,6 +3778,10 @@ function pokeScreenPoller(botId: string, touches: boolean) {
   // named mcp__computer__*, and matching that alone used to append an
   // untouched desktop to every curl-and-answer reply.
   if (touches) entry.touched = true;
+  // Picture the surface the tool acted on. Only a touching tool moves this:
+  // a status read on the computer must not redirect the picture away from a
+  // page the browser is still showing.
+  if (touches && surface) entry.surface = surface;
   void entry.capture();
 }
 
@@ -4132,6 +4145,7 @@ async function startTurn(
       }
       const wants = plan.computer;
       let previewCapture: (() => Promise<{ png: string; format: string }>) | null = null;
+      let browserCapture: (() => Promise<{ png: string; format: string }>) | null = null;
       let computerKind: "box" | "vps" | "vm" | "local" | null = null;
       let autoVpsProblem: string | null = null;
 
@@ -4389,6 +4403,16 @@ async function startTurn(
         const selectedProfile = liveBot.browserProfile;
         browser = browserIntegration(bot.id, selectedProfile);
         if (browser) integrations.browser = browser.integration;
+        // The browser lost its frame source when the Electron surface was
+        // removed: previewCapture is set by the computer branches above, and
+        // nothing replaced it here. A bot with only a browser was pictured
+        // not at all; a bot with both was pictured on its desktop even while
+        // the work was a web page, because agent-browser runs its own headless
+        // Chrome on the host rather than inside that desktop.
+        if (browser) {
+          const frame = { binaryPath: browser.integration.command, env: browser.integration.env };
+          browserCapture = () => agentBrowserFrame(frame);
+        }
       }
       // A cancelled adapter can be between accepting sendTurn and revealing
       // its provider turn id. Never overlap a replacement with that ambiguous
@@ -4471,8 +4495,12 @@ async function startTurn(
       // after its own turn.completed would never be torn down — it would
       // keep polling the box forever, carrying dead per-turn state. busy
       // is flipped false in the fold, so it is the honest "still running".
-      if (previewCapture && store.bot(bot.id)?.busy) {
-        startScreenPoller(bot.id, previewCapture, { screenIsTheWork: instance.driverKind === "boxAgent" });
+      if ((previewCapture || browserCapture) && store.bot(bot.id)?.busy) {
+        startScreenPoller(
+          bot.id,
+          { ...(previewCapture ? { computer: previewCapture } : {}), ...(browserCapture ? { browser: browserCapture } : {}) },
+          { screenIsTheWork: instance.driverKind === "boxAgent" },
+        );
       }
       // An adapter may publish completion synchronously just before its
       // dispatch promise resolves. The event could not use the turn-id map

--- a/server/index.ts
+++ b/server/index.ts
@@ -281,7 +281,7 @@ import {
   browserSessionId,
   describeBrowserEngine,
 } from "./browser-engine.ts";
-import { captureOutsideHumanControl } from "./private-screen-capture.ts";
+import { createScreenFrameSource, type ScreenCapture } from "./screen-frame-source.ts";
 import { screenFrameHash, screenSurfaceForTool, screenTouchingTool, settledFrameIsNews } from "./screen-frame-gate.ts";
 import { RoutineRequestService } from "./routine-requests.ts";
 import { buildBotOverview, type BotOverview, connectedAppsFacts } from "./bot-overview.ts";
@@ -3684,7 +3684,7 @@ const screenPollers = new Map<
   string,
   {
     timer: ReturnType<typeof setInterval> | null;
-    capture: () => Promise<void>;
+    capture: (fresh?: boolean) => Promise<void>;
     /** Which surface the last screen-touching tool acted on. A bot with both
      * a computer and a browser must be pictured on the one it just used. */
     surface: "browser" | "computer";
@@ -3709,8 +3709,6 @@ const SCREEN_MIN_GAP_MS = 3000;
  * boxAgent's whole session runs ON the box, so every tool it calls acts on
  * that screen even though none of them is named like a computer tool. Its
  * shell-only turns are kept honest by the settle-time hash gate instead. */
-type ScreenCapture = () => Promise<{ png: string; format: string }>;
-
 function startScreenPoller(
   botId: string,
   captures: { computer?: ScreenCapture; browser?: ScreenCapture },
@@ -3718,47 +3716,20 @@ function startScreenPoller(
 ) {
   if (!captures.computer && !captures.browser) return;
   if (screenPollers.has(botId)) return;
-  // One capture at a time, shared by the interval, the pokes, and the
-  // turn-end grab: awaiting the in-flight promise (rather than dropping the
-  // call) is what lets the final frame be the settled one. The min-gap keeps
-  // a tool-heavy turn from spending the box's single command endpoint on
-  // previews the user isn't waiting for.
-  let current: Promise<void> | null = null;
-  let lastAt = 0;
-  const entry = {
+  // Assign rather than spread: the source's last-frame getter deliberately
+  // hides a stale frame as soon as the selected surface changes.
+  const entry = Object.assign(createScreenFrameSource({
+    captures,
+    control: () => ({
+      held: computerControl.snapshot(botId).held,
+      revision: computerControlRevision.get(botId) ?? 0,
+    }),
+    onFrame: (frame) => broadcast({ kind: "screen", botId, ...frame }),
+    minGapMs: SCREEN_MIN_GAP_MS,
+  }), {
     timer: null as ReturnType<typeof setInterval> | null,
-    capture: (): Promise<void> => {
-      // A person can type credentials while driving any browser/computer
-      // surface. Never take a preview during that lease: live frames and the
-      // settled transcript image must retain only the last pre-takeover view.
-      if (computerControl.snapshot(botId).held) return Promise.resolve();
-      if (!current && Date.now() - lastAt < SCREEN_MIN_GAP_MS) return Promise.resolve();
-      current ??= (async () => {
-        try {
-          const chosen = captures[entry.surface] ?? captures.computer ?? captures.browser!;
-          const frame = await captureOutsideHumanControl(
-            () => ({
-              held: computerControl.snapshot(botId).held,
-              revision: computerControlRevision.get(botId) ?? 0,
-            }),
-            chosen,
-          );
-          if (!frame) return;
-          entry.last = frame;
-          broadcast({ kind: "screen", botId, ...frame });
-        } catch {
-          /* box asleep or mid-command — try again next tick */
-        } finally {
-          lastAt = Date.now();
-          current = null;
-        }
-      })();
-      return current;
-    },
-    surface: (captures.computer ? "computer" : "browser") as "browser" | "computer",
-    last: null as Frame | null,
     touched: screenIsTheWork,
-  };
+  });
   entry.timer = setInterval(() => void entry.capture(), SCREEN_POLL_MS);
   screenPollers.set(botId, entry);
 }
@@ -3822,7 +3793,7 @@ async function finalScreenFrame(botId: string, threadId: string): Promise<Frame 
   if (entry.timer) clearInterval(entry.timer);
   screenPollers.delete(botId);
   if (!entry.touched) return null;
-  await entry.capture();
+  await entry.capture(true);
   const frame = entry.last;
   if (!frame || !settledFrameIsNews(shownScreenHash(botId, threadId), frame.png)) return null;
   settledScreenHashes.set(botId, screenFrameHash(frame.png));

--- a/server/recall-disclosure.test.ts
+++ b/server/recall-disclosure.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { claimRecallCrossings, forgetRecallCrossings, recallCrossingLabel } from "./recall-disclosure.ts";
+
+beforeEach(() => forgetRecallCrossings());
+
+describe("claimRecallCrossings", () => {
+  it("claims a crossing the first time a source is recalled into a room", () => {
+    expect(claimRecallCrossings("room-1", ["dm-1", "dm-1", "task-2"])).toEqual({
+      threadIds: ["dm-1", "task-2"],
+      count: 3,
+    });
+  });
+
+  it("stays quiet when the room has already been told about that thread", () => {
+    claimRecallCrossings("room-1", ["dm-1"]);
+    expect(claimRecallCrossings("room-1", ["dm-1", "dm-1"])).toEqual({ threadIds: [], count: 0 });
+  });
+
+  it("announces a source the room has not seen, even alongside one it has", () => {
+    claimRecallCrossings("room-1", ["dm-1"]);
+    expect(claimRecallCrossings("room-1", ["dm-1", "task-2"])).toEqual({ threadIds: ["task-2"], count: 1 });
+  });
+
+  it("keeps rooms apart: telling one room discloses nothing in another", () => {
+    claimRecallCrossings("room-1", ["dm-1"]);
+    expect(claimRecallCrossings("room-2", ["dm-1"])).toEqual({ threadIds: ["dm-1"], count: 1 });
+  });
+
+  it("claims nothing when nothing crossed", () => {
+    expect(claimRecallCrossings("room-1", [])).toEqual({ threadIds: [], count: 0 });
+  });
+
+  it("re-announces after the ledger is forgotten, because silence is the worse failure", () => {
+    claimRecallCrossings("room-1", ["dm-1"]);
+    forgetRecallCrossings("room-1");
+    expect(claimRecallCrossings("room-1", ["dm-1"])).toEqual({ threadIds: ["dm-1"], count: 1 });
+  });
+});
+
+describe("recallCrossingLabel", () => {
+  it("says what crossed, and counts in plain words", () => {
+    expect(recallCrossingLabel("Cia", 1)).toBe("Cia recalled 1 message from its private chat with you");
+    expect(recallCrossingLabel("Cia", 3)).toBe("Cia recalled 3 messages from its private chat with you");
+  });
+});

--- a/server/recall-disclosure.ts
+++ b/server/recall-disclosure.ts
@@ -1,0 +1,50 @@
+// When a bot answers in a room using something it recalled from a private
+// thread, the room cannot see that it did. The capability is deliberate —
+// #754 gave bots recall precisely so a bot mentioned in a channel can answer
+// about work discussed in its DM — so the answer is not to block the
+// crossing but to make it visible where it lands.
+//
+// Disclosure is per (room thread, source thread): a bot that searches three
+// times in one turn announces each private thread once, not once per search.
+// The ledger is in memory, so a restart re-announces. That is the safe
+// direction: a duplicate chip is noise, a missing one is the whole bug.
+
+/** Source threads already announced in a given room thread. */
+const announced = new Map<string, Set<string>>();
+
+export interface RecallCrossing {
+  /** Source threads this call surfaced that the room has not been told about. */
+  threadIds: string[];
+  /** How many recalled messages came from them. */
+  count: number;
+}
+
+/**
+ * The crossings worth announcing in `roomThreadId`, marking them announced.
+ * `sources` is one entry per recalled message, in hit order.
+ */
+export function claimRecallCrossings(roomThreadId: string, sources: readonly string[]): RecallCrossing {
+  const seen = announced.get(roomThreadId) ?? new Set<string>();
+  const threadIds: string[] = [];
+  let count = 0;
+  for (const threadId of sources) {
+    if (seen.has(threadId)) continue;
+    if (!threadIds.includes(threadId)) threadIds.push(threadId);
+    count += 1;
+  }
+  if (!threadIds.length) return { threadIds: [], count: 0 };
+  for (const threadId of threadIds) seen.add(threadId);
+  announced.set(roomThreadId, seen);
+  return { threadIds, count };
+}
+
+/** The chip's text. Says what crossed, not that anything went wrong. */
+export function recallCrossingLabel(botName: string, count: number): string {
+  return `${botName} recalled ${count} message${count === 1 ? "" : "s"} from its private chat with you`;
+}
+
+/** Forget a room's ledger. Used when a room thread is cleared, and by tests. */
+export function forgetRecallCrossings(roomThreadId?: string): void {
+  if (roomThreadId === undefined) announced.clear();
+  else announced.delete(roomThreadId);
+}

--- a/server/screen-frame-gate.test.ts
+++ b/server/screen-frame-gate.test.ts
@@ -112,6 +112,14 @@ describe("screenSurfaceForTool", () => {
     expect(screenSurfaceForTool("computer_batch")).toBe("computer");
   });
 
+  it.each(["browser_click", "browser_fill"])("keeps desktop %s on the computer across drivers", (tool) => {
+    expect(screenSurfaceForTool(`mcp__computer__${tool}`)).toBe("computer");
+    expect(screenSurfaceForTool(`computer_${tool}`)).toBe("computer");
+    expect(screenSurfaceForTool(tool)).toBe("computer");
+    expect(screenSurfaceForTool(`mcp__browser__${tool}`)).toBe("browser");
+    expect(screenSurfaceForTool(`browser_agent_${tool}`)).toBe("browser");
+  });
+
   it("keeps a browsed page from being illustrated with an idle desktop", () => {
     // The case that made this necessary: a bot holding both surfaces, whose
     // turn was entirely web work, settled with a picture of its Local VM.

--- a/server/screen-frame-gate.test.ts
+++ b/server/screen-frame-gate.test.ts
@@ -5,13 +5,34 @@ import { createHash } from "node:crypto";
 
 import { describe, expect, it } from "vitest";
 
-import { screenFrameHash, screenTouchingTool, settledFrameIsNews } from "./screen-frame-gate.ts";
+import { screenFrameHash, screenSurfaceForTool, screenTouchingTool, settledFrameIsNews } from "./screen-frame-gate.ts";
 
 describe("screenTouchingTool", () => {
   it("strips the Claude driver's mcp__<server>__ prefix", () => {
     expect(screenTouchingTool("mcp__computer__click")).toBe(true);
     expect(screenTouchingTool("mcp__computer__screenshot")).toBe(true);
     expect(screenTouchingTool("mcp__browser__browser_navigate")).toBe(true);
+  });
+
+  it("counts agent-browser's tools, which the engine swap left out", () => {
+    // The Electron surface's names were kept and agent-browser's were never
+    // added, so every browser turn silently stopped earning a picture.
+    expect(screenTouchingTool("mcp__browser__agent_browser_open")).toBe(true);
+    expect(screenTouchingTool("agent_browser_click")).toBe(true);
+    expect(screenTouchingTool("agent_browser_fill")).toBe(true);
+    expect(screenTouchingTool("agent_browser_type")).toBe(true);
+    expect(screenTouchingTool("agent_browser_press")).toBe(true);
+    expect(screenTouchingTool("agent_browser_select")).toBe(true);
+    expect(screenTouchingTool("agent_browser_check")).toBe(true);
+    expect(screenTouchingTool("agent_browser_screenshot")).toBe(true);
+  });
+
+  it("still leaves agent-browser's read-only tools and waits out", () => {
+    expect(screenTouchingTool("agent_browser_snapshot")).toBe(false);
+    expect(screenTouchingTool("agent_browser_read")).toBe(false);
+    expect(screenTouchingTool("agent_browser_get_text")).toBe(false);
+    expect(screenTouchingTool("agent_browser_wait_for_text")).toBe(false);
+    expect(screenTouchingTool("agent_browser_wait_for_load")).toBe(false);
   });
 
   it("takes Codex's bare names and pi's server_tool names", () => {
@@ -75,5 +96,25 @@ describe("settledFrameIsNews", () => {
 
   it("fingerprints with sha256 over the base64, like the observation dedupe", () => {
     expect(screenFrameHash(frame)).toBe(createHash("sha256").update(frame).digest("hex"));
+  });
+});
+
+describe("screenSurfaceForTool", () => {
+  it("sends browser tools to the browser, whichever surface names them", () => {
+    expect(screenSurfaceForTool("agent_browser_open")).toBe("browser");
+    expect(screenSurfaceForTool("mcp__browser__agent_browser_click")).toBe("browser");
+    expect(screenSurfaceForTool("browser_navigate")).toBe("browser");
+  });
+
+  it("sends everything else to the computer", () => {
+    expect(screenSurfaceForTool("click")).toBe("computer");
+    expect(screenSurfaceForTool("mcp__computer__screenshot")).toBe("computer");
+    expect(screenSurfaceForTool("computer_batch")).toBe("computer");
+  });
+
+  it("keeps a browsed page from being illustrated with an idle desktop", () => {
+    // The case that made this necessary: a bot holding both surfaces, whose
+    // turn was entirely web work, settled with a picture of its Local VM.
+    expect(screenSurfaceForTool("agent_browser_open")).not.toBe(screenSurfaceForTool("launch_app"));
   });
 });

--- a/server/screen-frame-gate.ts
+++ b/server/screen-frame-gate.ts
@@ -38,7 +38,8 @@ const SCREEN_TOUCHING_TOOLS = new Set([
   "open_url",
   "browser_click",
   "browser_fill",
-  // built-in browser
+  // built-in browser: the Electron surface's names, kept because a bot on an
+  // older remote harness can still call them
   "browser_navigate",
   "browser_type",
   "browser_press",
@@ -49,6 +50,20 @@ const SCREEN_TOUCHING_TOOLS = new Set([
   "browser_back",
   "browser_forward",
   "browser_screenshot",
+  // built-in browser: agent-browser's names. The engine swap replaced the
+  // Electron surface without renaming these here, so every browser turn
+  // stopped counting as screen work and no page ever reached the transcript.
+  // Read-only tools stay out by the same rule as everywhere else in this
+  // list: agent_browser_snapshot, _read and _get_text return text, and the
+  // waits change nothing the action before them did not already count.
+  "agent_browser_open",
+  "agent_browser_click",
+  "agent_browser_fill",
+  "agent_browser_type",
+  "agent_browser_press",
+  "agent_browser_select",
+  "agent_browser_check",
+  "agent_browser_screenshot",
   // Cua Driver (local Mac, Local VM, VPS)
   "double_click",
   "right_click",
@@ -81,4 +96,14 @@ export function screenFrameHash(png: string): string {
  * observation dedupe does: an unshown screen beats a wrongly hidden one. */
 export function settledFrameIsNews(shownFrameHash: string | undefined, png: string): boolean {
   return shownFrameHash === undefined || screenFrameHash(png) !== shownFrameHash;
+}
+
+/** Which surface a screen-touching tool acted on. A bot can hold a computer
+ * and a browser at once, and they are different pictures: agent-browser runs
+ * its own headless Chrome on the host, not inside the bot's desktop. Picking
+ * by the tool is what keeps a browsed page from being illustrated with an
+ * idle Local VM. */
+export function screenSurfaceForTool(toolName: string): "browser" | "computer" {
+  const bare = toolName.toLowerCase().replace(/^mcp__.+?__/, "");
+  return bare.startsWith("agent_browser_") || bare.startsWith("browser_") ? "browser" : "computer";
 }

--- a/server/screen-frame-gate.ts
+++ b/server/screen-frame-gate.ts
@@ -104,6 +104,14 @@ export function settledFrameIsNews(shownFrameHash: string | undefined, png: stri
  * by the tool is what keeps a browsed page from being illustrated with an
  * idle Local VM. */
 export function screenSurfaceForTool(toolName: string): "browser" | "computer" {
-  const bare = toolName.toLowerCase().replace(/^mcp__.+?__/, "");
+  const name = toolName.toLowerCase();
+  // The computer server's browser_click/fill act inside the desktop, not
+  // in agent-browser. Keep the server identity before stripping prefixes.
+  if (name.startsWith("mcp__computer__") || name.startsWith("computer_")) return "computer";
+  if (name.startsWith("mcp__browser__")) return "browser";
+  const bare = name.replace(/^mcp__.+?__/, "");
+  // Codex reports bare names. These two belong to computer-proxy; the
+  // standalone browser now uses the unambiguous agent_browser_* names.
+  if (bare === "browser_click" || bare === "browser_fill") return "computer";
   return bare.startsWith("agent_browser_") || bare.startsWith("browser_") ? "browser" : "computer";
 }

--- a/server/screen-frame-source.test.ts
+++ b/server/screen-frame-source.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createScreenFrameSource, type ScreenCapture } from "./screen-frame-source.ts";
+
+afterEach(() => vi.restoreAllMocks());
+
+const frame = (png: string) => ({ png, format: "png" });
+const publicFrame = (png: string) => ({ png, mime: "image/png" });
+
+function fixture(captures?: { computer?: ScreenCapture; browser?: ScreenCapture }) {
+  let time = 100_000;
+  vi.spyOn(Date, "now").mockImplementation(() => time);
+  const control = { held: false, revision: 0 };
+  const computer = vi.fn(async () => frame("desktop"));
+  const browser = vi.fn(async () => frame("page"));
+  const onFrame = vi.fn();
+  const source = createScreenFrameSource({
+    captures: captures ?? { computer, browser },
+    control: () => ({ ...control }),
+    onFrame,
+    minGapMs: 3000,
+  });
+  return { source, computer, browser, control, onFrame, advance: (ms: number) => { time += ms; } };
+}
+
+describe("screen frame source", () => {
+  it("throttles previews on one surface, but takes a fresh settled frame", async () => {
+    const { source, computer, advance } = fixture();
+    await source.capture();
+    advance(1);
+    await source.capture();
+    expect(computer).toHaveBeenCalledTimes(1);
+    computer.mockResolvedValue(frame("settled desktop"));
+    await source.capture(true);
+    expect(computer).toHaveBeenCalledTimes(2);
+    expect(source.last).toEqual(publicFrame("settled desktop"));
+  });
+
+  it("switches to the browser inside the desktop preview's throttle window", async () => {
+    const { source, browser, advance } = fixture();
+    await source.capture();
+    advance(1);
+    source.surface = "browser";
+    expect(source.last).toBeNull();
+    await source.capture();
+    expect(browser).toHaveBeenCalledTimes(1);
+    expect(source.last).toEqual(publicFrame("page"));
+  });
+
+  it("waits for an in-flight desktop frame, discards it, then settles the browser", async () => {
+    let resolveDesktop!: (frame: { png: string; format: string }) => void;
+    const computer = vi.fn(() => new Promise<{ png: string; format: string }>((resolve) => { resolveDesktop = resolve; }));
+    const browser = vi.fn(async () => frame("page"));
+    const { source, onFrame } = fixture({ computer, browser });
+    const oldCapture = source.capture();
+    source.surface = "browser";
+    const settled = source.capture(true);
+    expect(browser).not.toHaveBeenCalled();
+    resolveDesktop(frame("stale desktop"));
+    await Promise.all([oldCapture, settled]);
+    expect(source.last).toEqual(publicFrame("page"));
+    expect(onFrame.mock.calls).toEqual([[publicFrame("page")]]);
+  });
+
+  it("also switches from the browser back to the desktop", async () => {
+    const { source } = fixture();
+    source.surface = "browser";
+    await source.capture();
+    source.surface = "computer";
+    await source.capture(true);
+    expect(source.last).toEqual(publicFrame("desktop"));
+  });
+
+  it("does not use an old desktop as fallback when the selected browser fails", async () => {
+    const { source, browser } = fixture();
+    await source.capture();
+    browser.mockRejectedValue(new Error("browser unavailable"));
+    source.surface = "browser";
+    await source.capture(true);
+    expect(source.last).toBeNull();
+  });
+
+  it("serializes concurrent preview requests even while switching surfaces", async () => {
+    const { source, computer } = fixture();
+    await Promise.all([source.capture(), source.capture(), source.capture()]);
+    expect(computer).toHaveBeenCalledTimes(1);
+  });
+
+  it("never captures while the human holds control, even for a settled frame", async () => {
+    const { source, computer, control } = fixture();
+    control.held = true;
+    await source.capture(true);
+    expect(computer).not.toHaveBeenCalled();
+    expect(source.last).toBeNull();
+  });
+
+  it("discards a frame if human control changed while it was in flight", async () => {
+    const { source, computer, control, onFrame } = fixture();
+    computer.mockImplementation(async () => {
+      control.revision += 2;
+      return frame("private");
+    });
+    await source.capture(true);
+    expect(source.last).toBeNull();
+    expect(onFrame).not.toHaveBeenCalled();
+  });
+
+  it("keeps the only available surface usable", async () => {
+    const { source } = fixture({ browser: async () => frame("only browser") });
+    expect(source.surface).toBe("browser");
+    await source.capture(true);
+    expect(source.last).toEqual(publicFrame("only browser"));
+  });
+});

--- a/server/screen-frame-source.ts
+++ b/server/screen-frame-source.ts
@@ -1,0 +1,58 @@
+import { captureOutsideHumanControl, type PrivateScreenFrame } from "./private-screen-capture.ts";
+
+export type ScreenCapture = () => Promise<{ png: string; format: string }>;
+type Surface = "browser" | "computer";
+
+/** One serialized preview source. A cached or in-flight desktop frame must
+ * never become the browser's settled picture after the bot switches surfaces. */
+export function createScreenFrameSource(input: {
+  captures: { computer?: ScreenCapture; browser?: ScreenCapture };
+  control: () => { held: boolean; revision: number };
+  onFrame: (frame: PrivateScreenFrame) => void;
+  minGapMs: number;
+}) {
+  let current: Promise<void> | null = null;
+  let lastAt = 0;
+  let attemptedSurface: Surface | undefined;
+  let last: PrivateScreenFrame | null = null;
+  let lastSurface: Surface | undefined;
+  const selectedSurface = (): Surface => input.captures[source.surface]
+    ? source.surface
+    : input.captures.computer ? "computer" : "browser";
+  const source = {
+    surface: (input.captures.computer ? "computer" : "browser") as Surface,
+    get last(): PrivateScreenFrame | null {
+      return lastSurface === selectedSurface() ? last : null;
+    },
+    async capture(fresh = false): Promise<void> {
+      // Wait for the previous source before selecting the next one. A final
+      // capture bypasses the preview throttle, even if a poke just finished.
+      while (current) await current;
+      if (input.control().held) return;
+      const surface = selectedSurface();
+      if (!fresh && attemptedSurface === surface && Date.now() - lastAt < input.minGapMs) return;
+      attemptedSurface = surface;
+      current = (async () => {
+        try {
+          const capture = input.captures[surface];
+          if (!capture) return;
+          const frame = await captureOutsideHumanControl(input.control, capture);
+          if (!frame || surface !== selectedSurface()) return;
+          last = frame;
+          lastSurface = surface;
+          input.onFrame(frame);
+        } catch {
+          // A sleeping or mid-command surface is retried by the next tick.
+        } finally {
+          lastAt = Date.now();
+        }
+      })();
+      try {
+        await current;
+      } finally {
+        current = null;
+      }
+    },
+  };
+  return source;
+}


### PR DESCRIPTION
Closes #906.

## The symptom

A bot opens a page on 0.1.61. `agent_browser_open`, `_screenshot` and `_snapshot` all run and are approved, the bot describes the page correctly — and the transcript settles with **no picture**. No image file is written, and the turn's messages carry payloads of 199 B to 1 KB, far too small for a PNG.

Meanwhile the Browser panel says *"Pages the bot looks at appear in the chat as screenshots."*

## Two causes

**The screen gate still lists the Electron surface's tool names.** `SCREEN_TOUCHING_TOOLS` has `browser_navigate`, `browser_type`, `browser_screenshot`. agent-browser's are `agent_browser_open`, `agent_browser_click`, `agent_browser_screenshot`. Nothing matches, so `entry.touched` never flips and `finalScreenFrame` returns `null` for every browser turn.

**Nothing supplies a browser frame.** `startScreenPoller` runs only when `previewCapture` is set, and that is assigned solely by the computer branches (Local VM, VPS, Box). The browser's capture lived in `server/drivers/browser-proxy.ts`, deleted with the Electron surface and never replaced.

## Why fixing only the first would be worse than the bug

agent-browser runs its own headless Chrome on the host, not inside the bot's desktop. For a bot holding **both** a computer and the browser, adding the tool names alone would settle a web-browsing turn with a picture of an idle Local VM — the interface confidently showing the wrong room. I wrote that version first; it is why this PR is shaped the way it is.

So the poller now holds both captures and pictures **whichever surface the touching tool acted on**. A browser tool gets the page, a computer tool gets the desktop, and a status read redirects nothing.

## The capture

`agentBrowserFrame()` runs the pinned binary with the **same session env as the MCP mount** (`AGENT_BROWSER_SESSION`, `AGENT_BROWSER_RESTORE`, the encryption key), so it photographs the daemon the bot is already driving rather than launching a second browser beside it.

A 10-second cap: the poller runs next to a live turn, and a hung browser must not hold the fold open. A missing picture beats a stuck turn.

Read-only browser tools stay out of the gate by the rule already applied throughout that list — `_snapshot`, `_read` and `_get_text` return text, and the waits change nothing the action before them did not already count.

## Overlap with #899

#899 touches `server/browser-engine.ts`, its test and `server/index.ts` as well, but for packaging — bundling the pinned binary and Chromium into desktop targets. Different intent, same files. Happy to rebase onto it whenever it lands; nothing here depends on how the binary arrives, only on running the one already resolved.

This does not overlap #834, which is frontend-only and predates the swap.

## Tests

`screenSurfaceForTool` — browser tools to the browser under every spelling, everything else to the computer, and the case that motivated it: a browsed page must not be illustrated with an idle desktop.

The gate — agent-browser's acting tools now count; its read-only tools and waits still do not.

`agentBrowserFrame`, driven by a fake binary — returns the picture the browser wrote, carries the mount's session env, fails with the browser's own reason, refuses to invent a picture the browser never wrote, and gives up on a hung browser rather than holding the turn open.

Full suite on Node 24: 3,924 passed, 0 failures. Typecheck and oxlint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added browser-specific screenshots for web-based tasks, including timeout and failure handling.
  - Screen updates now reflect whether the bot interacted with the browser or computer.
  - Room conversations now clearly announce when a bot recalls messages from a private conversation.
  - Repeated recalls from the same source are announced only once, while recalls within the private conversation remain undisclosed.
  - Saved model selections are now respected when creating bots.
  - Login sessions now remain active during continued use, and pairing details include a public URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->