### PR TITLE
fix(cli): guard stale model effort and missing phone hostname

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -54,9 +54,10 @@ Codex also offers device-code login for SSH. API-key connections currently
 support chat, not agent tools or computer use. The [setup guide](cli-onboarding.md)
 explains the choices, key storage, and how to run setup again safely.
 
-It then starts the server, keeps your data in `~/.openmausbot`, and prints a
-pairing link with a QR code: scan it with the phone, or open it on the
-laptop. Use `npx openmausbot setup` to configure without starting, or
+It then starts the server and keeps your data in `~/.openmausbot`. If you
+choose phone access, it prints a pairing link and QR code only after checking
+the HTTPS connection. Choosing **Skip for now** keeps the workspace local-only
+and creates no pairing invitation. Use `npx openmausbot setup` to configure without starting, or
 `npx openmausbot serve` to start non-interactively with your existing config
 (for services and scripts). Two ways to make it reachable from elsewhere:
 

--- a/server/cli-pair.test.ts
+++ b/server/cli-pair.test.ts
@@ -133,6 +133,17 @@ describe("guided phone pairing address discovery", () => {
     expectPhonePairing(advertisedOrigin);
   });
 
+  it("does not probe a fabricated origin when Tailscale has no MagicDNS name", async () => {
+    publicUrl = null;
+    mocks.readCliStartup.mockReturnValue({ access: "tailscale", phone: "ios" });
+    mocks.tailscaleStatus.mockResolvedValue({ status: { dnsName: null } });
+    expect(await runPair(options)).toBe(1);
+    expect(mocks.ui.choose).not.toHaveBeenCalled();
+    expect(fetchMock.mock.calls.filter(([url]) => String(url).startsWith("https://"))).toHaveLength(0);
+    expect(fetchMock.mock.calls.filter(([, init]) => init?.method === "POST")).toHaveLength(0);
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("running only on this computer"));
+  });
+
   it("does not mint a code when the advertised endpoint identifies another workspace", async () => {
     remoteWorkspaceId = "another-workspace";
     expect(await runPair(options)).toBe(1);

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -355,7 +355,7 @@ export async function runPair(options: CliOptions): Promise<number> {
       if (launch.tunnel) origin = describeTunnelAccount(createTunnelAccount({ dataDir: options.dataDir, version: serverVersion() }).credentials.read()).address ?? undefined;
       if (launch.tailscale) {
         const status = await tailscaleStatus();
-        if (!("failure" in status)) origin = `https://${status.status.dnsName}`;
+        if (!("failure" in status) && status.status.dnsName) origin = `https://${status.status.dnsName}`;
       }
     }
     if (!origin || !normalizePhoneOrigin(origin)) {

--- a/server/default-model-selection.test.ts
+++ b/server/default-model-selection.test.ts
@@ -11,6 +11,7 @@ const codex = {
     default: "codex-default",
     options: [{ id: "codex-default", label: "Default" }, { id: "selected-model", label: "Selected" }],
   } satisfies ModelCatalog,
+  capabilities: { effortLevels: ["low", "high"] as const },
 };
 const claude = {
   instanceId: "claude",
@@ -20,11 +21,27 @@ const claude = {
 };
 
 describe("new bot default model selection", () => {
-  it("honors the configured provider, model, and effort ahead of the Claude preference", () => {
-    const preferred = { instanceId: "codex", model: "selected-model", effort: "high" as const };
+  it.each(["low", "high"] as const)("honors the configured provider, model, and supported %s effort ahead of the Claude preference", (effort) => {
+    const preferred = { instanceId: "codex", model: "selected-model", effort };
     const selection = selectDefaultModelSelection([claude, codex], preferred);
     expect(selection).toEqual(preferred);
     expect(selection).not.toBe(preferred);
+  });
+
+  it.each([
+    { label: "missing capabilities", capabilities: undefined },
+    { label: "no effort control", capabilities: {} },
+    { label: "empty effort list", capabilities: { effortLevels: [] } },
+    { label: "changed effort support", capabilities: { effortLevels: ["low"] as const } },
+  ])("omits stale effort for $label without changing the provider, model, or saved preference", ({ capabilities }) => {
+    const preferred = { instanceId: "codex", model: "selected-model", effort: "high" as const };
+    const selection = selectDefaultModelSelection([
+      { ...claude, capabilities: { effortLevels: ["high"] } },
+      { ...codex, capabilities },
+    ], preferred);
+    expect(selection).toEqual({ instanceId: "codex", model: "selected-model" });
+    expect(selection).not.toHaveProperty("effort");
+    expect(preferred.effort).toBe("high");
   });
 
   it("accepts the provider default even when it is not repeated in its options", () => {

--- a/server/default-model-selection.ts
+++ b/server/default-model-selection.ts
@@ -1,10 +1,11 @@
-import type { ModelCatalog, ModelSelection, ProviderSnapshot } from "./contracts.ts";
+import type { EffortLevel, ModelCatalog, ModelSelection, ProviderSnapshot } from "./contracts.ts";
 
 interface SelectableInstance {
   instanceId: string;
   driverKind: string;
   snapshot: ProviderSnapshot;
   models: ModelCatalog;
+  capabilities?: { effortLevels?: readonly EffortLevel[] };
 }
 
 /** A saved choice is intentional: an unavailable provider or removed model
@@ -22,7 +23,11 @@ export function selectDefaultModelSelection(
     ) {
       return { instanceId: "", model: "" };
     }
-    return { ...preferred };
+    const selection = { ...preferred };
+    // A saved effort can outlive driver support. Keep the intentional model,
+    // but let the provider use its own effort default instead of failing turn 1.
+    if (selection.effort && !instance.capabilities?.effortLevels?.includes(selection.effort)) delete selection.effort;
+    return selection;
   }
   const available = instances.filter((instance) => instance.snapshot.state === "available");
   const pick = available.find((instance) => instance.driverKind === "claudeAgent") ?? available[0];


### PR DESCRIPTION
## Summary

Resolve the final review findings from #902 before publishing 0.1.62.

- Omit a saved default reasoning effort when the selected provider no longer supports it. Keep the selected provider/model and never mutate saved preferences.
- Do not construct a phone URL from a missing Tailscale MagicDNS name.
- Clarify that skipping phone setup keeps startup local and does not create a QR or invitation.

## Verification

- 25 selector/pairing tests pass, including stale/absent/changed effort capabilities, supported effort preservation, and missing MagicDNS.
- Typecheck and diff checks pass.
- Real isolated fake-engine fixture: config contained Claude with unsupported effort `none`; a newly created bot retained the selected model, omitted the stale effort, and completed its first turn. No live user data or account used.

The original Windows VM-fixture file-lock failure passed unchanged on a failed-job-only rerun. No fixture assertions or production atomic-file handling were changed.

The automatic draft build for #902 was cancelled before assembly so 0.1.62 can be built from the final merged commit instead. No release has been published or overwritten.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Model selection now respects each model’s supported effort levels and falls back to the provider default when a saved preference is unavailable.

- **Bug Fixes**
  - Pairing links and QR codes are shown only after HTTPS is verified and phone access is selected.
  - Choosing “Skip for now” keeps the workspace local-only without creating a pairing invitation.
  - Pairing now safely handles unavailable Tailscale addresses and clearly indicates when the workspace is computer-only.

- **Documentation**
  - Updated self-hosting instructions to reflect the revised pairing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->