### PR TITLE
fix(browser): ship the verified Windows startup fix

### DIFF
--- a/server/browser-bundle-release.ts
+++ b/server/browser-bundle-release.ts
@@ -3,8 +3,8 @@
 // This is Chromium's headless shell, not full Chrome (which includes Widevine).
 import { join } from "node:path";
 import {
-  AGENT_BROWSER_VERSION,
   agentBrowserReleaseUrl,
+  agentBrowserReleaseVersion,
   resolveAgentBrowserReleaseAsset,
 } from "./browser-engine-release.ts";
 
@@ -30,7 +30,7 @@ export function browserBundleSpec(target: string) {
     schemaVersion: 1,
     target,
     engine: {
-      version: AGENT_BROWSER_VERSION,
+      version: agentBrowserReleaseVersion(engine),
       asset: engine.asset,
       url: agentBrowserReleaseUrl(engine),
       bytes: engine.bytes,

--- a/server/browser-engine-release.ts
+++ b/server/browser-engine-release.ts
@@ -1,8 +1,8 @@
 // The pinned agent-browser release the harness downloads for the bots'
 // browser (docs/plans/browser-engine.md). Digests were computed from the
-// GitHub release assets on 2026-09-06; bump the version and every digest
-// together, through a pull request whose end-to-end run exercises the binary.
-// The Dockerfile pins the same version.
+// official GitHub assets on 2026-09-06, except the explicitly versioned Windows
+// vendor build below. Update pins through a reviewed native end-to-end run.
+// The Dockerfile retains the official Linux version.
 export const AGENT_BROWSER_VERSION = "0.36.0";
 
 export interface AgentBrowserReleaseAsset {
@@ -12,6 +12,10 @@ export interface AgentBrowserReleaseAsset {
   asset: string;
   sha256: string;
   bytes: number;
+  /** A reviewed platform-specific vendor revision; other assets use the upstream version. */
+  version?: string;
+  /** Exact release URL for a reviewed vendor build, never a mutable latest URL. */
+  url?: string;
 }
 
 const RELEASES = new Map<string, AgentBrowserReleaseAsset>([
@@ -41,12 +45,21 @@ const RELEASES = new Map<string, AgentBrowserReleaseAsset>([
   ],
   [
     "win32-x64",
-    { target: "win32-x64", asset: "agent-browser-win32-x64.exe", sha256: "412ff72737a109e93f5304b0ff76c988fb6f1f451d0fc7e010577922bcc20ff3", bytes: 13837312 },
+    {
+      target: "win32-x64", version: "0.36.0-omb.1",
+      asset: "agent-browser-win32-x64-0.36.0-omb.1.exe",
+      url: "https://github.com/milind-soni/OpenMausBot/releases/download/browser-engine-v0.36.0-omb.1/agent-browser-win32-x64-0.36.0-omb.1.exe",
+      sha256: "33bee834f6a6072ec8688b0914726e0262874d758f69f27e8baf7eaac6b5ed15", bytes: 13806080,
+    },
   ],
 ]);
 
 export function agentBrowserReleaseUrl(asset: AgentBrowserReleaseAsset): string {
-  return `https://github.com/vercel-labs/agent-browser/releases/download/v${AGENT_BROWSER_VERSION}/${asset.asset}`;
+  return asset.url ?? `https://github.com/vercel-labs/agent-browser/releases/download/v${AGENT_BROWSER_VERSION}/${asset.asset}`;
+}
+
+export function agentBrowserReleaseVersion(asset: AgentBrowserReleaseAsset | null): string {
+  return asset?.version ?? AGENT_BROWSER_VERSION;
 }
 
 /** The asset for this machine, or null where Vercel publishes none. */

--- a/server/browser-engine.test.ts
+++ b/server/browser-engine.test.ts
@@ -17,8 +17,8 @@ import {
   pinnedBinaryPath,
   resolveAgentBrowserBinary,
 } from "./browser-engine.ts";
-import { AGENT_BROWSER_VERSION, agentBrowserReleaseUrl, resolveAgentBrowserReleaseAsset } from "./browser-engine-release.ts";
-import { browserBundlePaths, SUPPORTED_BROWSER_TARGETS } from "./browser-bundle-release.ts";
+import { AGENT_BROWSER_VERSION, agentBrowserReleaseUrl, agentBrowserReleaseVersion, resolveAgentBrowserReleaseAsset } from "./browser-engine-release.ts";
+import { browserBundlePaths, browserBundleSpec, SUPPORTED_BROWSER_TARGETS } from "./browser-bundle-release.ts";
 import { removeTempDir } from "./testing/cleanup.ts";
 
 const posix = process.platform !== "win32";
@@ -34,6 +34,45 @@ afterEach(async () => {
 });
 
 describe("finding the browser engine", () => {
+  it("pins the native-verified Windows revision in both download and desktop manifests", () => {
+    const asset = resolveAgentBrowserReleaseAsset("win32", "x64")!;
+    expect(asset).toEqual({
+      target: "win32-x64", version: "0.36.0-omb.1",
+      asset: "agent-browser-win32-x64-0.36.0-omb.1.exe",
+      url: "https://github.com/milind-soni/OpenMausBot/releases/download/browser-engine-v0.36.0-omb.1/agent-browser-win32-x64-0.36.0-omb.1.exe",
+      bytes: 13806080, sha256: "33bee834f6a6072ec8688b0914726e0262874d758f69f27e8baf7eaac6b5ed15",
+    });
+    expect(agentBrowserReleaseVersion(asset)).toBe("0.36.0-omb.1");
+    expect(browserBundleSpec("win32-x64").engine).toEqual({
+      version: asset.version, asset: asset.asset, url: asset.url,
+      bytes: asset.bytes, sha256: asset.sha256, executable: "agent-browser.exe",
+    });
+    for (const [platform, arch] of [["darwin", "arm64"], ["darwin", "x64"], ["linux", "arm64"], ["linux", "x64"]] as const) {
+      expect(agentBrowserReleaseVersion(resolveAgentBrowserReleaseAsset(platform, arch))).toBe("0.36.0");
+    }
+  });
+
+  it("does not reuse a pre-fix Windows managed install for a revised release", () => {
+    const dataDir = join(tmpdir(), "omb-versioned-browser-fixture");
+    const old = join(dataDir, "tools", "agent-browser", "0.36.0", "agent-browser.exe");
+    const revised = pinnedBinaryPath(dataDir, "win32", "x64");
+    expect(revised).toBe(join(dataDir, "tools", "agent-browser", "0.36.0-omb.1", "agent-browser.exe"));
+    const files = new Set([old]);
+    const options = { dataDir, platform: "win32" as const, arch: "x64", env: { PATH: "" }, exists: (file: string) => files.has(file) };
+    expect(resolveAgentBrowserBinary(options)).toBeNull();
+    files.add(revised);
+    expect(browserEngineStatus(options)).toMatchObject({ kind: "ready", binaryPath: revised, version: "0.36.0-omb.1" });
+    expect(resolveAgentBrowserBinary({ ...options, env: { PATH: "", OMB_AGENT_BROWSER_PATH: old } })).toBe(old);
+  });
+
+  it("retains default upstream versions and permits a pinned platform-specific asset URL", () => {
+    const official = resolveAgentBrowserReleaseAsset("linux", "x64")!;
+    expect(agentBrowserReleaseVersion(official)).toBe(AGENT_BROWSER_VERSION);
+    const revised = { ...official, version: "0.36.0-omb.1", url: "https://example.invalid/releases/download/fixed/fixture.exe" };
+    expect(agentBrowserReleaseVersion(revised)).toBe("0.36.0-omb.1");
+    expect(agentBrowserReleaseUrl(revised)).toBe(revised.url);
+  });
+
   it.each(SUPPORTED_BROWSER_TARGETS)("uses the complete %s desktop bundle before old downloaded engines", (target) => {
     const [platform, arch] = target.split("-");
     const env = { OMB_RESOURCES_PATH: join(tmpdir(), "OMB resources"), PATH: "" };
@@ -102,7 +141,7 @@ describe("finding the browser engine", () => {
     expect(resolveAgentBrowserBinary({ dataDir, env: { ...env, OMB_AGENT_BROWSER_PATH: override }, exists })).toBe(override);
     // an override that does not exist is an error, not a silent fallback
     expect(resolveAgentBrowserBinary({ dataDir, env: { ...env, OMB_AGENT_BROWSER_PATH: join(dataDir, "missing", name) }, exists })).toBeNull();
-    expect(browserEngineStatus({ dataDir, env, exists })).toMatchObject({ kind: "ready", binaryPath: pinned, version: AGENT_BROWSER_VERSION });
+    expect(browserEngineStatus({ dataDir, env, exists })).toMatchObject({ kind: "ready", binaryPath: pinned, version: agentBrowserReleaseVersion(resolveAgentBrowserReleaseAsset()) });
   });
 
   it("knows every target Vercel publishes, and picks the musl build on Alpine", () => {
@@ -110,7 +149,8 @@ describe("finding the browser engine", () => {
       const asset = resolveAgentBrowserReleaseAsset(platform, arch);
       expect(asset, `${platform}-${arch}`).not.toBeNull();
       expect(asset?.sha256).toMatch(/^[0-9a-f]{64}$/u);
-      expect(agentBrowserReleaseUrl(asset!)).toContain(`/v${AGENT_BROWSER_VERSION}/`);
+      if (asset?.url) expect(agentBrowserReleaseUrl(asset)).toBe(asset.url);
+      else expect(agentBrowserReleaseUrl(asset!)).toContain(`/v${AGENT_BROWSER_VERSION}/`);
     }
     expect(resolveAgentBrowserReleaseAsset("linux", "x64", true)?.target).toBe("linux-musl-x64");
     expect(resolveAgentBrowserReleaseAsset("freebsd", "x64")).toBeNull();

--- a/server/browser-engine.ts
+++ b/server/browser-engine.ts
@@ -20,6 +20,7 @@ import { browserBundlePaths } from "./browser-bundle-release.ts";
 import {
   AGENT_BROWSER_VERSION,
   agentBrowserReleaseUrl,
+  agentBrowserReleaseVersion,
   resolveAgentBrowserReleaseAsset,
   type AgentBrowserReleaseAsset,
 } from "./browser-engine-release.ts";
@@ -41,8 +42,9 @@ export function isMusl(platform: NodeJS.Platform = process.platform, exists: (p:
   return platform === "linux" && (exists("/lib/ld-musl-x86_64.so.1") || exists("/lib/ld-musl-aarch64.so.1"));
 }
 
-export function pinnedBinaryPath(dataDir = DATA_DIR, platform: NodeJS.Platform = process.platform): string {
-  return join(dataDir, ENGINE_DIR, AGENT_BROWSER_VERSION, executableName(platform));
+export function pinnedBinaryPath(dataDir = DATA_DIR, platform: NodeJS.Platform = process.platform, arch: string = process.arch): string {
+  const version = agentBrowserReleaseVersion(resolveAgentBrowserReleaseAsset(platform, arch));
+  return join(dataDir, ENGINE_DIR, version, executableName(platform));
 }
 
 function onPath(env: NodeJS.ProcessEnv, platform: NodeJS.Platform, exists: (p: string) => boolean): string | null {
@@ -90,7 +92,7 @@ export function resolveAgentBrowserBinary(options: BrowserLookupOptions = {}): s
   if (override) return resolve(override) && exists(resolve(override)) ? resolve(override) : null;
   const bundle = packagedBrowser(options);
   if (bundle && exists(bundle.directory)) return completePackage(bundle, exists) ? bundle.engine : null;
-  const pinned = pinnedBinaryPath(options.dataDir, platform);
+  const pinned = pinnedBinaryPath(options.dataDir, platform, options.arch);
   if (exists(pinned)) return pinned;
   return onPath(env, platform, exists);
 }
@@ -110,11 +112,11 @@ export async function installAgentBrowserBinary(options: {
   const platform = options.platform ?? process.platform;
   const asset = options.asset ?? resolveAgentBrowserReleaseAsset(platform, options.arch ?? process.arch, options.musl ?? isMusl(platform));
   if (!asset) throw new Error(`agent-browser publishes no build for ${platform}-${options.arch ?? process.arch}.`);
-  const destination = pinnedBinaryPath(options.dataDir, platform);
+  const destination = pinnedBinaryPath(options.dataDir, platform, options.arch);
   const directory = join(destination, "..");
   mkdirSync(directory, { recursive: true, mode: 0o700 });
   const url = agentBrowserReleaseUrl(asset);
-  options.log?.(`downloading agent-browser ${AGENT_BROWSER_VERSION} (${Math.round(asset.bytes / 1024 / 1024)} MB, digest pinned)`);
+  options.log?.(`downloading agent-browser ${agentBrowserReleaseVersion(asset)} (${Math.round(asset.bytes / 1024 / 1024)} MB, digest pinned)`);
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
   timer.unref?.();
@@ -182,8 +184,13 @@ export function browserEngineEncryptionKey(dataDir = DATA_DIR): string {
 /** What the harness can offer bots right now, with the reason when nothing. */
 export function browserEngineStatus(options: BrowserLookupOptions = {}): BrowserEngineStatus {
   const binaryPath = resolveAgentBrowserBinary(options);
-  if (binaryPath) return { kind: "ready", binaryPath, version: AGENT_BROWSER_VERSION };
   const bundle = packagedBrowser(options);
+  if (binaryPath) {
+    const platform = options.platform ?? process.platform;
+    const managed = binaryPath === bundle?.engine || binaryPath === pinnedBinaryPath(options.dataDir, platform, options.arch);
+    const version = managed ? agentBrowserReleaseVersion(resolveAgentBrowserReleaseAsset(platform, options.arch)) : AGENT_BROWSER_VERSION;
+    return { kind: "ready", binaryPath, version };
+  }
   if (bundle && (options.exists ?? existsSync)(bundle.directory)) {
     return { kind: "unavailable", reason: "The desktop browser bundle is incomplete. Reinstall or update OpenMausBot to repair it.", installable: false };
   }


### PR DESCRIPTION
## Changes

Finish #913 by pinning the verified Windows agent-browser `0.36.0-omb.1` dependency for both desktop packaging and one-click/self-hosted installation.

- Exact published executable: 13,806,080 bytes; SHA-256 `33bee834f6a6072ec8688b0914726e0262874d758f69f27e8baf7eaac6b5ed15`.
- Distinct download filename avoids collisions with cached upstream 0.36.0 bytes.
- Version-aware managed installation path avoids silently reusing an old Windows executable.
- Status and bundled manifest report the Windows revision consistently. Explicit user overrides remain respected.
- All six non-Windows asset pins and download integrity checks remain unchanged.

## Verification

- [Native vendor build/check passed](https://github.com/milind-soni/OpenMausBot/actions/runs/34148517568): cold MCP navigation, full daemon shutdown/new PID, same-MCP reopen, title/input/clicks, screenshot after restart, guest-state clearing and second-bot isolation.
- Published [dependency release](https://github.com/milind-soni/OpenMausBot/releases/tag/browser-engine-v0.36.0-omb.1) includes exact source/patch/toolchain provenance and original notices; independently rechecked artifact hash/size.
- Focused integration/preparation/vendor tests and typecheck passed, including exact real Windows entry/manifest, migration from the old managed install, and explicit overrides.
- An isolated installer fixture installed the real verified bytes at the new Windows path and reported the correct revision.
- Independent review found no blocker.

The final 0.1.62 app release remains gated on the normal native packaged-browser checks, macOS signing/notarization, packaged-server startup and complete updater-feed integrity checks. No release gate is bypassed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Browser engine installations and status information now report the version associated with the selected platform and architecture.
  - Updated releases no longer incorrectly reuse older Windows installations.
  - Installation and download handling now supports platform-specific release URLs and versioned paths.

- **Improvements**
  - Windows x64 now uses the designated reviewed vendor build with its corresponding download details and integrity metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->