### PR TITLE
Make the thread header a label strip, not a toolbar

### DIFF
--- a/src/components/CallView.tsx
+++ b/src/components/CallView.tsx
@@ -149,7 +149,9 @@ export function CallTargetButton({
         aria-label={label}
         title={label}
         className={cn(
-          "relative flex size-9 items-center justify-center rounded-full transition-colors",
+          // sized with the other header controls: at size-9 this one button set the
+          // height of the whole strip
+          "relative flex size-8 items-center justify-center rounded-full transition-colors",
           active
             ? "bg-danger text-white hover:brightness-110"
             : unavailable

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -1114,22 +1114,25 @@ export function ChatView({ bot }: { bot: Bot }) {
         className={cn(
           // @container so the chips on the right can fold to icon bubbles
           // when the column is narrow (side panel open, small window)
-          "@container/chathead flex items-center justify-between px-5 py-3",
+          "@container/chathead flex items-center justify-between px-4 py-1.5",
+          // The header is a label for the thread, not a title bar: a hairline
+          // separates it from the messages instead of empty space.
+          "border-b border-hairline/40",
           // Room for the drawer button, which overlays this corner below md.
           "pl-11 md:pl-5",
         )}
       >
-        <div className="flex min-w-0 items-center gap-2.5 rounded-lg px-1.5 py-1">
+        <div className="flex min-w-0 items-center gap-2 rounded-lg px-1.5 py-0.5 transition-colors hover:bg-raised/50">
           <button
             onClick={() => dispatch({ type: "toggleSettings", open: true })}
-            className="flex size-10 shrink-0 items-center justify-center rounded-lg hover:bg-raised/50"
+            className="flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-lg"
             title={t("chat.openProfile")}
             aria-label={t("chat.openProfileAria", { name: bot.name })}
           >
             <BotAvatar
               bot={bot}
               state={stateForBot({ ...bot, messages })}
-              size={28}
+              size={18}
               motion={mascotMotion?.kind ?? "none"}
               motionKey={mascotMotion?.nonce ?? 0}
             />
@@ -1147,8 +1150,8 @@ export function ChatView({ bot }: { bot: Bot }) {
             }}
             onActivate={() => dispatch({ type: "toggleSettings", open: true })}
             showEditButton
-            className="truncate text-[15px] font-semibold text-ink"
-            inputClassName="max-w-[220px] rounded bg-inset px-1.5 py-0.5 text-[15px] font-semibold"
+            className="cursor-pointer truncate text-[13px] font-medium text-ink"
+            inputClassName="max-w-[220px] rounded bg-inset px-1.5 py-0.5 text-[13px] font-medium"
           />
           {bot.chiefOfStaff && (
             <span className="flex items-center gap-1 rounded-full bg-accent/12 px-2 py-0.5 text-[11px] font-medium text-accent">

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -1095,13 +1095,13 @@ export function GroupView({ group }: { group: Group }) {
       {/* Header: static member avatars; a ring + dot marks the working bot. */}
       <div
         className={cn(
-          "flex items-center justify-between px-5 py-3",
+          "flex items-center justify-between border-b border-hairline/40 px-4 py-1.5",
           // Room for the drawer button, which overlays this corner below md.
           "pl-11 md:pl-5",
         )}
       >
         <div className="flex min-w-0 items-center gap-2">
-          <span className="truncate text-[15px] font-semibold text-ink">{group.name}</span>
+          <span className="truncate text-[13px] font-medium text-ink">{group.name}</span>
           {!setupPending && !group.dm && <GroupTaskPicker group={group} />}
         </div>
         <div className="flex items-center gap-1.5">

--- a/src/components/RenameTitle.tsx
+++ b/src/components/RenameTitle.tsx
@@ -102,7 +102,7 @@ export function RenameTitle({
           onClick={startRename}
           aria-label={t("rename.named", { name: value })}
           title={t("rename.agent")}
-          className="flex size-10 shrink-0 items-center justify-center rounded text-ink-secondary opacity-70 hover:bg-raised hover:text-ink hover:opacity-100"
+          className="flex size-7 shrink-0 items-center justify-center rounded text-ink-secondary opacity-70 hover:bg-raised hover:text-ink hover:opacity-100"
         >
           <Pencil size={12} />
         </button>


### PR DESCRIPTION
The header above a thread measured **65px**. The same header in the app this
layout follows measures ~38px (calibrated against the 12px macOS close button
in a screenshot). It is now **45px**, and the two controls that were making it
tall are the reason it could shrink at all.

## What was setting the height

Nothing was styled around these; they were simply the tallest things in the row,
while every control beside them is 30px:

- the rename pencil in `RenameTitle`, at `size-10` (40px)
- the call button in `CallView`, at `size-9` (36px)

Both come down to match their neighbours. Then `py-3` → `py-1.5`, the bot name
15px semibold → 13px medium, its avatar 28 → 18.

## Two details that are not size

- **The name and the avatar open the same bot**, so they became one hover target
  carrying the tint a sidebar row uses. The pointer cursor has to be set
  explicitly: Tailwind v4's preflight dropped it from buttons, and the fix
  already in `styles.css` is scoped to `[data-sidebar]`.
- **A hairline under the header** replaces empty space as the separation from
  the messages — in the 1:1 thread and in a channel alike.

## On the weight

`font-medium` is not a lighter name. Inter renders visibly heavier than the SF
this layout was drawn against, so 500 here reads the way 600 reads there. The
same reasoning applies to the sidebar rows, but those live in another PR.

## Checks

`pnpm typecheck`, `pnpm lint`, and the component suite (317 tests). Header height
measured in the browser before and after: 65 → 45.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined call, chat, and room header controls for a more compact, consistent appearance.
  * Tightened header spacing and added subtle bottom borders in chat and room views.
  * Reduced title and room-name text sizing for improved visual hierarchy.
  * Updated profile, avatar, and rename controls with smaller dimensions and spacing.
  * Added pointer feedback to the chat profile control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->