### PR TITLE
fix(approvals): honor explicit Full access for delegated work

### DIFF
--- a/docs/approval-levels.md
+++ b/docs/approval-levels.md
@@ -7,7 +7,7 @@ when that provider resumes an existing native thread.
 | --- | --- |
 | **Ask for approval** | The provider asks before actions outside its normal workspace or network permissions. |
 | **Approve for me** | Uses native automatic review on Codex, Claude, and Cursor. Other providers fall back to Ask. Requests the native reviewer leaves for you are not overridden by OpenMausBot. Unattended Auto runs use Ask. |
-| **Full access** | Enables the provider's permissive mode for commands, edits, and selected-computer actions, including potentially destructive or sensitive work. Some providers still ask for approval. A turn another bot starts (ask_bot, delegate_bot) runs as **Approve for me** instead, so a teammate cannot hand a Full bot a destructive command with nobody watching. Questions and separate OpenMausBot confirmations still wait for you. |
+| **Full access** | Enables the provider's permissive mode for commands, edits, and selected-computer actions, including potentially destructive or sensitive work. Applies to this bot's direct, scheduled, and delegated work (ask_bot, delegate_bot); delegation uses the receiving bot's setting, never the sender's. Some providers still ask for approval. Questions and separate OpenMausBot confirmations still wait for you. |
 | **Custom (`config.toml`)** | Codex only. OpenMausBot reads and reapplies the effective approval and sandbox settings from your Codex configuration. |
 
 Full access is an elevated-risk standing approval. Full and Custom can only be
@@ -32,8 +32,11 @@ Choose Auto explicitly in the local packaged desktop app. Old Antigravity
 they never become unrestricted access on upgrade. Existing Full access bots
 now automatically answer remaining tool-permission requests too. Switching back
 to Ask restores prompts on the next turn. Questions, credential forms, and the
-separate confirmations described above still require an answer. Existing
-peer-started turn restrictions remain unchanged.
+separate confirmations described above still require an answer. A Chief or
+teammate can delegate work to this bot without downgrading its explicit Auto
+(full access) grant. This includes destructive commands and sensitive files:
+enable it only for bots you trust to run that work unattended. It does not
+enable Auto on any other bot, and the legacy Auto setting is not upgraded.
 
 Existing bots that used the old **Auto mode** keep that selection under
 **Approve for me** (except Antigravity, as described above), but now use native
@@ -73,6 +76,7 @@ private desktop-to-server grant protocol in a disposable fixture. It verifies
 HTTP elevation rejection, Full → Auto → Ask on resumed Claude turns, and
 Antigravity automatic tool approvals on new and resumed Full access turns across
 multiple model variants. It also checks that Ask and legacy Auto still prompt,
-peer-started Full turns still prompt, and questions remain interactive. Provider
+peer-started Full turns auto-approve, switching the receiving bot back to Ask
+restores prompts even for a Full-access sender, and questions remain interactive. Provider
 processes are scripted fakes; this does not verify live account eligibility or
 the quality of a provider's automatic reviewer. No live user data is used.

--- a/docs/approval-levels.md
+++ b/docs/approval-levels.md
@@ -77,6 +77,7 @@ HTTP elevation rejection, Full → Auto → Ask on resumed Claude turns, and
 Antigravity automatic tool approvals on new and resumed Full access turns across
 multiple model variants. It also checks that Ask and legacy Auto still prompt,
 peer-started Full turns auto-approve, switching the receiving bot back to Ask
-restores prompts even for a Full-access sender, and questions remain interactive. Provider
+restores prompts even for a Full-access sender, delegated Codex Custom uses the
+native Auto reviewer consistently, and questions remain interactive. Provider
 processes are scripted fakes; this does not verify live account eligibility or
 the quality of a provider's automatic reviewer. No live user data is used.

--- a/scripts/smoke-approval-modes.cjs
+++ b/scripts/smoke-approval-modes.cjs
@@ -1,6 +1,6 @@
 // Run with `pnpm exec electron scripts/smoke-approval-modes.cjs`.
 // Exercises the real private Electron utility-process grant protocol using
-// only a disposable home and fake Claude/Antigravity CLIs. Never uses the live app.
+// only a disposable home and fake Claude/Antigravity/Codex CLIs. Never uses the live app.
 const { app, utilityProcess } = require("electron");
 const assert = require("node:assert/strict");
 const { randomUUID, createHash } = require("node:crypto");
@@ -53,8 +53,10 @@ app.whenReady().then(async () => {
   }
   const agyDump = join(home, "agy.json");
   const agyRpc = join(home, "agy-rpc.json");
+  const codexDump = join(home, "codex.json");
   writeFileSync(join(home, "config.json"), JSON.stringify({ instances: {
     claude: { driver: "claudeAgent", config: { cli: join(root, "server/testing/fake-claude-cli.ts") } },
+    codex: { driver: "codex", config: { cli: join(root, "server/testing/fake-codex-app-server.ts") }, environment: { FAKE_CODEX_MODE: "approval", FAKE_CODEX_DUMP: codexDump } },
     agy: { driver: "antigravityAgent", config: { cli: agy }, environment: { FAKE_ACP_DUMP: agyDump, FAKE_ACP_RPC_DUMP: agyRpc } },
     "agy-question": { driver: "antigravityAgent", config: { cli: agy }, environment: { FAKE_ACP_MODE: "question" } },
   } }));
@@ -176,6 +178,20 @@ app.whenReady().then(async () => {
   assert.equal((await api(`/api/bots/${peerTarget.id}/respond`, "POST", { requestId: peerCard.requestId, behavior: "allow" })).status, 200);
   assert.equal((await askPeerRequest).status, 200);
   console.log(JSON.stringify({ provider: "antigravity", mode: "ask", senderMode: "full", peerInitiated: true, native: "default", humanApproved: true }));
+
+  // Custom is downgraded for delegated turns. Both the provider dispatch and
+  // the residual approval fold must use that same effective Auto mode.
+  const customTarget = (await api("/api/bots", "POST", { modelSelection: { instanceId: "codex", model: "gpt-fake-default" } })).body.bot;
+  await coordinator.request(child, customTarget.id, "custom");
+  const customRequest = api("/api/internal/ask-bot", "POST", { toBotId: customTarget.id, message: "Delegated Custom uses the native Auto reviewer" }, { authorization: `Bearer ${capability.body.token}` });
+  void customRequest.catch(() => {});
+  const customCard = await until(async () => pendingCard((await api("/api/bots")).body.bots.find((bot) => bot.id === customTarget.id)));
+  assert.equal(customCard.held, "The provider requires your approval for this action.");
+  assert.equal((await api(`/api/bots/${customTarget.id}/respond`, "POST", { requestId: customCard.requestId, behavior: "allow" })).status, 200);
+  assert.equal((await customRequest).status, 200);
+  const customCalls = JSON.parse(readFileSync(codexDump, "utf8")).calls;
+  assert.equal(customCalls.find((call) => call.method === "turn/start")?.params.approvalsReviewer, "auto_review");
+  console.log(JSON.stringify({ provider: "codex", mode: "custom", peerInitiated: true, effectiveMode: "auto", nativeApprovalShown: true }));
   console.log("Approval smoke passed; HTTP elevation rejected, private grant and resumed mode transitions verified.");
 }).catch((error) => {
   console.error(error);

--- a/scripts/smoke-approval-modes.cjs
+++ b/scripts/smoke-approval-modes.cjs
@@ -152,18 +152,30 @@ app.whenReady().then(async () => {
   assert.equal(capability.status, 201);
   const peerRequest = api("/api/internal/ask-bot", "POST", { toBotId: peerTarget.id, message: "Peer-initiated permission fixture" }, { authorization: `Bearer ${capability.body.token}` });
   void peerRequest.catch(() => {});
-  const peerCard = await until(async () => pendingCard((await api("/api/bots")).body.bots.find((bot) => bot.id === peerTarget.id)));
-  assert.equal(peerCard.held, "The provider requires your approval for this action.");
-  const peerCalls = JSON.parse(readFileSync(`${agyDump}.config.json`, "utf8"));
-  assert.equal(peerCalls.find((call) => call.params.configId === "mode")?.params.value, "default");
-  assert.equal((await api(`/api/bots/${peerTarget.id}/respond`, "POST", { requestId: peerCard.requestId, behavior: "allow" })).status, 200);
-  assert.equal((await peerRequest).status, 200);
   const peerDecisions = await until(async () => {
     const rows = (await api("/api/decisions")).body.decisions.filter((row) => row.botId === peerTarget.id);
-    return rows.some((row) => row.source === "native-approval" && row.decision === "card-shown") && rows;
+    return rows.some((row) => row.source === "full-access") && rows;
   });
-  assert.ok(!peerDecisions.some((row) => row.source === "full-access"));
-  console.log(JSON.stringify({ provider: "antigravity", mode: "full", peerInitiated: true, native: "default", nativeApprovalShown: true, humanApproved: true }));
+  assert.equal((await peerRequest).status, 200);
+  const completedPeer = (await api("/api/bots")).body.bots.find((bot) => bot.id === peerTarget.id);
+  assert.ok(!pendingCard(completedPeer));
+  assert.ok(!peerDecisions.some((row) => row.decision === "card-shown"));
+  const peerCalls = JSON.parse(readFileSync(`${agyDump}.config.json`, "utf8"));
+  assert.equal(peerCalls.find((call) => call.params.configId === "mode")?.params.value, "yolo");
+  console.log(JSON.stringify({ provider: "antigravity", mode: "full", peerInitiated: true, native: "yolo", autoApproved: true, humanApproved: false }));
+
+  // Revoking the receiving bot's grant must restore prompts on the resumed
+  // delegated session, even when the sender itself has Full access.
+  await coordinator.request(child, id, "full");
+  await coordinator.request(child, peerTarget.id, "ask");
+  const askPeerRequest = api("/api/internal/ask-bot", "POST", { toBotId: peerTarget.id, message: "Ask target must not inherit sender Full" }, { authorization: `Bearer ${capability.body.token}` });
+  void askPeerRequest.catch(() => {});
+  const peerCard = await until(async () => pendingCard((await api("/api/bots")).body.bots.find((bot) => bot.id === peerTarget.id)));
+  const askPeerCalls = JSON.parse(readFileSync(`${agyDump}.config.json`, "utf8"));
+  assert.equal(askPeerCalls.find((call) => call.params.configId === "mode")?.params.value, "default");
+  assert.equal((await api(`/api/bots/${peerTarget.id}/respond`, "POST", { requestId: peerCard.requestId, behavior: "allow" })).status, 200);
+  assert.equal((await askPeerRequest).status, 200);
+  console.log(JSON.stringify({ provider: "antigravity", mode: "ask", senderMode: "full", peerInitiated: true, native: "default", humanApproved: true }));
   console.log("Approval smoke passed; HTTP elevation rejected, private grant and resumed mode transitions verified.");
 }).catch((error) => {
   console.error(error);

--- a/server/auto-approve.test.ts
+++ b/server/auto-approve.test.ts
@@ -222,9 +222,7 @@ describe("autoDecision", () => {
   });
 });
 
-// Full is a decision about the person's OWN sessions with a bot. A turn
-// another bot started is not one, so it runs as Approve for me: the guards
-// card, an unattended sender's block holds, and the fold logs every answer.
+// Full is an explicit grant to the receiving bot, including delegated turns.
 describe("approvalModeForOrigin", () => {
   const person = { peerInitiated: false };
   const peer = { peerInitiated: true };
@@ -235,12 +233,21 @@ describe("approvalModeForOrigin", () => {
     }
   });
 
-  it("runs a peer-started turn on a Full or Custom bot as Approve for me", () => {
-    expect(approvalModeForOrigin("full", peer)).toBe("auto");
+  it("preserves explicit Full for delegated work without elevating other modes", () => {
+    expect(approvalModeForOrigin("full", peer)).toBe("full");
     expect(approvalModeForOrigin("custom", peer)).toBe("auto");
     // and never widens the lower modes
     expect(approvalModeForOrigin("ask", peer)).toBe("ask");
     expect(approvalModeForOrigin("auto", peer)).toBe("auto");
+  });
+
+  it("honors the receiving Full grant for unattended delegated tool permissions", () => {
+    const mode = approvalModeForOrigin("full", peer);
+    for (const [tool, summary] of [["shell", "cmd.exe /c python upload.py"], ["edit", "Run client_edit_file?"], ["shell", "rm -rf build"], ["Read", ".env"]]) {
+      expect(autoVerdict({ approvalMode: mode }, tool, summary, {
+        unattended: true, scope: "local-computer", requiresExplicitApproval: true,
+      }).source).toBe("full-access");
+    }
   });
 });
 
@@ -286,14 +293,13 @@ describe("approvalHeldReason", () => {
     expect(held).not.toContain("Full access");
   });
 
-  it("explains a peer-started Full bot as Auto without promising Full bypasses the origin guard", () => {
+  it("does not describe a peer-started Full bot as paused Auto", () => {
     const held = approvalHeldReason({
       ...auto, unattended: true,
       mode: approvalModeForOrigin("full", { peerInitiated: true }),
       fullAccessAvailable: false,
     });
-    expect(held).toContain("every action asks");
-    expect(held).not.toContain("Full access");
+    expect(held).toBeUndefined();
   });
 
   it("keeps the native and sandbox notes ahead of any mode explanation", () => {

--- a/server/auto-approve.ts
+++ b/server/auto-approve.ts
@@ -13,27 +13,13 @@
 
 import { approvalModeFor, type ApprovalMode } from "../shared/approval-mode.ts";
 
-/** The mode a turn actually runs under, given where the turn came from.
- *
- * Full and Custom are Codex's: on any other engine they fall to Ask, so a
- * hand-edited record cannot hand Claude a bypass it was never granted.
- *
- * And Full is a decision the person made about THEIR OWN sessions with a
- * bot — "run without asking me". A turn started by another bot is not one
- * of those: the person never saw the request, and the sender may itself be
- * unattended or working off a page it just read. A Full target reached that
- * way runs as Approve for me instead — ordinary requests still flow, the
- * destructive and sensitive guards card, an unattended sender's block holds,
- * and every answer goes through the fold and into the decision log, where a
- * driver-side Full accept never appears. A webhook or scheduled turn on a
- * Full bot is unchanged: the person opted into that, and the docs say so. */
+/** Full access is the person's explicit grant to this receiving bot, including
+ * delegated work. It never inherits the sender's mode or elevates another bot.
+ * Custom is a provider-config choice rather than an app Full-access grant, so
+ * peer-started Custom turns still use Auto and its unattended downgrade.
+ * Provider support and grant confirmation are checked by the caller. */
 export function approvalModeForOrigin(mode: ApprovalMode, origin: { peerInitiated: boolean }): ApprovalMode {
-  // Provider support is settled by supportsApprovalMode at the call site;
-  // this only answers who STARTED the turn. A permissive mode is the
-  // person's grant to the bot they talk to, not to every teammate that can
-  // reach it, so a peer-started turn runs one notch down and still gets the
-  // unattended downgrade after this.
-  if ((mode === "full" || mode === "custom") && origin.peerInitiated) return "auto";
+  if (mode === "custom" && origin.peerInitiated) return "auto";
   return mode;
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -2916,10 +2916,9 @@ bus.subscribe((event: RuntimeEvent) => {
             unattended,
             scope: event.approvalScope,
             requiresExplicitApproval: event.requiresExplicitApproval,
-            // Match Antigravity's dispatched mode, including delegated Full
-            // access and unattended Auto's downgrade to Ask.
-            nativeApproval: requiresNativeApproval(event.provider, event.provider === "antigravityAgent"
-              ? effectiveApprovalMode : approvalModeForTurn(asker)),
+            // Match the dispatched mode for every provider, including
+            // delegated Custom and unattended Auto downgrades.
+            nativeApproval: requiresNativeApproval(event.provider, effectiveApprovalMode),
           })
         : null;
       if (verdict?.approve && asker && event.requestId) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1250,8 +1250,8 @@ async function botOverview(bot: BotRecord): Promise<BotOverview> {
 /** Defense in depth for hand-edited/corrupt durable records: elevated
  * approval semantics require an implemented provider mapping. The trusted transition enforces
  * this too, but no provider dispatch or later permission callback relies on
- * persistence having been produced exclusively by that route. And a turn
- * another bot started never runs as Full — see approvalModeForOrigin. */
+ * persistence having been produced exclusively by that route. Delegation
+ * uses the receiving bot's grant, never the sender's — see approvalModeForOrigin. */
 const approvalModeForTurn = (bot: BotRecord, peerInitiated = false): ApprovalMode => {
   const mode = approvalModeForOrigin(approvalModeFor(bot), { peerInitiated });
   if (!supportsApprovalMode(registry.cliTarget(bot.modelSelection.instanceId)?.driverKind, mode)) {
@@ -2908,8 +2908,7 @@ bus.subscribe((event: RuntimeEvent) => {
       const effectiveApprovalMode = asker ? approvalModeForTurn(asker, isInternalTurn(event.threadId)) : "ask";
       const verdict = permission && asker && event.requestId
         ? autoVerdict({
-            // the same origin the dispatch used, so a peer-started turn's
-            // residual asks are judged as Approve for me here too
+            // Use the same receiving-bot mode as the provider dispatch.
             approvalMode: effectiveApprovalMode,
             autoApprove: false,
             alwaysAllow: asker.alwaysAllow,
@@ -2917,9 +2916,8 @@ bus.subscribe((event: RuntimeEvent) => {
             unattended,
             scope: event.approvalScope,
             requiresExplicitApproval: event.requiresExplicitApproval,
-            // Antigravity's residual asks must use a peer-started turn's
-            // effective safe Auto mode, not its durable Full grant.
-            // Preserve the existing policy of every other provider.
+            // Match Antigravity's dispatched mode, including delegated Full
+            // access and unattended Auto's downgrade to Ask.
             nativeApproval: requiresNativeApproval(event.provider, event.provider === "antigravityAgent"
               ? effectiveApprovalMode : approvalModeForTurn(asker)),
           })

--- a/src/components/ApprovalModeSelector.test.ts
+++ b/src/components/ApprovalModeSelector.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { FullAccessWarning } from "./FullAccessWarning";
 
 import {
   ApprovalModeSelector,
@@ -10,6 +11,14 @@ import {
 } from "./ApprovalModeSelector";
 
 describe("approval mode selector", () => {
+  it("discloses delegated work in the Full access confirmation", () => {
+    const html = renderToStaticMarkup(createElement(FullAccessWarning, {
+      open: true, onCancel: () => {}, onConfirm: () => {},
+    }));
+    expect(html).toContain("tasks delegated by your Chief or other bots");
+    expect(html).toContain("does not enable Full access on other bots");
+    expect(html).not.toContain("Requests that come from another bot still get the usual checks");
+  });
   it("matches the four Codex approval levels and their plain-language copy", () => {
     expect(approvalModeOptions().map(({ mode, label, description }) => ({ mode, label, description }))).toEqual([
       {

--- a/src/components/FullAccessWarning.tsx
+++ b/src/components/FullAccessWarning.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from "react";
 import { ShieldAlert } from "lucide-react";
 
 export const FULL_ACCESS_WARNING =
-  "This bot can read, edit, delete files, use the internet, and control its selected computer without asking—even for potentially destructive or sensitive actions. Some providers may still require approval. Requests that come from another bot still get the usual checks. Questions and separate OpenMausBot confirmations still wait for you. This does not grant operating-system permissions or access to accounts you have not connected.";
+  "This bot can read, edit, delete files, use the internet, and control its selected computer without asking—even for potentially destructive or sensitive actions. This also applies to scheduled work and tasks delegated by your Chief or other bots. It does not enable Full access on other bots. Some providers may still require approval. Questions and separate OpenMausBot confirmations still wait for you. This does not grant operating-system permissions or access to accounts you have not connected.";
 
 export function FullAccessWarning({
   open,


### PR DESCRIPTION
## Summary

Fix the mismatch where Antigravity shows Auto (full access), but tool permissions ask again when a Chief or another bot starts the task.

- Preserve the receiving bot's explicitly selected Full access during delegated work, using the existing shared approval-mode boundary.
- Antigravity keeps native yolo mode and automatically answers residual tool-permission requests on those turns.
- Keep Ask, legacy Auto, and Custom behavior unchanged. A Full sender cannot elevate an Ask target. Pending/unconfirmed grants still resolve to Ask.
- Update the Full access confirmation and approval documentation to explicitly disclose delegated work, including destructive commands and sensitive files.
- Address CodeRabbit's review: native permission handling now uses the dispatched effective mode for every provider, including delegated Codex Custom.

This intentionally broadens existing Full-access grants to delegated work across supported providers. It does not auto-enable Full on other bots, change provider-specific remaining restrictions, or bypass questions, separate app confirmations, OS permissions, or account authentication.

## Verification

- Typecheck passed.
- Approval-policy and mode-selector tests passed (89 tests across the focused files, including the new consent-text test).
- Isolated Electron approval smoke passed with disposable data and fake Claude/Antigravity/Codex providers: direct and resumed Auto/full requests, both Gemini variants, delegated Full auto-approval, and switching that target back to Ask with a Full sender. Questions remain interactive and HTTP elevation remains rejected. The new delegated Codex Custom regression fails on the prior head and passes with the review fix, checking native reviewer selection and residual native-approval deferral.
- Full Vitest suite passed on the initial head: 4,266 tests across 353 passing files (39 skipped, 1 todo). Focused tests, typecheck, and the expanded Electron smoke passed again after the review fix. Final-head CI passed on macOS, Ubuntu, and Windows, plus Linux packaging, iOS, Android, and control-plane checks; CodeRabbit confirmed its finding addressed. CI run: https://github.com/milind-soni/OpenMausBot/actions/runs/34154628875

No live user data was touched. This verifies the actual app approval flow with scripted providers, not a live Windows Antigravity account. No version bump or release is included.
