### PR TITLE
Preserve the agent PATH when mounting browser tools

### DIFF
--- a/server/browser-codex-path.integration.test.ts
+++ b/server/browser-codex-path.integration.test.ts
@@ -1,0 +1,119 @@
+// Exercise the harness caller that constructs browser integrations: a direct
+// driver test would miss a browser MCP environment replacing its augmented PATH.
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { stripTypeScriptTypes } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { removeTempDir, waitForExit } from "./testing/cleanup.ts";
+import { freePortBlock } from "./testing/ports.ts";
+import { openSse, type SseRecorder } from "./testing/sse.ts";
+
+const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
+const FINDER_PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
+
+// This regression concerns Unix shebang lookup and macOS Finder's PATH;
+// Windows resolves CLI shims through a separate launch contract.
+describe.skipIf(process.platform === "win32")("Codex browser turns with a minimal GUI PATH", () => {
+  let home: string;
+  let bin: string;
+  let browser: string;
+  let base: string;
+  let child: ChildProcess;
+  let events: SseRecorder;
+  let stderr = "";
+
+  const api = async (method: string, path: string, body?: unknown) => {
+    const response = await fetch(`${base}${path}`, {
+      method,
+      headers: body === undefined ? undefined : { "content-type": "application/json" },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    return { status: response.status, body: await response.json() as any };
+  };
+
+  beforeAll(async () => {
+    home = mkdtempSync(join(tmpdir(), "omb-browser-codex-path-"));
+    bin = join(home, ".local", "bin");
+    const data = join(home, ".openmausbot");
+    mkdirSync(bin, { recursive: true });
+    mkdirSync(data);
+    // The extensionless executable must exercise /usr/bin/env node, rather
+    // than the driver's explicit .ts-file launch through process.execPath.
+    const codex = join(bin, "codex");
+    writeFileSync(codex, '#!/usr/bin/env node\nimport("./fake-codex-app-server.mjs");\n', { mode: 0o755 });
+    // A Linux system Node may precede our symlink; it need not support .ts.
+    writeFileSync(join(bin, "fake-codex-app-server.mjs"), stripTypeScriptTypes(
+      readFileSync(join(SERVER_DIR, "testing", "fake-codex-app-server.ts"), "utf8"),
+    ));
+    symlinkSync(process.execPath, join(bin, "node"));
+    browser = join(bin, "agent-browser");
+    // The fake provider records MCP configuration without starting a browser.
+    writeFileSync(browser, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    writeFileSync(join(data, "config.json"), JSON.stringify({
+      features: { browser: true },
+      instances: Object.fromEntries(["default", "absolute"].map((id) => [id, {
+        driver: "codex",
+        environment: { FAKE_CODEX_DUMP: join(home, `${id}.json`) },
+        config: { cli: id === "default" ? "codex" : codex },
+      }])),
+    }));
+    const port = await freePortBlock([0, 1]);
+    base = `http://127.0.0.1:${port}`;
+    child = spawn(process.execPath, [join(SERVER_DIR, "index.ts")], {
+      cwd: join(SERVER_DIR, ".."),
+      env: {
+        PATH: FINDER_PATH, HOME: home, OMB_DATA_DIR: data, OMB_PORT: String(port),
+        OMB_AGENT_BROWSER_PATH: browser, VITEST: "1",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stderr!.on("data", (chunk) => { stderr += chunk; });
+    await new Promise<void>((resolve, reject) => {
+      let output = "";
+      const timer = setTimeout(() => reject(new Error(`Fixture did not listen: ${stderr}`)), 25_000);
+      child.once("error", (error) => { clearTimeout(timer); reject(error); });
+      child.once("exit", () => { clearTimeout(timer); reject(new Error(`Fixture exited: ${stderr}`)); });
+      child.stdout!.on("data", (chunk) => {
+        output += chunk;
+        if (output.includes(`openmausbot server on ${base}`)) { clearTimeout(timer); resolve(); }
+      });
+    });
+    events = await openSse(`${base}/api/events`);
+  }, 30_000);
+
+  afterAll(async () => {
+    events?.close();
+    await waitForExit(child, { signal: "SIGTERM" });
+    if (home) await removeTempDir(home);
+  });
+
+  it.each(["default", "absolute"])("keeps the browser mounted and completes a turn with the %s Codex CLI", async (instanceId) => {
+    const created = await api("POST", "/api/bots", {
+      name: `Browser PATH ${instanceId}`, browser: true,
+      modelSelection: { instanceId, model: "gpt-fake-default" },
+    });
+    expect(created.status).toBe(201);
+    const botId = created.body.bot.id;
+    const since = events.frames.length;
+    expect((await api("POST", `/api/bots/${botId}/messages`, { text: "Check the browser integration." })).status).toBe(202);
+    const started = await events.until((frame) => events.frames.indexOf(frame) >= since && frame.kind === "bot" && frame.bot?.id === botId && frame.bot?.busy === true);
+    // The creation's idle event can arrive after its HTTP response. Only
+    // accept an idle event ordered after this turn became busy.
+    await events.until((frame) => events.frames.indexOf(frame) > events.frames.indexOf(started) && frame.kind === "bot" && frame.bot?.id === botId && frame.bot?.busy === false);
+    const bot = (await api("GET", "/api/bots")).body.bots.find((item: any) => item.id === botId);
+    const replies = bot.messages.filter((message: any) => message.role === "bot").map((message: any) => message.text);
+    expect(replies, JSON.stringify(replies)).toContain("done from fake codex");
+    const dump = JSON.parse(readFileSync(join(home, `${instanceId}.json`), "utf8"));
+    // Linux may provide /usr/bin/node, so completion alone cannot prove the
+    // absolute CLI retained access to the user's discovered runtime directory.
+    expect(dump.env.PATH.split(":")).toContain(bin);
+    expect(dump.env.PATH).toContain(FINDER_PATH);
+    expect(dump.argv).toContain(`mcp_servers.browser.command=${JSON.stringify(browser)}`);
+    expect(dump.argv).toContain('mcp_servers.browser.args=["mcp","--tools","core","--no-webmcp"]');
+    expect(dump.env.AGENT_BROWSER_SESSION).toBeTruthy();
+    expect(dump.calls.some((call: any) => call.method === "turn/start")).toBe(true);
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -803,6 +803,7 @@ function browserIntegration(botId: string, profile: string | undefined) {
       session,
       encryptionKey: browserEngineEncryptionKey(),
       persistent: profile !== "guest",
+      env: { ...process.env, PATH: augmentedPath() },
     }),
   };
 }


### PR DESCRIPTION
## What changed

Preserve the discovered agent `PATH` when the harness mounts the browser MCP server. Add an isolated regression covering both a bare `codex` command and an absolute Codex CLI path with a minimal GUI environment.

Prepared from upstream `6da5f944ab1189e79f77d55c86ebaaea2c406016` on branch `fix/browser-codex-path`, head `8016c399af79046f06f72dd3740210c95307ea47`.

## Why

When the app starts from Finder, its inherited `PATH` can omit the user's CLI and Node installation directories. The Codex driver augments that path, but mounting the browser MCP server copies its environment over the driver's environment. Passing the original path into that mount can make Codex unavailable or prevent an absolute CLI with a Node shebang from starting.

The browser integration now receives the existing `augmentedPath()` result. This adds no dependencies or new path-discovery behavior.

## How it was verified

Checked on macOS arm64 with Node 24.20.0 and pnpm 10.33.0, after applying the change to the upstream base above:

- `pnpm install --frozen-lockfile` completed without lockfile changes.
- `pnpm exec vitest run server/browser-codex-path.integration.test.ts`: both cases fail without the fix and pass with it. The test uses a temporary home, fake Codex, and fake browser configuration; it checks successful replies, the augmented path, and mounted browser MCP arguments. Unix shebang-specific cases are skipped on Windows.
- `pnpm typecheck` passed.
- `pnpm test` passed: main suite 4,283 passed, 39 skipped, 1 todo; broker 8 passed; Electron 146 passed; packaged-server smoke passed.
- The documented isolated `control:omb` workflow passed: launch, doctor, new-bot, send, wait (`settled`), and messages (fake provider reply). The foreground launcher was stopped and its temporary data removed.

The control workflow verifies general chat behavior. The dedicated regression verifies the browser environment mount; it does not open a real browser. Linux and Windows were not run locally.

## Screenshots (UI changes)

Not applicable: no UI changes.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (see CONTRIBUTING.md → Tests)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser integrations so spawned browser processes retain the augmented executable PATH.
  * Preserved access to user-installed command-line tools when browser automation is enabled.

* **Tests**
  * Added integration coverage for browser sessions using both PATH-resolved and absolute CLI configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->