### PR TITLE
chore(release): bump version to 0.1.63

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openmausbot",
   "private": true,
-  "version": "0.1.62",
+  "version": "0.1.63",
   "description": "A local-first chat app for running a team of AI agents.",
   "homepage": "https://github.com/milind-soni/OpenMausBot",
   "repository": {


### PR DESCRIPTION
Bumps the desktop and self-hosted npm release from 0.1.62 to 0.1.63. Includes changes already merged into main: broader interface translations and explicit Full access handling for delegated work. Version-only change; existing local work and unmerged PRs are untouched. After CI passes, merge to trigger the standard signed multi-platform release, verify both updater feeds, then publish npm and Docker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the package version to 0.1.63.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->