### PR TITLE
fix(release): build and verify the Windows browser startup backport

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,6 @@ shared/mascot-bodies.ts text eol=lf
 deploy/podman/*.sh text eol=lf
 ios/Sources/CompanionCore/MausBodies.swift text eol=lf
 android/app/src/main/kotlin/com/openmausbot/companion/ui/MausBodies.kt text eol=lf
+# Vendor patch hashes and original notices must survive Windows checkout
+# byte-for-byte. Do not let core.autocrlf rewrite these reviewed inputs.
+third_party/browser/** text eol=lf

--- a/.github/workflows/browser-vendor-windows.yml
+++ b/.github/workflows/browser-vendor-windows.yml
@@ -1,0 +1,77 @@
+# Temporary, reviewed Windows-only agent-browser backport. This workflow
+# produces a candidate, never publishes it. Pin its verified artifact digest
+# before the normal package/release gates consume it.
+name: Windows browser vendor build
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/browser-vendor-windows.yml
+      - scripts/build-windows-browser-vendor.mjs
+      - scripts/build-windows-browser-vendor.test.mjs
+      - scripts/smoke-browser-bundle.mjs
+      - third_party/browser/agent-browser-windows-stdio.patch
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build reviewed Windows browser
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      RUSTUP_TOOLCHAIN: 1.97.1
+      CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: x86_64-w64-mingw32-gcc
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      # This is upstream's package manager, not OpenMausBot's pnpm version.
+      - run: npm install --global pnpm@11.1.3
+      - name: Install the pinned Rust toolchain and upstream Windows linker
+        run: |
+          rustup toolchain install 1.97.1 --profile minimal --target x86_64-pc-windows-gnu
+          sudo apt-get update
+          sudo apt-get install -y mingw-w64
+      - name: Build from the verified source and local backport
+        run: node scripts/build-windows-browser-vendor.mjs --output "$RUNNER_TEMP/browser-vendor"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-browser-vendor
+          path: ${{ runner.temp }}/browser-vendor/
+          if-no-files-found: error
+          retention-days: 14
+
+  smoke:
+    name: Cold-start and restart on Windows
+    needs: build
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: windows-browser-vendor
+          path: ${{ runner.temp }}/browser-vendor
+      - name: Stage the pinned Chromium and notices
+        run: node scripts/prepare-browser.mjs --current
+      - name: Prove cold start and close/reopen with captured MCP output
+        shell: pwsh
+        run: |
+          $resources = "$env:RUNNER_TEMP/browser-vendor-resources"
+          New-Item -ItemType Directory -Path $resources | Out-Null
+          Copy-Item -Recurse "$env:GITHUB_WORKSPACE/dist-native/browser/win32-x64" "$resources/browser-engine"
+          node scripts/smoke-browser-bundle.mjs --resources "$resources" --engine-candidate "$env:RUNNER_TEMP/browser-vendor/agent-browser-win32-x64.exe"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -127,7 +127,9 @@ jobs:
   publish:
     name: publish to GHCR
     needs: build-and-smoke
-    if: github.event_name == 'push'
+    # Release dispatches on its published tag because GITHUB_TOKEN-created
+    # tags do not start another workflow. A manual branch run is smoke-only.
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/sync-published-release.yml
+++ b/.github/workflows/sync-published-release.yml
@@ -23,6 +23,9 @@ concurrency:
 jobs:
   mirror:
     name: Preserve legacy updater compatibility
+    # Dependency prereleases are not desktop updates. Manual recovery still
+    # reaches the strict stable-tag and artifact checks below.
+    if: github.event_name == 'workflow_dispatch' || (!github.event.release.prerelease && startsWith(github.event.release.tag_name, 'v'))
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:

--- a/docs/browser-packaging.md
+++ b/docs/browser-packaging.md
@@ -67,6 +67,30 @@ pins, run preparation/tests and the native package gates, and ship promptly
 when browser security updates are needed. There is no independent automatic
 browser updater in the desktop bundle.
 
+### Temporary Windows engine backport
+
+Windows uses an explicitly identified OpenMausBot build of agent-browser
+0.36.0, with the handle-inheritance fix from
+[upstream PR #1781](https://github.com/vercel-labs/agent-browser/pull/1781).
+The original binary can hang when a newly started background browser holds
+the tool call's output connection open. The backport changes that Windows
+startup behavior; it does not include the PR's broader output-reader rewrite
+or unrelated changes from upstream main.
+
+The artifact-only **Windows browser vendor build** workflow builds the pinned
+source and checked-in patch, retains the licenses and build provenance, and
+tests cold start plus close/reopen through the same MCP connection on Windows.
+Its candidate must be reviewed and its exact size and SHA-256 pinned before
+the normal application packaging workflow consumes it. Candidate testing does
+not replace the packaged-app tests. Published vendor bytes must not be
+overwritten; a changed build needs a new revision and reviewed pins.
+
+The Windows revision has a separate managed installation directory so an old
+0.36.0 download is not mistaken for the patched engine. Desktop packages use
+their bundled engine. Explicit executable overrides remain user-managed.
+Remove the backport when an official release includes the fix and passes the
+same native cold-start and restart tests.
+
 Complete upstream notices and provenance are in
 [`third_party/browser`](../third_party/browser/README.md). The full Google
 Chrome distribution and its proprietary Widevine component are not bundled.

--- a/scripts/build-windows-browser-vendor.mjs
+++ b/scripts/build-windows-browser-vendor.mjs
@@ -1,0 +1,125 @@
+// One-off dependency build, not part of normal app packaging. After native
+// Windows verification, publish these bytes and pin their digest in the app.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { executableTarget } from "./prepare-cloudflared.mjs";
+import { bundleInventory, releaseBytes } from "./prepare-browser.mjs";
+
+export const WINDOWS_VENDOR_VERSION = "0.36.0-omb.1";
+export const WINDOWS_VENDOR_TARGET = "x86_64-pc-windows-gnu";
+export const WINDOWS_VENDOR_SOURCE = {
+  commit: "eb05921bad874cd2a1b4fa5d1149f1ed26576cae",
+  asset: "agent-browser-eb05921bad874cd2a1b4fa5d1149f1ed26576cae.tar.gz",
+  url: "https://codeload.github.com/vercel-labs/agent-browser/tar.gz/eb05921bad874cd2a1b4fa5d1149f1ed26576cae",
+  bytes: 1904718,
+  sha256: "ed24a72a5260d9c1ea454cd849c44159bac570a6939ac645e4c5bdb98a421646",
+};
+export const WINDOWS_VENDOR_PATCH_SHA256 = "27a268a90de47603a473daefb5679ef9ddde3fad9152d52b04e563b3e192c9a9";
+export const WINDOWS_VENDOR_RUST = "1.97.1";
+export const WINDOWS_VENDOR_PNPM = "11.1.3";
+const repository = fileURLToPath(new URL("../", import.meta.url));
+const patchPath = join(repository, "third_party/browser/agent-browser-windows-stdio.patch");
+const digest = (bytes) => createHash("sha256").update(bytes).digest("hex");
+
+export function parseVendorBuildArgs(args) {
+  if (args.length !== 2 || args[0] !== "--output" || !isAbsolute(args[1])) {
+    throw new Error("Usage: node scripts/build-windows-browser-vendor.mjs --output ABSOLUTE_NEW_DIRECTORY");
+  }
+  return resolve(args[1]);
+}
+
+export function verifyVendorPatch(bytes) {
+  assert.equal(digest(bytes), WINDOWS_VENDOR_PATCH_SHA256, "Windows vendor patch failed pinned SHA-256 verification");
+}
+
+// Candidate artifacts are tested before their executable digest is committed
+// to the normal release resolver. This verifies build identity and transport
+// integrity, not publication approval; normal packaging never uses this path.
+export function verifyVendorCandidate(provenance, bytes) {
+  assert.equal(provenance.version, WINDOWS_VENDOR_VERSION);
+  assert.equal(provenance.target, WINDOWS_VENDOR_TARGET);
+  assert.deepEqual(provenance.source, WINDOWS_VENDOR_SOURCE);
+  assert.equal(provenance.patch.sha256, WINDOWS_VENDOR_PATCH_SHA256);
+  assert.equal(provenance.executable.asset, "agent-browser-win32-x64.exe");
+  assert.equal(provenance.executable.bytes, bytes.length, "Candidate executable size differs from build provenance");
+  assert.equal(provenance.executable.sha256, digest(bytes), "Candidate executable SHA-256 differs from build provenance");
+}
+
+function command(file, args, cwd, { input, capture = false } = {}) {
+  const result = spawnSync(file, args, {
+    cwd, input, encoding: "utf8", timeout: 30 * 60_000,
+    stdio: capture || input !== undefined ? ["pipe", "pipe", "pipe"] : "inherit",
+    env: { ...process.env, NEXT_TELEMETRY_DISABLED: "1", CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: "x86_64-w64-mingw32-gcc" },
+  });
+  if (result.error || result.status !== 0) throw new Error(`${file} ${args.join(" ")} failed: ${result.error?.message ?? result.stderr ?? result.status}`);
+  return result.stdout?.trim() ?? "";
+}
+
+export async function buildWindowsBrowserVendor(output) {
+  assert.equal(process.platform, "linux", "Build this dependency on the reviewed Linux GNU cross-compiler runner");
+  assert.equal(process.arch, "x64", "The reviewed build runner is Linux x64");
+  assert(Number(process.versions.node.split(".")[0]) >= 24, "Node 24 or later is required");
+  assert(isAbsolute(output) && !existsSync(output), "Output must be a new absolute directory; existing artifacts are never overwritten");
+  const patch = readFileSync(patchPath);
+  verifyVendorPatch(patch);
+  const rust = command("rustc", ["--version"], repository, { capture: true });
+  const cargo = command("cargo", ["--version"], repository, { capture: true });
+  const mingw = command("x86_64-w64-mingw32-gcc", ["--version"], repository, { capture: true }).split("\n")[0];
+  const linker = command("x86_64-w64-mingw32-ld", ["--version"], repository, { capture: true }).split("\n")[0];
+  assert(rust.startsWith(`rustc ${WINDOWS_VENDOR_RUST} `), `Expected Rust ${WINDOWS_VENDOR_RUST}, got ${rust}`);
+  assert(cargo.startsWith(`cargo ${WINDOWS_VENDOR_RUST} `), `Expected Cargo ${WINDOWS_VENDOR_RUST}, got ${cargo}`);
+  const scratch = mkdtempSync(join(tmpdir(), "omb-browser-vendor-"));
+  try {
+    const source = join(scratch, "source");
+    mkdirSync(source);
+    const archive = join(scratch, WINDOWS_VENDOR_SOURCE.asset);
+    writeFileSync(archive, await releaseBytes(WINDOWS_VENDOR_SOURCE));
+    command("tar", ["-xzf", archive, "--strip-components=1", "-C", source], scratch);
+    command("git", ["apply", "--check", "-"], source, { input: patch });
+    command("git", ["apply", "--whitespace=error-all", "-"], source, { input: patch });
+    const pnpm = command("pnpm", ["--version"], source, { capture: true });
+    assert.equal(pnpm, WINDOWS_VENDOR_PNPM, `Expected pnpm ${WINDOWS_VENDOR_PNPM}`);
+    // Keep the real upstream dashboard: build.rs otherwise silently embeds a
+    // placeholder. The frozen pnpm lock and Cargo --locked retain dependencies.
+    command("pnpm", ["install", "--frozen-lockfile", "--ignore-scripts"], source);
+    command("pnpm", ["--filter", "dashboard", "build"], source);
+    const dashboard = join(source, "packages/dashboard/out");
+    assert(!readFileSync(join(dashboard, "index.html"), "utf8").includes("Dashboard not built"));
+    command("cargo", ["build", "--locked", "--release", "--manifest-path", "cli/Cargo.toml", "--target", WINDOWS_VENDOR_TARGET], source);
+    const binary = join(source, "cli/target", WINDOWS_VENDOR_TARGET, "release/agent-browser.exe");
+    const bytes = readFileSync(binary);
+    assert.equal(executableTarget(bytes), "win32-x64", "Vendor build did not produce a Windows x64 executable");
+    mkdirSync(output, { recursive: true });
+    const asset = "agent-browser-win32-x64.exe";
+    copyFileSync(binary, join(output, asset));
+    for (const [from, to] of [
+      ["LICENSE", "agent-browser-LICENSE.txt"],
+      ["cli/src/native/a11y/LICENSE-axe-core.txt", "LICENSE-axe-core.txt"],
+      ["cli/src/native/a11y/LICENSE-axe-core-THIRD-PARTY.txt", "LICENSE-axe-core-THIRD-PARTY.txt"],
+    ]) copyFileSync(join(source, from), join(output, to));
+    copyFileSync(patchPath, join(output, "agent-browser-windows-stdio.patch"));
+    copyFileSync(join(repository, "third_party/browser/README.md"), join(output, "README.md"));
+    const provenance = {
+      schemaVersion: 1, version: WINDOWS_VENDOR_VERSION, target: WINDOWS_VENDOR_TARGET,
+      source: WINDOWS_VENDOR_SOURCE,
+      patch: { upstream: "https://github.com/vercel-labs/agent-browser/pull/1781", commit: "81a98c349d04195396ffae6898bd375ad64280de", sha256: WINDOWS_VENDOR_PATCH_SHA256, scope: "Windows handle inheritance only; no MCP reader rewrite" },
+      toolchain: { rust, cargo, pnpm, node: process.version, mingw, linker },
+      cargoLockSha256: digest(readFileSync(join(source, "cli/Cargo.lock"))),
+      pnpmLockSha256: digest(readFileSync(join(source, "pnpm-lock.yaml"))),
+      dashboardInventorySha256: digest(JSON.stringify(bundleInventory(dashboard))),
+      executable: { asset, bytes: bytes.length, sha256: digest(bytes) },
+    };
+    writeFileSync(join(output, "provenance.json"), `${JSON.stringify(provenance, null, 2)}\n`);
+    console.log(JSON.stringify(provenance, null, 2));
+    return provenance;
+  } finally { rmSync(scratch, { recursive: true, force: true }); }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  await buildWindowsBrowserVendor(parseVendorBuildArgs(process.argv.slice(2)));
+}

--- a/scripts/build-windows-browser-vendor.test.mjs
+++ b/scripts/build-windows-browser-vendor.test.mjs
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { WINDOWS_VENDOR_PATCH_SHA256, WINDOWS_VENDOR_PNPM, WINDOWS_VENDOR_RUST, WINDOWS_VENDOR_SOURCE, WINDOWS_VENDOR_TARGET, WINDOWS_VENDOR_VERSION, parseVendorBuildArgs, verifyVendorCandidate, verifyVendorPatch } from "./build-windows-browser-vendor.mjs";
+import { verifyAssetBytes } from "./prepare-browser.mjs";
+
+describe("reviewed Windows browser dependency build", () => {
+  it("pins the released base, toolchain, vendor revision and exact patch bytes", () => {
+    expect(WINDOWS_VENDOR_SOURCE.commit).toBe("eb05921bad874cd2a1b4fa5d1149f1ed26576cae");
+    expect(WINDOWS_VENDOR_SOURCE.url).toContain(WINDOWS_VENDOR_SOURCE.commit);
+    expect(WINDOWS_VENDOR_TARGET).toBe("x86_64-pc-windows-gnu");
+    expect(WINDOWS_VENDOR_VERSION).toBe("0.36.0-omb.1");
+    expect(WINDOWS_VENDOR_RUST).toBe("1.97.1");
+    expect(WINDOWS_VENDOR_PNPM).toBe("11.1.3");
+    expect(WINDOWS_VENDOR_PATCH_SHA256).toMatch(/^[0-9a-f]{64}$/);
+    const patch = readFileSync(new URL("../third_party/browser/agent-browser-windows-stdio.patch", import.meta.url));
+    expect(() => verifyVendorPatch(patch)).not.toThrow();
+    expect(() => verifyVendorPatch(Buffer.concat([patch, Buffer.from("\n")]))).toThrow(/SHA-256/);
+    const changed = [...patch.toString().matchAll(/^diff --git a\/(\S+) /gm)].map((match) => match[1]);
+    expect(changed).toEqual(["cli/src/connection.rs", "cli/src/main.rs", "cli/Cargo.toml", "cli/Cargo.lock"]);
+    expect(patch.toString()).toContain("SetHandleInformation(handle as isize, HANDLE_FLAG_INHERIT, 0)");
+    expect(patch.toString()).not.toContain("run_command_returns_partial_output");
+  });
+
+  it("refuses unreviewed source archive bytes", () => {
+    expect(() => verifyAssetBytes(Buffer.from("unreviewed source"), WINDOWS_VENDOR_SOURCE)).toThrow(/SHA-256/);
+  });
+
+  it("rejects changed candidate bytes or provenance instead of weakening normal release pins", () => {
+    const bytes = Buffer.from("synthetic candidate, never executed");
+    const provenance = {
+      version: WINDOWS_VENDOR_VERSION, target: WINDOWS_VENDOR_TARGET,
+      source: WINDOWS_VENDOR_SOURCE, patch: { sha256: WINDOWS_VENDOR_PATCH_SHA256 },
+      executable: { asset: "agent-browser-win32-x64.exe", bytes: bytes.length, sha256: createHash("sha256").update(bytes).digest("hex") },
+    };
+    expect(() => verifyVendorCandidate(provenance, bytes)).not.toThrow();
+    expect(() => verifyVendorCandidate(provenance, Buffer.from("wrong"))).toThrow();
+    expect(() => verifyVendorCandidate({ ...provenance, version: "0.36.0" }, bytes)).toThrow();
+    expect(() => verifyVendorCandidate({ ...provenance, source: { ...WINDOWS_VENDOR_SOURCE, commit: "unreviewed" } }, bytes)).toThrow();
+    expect(() => verifyVendorCandidate({ ...provenance, patch: { sha256: "0".repeat(64) } }, bytes)).toThrow();
+    expect(() => verifyVendorCandidate({ ...provenance, executable: { ...provenance.executable, sha256: "0".repeat(64) } }, bytes)).toThrow();
+  });
+
+  it("requires an explicit absolute output without accepting extra options", () => {
+    const output = join(tmpdir(), "omb-vendor-output");
+    expect(parseVendorBuildArgs(["--output", output])).toBe(output);
+    for (const args of [[], ["--output", "relative"], ["--output", output, "--skip-verify"], ["--source", output]]) {
+      expect(() => parseVendorBuildArgs(args)).toThrow(/Usage/);
+    }
+  });
+});

--- a/scripts/smoke-browser-bundle.mjs
+++ b/scripts/smoke-browser-bundle.mjs
@@ -8,18 +8,21 @@ import { once } from "node:events";
 import { mkdtemp, mkdir, readFile, readdir, rm, stat } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
-import { isAbsolute, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { parseArgs } from "node:util";
 import { inflateSync } from "node:zlib";
 import { browserBundlePaths, browserBundleSpec } from "../server/browser-bundle-release.ts";
+import { executableTarget } from "./prepare-cloudflared.mjs";
+import { WINDOWS_VENDOR_VERSION, verifyVendorCandidate, verifyVendorPatch } from "./build-windows-browser-vendor.mjs";
 
 const { values } = parseArgs({ options: {
   resources: { type: "string" }, target: { type: "string" },
+  "engine-candidate": { type: "string" },
   "check-only": { type: "boolean", default: false }, help: { type: "boolean" },
 } });
 if (values.help) {
-  console.log("Usage: node scripts/smoke-browser-bundle.mjs --resources /absolute/app/resources [--target darwin-arm64] [--check-only]");
+  console.log("Usage: node scripts/smoke-browser-bundle.mjs --resources /absolute/app/resources [--target darwin-arm64] [--check-only] [--engine-candidate /absolute/vendor/agent-browser-win32-x64.exe]");
   process.exit(0);
 }
 assert(values.resources && isAbsolute(values.resources), "--resources must be an absolute packaged Resources/resources directory");
@@ -37,6 +40,26 @@ for (const component of ["engine", "chrome"]) {
 assert((await readdir(paths.licenses)).length > 0, "Missing bundled third-party notices");
 assert((await stat(join(paths.directory, spec.chrome.license))).size > 0, "Missing Chromium license");
 assert((await stat(join(paths.directory, spec.chrome.about))).size > 0, "Missing Chromium notice");
+let enginePath = paths.engine;
+let engineVersionExpected = spec.engine.version;
+if (values["engine-candidate"] !== undefined) {
+  // Only the artifact-only vendor workflow uses this explicit mode. Standard
+  // app release calls still discover and execute the bundled, pinned engine.
+  assert.equal(process.platform, "win32", "Windows vendor candidates require a native Windows runner");
+  assert.equal(target, "win32-x64");
+  assert(!values["check-only"], "A candidate must execute the native browser checks");
+  assert(isAbsolute(values["engine-candidate"]), "--engine-candidate must be absolute");
+  enginePath = resolve(values["engine-candidate"]);
+  const candidateDirectory = dirname(enginePath);
+  const candidateBytes = await readFile(enginePath);
+  verifyVendorCandidate(JSON.parse(await readFile(join(candidateDirectory, "provenance.json"), "utf8")), candidateBytes);
+  verifyVendorPatch(await readFile(join(candidateDirectory, "agent-browser-windows-stdio.patch")));
+  assert.equal(executableTarget(candidateBytes), "win32-x64");
+  for (const license of ["agent-browser-LICENSE.txt", "LICENSE-axe-core.txt", "LICENSE-axe-core-THIRD-PARTY.txt"]) {
+    assert.deepEqual(await readFile(join(candidateDirectory, license)), await readFile(join(paths.licenses, license)), `Candidate changed upstream notice ${license}`);
+  }
+  engineVersionExpected = WINDOWS_VENDOR_VERSION;
+}
 // Signing changes Mach-O bytes. Source-archive digests are checked before signing;
 // this gate checks the final layout, versions, and real browser behavior instead.
 if (values["check-only"]) {
@@ -73,6 +96,7 @@ const env = {
   XDG_DATA_HOME: join(fixture, "data"), XDG_RUNTIME_DIR: join(fixture, "run"),
   TMPDIR: join(fixture, "tmp"), TMP: join(fixture, "tmp"), TEMP: join(fixture, "tmp"),
   OMB_DATA_DIR: join(fixture, "omb"), OMB_RESOURCES_PATH: resolve(values.resources),
+  ...(values["engine-candidate"] ? { OMB_AGENT_BROWSER_PATH: enginePath, AGENT_BROWSER_EXECUTABLE_PATH: paths.chrome } : {}),
   // macOS's per-user temp directory is long; keep Unix socket paths <104 bytes.
   AGENT_BROWSER_SOCKET_DIR: join(fixture, "s"),
   AGENT_BROWSER_DEFAULT_TIMEOUT: "15000", LANG: "en_US.UTF-8", NO_COLOR: "1",
@@ -216,6 +240,23 @@ function pngInfo(buffer) {
   return { width, height, bytes: buffer.length, sha256: createHash("sha256").update(buffer).digest("hex") };
 }
 
+async function ownedDaemonPid(client) {
+  const session = client.integration.env.AGENT_BROWSER_SESSION;
+  const value = (await readFile(join(env.AGENT_BROWSER_SOCKET_DIR, `${session}.pid`), "utf8")).trim();
+  assert(/^[1-9][0-9]*$/.test(value), "Owned browser daemon did not record a valid PID");
+  return Number(value);
+}
+
+async function waitForOwnedDaemonExit(pid) {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    try { process.kill(pid, 0); }
+    catch (error) { if (error.code === "ESRCH") return; throw error; }
+    await new Promise((done) => setTimeout(done, 25));
+  }
+  throw new Error(`Owned browser daemon ${pid} did not exit after close`);
+}
+
 const interrupt = () => { for (const proc of children) proc.kill("SIGTERM"); };
 process.once("SIGINT", interrupt);
 process.once("SIGTERM", interrupt);
@@ -223,10 +264,10 @@ try {
   const { browserEngineStatus, agentBrowserIntegration } = await import("../server/browser-engine.ts");
   const status = browserEngineStatus({ dataDir: env.OMB_DATA_DIR, env });
   assert.equal(status.kind, "ready", `Fresh-home runtime did not discover the bundle: ${JSON.stringify(status)}`);
-  assert.equal(resolve(status.binaryPath), resolve(paths.engine), "Runtime fell back to an unbundled engine");
-  const engineVersion = await run(paths.engine, ["--version"], env);
+  assert.equal(resolve(status.binaryPath), resolve(enginePath), "Runtime did not select the engine under test");
+  const engineVersion = await run(enginePath, ["--version"], env);
   const chromeVersion = await run(paths.chrome, ["--version"], env);
-  assert(engineVersion.includes(spec.engine.version), `Unexpected engine version: ${engineVersion}`);
+  assert.equal(engineVersion, `agent-browser ${engineVersionExpected}`, `Unexpected engine version: ${engineVersion}`);
   assert(chromeVersion.includes(spec.chrome.version), `Unexpected Chromium version: ${chromeVersion}`);
 
   const title = `OpenMausBot bundled browser ${randomBytes(6).toString("hex")}`;
@@ -266,13 +307,28 @@ try {
   assert.deepEqual((await beta.tool("agent_browser_eval", { script: storage })).data.result, { local: null, cookie: "" }, "Second bot inherited first bot's state");
   assert.deepEqual((await beta.tool("agent_browser_eval", { script: setStorage("beta") })).data.result, { local: "beta", cookie: "omb_smoke=beta" });
   assert.deepEqual((await alpha.tool("agent_browser_eval", { script: storage })).data.result, { local: "alpha", cookie: "omb_smoke=alpha" }, "First bot's state was overwritten by the second bot");
+  // Reopen through the SAME MCP process: warming a daemon before MCP would
+  // conceal the Windows inherited-pipe bug, which returns after a close.
+  const previousDaemonPid = await ownedDaemonPid(alpha);
+  await alpha.tool("agent_browser_close");
+  // Upstream acknowledges close before its delayed daemon shutdown. Wait for
+  // this exact owned process, otherwise reopen could race the old daemon.
+  await waitForOwnedDaemonExit(previousDaemonPid);
+  await alpha.tool("agent_browser_open", { url });
+  assert.notEqual(await ownedDaemonPid(alpha), previousDaemonPid, "Reopen reused the closed daemon");
+  assert.equal((await alpha.tool("agent_browser_get_title")).data.title, title);
+  assert.deepEqual((await alpha.tool("agent_browser_eval", { script: storage })).data.result, { local: null, cookie: "" }, "Guest state was restored after close");
+  assert.deepEqual((await beta.tool("agent_browser_eval", { script: storage })).data.result, { local: "beta", cookie: "omb_smoke=beta" }, "Restarting the first bot changed the second bot's state");
+  await alpha.tool("agent_browser_fill", { selector: "#message", text: "Reopened browser works" });
+  await alpha.tool("agent_browser_click", { selector: "#submit" });
+  assert.equal((await alpha.tool("agent_browser_get_text", { selector: "#result" })).data.text, "Reopened browser works");
   const screenshotPath = join(fixture, "browser.png");
   const screenshot = await alpha.tool("agent_browser_screenshot", { path: screenshotPath });
   const image = screenshot.content.find((item) => item.type === "image" && item.mimeType === "image/png");
   assert(image?.data, "MCP did not return the screenshot image to the agent");
   const screenshotInfo = pngInfo(await readFile(screenshotPath));
   assert.deepEqual(pngInfo(Buffer.from(image.data, "base64")), screenshotInfo, "MCP image differs from screenshot file");
-  report = { ok: true, target, engineVersion, chromeVersion, checks: ["fresh-home auto-discovery", "real MCP navigation", "title", "input and click", "PNG screenshot", "two-bot cookie and localStorage isolation"], screenshot: screenshotInfo };
+  report = { ok: true, target, engineMode: values["engine-candidate"] ? "vendor-candidate" : "packaged", engineVersion, chromeVersion, checks: ["fresh-home auto-discovery", "real MCP cold-start navigation", "title", "input and click", "same-MCP close and reopen", "PNG screenshot after restart", "two-bot cookie and localStorage isolation"], screenshot: screenshotInfo };
 } catch (error) {
   failure = error;
   try { await failureDiagnostics(); } catch (diagnosticError) {

--- a/server/browser-engine.test.ts
+++ b/server/browser-engine.test.ts
@@ -71,6 +71,7 @@ describe("finding the browser engine", () => {
     const spec = agentBrowserIntegration({ binaryPath: bundle.engine, session: "isolated", encryptionKey: "key", env });
     expect(spec.env.AGENT_BROWSER_EXECUTABLE_PATH).toBe(bundle.chrome);
     expect(spec.env.AGENT_BROWSER_SESSION).toBe("isolated");
+    expect(spec.env.AGENT_BROWSER_NO_WEBMCP).toBe("1");
     expect(spec.env).not.toHaveProperty("OMB_RESOURCES_PATH");
     const override = agentBrowserIntegration({ binaryPath: bundle.engine, session: "isolated", encryptionKey: "key", env: { ...env, AGENT_BROWSER_EXECUTABLE_PATH: "/explicit/chrome" } });
     expect(override.env.AGENT_BROWSER_EXECUTABLE_PATH).toBe("/explicit/chrome");
@@ -160,11 +161,11 @@ describe("what a bot gets", () => {
         PATH: "/usr/bin", AGENT_BROWSER_EXECUTABLE_PATH: "/opt/trusted chrome/chrome",
         PRIVATE_WORKSPACE_SECRET: "synthetic-secret",
         AGENT_BROWSER_SESSION: "wrong-session", AGENT_BROWSER_ENCRYPTION_KEY: "wrong-key",
-        AGENT_BROWSER_ARGS: "--no-sandbox",
+        AGENT_BROWSER_ARGS: "--no-sandbox", AGENT_BROWSER_NO_WEBMCP: "0",
       },
     });
     expect(spec.env).toEqual({
-      AGENT_BROWSER_SESSION: "bot-1", AGENT_BROWSER_RESTORE: "bot-1",
+      AGENT_BROWSER_SESSION: "bot-1", AGENT_BROWSER_NO_WEBMCP: "1", AGENT_BROWSER_RESTORE: "bot-1",
       AGENT_BROWSER_RESTORE_SAVE: "auto", AGENT_BROWSER_ENCRYPTION_KEY: "session-key",
       AGENT_BROWSER_HEADLESS: "1", PATH: "/usr/bin",
       AGENT_BROWSER_EXECUTABLE_PATH: "/opt/trusted chrome/chrome",
@@ -177,7 +178,7 @@ describe("what a bot gets", () => {
     vi.stubEnv("PRIVATE_WORKSPACE_SECRET", "synthetic-process-secret");
     const spec = agentBrowserIntegration({ binaryPath: "/x/agent-browser", session: "bot-1", encryptionKey: "session-key" });
     expect(spec.env).toEqual({
-      AGENT_BROWSER_SESSION: "bot-1", AGENT_BROWSER_RESTORE: "bot-1",
+      AGENT_BROWSER_SESSION: "bot-1", AGENT_BROWSER_NO_WEBMCP: "1", AGENT_BROWSER_RESTORE: "bot-1",
       AGENT_BROWSER_RESTORE_SAVE: "auto", AGENT_BROWSER_ENCRYPTION_KEY: "session-key",
       AGENT_BROWSER_HEADLESS: "1", PATH: "/usr/bin",
       AGENT_BROWSER_EXECUTABLE_PATH: "/opt/process-chrome/chrome",

--- a/server/browser-engine.ts
+++ b/server/browser-engine.ts
@@ -209,6 +209,10 @@ export function agentBrowserIntegration(input: {
 }): { command: string; args: string[]; env: Record<string, string> } {
   const env: Record<string, string> = {
     AGENT_BROWSER_SESSION: input.session,
+    // The MCP server invokes child CLI commands without forwarding its own
+    // global flags. The environment keeps page-provided tools disabled in
+    // those commands too, and avoids changing browser launch settings later.
+    AGENT_BROWSER_NO_WEBMCP: "1",
     // This is a restore *name*, not a boolean. "1" would give every bot
     // the same saved cookies despite using different daemon sessions.
     AGENT_BROWSER_RESTORE: input.session,

--- a/third_party/browser/README.md
+++ b/third_party/browser/README.md
@@ -1,6 +1,6 @@
 # Bundled bot browser: upstream provenance and notices
 
-The desktop application ships two separate, unmodified upstream components:
+The desktop application ships two separate components:
 
 - **agent-browser 0.36.0**, official Vercel release executables from
   <https://github.com/vercel-labs/agent-browser/releases/tag/v0.36.0>.
@@ -9,6 +9,20 @@ The desktop application ships two separate, unmodified upstream components:
   included as `LICENSE-axe-core.txt` and `LICENSE-axe-core-THIRD-PARTY.txt`.
   These files are copied from the same `v0.36.0` source tag; there is no
   root-level NOTICE in that tag.
+- **Windows exception: agent-browser 0.36.0-omb.1** is an OpenMausBot vendor
+  build, not an official or unmodified Vercel executable. It starts from exact
+  v0.36.0 commit `eb05921bad874cd2a1b4fa5d1149f1ed26576cae` and carries only
+  the Windows handle-inheritance fix contributed by `holny` in upstream
+  [PR1781](https://github.com/vercel-labs/agent-browser/pull/1781), commit
+  `81a98c349d04195396ffae6898bd375ad64280de`. The separate MCP output-reader
+  rewrite is deliberately excluded. `agent-browser-windows-stdio.patch`
+  includes the exact changes and modification notices, plus package-version
+  metadata; dependency versions remain locked. The original Apache and axe
+  notices remain unchanged. `scripts/build-windows-browser-vendor.mjs` pins
+  the source archive, patch, Rust 1.97.1, pnpm 11.1.3 and Windows GNU target,
+  builds the real upstream dashboard, and emits executable and build-input
+  digests in `provenance.json`. Native Windows cold-start and close/reopen
+  checks are required before those executable bytes are published and pinned.
 - **Chromium Headless Shell 152.0.7977.82**, Google's official
   `chrome-headless-shell` assets published through Chrome for Testing:
   <https://googlechromelabs.github.io/chrome-for-testing/152.0.7977.82.json>.

--- a/third_party/browser/agent-browser-windows-stdio.patch
+++ b/third_party/browser/agent-browser-windows-stdio.patch
@@ -1,0 +1,93 @@
+OpenMausBot Windows vendor revision 0.36.0-omb.1.
+Base: vercel-labs/agent-browser eb05921bad874cd2a1b4fa5d1149f1ed26576cae.
+Carries only the Windows handle-inheritance fix from upstream PR1781,
+commit 81a98c349d04195396ffae6898bd375ad64280de, plus modification notices
+and package-version metadata. The MCP output-reader rewrite is not included.
+
+diff --git a/cli/src/connection.rs b/cli/src/connection.rs
+--- a/cli/src/connection.rs
++++ b/cli/src/connection.rs
+@@ -1,3 +1,4 @@
++// Modified by OpenMausBot: Windows stdio inheritance fix from upstream PR1781.
+ use crate::validation::sanitize_session_component;
+ use serde::{Deserialize, Serialize};
+ use serde_json::{json, Value};
+@@ -789,6 +790,29 @@ fn stop_existing_daemon_for_restart(session: &str) {
+     }
+ }
+ 
++/// On Windows a spawned child inherits every inheritable handle we hold. Our
++/// stdout/stderr may be pipes that a parent reads to EOF (the MCP server's
++/// `run_cli`, or a PowerShell capture). The detached daemon we are about to
++/// spawn is long-lived; if it keeps those write ends open the parent blocks
++/// forever waiting for EOF that never arrives. Mark our own stdio handles
++/// non-inheritable so the daemon cannot hold the pipes open.
++#[cfg(windows)]
++pub(crate) fn prevent_stdio_handle_inheritance() {
++    use std::os::windows::io::AsRawHandle;
++    use windows_sys::Win32::Foundation::{SetHandleInformation, HANDLE_FLAG_INHERIT};
++
++    unsafe {
++        for handle in [
++            std::io::stdout().as_raw_handle(),
++            std::io::stderr().as_raw_handle(),
++        ] {
++            if !handle.is_null() {
++                let _ = SetHandleInformation(handle as isize, HANDLE_FLAG_INHERIT, 0);
++            }
++        }
++    }
++}
++
+ pub fn ensure_daemon(session: &str, opts: &DaemonOptions) -> Result<DaemonResult, String> {
+     let mut restarted = false;
+ 
+@@ -898,6 +922,8 @@ pub fn ensure_daemon(session: &str, opts: &DaemonOptions) -> Result<DaemonResult
+     {
+         use std::os::windows::process::CommandExt;
+ 
++        prevent_stdio_handle_inheritance();
++
+         let mut cmd = Command::new(&exe_path);
+         cmd.env("AGENT_BROWSER_DAEMON", "1");
+         apply_daemon_env(&mut cmd, session, opts);
+diff --git a/cli/src/main.rs b/cli/src/main.rs
+--- a/cli/src/main.rs
++++ b/cli/src/main.rs
+@@ -1,3 +1,4 @@
++// Modified by OpenMausBot: Windows stdio inheritance fix from upstream PR1781.
+ mod ca_bundle;
+ mod chat;
+ mod color;
+@@ -1105,6 +1106,7 @@ fn run_dashboard_start(port: u16, allowed_origins: Vec<String>, json_mode: bool)
+         use std::os::windows::process::CommandExt;
+         const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
+         const DETACHED_PROCESS: u32 = 0x00000008;
++        connection::prevent_stdio_handle_inheritance();
+         cmd.creation_flags(CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS);
+     }
+ 
+diff --git a/cli/Cargo.toml b/cli/Cargo.toml
+--- a/cli/Cargo.toml
++++ b/cli/Cargo.toml
+@@ -1,6 +1,7 @@
++# Modified by OpenMausBot: distinguish the patched Windows vendor build.
+ [package]
+ name = "agent-browser"
+-version = "0.36.0"
++version = "0.36.0-omb.1"
+ edition = "2021"
+ description = "Fast browser automation CLI for AI agents"
+ license = "Apache-2.0"
+diff --git a/cli/Cargo.lock b/cli/Cargo.lock
+--- a/cli/Cargo.lock
++++ b/cli/Cargo.lock
+@@ -45,7 +45,7 @@
+ 
+ [[package]]
+ name = "agent-browser"
+-version = "0.36.0"
++version = "0.36.0-omb.1"
+ dependencies = [
+  "aes-gcm",
+  "async-trait",


### PR DESCRIPTION
## Why

The 0.1.62 native Windows release gate caught agent-browser 0.36.0 hanging on the first MCP browser call. Its detached daemon inherits captured output handles, so the MCP caller never receives EOF even after navigation succeeds.

## Changes

- Carry only the Windows handle-inheritance fix from vercel-labs/agent-browser#1781 on exact released source `eb05921bad874cd2a1b4fa5d1149f1ed26576cae`. Exclude the broader MCP reader rewrite and unrelated upstream-main changes.
- Add an artifact-only source build with pinned source/patch hashes, locked dependencies, a distinct `0.36.0-omb.1` identity, original notices, and build provenance.
- Verify the candidate on native Windows, including cold start and a real daemon close/restart through the same MCP connection. Normal app release gates keep testing their bundled engine.
- Propagate the WebMCP opt-out into child CLI processes so the configured behavior stays consistent.
- Make explicit Docker release-tag dispatches publish after their smoke checks; manual branch runs stay test-only.
- Exclude dependency prereleases from desktop updater mirroring; keep strict stable-release recovery checks.

## Rollout

This bootstrap does not yet change the shipped engine asset pins. After the vendor build and native candidate checks pass, publish the verified dependency bytes as a non-latest prerelease and pin their exact size/hash in a small follow-up. Then rebuild the application from one fixed release commit and require all normal native/signing/updater gates before publishing 0.1.62.

No CI speed refactor or safety-gate removal is included. The user's live application and data were not used for verification.

## Verification

- Browser integration/preparation tests and typecheck passed locally.
- Server bundle, standalone packaged-server smoke (all nine helper paths and MCP shutdown), and production UI build passed.
- Isolated doctor/new-bot/send/wait/messages workflow settled with the fake Claude engine; fixture was stopped and evidence retained.
- Additional vendor-build and restart checks are recorded in CI before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows browser startup and restart reliability by preventing background processes from retaining terminal handles.
  - Browser engine processes now consistently disable page-provided WebMCP tools, including nested commands.

- **New Features**
  - Added validated Windows browser engine candidates with provenance checks, licensing information, and native cold-start/restart smoke tests.
  - Added automated support for building and testing the Windows browser vendor package.

- **Documentation**
  - Documented Windows packaging, verification requirements, and the temporary browser engine build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->