### PR TITLE
Sidebar: drag the divider, drag the rows, edit the headings

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,9 +1,11 @@
 import { track } from "@/lib/analytics";
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import {
   Archive,
+  ArrowDown,
   ArrowDownToLine,
+  ArrowUp,
   BellDot,
   Bot as BotIcon,
   CalendarDays,
@@ -16,21 +18,21 @@ import {
   FolderPlus,
   Library,
   Loader2,
-  Network,
   MoreHorizontal,
-  Pencil,
+  Network,
   PanelLeftClose,
   PanelLeftOpen,
+  Pencil,
   Pin,
   PinOff,
   Plus,
-  Search,
   Puzzle,
+  Search,
   Trash2,
   Users,
   X,
 } from "lucide-react";
-import { api, useStore, formatTime, visibleMessages, currentTaskBot, type AppState, type Bot, type Group } from "@/state/store";
+import { api, useStore, visibleMessages, currentTaskBot, type AppState, type Bot, type Group } from "@/state/store";
 
 import { BotAvatar, InitialsAvatar } from "./Avatar";
 import { stateForBot } from "@/lib/mascot";
@@ -52,11 +54,22 @@ import { folderUnreadThreadIds, markFolderRead } from "@/lib/folder-read";
 import { SidebarThreadRow, visibleSidebarThreads } from "./SidebarThreadRow";
 import {
   loadCollapsedSections,
+  loadRowOrder,
   loadSectionOrder,
+  SIDEBAR_DEFAULT_WIDTH,
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_MIN_EXPANDED_WIDTH,
+  SIDEBAR_RAIL_WIDTH,
+  clampSidebarWidth,
   loadSidebarDensity,
+  loadSidebarWidth,
   saveCollapsedSections,
+  saveRowOrder,
   saveSectionOrder,
   saveSidebarDensity,
+  saveSidebarWidth,
+  sidebarIsRail,
+  widthForDensity,
   toggleCollapsedSection,
   type SidebarDensity,
 } from "@/lib/sidebar-preferences";
@@ -66,6 +79,8 @@ import {
   CHANNELS_SECTION_ID,
   PINNED_SECTION_ID,
   mergeSectionOrder,
+  moveRowWithinList,
+  orderedSidebarRows,
   moveSection,
   orderedSidebarSections,
   partitionSidebarBots,
@@ -75,6 +90,7 @@ import {
   sidebarGoalRunPreview,
   sidebarLayoutInteractive,
   sidebarSectionCollapsed,
+  sidebarStamp,
   sidebarSectionLabel,
   userSectionId,
   userSectionName,
@@ -221,7 +237,7 @@ export function GroupListItem({
       <div className={cn("min-w-0 flex-1", density === "icons" && "hidden")}>
         <div className="flex items-baseline justify-between gap-2">
           <span className="truncate text-[14px] font-semibold text-ink">{group.name}</span>
-          {selected && last && !expanded && <span className="shrink-0 text-[10px] text-ink-secondary">{formatTime(last.at)}</span>}
+          {selected && last && !expanded && <span className="shrink-0 text-[10px] text-ink-secondary">{sidebarStamp(last.at)}</span>}
           {expanded && group.unread && <span className="size-1.5 shrink-0 rounded-full bg-accent" aria-label={t("task.unreadMany")} />}
         </div>
         {!expanded && <div className="flex items-center justify-between gap-2">
@@ -280,10 +296,15 @@ function RoomContextMenu({
   menu,
   onClose,
   onMoveToSection,
+  moveList = [],
+  onMoveRow = () => {},
 }: {
   menu: { groupId: string; x: number; y: number };
   onClose: () => void;
   onMoveToSection: (groupId: string) => void;
+  /** ids of the list this group reorders inside, in render order */
+  moveList?: string[];
+  onMoveRow?: (direction: -1 | 1) => void;
 }) {
   const { state, dispatch } = useStore();
   const remoteClient = window.ogb?.remoteClient?.active === true;
@@ -313,7 +334,9 @@ function RoomContextMenu({
     if (name) dispatch({ type: "patchGroup", groupId: group.id, patch: { name } });
     onClose();
   };
-  const top = Math.min(menu.y, window.innerHeight - 204);
+  const position = moveList.indexOf(group.id);
+  const canReorder = position >= 0 && moveList.length > 1;
+  const top = Math.max(8, Math.min(menu.y, window.innerHeight - 204 - (canReorder ? 80 : 0)));
   const left = Math.min(menu.x, window.innerWidth - 240);
   return createPortal(
     <div
@@ -374,6 +397,38 @@ function RoomContextMenu({
           {isBotChat ? t("sidebar.room.renameChat") : t("sidebar.room.renameChannel")}
         </button>
       ))}
+      {canReorder && (
+        <>
+          <button
+            onClick={() => {
+              onMoveRow(-1);
+              onClose();
+            }}
+            disabled={position === 0}
+            className={cn(
+              "flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-ink",
+              position === 0 ? "cursor-default opacity-40" : "hover:bg-raised/70",
+            )}
+          >
+            <ArrowUp size={16} className="text-ink-secondary" />
+            {t("sidebar.bot.moveUp")}
+          </button>
+          <button
+            onClick={() => {
+              onMoveRow(1);
+              onClose();
+            }}
+            disabled={position === moveList.length - 1}
+            className={cn(
+              "flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-ink",
+              position === moveList.length - 1 ? "cursor-default opacity-40" : "hover:bg-raised/70",
+            )}
+          >
+            <ArrowDown size={16} className="text-ink-secondary" />
+            {t("sidebar.bot.moveDown")}
+          </button>
+        </>
+      )}
       {!remoteClient && !isBotChat && (
         <button
           onClick={() => {
@@ -493,6 +548,140 @@ function NewRoomPanel({ onClose }: { onClose: () => void }) {
  * target's current one), a create field, and a remove action. Serves bots
  * and channels alike — the caller supplies the assignment. Mirrors the
  * context menu's fixed positioning + dismiss-on-outside-click contract. */
+/** A heading's own menu: rename the context, step it up or down, or take the
+ * label off. Built-in headings (Pinned, Groups, Bot threads, Bots) are derived
+ * from bot state rather than typed by anyone, so they get only the two moves. */
+function SectionContextMenu({
+  menu,
+  label,
+  editable,
+  canMoveUp,
+  canMoveDown,
+  onClose,
+  onMove,
+  onRename,
+  onDelete,
+}: {
+  menu: { id: string; x: number; y: number };
+  label: string;
+  /** built-in headings (Pinned, Groups, Bots…) are not user labels */
+  editable: boolean;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onClose: () => void;
+  onMove: (direction: -1 | 1) => void;
+  onRename: (name: string) => void;
+  onDelete: () => void;
+}) {
+  const [renaming, setRenaming] = useState(false);
+  const [draft, setDraft] = useState(label);
+
+  useEffect(() => {
+    const onDown = (e: MouseEvent) => {
+      if (!(e.target instanceof Element) || !e.target.closest("[data-section-menu]")) onClose();
+    };
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    window.addEventListener("mousedown", onDown);
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("blur", onClose);
+    return () => {
+      window.removeEventListener("mousedown", onDown);
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("blur", onClose);
+    };
+  }, [onClose]);
+
+  const saveRename = () => {
+    const name = nextRename(label, draft);
+    if (name) onRename(name);
+    onClose();
+  };
+  const row = (disabled: boolean) =>
+    cn(
+      "flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-ink",
+      disabled ? "cursor-default opacity-40" : "hover:bg-raised/70",
+    );
+  const top = Math.min(menu.y, window.innerHeight - 200);
+  const left = Math.min(menu.x, window.innerWidth - 240);
+
+  return createPortal(
+    <div
+      data-section-menu
+      data-sidebar
+      style={{ top, left }}
+      className="fixed z-40 w-[228px] overflow-hidden rounded-xl border border-hairline/50 bg-menu py-1.5 shadow-2xl shadow-black/60"
+    >
+      {editable && (renaming ? (
+        <div className="flex items-center gap-1 px-2 py-1">
+          <input
+            autoFocus
+            value={draft}
+            maxLength={60}
+            aria-label={t("sidebar.section.renameContextAria", { name: label })}
+            onFocus={(event) => event.currentTarget.select()}
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !event.nativeEvent.isComposing) {
+                event.preventDefault();
+                saveRename();
+              }
+              if (event.key === "Escape") {
+                event.preventDefault();
+                onClose();
+              }
+            }}
+            className="min-w-0 flex-1 rounded-lg bg-raised px-2 py-1.5 text-[14px] text-ink focus:outline-none focus:ring-1 focus:ring-accent"
+          />
+          <button
+            type="button"
+            onClick={saveRename}
+            aria-label={t("common.save")}
+            title={t("common.save")}
+            className="flex size-8 shrink-0 items-center justify-center rounded-lg text-ink-secondary hover:bg-raised hover:text-ink"
+          >
+            <Check size={15} />
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={() => {
+            setDraft(label);
+            setRenaming(true);
+          }}
+          className={row(false)}
+        >
+          <Pencil size={16} className="text-ink-secondary" />
+          {t("sidebar.section.renameContext")}
+        </button>
+      ))}
+      <button onClick={() => { onMove(-1); onClose(); }} disabled={!canMoveUp} className={row(!canMoveUp)}>
+        <ArrowUp size={16} className="text-ink-secondary" />
+        {t("sidebar.bot.moveUp")}
+      </button>
+      <button onClick={() => { onMove(1); onClose(); }} disabled={!canMoveDown} className={row(!canMoveDown)}>
+        <ArrowDown size={16} className="text-ink-secondary" />
+        {t("sidebar.bot.moveDown")}
+      </button>
+      {editable && (
+        <>
+          <div className="mx-2 my-1 border-t border-hairline/40" />
+          <button
+            onClick={() => {
+              onDelete();
+              onClose();
+            }}
+            className="flex w-full items-center gap-3 px-3.5 py-2 text-left text-[14px] text-danger hover:bg-raised/70"
+          >
+            <Trash2 size={16} />
+            {t("sidebar.section.deleteContext")}
+          </button>
+        </>
+      )}
+    </div>,
+    document.body,
+  );
+}
+
 function SectionPicker({
   current,
   anchor,
@@ -619,12 +808,17 @@ export function BotContextMenu({
   onDelete,
   onMoveToSection,
   onNewFolder,
+  moveList = [],
+  onMoveRow = () => {},
 }: {
   menu: MenuState;
   onClose: () => void;
   onArchive: (bot: Bot) => void;
   onDelete: (bot: Bot) => void;
   onMoveToSection: (botId: string) => void;
+  /** ids of the list this bot reorders inside, in render order */
+  moveList?: string[];
+  onMoveRow?: (direction: -1 | 1) => void;
   onNewFolder: (botId: string) => void;
 }) {
   const { state, dispatch } = useStore();
@@ -671,6 +865,8 @@ export function BotContextMenu({
   const deleting = state.deletingBots[bot.id] === true;
   const engine = state.instances.find((instance) => instance.instanceId === bot.modelSelection.instanceId);
   const canCoordinate = engine?.capabilities?.agentsMcp === true;
+  const position = moveList.indexOf(bot.id);
+  const canReorder = position >= 0 && moveList.length > 1;
   const visibleBotCount = state.bots.filter((candidate) => !candidate.hidden).length;
   const archiveBlocked = Boolean(bot.chiefOfStaff) || visibleBotCount <= 1;
   const archiveHint = bot.chiefOfStaff
@@ -753,6 +949,15 @@ export function BotContextMenu({
           onClose();
           onMoveToSection(bot.id);
         }),
+        // For the people who never discover that a row is draggable.
+        ...(canReorder ? [
+          item(<ArrowUp size={16} className="text-ink-secondary" />, t("sidebar.bot.moveUp"), () => onMoveRow(-1), {
+            disabled: position === 0,
+          }),
+          item(<ArrowDown size={16} className="text-ink-secondary" />, t("sidebar.bot.moveDown"), () => onMoveRow(1), {
+            disabled: position === moveList.length - 1,
+          }),
+        ] : []),
         item(<BellDot size={16} className="text-ink-secondary" />, t("sidebar.bot.markUnread"), () =>
           dispatch({ type: "markUnread", botId: bot.id }),
         ),
@@ -1105,7 +1310,7 @@ export function BotListItem({
           </span>
           {selected && last && !renaming && !expanded && (
             <span className="shrink-0 text-xs text-ink-secondary transition-opacity group-hover:opacity-0 group-focus-within:opacity-0">
-              {formatTime(last.at)}
+              {sidebarStamp(last.at)}
             </span>
           )}
           {expanded && unread && <span className="size-1.5 shrink-0 rounded-full bg-accent" aria-label={t("task.unreadMany")} />}
@@ -1390,8 +1595,33 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
     return saved === "icons" ? "comfortable" : saved;
   });
   const [densityOpen, setDensityOpen] = useState(false);
+  // Density is the shape of a row; width is how much room the column gives it.
+  // They meet at the rail: drag far enough left and the sidebar becomes the
+  // "icons" density, so the rail stays reachable from the handle and the menu.
+  const [width, setWidthState] = useState<number>(() => loadSidebarWidth());
+  // What the collapse button restores. Someone who dragged to 420 and folded
+  // the sidebar away expects 420 back, not the default.
+  const [lastExpandedWidth, setLastExpandedWidth] = useState<number>(() => {
+    const saved = loadSidebarWidth();
+    return sidebarIsRail(saved) ? SIDEBAR_DEFAULT_WIDTH : saved;
+  });
+  const [dragging, setDragging] = useState(false);
+  const dragFrom = useRef<{ x: number; width: number } | null>(null);
   const [collapsedSections, setCollapsedSections] = useState<string[]>(() => loadCollapsedSections());
   const [sectionOrder, setSectionOrder] = useState<string[]>(() => loadSectionOrder());
+  // Row order is one flat list for the whole sidebar; a drag only ever moves
+  // a row next to another row in the same list, so the section it belongs to
+  // — which is a team boundary, not decoration — can never change here.
+  const [rowOrder, setRowOrder] = useState<string[]>(() => loadRowOrder());
+  const [draggingRowId, setDraggingRowId] = useState<string | null>(null);
+  const [rowDropTarget, setRowDropTarget] = useState<{ id: string; place: SectionDropPlace } | null>(null);
+  const rowDragRef = useRef<{
+    from: string | null;
+    list: string[];
+    over: { id: string; place: SectionDropPlace } | null;
+  }>({ from: null, list: [], over: null });
+  const [sectionMenu, setSectionMenu] = useState<{ id: string; x: number; y: number } | null>(null);
+  const [sectionConfirm, setSectionConfirm] = useState<{ id: string; name: string; count: number } | null>(null);
   const [draggingSectionId, setDraggingSectionId] = useState<string | null>(null);
   const [dropTarget, setDropTarget] = useState<{ id: string; place: SectionDropPlace } | null>(null);
   const [reorderAnnouncement, setReorderAnnouncement] = useState("");
@@ -1400,22 +1630,78 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
     over: { id: string; place: SectionDropPlace } | null;
   }>({ from: null, over: null });
 
-  const setDensity = (next: SidebarDensity) => {
+  const applyWidth = (next: number, persist: boolean) => {
+    setWidthState(next);
+    if (!sidebarIsRail(next)) setLastExpandedWidth(next);
+    if (persist) saveSidebarWidth(next);
+  };
+
+  const setDensity = (next: SidebarDensity, nextWidth = widthForDensity(next)) => {
     setDensityState(next);
     if (next !== "icons") setLastExpandedDensity(next);
     // Search is hidden in avatar-only mode. Keeping its value would silently
     // filter bots, rooms, and message results with no visible way to clear it.
     else setQuery("");
     saveSidebarDensity(next);
+    applyWidth(next === "icons" ? SIDEBAR_RAIL_WIDTH : nextWidth, true);
     setDensityOpen(false);
   };
 
+  /** The drag writes the width; crossing the snap point is what switches the
+   * density, so a drag and the menu cannot disagree about the rail. */
+  const setWidth = (value: number, persist: boolean) => {
+    const clamped = clampSidebarWidth(value);
+    const wantsRail = sidebarIsRail(clamped);
+    if (wantsRail !== (density === "icons")) {
+      setDensityState(wantsRail ? "icons" : lastExpandedDensity);
+      if (wantsRail) setQuery("");
+      saveSidebarDensity(wantsRail ? "icons" : lastExpandedDensity);
+    }
+    applyWidth(clamped, persist);
+  };
+
   const toggleCollapsed = () => {
-    if (density === "icons") setDensity(lastExpandedDensity);
+    if (density === "icons") setDensity(lastExpandedDensity, lastExpandedWidth);
     else {
       setLastExpandedDensity(density);
       setDensity("icons");
     }
+  };
+
+  // The same drag ComputerPanel.tsx uses on its own edge, mirrored: pointer
+  // capture so the pointer may leave the handle, and one write to storage on
+  // release rather than one per frame.
+  const onResizeStart = (event: React.PointerEvent<HTMLDivElement>) => {
+    dragFrom.current = { x: event.clientX, width };
+    setDragging(true);
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+  const onResizeMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragFrom.current) return;
+    setWidth(dragFrom.current.width + (event.clientX - dragFrom.current.x), false);
+  };
+  const onResizeEnd = (event: React.PointerEvent<HTMLDivElement>) => {
+    const from = dragFrom.current;
+    if (!from) return;
+    dragFrom.current = null;
+    setDragging(false);
+    event.currentTarget.releasePointerCapture(event.pointerId);
+    // From the event, not from `width`: a pointerup in the same frame as the
+    // last move would otherwise persist the width before that move.
+    setWidth(from.width + (event.clientX - from.x), true);
+  };
+  // A pointer-only separator is unusable without a mouse. A step of 16px would
+  // never cross the dead zone on its own, so the two edges of it are jumps:
+  // one press leaves the rail, one press collapses back to it.
+  const onResizeKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const step = event.key === "ArrowLeft" ? -16 : event.key === "ArrowRight" ? 16 : 0;
+    if (!step) return;
+    event.preventDefault();
+    if (density === "icons") {
+      if (step > 0) setWidth(SIDEBAR_MIN_EXPANDED_WIDTH, true);
+      return;
+    }
+    setWidth(width <= SIDEBAR_MIN_EXPANDED_WIDTH && step < 0 ? SIDEBAR_RAIL_WIDTH : width + step, true);
   };
 
   // Esc closes the drawer, mirroring ApiKeys.tsx:75-85. Bound only while the
@@ -1618,6 +1904,179 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
     );
   };
 
+  // Every visible row, in the order it renders. `placeSection` needs both ids
+  // present in the array it edits, so a first drag starts from this rather
+  // than from an empty saved list.
+  const rowBase = orderedSidebarSections(
+    [
+      ...(unsectionedChief ? [unsectionedChief.id] : []),
+      ...pinnedBots.map((bot) => bot.id),
+      ...sectionChiefs.map((bot) => bot.id),
+      ...sectionedBots.map((bot) => bot.id),
+      ...unsectionedBots.map((bot) => bot.id),
+      ...botChats.map((group) => group.id),
+      ...unsectionedRooms.map((group) => group.id),
+      ...sectionedRooms.map((group) => group.id),
+    ],
+    rowOrder,
+  );
+
+  const commitRowOrder = (next: string[]) => {
+    // Merged, not replaced: a bot that is archived or filtered out right now
+    // is absent from `next`, and its saved place should survive.
+    const merged = mergeSectionOrder(rowOrder, next);
+    if (sameSectionOrder(merged, rowOrder)) return;
+    setRowOrder(merged);
+    saveRowOrder(merged);
+  };
+
+  /** `orderedList` is the row's own list under the order it just landed in —
+   * never the saved array, which spans every section and would announce a
+   * position the user cannot see. */
+  const announceRowPosition = (id: string, orderedList: string[]) => {
+    const position = orderedList.indexOf(id);
+    // Rows are bots AND groups; naming only bots left every group move silent
+    // for a screen reader.
+    const name =
+      state.bots.find((candidate) => candidate.id === id)?.name ??
+      state.groups.find((candidate) => candidate.id === id)?.name;
+    if (position < 0 || !name) return;
+    setReorderAnnouncement(
+      t("sidebar.section.moved", { name, position: position + 1, count: orderedList.length }),
+    );
+  };
+
+  /** One step, and only against a neighbour from the same rendered list. */
+  const moveRow = (id: string, listIds: string[], direction: -1 | 1) => {
+    if (!layoutInteractive) return;
+    const ordered = orderedSidebarSections(listIds, rowOrder);
+    const next = moveRowWithinList(rowBase, ordered, id, direction);
+    commitRowOrder(next);
+    announceRowPosition(id, orderedSidebarSections(listIds, next));
+  };
+
+  const resetRowDrag = () => {
+    rowDragRef.current = { from: null, list: [], over: null };
+    setDraggingRowId(null);
+    setRowDropTarget(null);
+  };
+
+  const startRowDrag = (event: React.DragEvent<HTMLDivElement>, id: string, listIds: string[]) => {
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData("application/x-openmausbot-sidebar-row", id);
+    rowDragRef.current = { from: id, list: listIds, over: null };
+    setDraggingRowId(id);
+  };
+
+  const updateRowDropTarget = (event: React.DragEvent<HTMLDivElement>, id: string, listIds: string[]) => {
+    const from = rowDragRef.current.from;
+    // Only inside the list the drag started in: crossing a section boundary
+    // would change the bot's team, which a drag must never do silently.
+    if (!layoutInteractive || !from || from === id || !listIds.includes(from)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = "move";
+    const rect = event.currentTarget.getBoundingClientRect();
+    const place: SectionDropPlace = event.clientY < rect.top + rect.height / 2 ? "before" : "after";
+    const next = { id, place };
+    rowDragRef.current.over = next;
+    setRowDropTarget(next);
+  };
+
+  const dropRow = (event: React.DragEvent<HTMLDivElement>) => {
+    const { from, list, over } = rowDragRef.current;
+    if (from && over && list.includes(over.id)) {
+      event.preventDefault();
+      event.stopPropagation();
+      const next = placeSection(rowBase, from, over.id, over.place);
+      commitRowOrder(next);
+      announceRowPosition(from, orderedSidebarSections(list, next));
+    }
+    resetRowDrag();
+  };
+
+  /** A row plus its drop indicators. The wrapper carries the drag, so the row
+   * component stays a row and knows nothing about ordering. */
+  const rowWrapper = (id: string, listIds: string[], child: ReactNode) => {
+    const reorderable = layoutInteractive && listIds.length > 1;
+    const marker = (place: SectionDropPlace) =>
+      rowDropTarget?.id === id && rowDropTarget.place === place && draggingRowId !== id ? (
+        <div className="mx-2 h-0.5 rounded-full bg-accent" />
+      ) : null;
+    return (
+      <div
+        key={id}
+        draggable={reorderable}
+        onDragStart={reorderable ? (event) => startRowDrag(event, id, listIds) : undefined}
+        onDragEnd={resetRowDrag}
+        onDragOver={(event) => updateRowDropTarget(event, id, listIds)}
+        onDrop={dropRow}
+        className={cn("flex flex-col gap-0.5", draggingRowId === id && "opacity-40")}
+      >
+        {marker("before")}
+        {child}
+        {marker("after")}
+      </div>
+    );
+  };
+
+  /** The list a group reorders inside. Empty while reordering is off — on the
+   * rail and during a search — so the menus do not offer a move that `moveRow`
+   * would refuse. */
+  const rowListForGroup = (groupId: string): string[] => {
+    const group = state.groups.find((candidate) => candidate.id === groupId);
+    if (!group || !layoutInteractive) return [];
+    const list = group.dm
+      ? botChats
+      : group.section
+        ? sectionedRooms.filter((candidate) => candidate.section === group.section)
+        : unsectionedRooms;
+    return orderedSidebarSections(list.map((candidate) => candidate.id), rowOrder);
+  };
+
+  /** The list a bot reorders inside — the one it renders in, never wider. */
+  const rowListForBot = (botId: string): string[] => {
+    const bot = state.bots.find((candidate) => candidate.id === botId);
+    if (!bot || bot.hidden || bot.chiefOfStaff || !layoutInteractive) return [];
+    const list = bot.pinned
+      ? pinnedBots
+      : bot.section
+        ? sectionedBots.filter((candidate) => candidate.section === bot.section)
+        : unsectionedBots;
+    return orderedSidebarSections(list.map((candidate) => candidate.id), rowOrder);
+  };
+
+  const sectionMembers = (name: string) => ({
+    bots: state.bots.filter((bot) => !bot.hidden && bot.section === name),
+    groups: state.groups.filter((group) => group.section === name),
+  });
+
+  /** A context is a label its members carry, so renaming and deleting are the
+   * same write: put a different label — or none — on every member. */
+  const relabelSection = (name: string, next: string) => {
+    const { bots, groups } = sectionMembers(name);
+    if (remoteClient) {
+      if (bots.length > 0) {
+        void api("/api/sidebar-sections", {
+          method: "POST",
+          body: JSON.stringify({ name: next, botIds: bots.map((bot) => bot.id) }),
+        })
+          .then(({ bots: updated }) => updated.forEach((bot: Bot) => dispatch({ type: "botPatched", bot })))
+          .catch((cause) => dispatch({ type: "error", message: cause instanceof Error ? cause.message : String(cause) }));
+      }
+    } else {
+      for (const bot of bots) {
+        // "" and not undefined: JSON.stringify drops an undefined field, so
+        // the clear would never reach the server — the same empty string the
+        // context picker sends to remove one row from a context.
+        dispatch({ type: "updateBot", botId: bot.id, patch: { section: next } });
+      }
+    }
+    for (const group of groups) {
+      dispatch({ type: "patchGroup", groupId: group.id, patch: { section: next } });
+    }
+  };
+
   const moveSidebarSection = (id: string, direction: -1 | 1) => {
     const next = moveSection(sectionIds, id, direction);
     if (sameSectionOrder(next, sectionIds)) return;
@@ -1669,9 +2128,15 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
       aria-label={t("sidebar.aria")}
       data-native-view-overlay
       data-sidebar
+      style={{ width }}
       className={cn(
-        "flex h-full shrink-0 flex-col border-r border-hairline/40 bg-panel transition-[width] duration-200",
-        density === "icons" ? "w-[80px]" : density === "compact" ? "w-[272px]" : "w-[320px]",
+        "relative flex h-full shrink-0 flex-col border-r border-hairline/40 bg-panel",
+        // No width transition mid-drag: the pointer is the animation, and a
+        // 200ms ease would lag a frame behind it.
+        dragging ? "" : "transition-[width] duration-200",
+        // The drawer below md keeps a width of its own; the inline width and
+        // the handle are desktop only.
+        "max-md:!w-[320px]",
         // Below md only: the sidebar leaves the flow and slides in over the chat.
         // Scoped with max-md: rather than cancelled with md: on purpose — Tailwind
         // v4 emits the native `translate` property, and any value other than
@@ -1684,6 +2149,25 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
         open ? "max-md:translate-x-0" : "max-md:-translate-x-full",
       )}
     >
+      {/* Drag the divider itself, the way the Computer panel is resized. It
+          is focusable and carries its value, because arrow keys resize from
+          here; it is only the drawer layout below md that has no divider. */}
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        aria-label={t("sidebar.resizeAria")}
+        aria-valuenow={width}
+        aria-valuemin={SIDEBAR_RAIL_WIDTH}
+        aria-valuemax={SIDEBAR_MAX_WIDTH}
+        tabIndex={0}
+        onPointerDown={onResizeStart}
+        onPointerMove={onResizeMove}
+        onPointerUp={onResizeEnd}
+        onPointerCancel={onResizeEnd}
+        onKeyDown={onResizeKeyDown}
+        onDoubleClick={toggleCollapsed}
+        className="absolute inset-y-0 -right-0.5 z-20 w-1.5 cursor-col-resize hover:bg-accent/40 focus-visible:bg-accent/40 focus-visible:outline-none max-md:hidden"
+      />
       {/* macOS owns inset traffic lights; Linux/Windows use native chrome. */}
       <div
         className={cn("flex items-center pt-3.5 pb-1", density === "icons" ? "flex-col gap-1 px-2" : "justify-between px-4")}
@@ -1871,22 +2355,30 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
             const sectionChiefItems = sectionName
               ? sectionChiefs.filter((bot) => bot.section === sectionName)
               : [];
-            const sectionGroupItems =
+            const sectionGroupItems = orderedSidebarRows(
               id === CHANNELS_SECTION_ID
                 ? unsectionedRooms
                 : id === BOT_CHATS_SECTION_ID
                   ? botChats
                   : sectionName
                     ? sectionedRooms.filter((group) => group.section === sectionName)
-                    : [];
-            const sectionBotItems =
+                    : [],
+              rowOrder,
+            );
+            const sectionBotItems = orderedSidebarRows(
               id === PINNED_SECTION_ID
                 ? pinnedBots
                 : id === BOTS_SECTION_ID
                   ? unsectionedBots
                   : sectionName
                     ? sectionedBots.filter((bot) => bot.section === sectionName)
-                    : [];
+                    : [],
+              rowOrder,
+            );
+            // Groups and bots are separate lists inside one section, so a drag
+            // never interleaves a group into the bots below it.
+            const groupListIds = sectionGroupItems.map((group) => group.id);
+            const botListIds = sectionBotItems.map((bot) => bot.id);
             const collapsed = sectionCollapsed(id);
             const queued = collapsed ? [...sectionChiefItems, ...sectionBotItems].flatMap((bot) =>
               sidebarBotActivityTasks(bot, state.pendingQueued).filter((task) => task.queued).map((task) => `${bot.name}: ${task.title}`)) : [];
@@ -1927,6 +2419,7 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
                     }}
                     onDragEnd={resetSectionDrag}
                     onMove={(direction) => moveSidebarSection(id, direction)}
+                    onOpenMenu={layoutInteractive ? (point) => setSectionMenu({ id, ...point }) : undefined}
                   />
                 )}
                 {collapsed && queued.length > 0 && <button type="button" onClick={() => toggleSection(id)}
@@ -1943,24 +2436,22 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
                         onMenu={setMenu}
                       />
                     ))}
-                    {sectionGroupItems.map((group) => (
+                    {sectionGroupItems.map((group) => rowWrapper(group.id, groupListIds, (
                       <GroupListItem
-                        key={group.id}
                         group={group}
                         density={density}
                         query={q}
                         onMenu={setRoomMenu}
                       />
-                    ))}
-                    {sectionBotItems.map((bot) => (
+                    )))}
+                    {sectionBotItems.map((bot) => rowWrapper(bot.id, botListIds, (
                       <BotListItem
-                        key={bot.id}
                         bot={bot}
                         density={density}
                         query={q}
                         onMenu={setMenu}
                       />
-                    ))}
+                    )))}
                   </>
                 )}
                 {dropTarget?.id === id && dropTarget.place === "after" && draggingSectionId !== id && (
@@ -2082,6 +2573,8 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
 
       {menu && (
         <BotContextMenu
+          moveList={rowListForBot(menu.botId)}
+          onMoveRow={(direction) => moveRow(menu.botId, rowListForBot(menu.botId), direction)}
           menu={menu}
           onClose={() => setMenu(null)}
           onArchive={requestArchive}
@@ -2105,6 +2598,46 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
           else dispatch({ type: "deleteBot", botId: bot.id });
         }}
       />
+      {sectionMenu && (
+        <SectionContextMenu
+          key={sectionMenu.id}
+          menu={sectionMenu}
+          label={sectionLabel(sectionMenu.id)}
+          editable={userSectionName(sectionMenu.id) !== null}
+          canMoveUp={layoutInteractive && sectionIds.indexOf(sectionMenu.id) > 0}
+          canMoveDown={
+            layoutInteractive &&
+            sectionIds.indexOf(sectionMenu.id) >= 0 &&
+            sectionIds.indexOf(sectionMenu.id) < sectionIds.length - 1
+          }
+          onClose={() => setSectionMenu(null)}
+          onMove={(direction) => moveSidebarSection(sectionMenu.id, direction)}
+          onRename={(next) => {
+            const name = userSectionName(sectionMenu.id);
+            if (name) relabelSection(name, next);
+          }}
+          onDelete={() => {
+            const name = userSectionName(sectionMenu.id);
+            if (!name) return;
+            const { bots, groups } = sectionMembers(name);
+            setSectionConfirm({ id: sectionMenu.id, name, count: bots.length + groups.length });
+          }}
+        />
+      )}
+      <ConfirmDialog
+        open={Boolean(sectionConfirm)}
+        title={t("sidebar.section.deleteTitle", { name: sectionConfirm?.name ?? "" })}
+        body={t("sidebar.section.deleteBody", { count: sectionConfirm?.count ?? 0 })}
+        confirmLabel={t("common.delete")}
+        tone="danger"
+        icon={<Trash2 size={18} />}
+        returnFocusRef={sidebarRef}
+        onCancel={() => setSectionConfirm(null)}
+        onConfirm={() => {
+          if (sectionConfirm) relabelSection(sectionConfirm.name, "");
+          setSectionConfirm(null);
+        }}
+      />
       {sectionPicker && (
         <SectionPicker
           current={state.bots.find((b) => b.id === sectionPicker.botId)?.section}
@@ -2126,6 +2659,8 @@ export function Sidebar({ open, onClose }: { open: boolean; onClose: () => void 
       )}
       {roomMenu && (
         <RoomContextMenu
+          moveList={rowListForGroup(roomMenu.groupId)}
+          onMoveRow={(direction) => moveRow(roomMenu.groupId, rowListForGroup(roomMenu.groupId), direction)}
           key={roomMenu.groupId}
           menu={roomMenu}
           onClose={() => setRoomMenu(null)}

--- a/src/components/SidebarSectionHeader.tsx
+++ b/src/components/SidebarSectionHeader.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronRight, GripVertical } from "lucide-react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import type { DragEvent, KeyboardEvent } from "react";
 
 import { cn } from "@/lib/cn";
@@ -18,6 +18,7 @@ export function SidebarSectionHeader({
   onDragStart,
   onDragEnd,
   onMove,
+  onOpenMenu,
 }: {
   name: string;
   collapsed: boolean;
@@ -25,13 +26,23 @@ export function SidebarSectionHeader({
   onToggle?: () => void;
   reorderable: boolean;
   dragging: boolean;
-  onDragStart?: (event: DragEvent<HTMLSpanElement>) => void;
+  onDragStart?: (event: DragEvent<HTMLDivElement>) => void;
   onDragEnd?: () => void;
   onMove?: (direction: -1 | 1) => void;
+  /** the heading's own menu: rename, reorder, remove the label. Takes a point
+   * rather than an event, so the keyboard can open it at the row. */
+  onOpenMenu?: (point: { x: number; y: number }) => void;
 }) {
   const Chevron = collapsed ? ChevronRight : ChevronDown;
   const attentionLabel = attention ? sidebarAttentionLabel(attention) : "";
   const onHeaderKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    // The same two keys that open a bot row's menu.
+    if (onOpenMenu && (event.key === "ContextMenu" || (event.shiftKey && event.key === "F10"))) {
+      event.preventDefault();
+      const rect = event.currentTarget.getBoundingClientRect();
+      onOpenMenu({ x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 });
+      return;
+    }
     if (!reorderable || !event.altKey) return;
     if (event.key === "ArrowUp") {
       event.preventDefault();
@@ -43,7 +54,21 @@ export function SidebarSectionHeader({
   };
 
   return (
-    <div className="flex items-center gap-1 px-2 pb-1" data-section={name}>
+    <div
+      className={cn("flex items-center gap-1 px-2 pb-1", dragging && "opacity-40")}
+      data-section={name}
+      draggable={reorderable}
+      onDragStart={reorderable ? onDragStart : undefined}
+      onDragEnd={reorderable ? onDragEnd : undefined}
+      onContextMenu={
+        onOpenMenu
+          ? (event) => {
+              event.preventDefault();
+              onOpenMenu({ x: event.clientX, y: event.clientY });
+            }
+          : undefined
+      }
+    >
       {onToggle ? (
         <button
           type="button"
@@ -99,21 +124,6 @@ export function SidebarSectionHeader({
           </span>
           {attentionLabel && <span className="sr-only">{attentionLabel}</span>}
         </div>
-      )}
-      {reorderable && (
-        <span
-          aria-hidden="true"
-          draggable
-          title={t("sidebar.section.dragToReorder")}
-          onDragStart={onDragStart}
-          onDragEnd={onDragEnd}
-          className={cn(
-            "flex size-6 shrink-0 cursor-grab items-center justify-center rounded text-ink-secondary hover:bg-raised hover:text-ink",
-            dragging && "opacity-40",
-          )}
-        >
-          <GripVertical size={13} />
-        </span>
       )}
     </div>
   );

--- a/src/lib/sidebar-layout.test.ts
+++ b/src/lib/sidebar-layout.test.ts
@@ -1,17 +1,22 @@
 import { describe, expect, it } from "vitest";
 
+import { setLocale } from "./i18n";
+
 import {
   BOT_CHATS_SECTION_ID,
   BOTS_SECTION_ID,
   CHANNELS_SECTION_ID,
   PINNED_SECTION_ID,
   mergeSectionOrder,
+  moveRowWithinList,
   moveSection,
+  orderedSidebarRows,
   orderedSidebarSections,
   partitionSidebarBots,
   partitionSidebarGroups,
   placeSection,
   sidebarLayoutInteractive,
+  sidebarStamp,
   sidebarGoalRunPreview,
   sidebarSectionCollapsed,
   sidebarSectionLabel,
@@ -172,5 +177,58 @@ describe("sidebar section ordering", () => {
       work,
       PINNED_SECTION_ID,
     ]);
+  });
+});
+
+describe("sidebar row stamp", () => {
+  // Fixed points, so the boundaries are the subject rather than the clock.
+  const now = new Date(2026, 8, 8, 10, 0).getTime(); // Tue 8 Sep 2026, 10:00
+  const at = (day: number, hour = 9, minute = 30) => new Date(2026, 8, day, hour, minute).getTime();
+
+  it("moves from the time, through yesterday and the weekday, to the date", () => {
+    setLocale("en");
+    expect(sidebarStamp(at(8, 9, 30), now)).toMatch(/9:30/);
+    expect(sidebarStamp(at(7), now)).toBe("Yesterday");
+    expect(sidebarStamp(at(4), now)).toBe("Friday");
+    // seven days back is no longer "this week", so it becomes a date
+    expect(sidebarStamp(at(1), now)).toBe("09/01");
+  });
+
+  it("counts calendar days, not elapsed hours", () => {
+    setLocale("en");
+    // one minute earlier, but the day before: yesterday, never "23:59"
+    expect(sidebarStamp(new Date(2026, 8, 7, 23, 59).getTime(), new Date(2026, 8, 8, 0, 1).getTime())).toBe(
+      "Yesterday",
+    );
+  });
+
+  it("reads a clock that runs ahead as today rather than as an error", () => {
+    setLocale("en");
+    expect(sidebarStamp(at(9, 11, 15), now)).toMatch(/11:15/);
+  });
+});
+
+describe("row order", () => {
+  const rows = [{ id: "a" }, { id: "b" }, { id: "c" }];
+
+  it("follows the saved order and keeps unseen rows next to their neighbours", () => {
+    // "b" was never dragged, so it lands beside the neighbour it still has:
+    // ahead of "c", because the saved order put "c" before "a"
+    expect(orderedSidebarRows(rows, ["c", "a"]).map((row) => row.id)).toEqual(["b", "c", "a"]);
+    expect(orderedSidebarRows(rows, []).map((row) => row.id)).toEqual(["a", "b", "c"]);
+    // a saved id that no longer exists is ignored, not rendered
+    expect(orderedSidebarRows(rows, ["gone", "b"]).map((row) => row.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("moves a row only against a neighbour from its own list", () => {
+    // "b" and "e" share a saved order but sit in different sections
+    const saved = ["a", "b", "c", "d", "e"];
+    const list = ["b", "d"];
+    expect(moveRowWithinList(saved, list, "d", -1)).toEqual(["a", "d", "b", "c", "e"]);
+    // at the end of its own list nothing happens, even though "e" follows it
+    expect(moveRowWithinList(saved, list, "d", 1)).toEqual(saved);
+    expect(moveRowWithinList(saved, list, "b", -1)).toEqual(saved);
+    // a row outside the list cannot be moved by it
+    expect(moveRowWithinList(saved, list, "c", 1)).toEqual(saved);
   });
 });

--- a/src/lib/sidebar-layout.ts
+++ b/src/lib/sidebar-layout.ts
@@ -1,3 +1,4 @@
+import { activeLocale, t } from "@/lib/i18n";
 import type { GroupGoalRunCardData } from "../../shared/group-goal-run";
 
 export const PINNED_SECTION_ID = "builtin:pinned";
@@ -63,6 +64,24 @@ export function sidebarGoalRunPreview(run: GroupGoalRunCardData): string {
   const summary = detail || goal;
   const label = GOAL_RUN_PREVIEW_LABEL[run.status];
   return summary ? `${label}: ${summary}` : label;
+}
+
+/** The stamp on a sidebar row: how long ago the last message was, at the
+ * resolution that is useful at that distance — the time today, "yesterday",
+ * the weekday inside the week, then the date. `now` is a parameter so the
+ * boundaries can be tested; days are counted from local midnight, not from
+ * elapsed hours, so 23:59 → 00:01 reads as yesterday and not as "today". */
+export function sidebarStamp(at: number, now: number = Date.now()): string {
+  const date = new Date(at);
+  const startOfDay = (value: Date) =>
+    new Date(value.getFullYear(), value.getMonth(), value.getDate()).getTime();
+  const days = Math.round((startOfDay(new Date(now)) - startOfDay(date)) / 86_400_000);
+  // A timestamp in the future is a clock that disagrees, not an error worth
+  // showing: it reads as today.
+  if (days <= 0) return date.toLocaleTimeString(activeLocale(), { hour: "numeric", minute: "2-digit" });
+  if (days === 1) return t("chat.day.yesterday");
+  if (days < 7) return date.toLocaleDateString(activeLocale(), { weekday: "long" });
+  return date.toLocaleDateString(activeLocale(), { day: "2-digit", month: "2-digit" });
 }
 
 export function sidebarLayoutInteractive(density: SidebarDensityMode, query: string): boolean {
@@ -135,6 +154,35 @@ export function orderedSidebarSections(
     }
   }
   return result;
+}
+
+/** Rows carry the order the user dragged them into; a row the saved order
+ * has never seen keeps its natural position. That is the same problem as
+ * section order, so it is the same function underneath. */
+export function orderedSidebarRows<T extends { id: string }>(
+  rows: T[],
+  savedOrder: SidebarSectionId[],
+): T[] {
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  return orderedSidebarSections(rows.map((row) => row.id), savedOrder)
+    .map((id) => byId.get(id))
+    .filter((row): row is T => Boolean(row));
+}
+
+/** One step up or down inside a row's own list, expressed as a move in the
+ * whole saved order. The neighbour is read from the list, never from the
+ * saved array, so a row can only ever move within the section it is in —
+ * moving between sections is a team change, not a reorder. */
+export function moveRowWithinList(
+  savedOrder: SidebarSectionId[],
+  listIds: SidebarSectionId[],
+  id: SidebarSectionId,
+  direction: -1 | 1,
+): SidebarSectionId[] {
+  const index = listIds.indexOf(id);
+  const neighbour = index < 0 ? undefined : listIds[index + direction];
+  if (!neighbour) return savedOrder;
+  return placeSection(savedOrder, id, neighbour, direction < 0 ? "before" : "after");
 }
 
 export function moveSection(

--- a/src/lib/sidebar-preferences.test.ts
+++ b/src/lib/sidebar-preferences.test.ts
@@ -2,6 +2,15 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   SIDEBAR_COLLAPSED_SECTIONS_KEY,
+  SIDEBAR_DEFAULT_WIDTH,
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_MIN_EXPANDED_WIDTH,
+  SIDEBAR_RAIL_WIDTH,
+  SIDEBAR_WIDTH_KEY,
+  clampSidebarWidth,
+  loadSidebarWidth,
+  saveSidebarWidth,
+  sidebarIsRail,
   SIDEBAR_DENSITY_KEY,
   SIDEBAR_SECTION_ORDER_KEY,
   loadCollapsedSections,
@@ -93,5 +102,34 @@ describe("sidebar section preferences", () => {
 
     saveSectionOrder(ids, storage);
     expect(loadSectionOrder(storage)).toEqual(ids);
+  });
+});
+
+describe("sidebar width preference", () => {
+  it("snaps to the rail below the dead zone and clamps at both ends", () => {
+    expect(clampSidebarWidth(60)).toBe(SIDEBAR_RAIL_WIDTH);
+    expect(clampSidebarWidth(179)).toBe(SIDEBAR_RAIL_WIDTH);
+    // the dead zone: no sidebar is ever 200px wide
+    expect(clampSidebarWidth(200)).toBe(SIDEBAR_MIN_EXPANDED_WIDTH);
+    expect(clampSidebarWidth(9000)).toBe(SIDEBAR_MAX_WIDTH);
+    expect(clampSidebarWidth(321)).toBe(321);
+    expect(clampSidebarWidth(Number.NaN)).toBe(SIDEBAR_DEFAULT_WIDTH);
+    expect(sidebarIsRail(SIDEBAR_RAIL_WIDTH)).toBe(true);
+    expect(sidebarIsRail(SIDEBAR_MIN_EXPANDED_WIDTH)).toBe(false);
+  });
+
+  it("falls back to the saved density instead of resetting the width", () => {
+    expect(loadSidebarWidth({ getItem: (key) => (key === SIDEBAR_DENSITY_KEY ? "icons" : null) })).toBe(
+      SIDEBAR_RAIL_WIDTH,
+    );
+    expect(loadSidebarWidth({ getItem: (key) => (key === SIDEBAR_DENSITY_KEY ? "compact" : null) })).toBe(272);
+    expect(loadSidebarWidth({ getItem: () => null })).toBe(SIDEBAR_DEFAULT_WIDTH);
+    expect(loadSidebarWidth({ getItem: () => "288" })).toBe(288);
+    expect(loadSidebarWidth({ getItem: () => "garbage" })).toBe(SIDEBAR_DEFAULT_WIDTH);
+    expect(loadSidebarWidth({ getItem: () => { throw new Error("blocked"); } })).toBe(SIDEBAR_DEFAULT_WIDTH);
+
+    const setItem = vi.fn();
+    saveSidebarWidth(300, { setItem });
+    expect(setItem).toHaveBeenCalledWith(SIDEBAR_WIDTH_KEY, "300");
   });
 });

--- a/src/lib/sidebar-preferences.ts
+++ b/src/lib/sidebar-preferences.ts
@@ -39,14 +39,72 @@ export function saveSidebarDensity(
   }
 }
 
+/* The column width is dragged, and it is stored on its own: density decides
+ * the shape of a row, the width decides how much room that row gets. Drag far
+ * enough left and the sidebar becomes the avatar rail, which is the "icons"
+ * density — the two ends stay in step, so the rail is reachable both from the
+ * menu and from the handle. */
+export const SIDEBAR_WIDTH_KEY = "openmausbot.sidebarWidth";
+export const SIDEBAR_ROW_ORDER_KEY = "openmausbot.sidebarRowOrder.v1";
+
+export const SIDEBAR_RAIL_WIDTH = 80;
+/** Narrowest a sidebar with text can be before the preview stops being
+ * readable. Between the rail and this there is nothing to land on. */
+export const SIDEBAR_MIN_EXPANDED_WIDTH = 240;
+export const SIDEBAR_MAX_WIDTH = 480;
+export const SIDEBAR_DEFAULT_WIDTH = 320;
+/** Drag left past this and the sidebar collapses to the rail. */
+export const SIDEBAR_RAIL_SNAP_WIDTH = 180;
+
+/** The input is a pointer position, so it is unbounded in both directions and
+ * can be NaN when a drag starts before layout. The dead zone is deliberate:
+ * a 140px sidebar shows a truncated word and nothing else. */
+export function clampSidebarWidth(value: number): number {
+  if (!Number.isFinite(value)) return SIDEBAR_DEFAULT_WIDTH;
+  if (value < SIDEBAR_RAIL_SNAP_WIDTH) return SIDEBAR_RAIL_WIDTH;
+  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_EXPANDED_WIDTH, Math.round(value)));
+}
+
+export function sidebarIsRail(width: number): boolean {
+  return width <= SIDEBAR_RAIL_WIDTH;
+}
+
+/** A build that only had the density menu saved no width. Map the mode it did
+ * save so an upgrade does not silently reset everyone to the default. */
+export function widthForDensity(density: SidebarDensity): number {
+  if (density === "icons") return SIDEBAR_RAIL_WIDTH;
+  return density === "compact" ? 272 : SIDEBAR_DEFAULT_WIDTH;
+}
+
+export function loadSidebarWidth(storage?: Pick<Storage, "getItem"> | null): number {
+  try {
+    const target = storage === undefined ? (globalThis.localStorage ?? null) : storage;
+    const stored = Number(target?.getItem(SIDEBAR_WIDTH_KEY));
+    if (Number.isFinite(stored) && stored > 0) return clampSidebarWidth(stored);
+    return widthForDensity(parseSidebarDensity(target?.getItem(SIDEBAR_DENSITY_KEY) ?? null));
+  } catch {
+    return SIDEBAR_DEFAULT_WIDTH;
+  }
+}
+
+export function saveSidebarWidth(width: number, storage?: Pick<Storage, "setItem"> | null): void {
+  try {
+    const target = storage === undefined ? (globalThis.localStorage ?? null) : storage;
+    target?.setItem(SIDEBAR_WIDTH_KEY, String(clampSidebarWidth(width)));
+  } catch {
+    // Private browsing and locked-down webviews may reject localStorage.
+    // The in-memory React state still makes the drag useful this session.
+  }
+}
+
 const stringListSchema = z.array(z.string().min(1).max(240));
 
-function parseStringList(raw: string | null): string[] {
+function parseStringList(raw: string | null, limit = 100): string[] {
   if (!raw) return [];
   try {
     const parsed: unknown = JSON.parse(raw);
     const result = stringListSchema.safeParse(parsed);
-    return result.success ? [...new Set(result.data)].slice(0, 100) : [];
+    return result.success ? [...new Set(result.data)].slice(0, limit) : [];
   } catch {
     return [];
   }
@@ -55,10 +113,11 @@ function parseStringList(raw: string | null): string[] {
 function loadStringList(
   key: string,
   storage?: Pick<Storage, "getItem"> | null,
+  limit = 100,
 ): string[] {
   try {
     const target = storage === undefined ? (globalThis.localStorage ?? null) : storage;
-    return parseStringList(target?.getItem(key) ?? null);
+    return parseStringList(target?.getItem(key) ?? null, limit);
   } catch {
     return [];
   }
@@ -68,12 +127,13 @@ function saveStringList(
   key: string,
   values: string[],
   storage?: Pick<Storage, "setItem"> | null,
+  limit = 100,
 ): void {
   try {
     const target = storage === undefined ? (globalThis.localStorage ?? null) : storage;
     const safe = [
       ...new Set(values.filter((value) => value.length > 0 && value.length <= 240)),
-    ].slice(0, 100);
+    ].slice(0, limit);
     target?.setItem(key, JSON.stringify(safe));
   } catch {
     // Private browsing and locked-down webviews may reject localStorage.
@@ -105,4 +165,17 @@ export function saveSectionOrder(
   storage?: Pick<Storage, "setItem"> | null,
 ): void {
   saveStringList(SIDEBAR_SECTION_ORDER_KEY, ids, storage);
+}
+
+/** A roster is not a handful of section names, so the saved row order gets a
+ * ceiling of its own. Rows past it keep their natural position rather than
+ * being dropped from the list. */
+const ROW_ORDER_LIMIT = 500;
+
+export function loadRowOrder(storage?: Pick<Storage, "getItem"> | null): string[] {
+  return loadStringList(SIDEBAR_ROW_ORDER_KEY, storage, ROW_ORDER_LIMIT);
+}
+
+export function saveRowOrder(ids: string[], storage?: Pick<Storage, "setItem"> | null): void {
+  saveStringList(SIDEBAR_ROW_ORDER_KEY, ids, storage, ROW_ORDER_LIMIT);
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -262,7 +262,6 @@
   "sidebar.section.collapse": "{name} einklappen",
   "sidebar.section.expandReorder": "{name} ausklappen. Alt+Auf/Ab ordnet um.",
   "sidebar.section.collapseReorder": "{name} einklappen. Alt+Auf/Ab ordnet um.",
-  "sidebar.section.dragToReorder": "Zum Umsortieren ziehen",
   "sidebar.profile.you": "Du",
   "sidebar.menu.yourPhone": "Dein Telefon",
   "sidebar.menu.getIos": "OpenMausBot für iOS holen",
@@ -1389,5 +1388,13 @@
   "remote.signInAccess.empty": "Noch niemand. Füge eine Adresse hinzu, oder @deinefirma.de für alle in deiner Firma.",
   "remote.signInAccess.invalid": "Gib eine E-Mail-Adresse ein oder @domain für alle dieser Domain.",
   "remote.signInAccess.note": "Änderungen gelten sofort. Wer entfernt wird, kann sich nicht neu anmelden; bestehende Geräte bleiben angemeldet, bis du sie oben abmeldest.",
-  "remote.signInAccess.error": "Konnte nicht speichern: {error}"
+  "remote.signInAccess.error": "Konnte nicht speichern: {error}",
+  "sidebar.resizeAria": "Breite der Seitenleiste ändern",
+  "sidebar.section.renameContext": "Kontext umbenennen",
+  "sidebar.section.renameContextAria": "Kontext {name} umbenennen",
+  "sidebar.section.deleteContext": "Kontext löschen",
+  "sidebar.section.deleteTitle": "{name} löschen?",
+  "sidebar.section.deleteBody": "Die Überschrift verschwindet. Die {count} Zeilen darin behalten alles und sind wieder ohne Kontext, wie ein neu erstellter Bot.",
+  "sidebar.bot.moveUp": "Nach oben",
+  "sidebar.bot.moveDown": "Nach unten"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -266,7 +266,6 @@
   "sidebar.section.collapse": "Collapse {name}",
   "sidebar.section.expandReorder": "Expand {name}. Alt+Up/Down reorders it.",
   "sidebar.section.collapseReorder": "Collapse {name}. Alt+Up/Down reorders it.",
-  "sidebar.section.dragToReorder": "Drag to reorder",
   "sidebar.profile.you": "You",
   "sidebar.menu.yourPhone": "Your phone",
   "sidebar.menu.getIos": "Get OpenMausBot for iOS",
@@ -1656,5 +1655,13 @@
   "remote.signInAccess.empty": "Nobody yet. Add an address, or @yourcompany.com for everyone at your company.",
   "remote.signInAccess.invalid": "Enter an email address, or @domain for everyone at that domain.",
   "remote.signInAccess.note": "Changes apply immediately. Removing someone stops new sign-ins; their existing devices stay signed in until you sign them out above.",
-  "remote.signInAccess.error": "Could not save: {error}"
+  "remote.signInAccess.error": "Could not save: {error}",
+  "sidebar.resizeAria": "Resize sidebar",
+  "sidebar.section.renameContext": "Rename context",
+  "sidebar.section.renameContextAria": "Rename the {name} context",
+  "sidebar.section.deleteContext": "Delete context",
+  "sidebar.section.deleteTitle": "Delete {name}?",
+  "sidebar.section.deleteBody": "The heading goes away. Its {count} rows keep everything they have and go back to being uncategorised, the way a new bot starts.",
+  "sidebar.bot.moveUp": "Move up",
+  "sidebar.bot.moveDown": "Move down"
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -187,7 +187,6 @@
   "sidebar.section.collapse": "Contraer {name}",
   "sidebar.section.expandReorder": "Expandir {name}. Alt+Arriba/Abajo lo reordena.",
   "sidebar.section.collapseReorder": "Contraer {name}. Alt+Arriba/Abajo lo reordena.",
-  "sidebar.section.dragToReorder": "Arrastra para reordenar",
   "sidebar.profile.you": "Tú",
   "sidebar.menu.yourPhone": "Tu teléfono",
   "sidebar.menu.getIos": "Consigue OpenMausBot para iOS",
@@ -1389,5 +1388,13 @@
   "remote.signInAccess.empty": "Nadie todavía. Añade una dirección, o @tuempresa.com para todos en tu empresa.",
   "remote.signInAccess.invalid": "Escribe un email, o @dominio para todos los de ese dominio.",
   "remote.signInAccess.note": "Los cambios se aplican al instante. Quitar a alguien impide nuevos inicios de sesión; sus dispositivos siguen conectados hasta que los cierres arriba.",
-  "remote.signInAccess.error": "No se pudo guardar: {error}"
+  "remote.signInAccess.error": "No se pudo guardar: {error}",
+  "sidebar.resizeAria": "Cambiar el ancho de la barra lateral",
+  "sidebar.section.renameContext": "Renombrar contexto",
+  "sidebar.section.renameContextAria": "Renombrar el contexto {name}",
+  "sidebar.section.deleteContext": "Eliminar contexto",
+  "sidebar.section.deleteTitle": "¿Eliminar {name}?",
+  "sidebar.section.deleteBody": "El encabezado desaparece. Sus {count} conversaciones conservan todo y vuelven a quedar sin contexto, como un bot recién creado.",
+  "sidebar.bot.moveUp": "Mover arriba",
+  "sidebar.bot.moveDown": "Mover abajo"
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -187,7 +187,6 @@
   "sidebar.section.collapse": "Replier {name}",
   "sidebar.section.expandReorder": "Déplier {name}. Alt+Haut/Bas le réordonne.",
   "sidebar.section.collapseReorder": "Replier {name}. Alt+Haut/Bas le réordonne.",
-  "sidebar.section.dragToReorder": "Faites glisser pour réordonner",
   "sidebar.profile.you": "Vous",
   "sidebar.menu.yourPhone": "Votre téléphone",
   "sidebar.menu.getIos": "Obtenir OpenMausBot pour iOS",
@@ -1389,5 +1388,13 @@
   "remote.signInAccess.empty": "Personne pour l’instant. Ajoutez une adresse, ou @votreentreprise.com pour toute l’entreprise.",
   "remote.signInAccess.invalid": "Saisissez une adresse e-mail, ou @domaine pour tout le monde sur ce domaine.",
   "remote.signInAccess.note": "Les changements s’appliquent immédiatement. Retirer quelqu’un bloque les nouvelles connexions ; ses appareils déjà connectés le restent jusqu’à ce que vous les déconnectiez ci-dessus.",
-  "remote.signInAccess.error": "Enregistrement impossible : {error}"
+  "remote.signInAccess.error": "Enregistrement impossible : {error}",
+  "sidebar.resizeAria": "Redimensionner la barre latérale",
+  "sidebar.section.renameContext": "Renommer le contexte",
+  "sidebar.section.renameContextAria": "Renommer le contexte {name}",
+  "sidebar.section.deleteContext": "Supprimer le contexte",
+  "sidebar.section.deleteTitle": "Supprimer {name} ?",
+  "sidebar.section.deleteBody": "Le titre disparaît. Ses {count} conversations gardent tout et redeviennent sans contexte, comme un bot qui vient d'être créé.",
+  "sidebar.bot.moveUp": "Monter",
+  "sidebar.bot.moveDown": "Descendre"
 }

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -187,7 +187,6 @@
   "sidebar.section.collapse": "{name} समेटें",
   "sidebar.section.expandReorder": "{name} खोलें। Alt+ऊपर/नीचे से क्रम बदलें।",
   "sidebar.section.collapseReorder": "{name} समेटें। Alt+ऊपर/नीचे से क्रम बदलें।",
-  "sidebar.section.dragToReorder": "क्रम बदलने के लिए खींचें",
   "sidebar.profile.you": "आप",
   "sidebar.menu.yourPhone": "आपका फ़ोन",
   "sidebar.menu.getIos": "iOS के लिए OpenMausBot पाएँ",
@@ -1389,5 +1388,13 @@
   "remote.signInAccess.empty": "अभी कोई नहीं। कोई पता जोड़ें, या पूरी कंपनी के लिए @yourcompany.com।",
   "remote.signInAccess.invalid": "ईमेल पता लिखें, या उस डोमेन के सभी के लिए @domain।",
   "remote.signInAccess.note": "बदलाव तुरंत लागू होते हैं। किसी को हटाने से नए साइन-इन रुक जाते हैं; उनके मौजूदा डिवाइस तब तक साइन इन रहते हैं जब तक आप उन्हें ऊपर साइन आउट न करें।",
-  "remote.signInAccess.error": "सहेज नहीं सका: {error}"
+  "remote.signInAccess.error": "सहेज नहीं सका: {error}",
+  "sidebar.resizeAria": "साइडबार का आकार बदलें",
+  "sidebar.section.renameContext": "संदर्भ का नाम बदलें",
+  "sidebar.section.renameContextAria": "{name} संदर्भ का नाम बदलें",
+  "sidebar.section.deleteContext": "संदर्भ हटाएँ",
+  "sidebar.section.deleteTitle": "{name} हटाएँ?",
+  "sidebar.section.deleteBody": "शीर्षक हट जाएगा। उसमें मौजूद {count} बातचीत सब कुछ बनाए रखती हैं और फिर से बिना संदर्भ के हो जाती हैं, जैसे कोई नया बॉट।",
+  "sidebar.bot.moveUp": "ऊपर ले जाएँ",
+  "sidebar.bot.moveDown": "नीचे ले जाएँ"
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -187,7 +187,6 @@
   "sidebar.section.collapse": "{name} を畳む",
   "sidebar.section.expandReorder": "{name} を開きます。Alt+上下で並べ替えます。",
   "sidebar.section.collapseReorder": "{name} を畳みます。Alt+上下で並べ替えます。",
-  "sidebar.section.dragToReorder": "ドラッグして並べ替え",
   "sidebar.profile.you": "あなた",
   "sidebar.menu.yourPhone": "あなたのスマートフォン",
   "sidebar.menu.getIos": "iOS 版 OpenMausBot を入手",
@@ -1389,5 +1388,13 @@
   "remote.signInAccess.empty": "まだ誰もいません。アドレスを追加するか、会社全員なら @yourcompany.com を追加してください。",
   "remote.signInAccess.invalid": "メールアドレス、またはそのドメイン全員を表す @domain を入力してください。",
   "remote.signInAccess.note": "変更はすぐに反映されます。削除すると新しいサインインはできなくなります。既存のデバイスは上でサインアウトするまで残ります。",
-  "remote.signInAccess.error": "保存できませんでした: {error}"
+  "remote.signInAccess.error": "保存できませんでした: {error}",
+  "sidebar.resizeAria": "サイドバーの幅を変更",
+  "sidebar.section.renameContext": "コンテキスト名を変更",
+  "sidebar.section.renameContextAria": "{name} コンテキストの名前を変更",
+  "sidebar.section.deleteContext": "コンテキストを削除",
+  "sidebar.section.deleteTitle": "{name} を削除しますか？",
+  "sidebar.section.deleteBody": "見出しだけがなくなります。中の {count} 件はそのまま残り、新しいボットと同じようにコンテキストなしに戻ります。",
+  "sidebar.bot.moveUp": "上に移動",
+  "sidebar.bot.moveDown": "下に移動"
 }

--- a/src/locales/pt-br.json
+++ b/src/locales/pt-br.json
@@ -262,7 +262,6 @@
   "sidebar.section.collapse": "Recolher {name}",
   "sidebar.section.expandReorder": "Expandir {name}. Alt+Cima/Baixo reordena.",
   "sidebar.section.collapseReorder": "Recolher {name}. Alt+Cima/Baixo reordena.",
-  "sidebar.section.dragToReorder": "Arraste para reordenar",
   "sidebar.profile.you": "Você",
   "sidebar.menu.yourPhone": "Seu celular",
   "sidebar.menu.getIos": "Baixar o OpenMausBot para iOS",
@@ -1389,5 +1388,13 @@
   "remote.signInAccess.empty": "Ninguém ainda. Adicione um endereço, ou @suaempresa.com para todos da empresa.",
   "remote.signInAccess.invalid": "Digite um e-mail, ou @domínio para todos daquele domínio.",
   "remote.signInAccess.note": "As mudanças valem na hora. Remover alguém impede novos logins; os dispositivos já conectados continuam até você desconectá-los acima.",
-  "remote.signInAccess.error": "Não foi possível salvar: {error}"
+  "remote.signInAccess.error": "Não foi possível salvar: {error}",
+  "sidebar.resizeAria": "Redimensionar a barra lateral",
+  "sidebar.section.renameContext": "Renomear contexto",
+  "sidebar.section.renameContextAria": "Renomear o contexto {name}",
+  "sidebar.section.deleteContext": "Excluir contexto",
+  "sidebar.section.deleteTitle": "Excluir {name}?",
+  "sidebar.section.deleteBody": "O título some. As {count} conversas dentro dele mantêm tudo e voltam a ficar sem contexto, como um bot recém-criado.",
+  "sidebar.bot.moveUp": "Mover para cima",
+  "sidebar.bot.moveDown": "Mover para baixo"
 }

--- a/src/locales/source-hashes.json
+++ b/src/locales/source-hashes.json
@@ -265,7 +265,6 @@
       "sidebar.section.collapse": "19f25826b84b030c2c08c3166fe344167a98e50cc672a669aa5a86397d1f7cae",
       "sidebar.section.expandReorder": "c6fb575f359cde47dd4e5b01cb80e68c3e4bc7681fac74004df1f56e3dc11355",
       "sidebar.section.collapseReorder": "7fedebab5a9fd26cfd13c414017b2aaa190e314183faee83a9625ff4b6970a71",
-      "sidebar.section.dragToReorder": "ef86a0ed928794a4be6a964201fac2fb1d57e1836b14e307e6376ba36ad7a29a",
       "sidebar.profile.you": "08b041935798fbf6fd6ff51099ffedb140a475889986d14f5559ff8e7fc571dd",
       "sidebar.menu.yourPhone": "807163670bbc384df37a2de03c8850b5e9632b6c3344e72699877edf63144bb6",
       "sidebar.menu.getIos": "5f0214a062aca6bcb857c46f03582deda4ca99c92486c61a771815de3f91ee5d",
@@ -1392,7 +1391,15 @@
       "remote.signInAccess.empty": "7166fa8f2d9ef4f4fbbbe7da946c67814553260b89fa71481e6e03a533284a86",
       "remote.signInAccess.invalid": "f7571753e84241b531638ab312bb1b704d261eebae3a05d27f24c02a5ba5061e",
       "remote.signInAccess.note": "ce9c15dc3fe23bbed92cb66d4cd54b8fdf0498f52f6bd2250067134b1ac65783",
-      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d"
+      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d",
+      "sidebar.resizeAria": "243854b4d0c709a06e41005bc74a72d6b49463cc2d9ac5bc2967666f6b988c88",
+      "sidebar.section.renameContext": "d7ef0f1a379aa37491dbc4f72a0ba7a5bf053a6d56307255faf2a2e5eecccbe5",
+      "sidebar.section.renameContextAria": "57c2cb0c15dd1c49d849af217bd482cf3fc9d422caa020bd0e27a4980f566afe",
+      "sidebar.section.deleteContext": "3d33673c8203482e2b03e1b8575d2f96a59199c1c23a0e4b299930cd62d49690",
+      "sidebar.section.deleteTitle": "a4b982a9e0bc24133bce18717f9db74bd70095b79c24ee45c57a8194fb727d4d",
+      "sidebar.section.deleteBody": "0aa93d2dd16e0d39ba61234387432b92d32523867d9eca595ecc83252e827446",
+      "sidebar.bot.moveUp": "c66feb5eb8f217c76bfb0f1b41e3ee73ab41cb9959fae8284911bd3ad3816086",
+      "sidebar.bot.moveDown": "40bb50da160cdc21d6029a927b68f92b07fd450688e609826cbc70d202db96da"
     },
     "es": {
       "noEngines.title": "af88855a5f80377de709995229ba3907df9e8fb3b940fbf7c0d9cbe6eea54afe",
@@ -1583,7 +1590,6 @@
       "sidebar.section.collapse": "19f25826b84b030c2c08c3166fe344167a98e50cc672a669aa5a86397d1f7cae",
       "sidebar.section.expandReorder": "c6fb575f359cde47dd4e5b01cb80e68c3e4bc7681fac74004df1f56e3dc11355",
       "sidebar.section.collapseReorder": "7fedebab5a9fd26cfd13c414017b2aaa190e314183faee83a9625ff4b6970a71",
-      "sidebar.section.dragToReorder": "ef86a0ed928794a4be6a964201fac2fb1d57e1836b14e307e6376ba36ad7a29a",
       "sidebar.profile.you": "08b041935798fbf6fd6ff51099ffedb140a475889986d14f5559ff8e7fc571dd",
       "sidebar.menu.yourPhone": "807163670bbc384df37a2de03c8850b5e9632b6c3344e72699877edf63144bb6",
       "sidebar.menu.getIos": "5f0214a062aca6bcb857c46f03582deda4ca99c92486c61a771815de3f91ee5d",
@@ -2785,7 +2791,15 @@
       "remote.signInAccess.empty": "7166fa8f2d9ef4f4fbbbe7da946c67814553260b89fa71481e6e03a533284a86",
       "remote.signInAccess.invalid": "f7571753e84241b531638ab312bb1b704d261eebae3a05d27f24c02a5ba5061e",
       "remote.signInAccess.note": "ce9c15dc3fe23bbed92cb66d4cd54b8fdf0498f52f6bd2250067134b1ac65783",
-      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d"
+      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d",
+      "sidebar.resizeAria": "243854b4d0c709a06e41005bc74a72d6b49463cc2d9ac5bc2967666f6b988c88",
+      "sidebar.section.renameContext": "d7ef0f1a379aa37491dbc4f72a0ba7a5bf053a6d56307255faf2a2e5eecccbe5",
+      "sidebar.section.renameContextAria": "57c2cb0c15dd1c49d849af217bd482cf3fc9d422caa020bd0e27a4980f566afe",
+      "sidebar.section.deleteContext": "3d33673c8203482e2b03e1b8575d2f96a59199c1c23a0e4b299930cd62d49690",
+      "sidebar.section.deleteTitle": "a4b982a9e0bc24133bce18717f9db74bd70095b79c24ee45c57a8194fb727d4d",
+      "sidebar.section.deleteBody": "0aa93d2dd16e0d39ba61234387432b92d32523867d9eca595ecc83252e827446",
+      "sidebar.bot.moveUp": "c66feb5eb8f217c76bfb0f1b41e3ee73ab41cb9959fae8284911bd3ad3816086",
+      "sidebar.bot.moveDown": "40bb50da160cdc21d6029a927b68f92b07fd450688e609826cbc70d202db96da"
     },
     "fr": {
       "noEngines.title": "af88855a5f80377de709995229ba3907df9e8fb3b940fbf7c0d9cbe6eea54afe",
@@ -2976,7 +2990,6 @@
       "sidebar.section.collapse": "19f25826b84b030c2c08c3166fe344167a98e50cc672a669aa5a86397d1f7cae",
       "sidebar.section.expandReorder": "c6fb575f359cde47dd4e5b01cb80e68c3e4bc7681fac74004df1f56e3dc11355",
       "sidebar.section.collapseReorder": "7fedebab5a9fd26cfd13c414017b2aaa190e314183faee83a9625ff4b6970a71",
-      "sidebar.section.dragToReorder": "ef86a0ed928794a4be6a964201fac2fb1d57e1836b14e307e6376ba36ad7a29a",
       "sidebar.profile.you": "08b041935798fbf6fd6ff51099ffedb140a475889986d14f5559ff8e7fc571dd",
       "sidebar.menu.yourPhone": "807163670bbc384df37a2de03c8850b5e9632b6c3344e72699877edf63144bb6",
       "sidebar.menu.getIos": "5f0214a062aca6bcb857c46f03582deda4ca99c92486c61a771815de3f91ee5d",
@@ -4178,7 +4191,15 @@
       "remote.signInAccess.empty": "7166fa8f2d9ef4f4fbbbe7da946c67814553260b89fa71481e6e03a533284a86",
       "remote.signInAccess.invalid": "f7571753e84241b531638ab312bb1b704d261eebae3a05d27f24c02a5ba5061e",
       "remote.signInAccess.note": "ce9c15dc3fe23bbed92cb66d4cd54b8fdf0498f52f6bd2250067134b1ac65783",
-      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d"
+      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d",
+      "sidebar.resizeAria": "243854b4d0c709a06e41005bc74a72d6b49463cc2d9ac5bc2967666f6b988c88",
+      "sidebar.section.renameContext": "d7ef0f1a379aa37491dbc4f72a0ba7a5bf053a6d56307255faf2a2e5eecccbe5",
+      "sidebar.section.renameContextAria": "57c2cb0c15dd1c49d849af217bd482cf3fc9d422caa020bd0e27a4980f566afe",
+      "sidebar.section.deleteContext": "3d33673c8203482e2b03e1b8575d2f96a59199c1c23a0e4b299930cd62d49690",
+      "sidebar.section.deleteTitle": "a4b982a9e0bc24133bce18717f9db74bd70095b79c24ee45c57a8194fb727d4d",
+      "sidebar.section.deleteBody": "0aa93d2dd16e0d39ba61234387432b92d32523867d9eca595ecc83252e827446",
+      "sidebar.bot.moveUp": "c66feb5eb8f217c76bfb0f1b41e3ee73ab41cb9959fae8284911bd3ad3816086",
+      "sidebar.bot.moveDown": "40bb50da160cdc21d6029a927b68f92b07fd450688e609826cbc70d202db96da"
     },
     "hi": {
       "noEngines.title": "af88855a5f80377de709995229ba3907df9e8fb3b940fbf7c0d9cbe6eea54afe",
@@ -4369,7 +4390,6 @@
       "sidebar.section.collapse": "19f25826b84b030c2c08c3166fe344167a98e50cc672a669aa5a86397d1f7cae",
       "sidebar.section.expandReorder": "c6fb575f359cde47dd4e5b01cb80e68c3e4bc7681fac74004df1f56e3dc11355",
       "sidebar.section.collapseReorder": "7fedebab5a9fd26cfd13c414017b2aaa190e314183faee83a9625ff4b6970a71",
-      "sidebar.section.dragToReorder": "ef86a0ed928794a4be6a964201fac2fb1d57e1836b14e307e6376ba36ad7a29a",
       "sidebar.profile.you": "08b041935798fbf6fd6ff51099ffedb140a475889986d14f5559ff8e7fc571dd",
       "sidebar.menu.yourPhone": "807163670bbc384df37a2de03c8850b5e9632b6c3344e72699877edf63144bb6",
       "sidebar.menu.getIos": "5f0214a062aca6bcb857c46f03582deda4ca99c92486c61a771815de3f91ee5d",
@@ -5571,7 +5591,15 @@
       "remote.signInAccess.empty": "7166fa8f2d9ef4f4fbbbe7da946c67814553260b89fa71481e6e03a533284a86",
       "remote.signInAccess.invalid": "f7571753e84241b531638ab312bb1b704d261eebae3a05d27f24c02a5ba5061e",
       "remote.signInAccess.note": "ce9c15dc3fe23bbed92cb66d4cd54b8fdf0498f52f6bd2250067134b1ac65783",
-      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d"
+      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d",
+      "sidebar.resizeAria": "243854b4d0c709a06e41005bc74a72d6b49463cc2d9ac5bc2967666f6b988c88",
+      "sidebar.section.renameContext": "d7ef0f1a379aa37491dbc4f72a0ba7a5bf053a6d56307255faf2a2e5eecccbe5",
+      "sidebar.section.renameContextAria": "57c2cb0c15dd1c49d849af217bd482cf3fc9d422caa020bd0e27a4980f566afe",
+      "sidebar.section.deleteContext": "3d33673c8203482e2b03e1b8575d2f96a59199c1c23a0e4b299930cd62d49690",
+      "sidebar.section.deleteTitle": "a4b982a9e0bc24133bce18717f9db74bd70095b79c24ee45c57a8194fb727d4d",
+      "sidebar.section.deleteBody": "0aa93d2dd16e0d39ba61234387432b92d32523867d9eca595ecc83252e827446",
+      "sidebar.bot.moveUp": "c66feb5eb8f217c76bfb0f1b41e3ee73ab41cb9959fae8284911bd3ad3816086",
+      "sidebar.bot.moveDown": "40bb50da160cdc21d6029a927b68f92b07fd450688e609826cbc70d202db96da"
     },
     "ja": {
       "noEngines.title": "af88855a5f80377de709995229ba3907df9e8fb3b940fbf7c0d9cbe6eea54afe",
@@ -5762,7 +5790,6 @@
       "sidebar.section.collapse": "19f25826b84b030c2c08c3166fe344167a98e50cc672a669aa5a86397d1f7cae",
       "sidebar.section.expandReorder": "c6fb575f359cde47dd4e5b01cb80e68c3e4bc7681fac74004df1f56e3dc11355",
       "sidebar.section.collapseReorder": "7fedebab5a9fd26cfd13c414017b2aaa190e314183faee83a9625ff4b6970a71",
-      "sidebar.section.dragToReorder": "ef86a0ed928794a4be6a964201fac2fb1d57e1836b14e307e6376ba36ad7a29a",
       "sidebar.profile.you": "08b041935798fbf6fd6ff51099ffedb140a475889986d14f5559ff8e7fc571dd",
       "sidebar.menu.yourPhone": "807163670bbc384df37a2de03c8850b5e9632b6c3344e72699877edf63144bb6",
       "sidebar.menu.getIos": "5f0214a062aca6bcb857c46f03582deda4ca99c92486c61a771815de3f91ee5d",
@@ -6964,7 +6991,15 @@
       "remote.signInAccess.empty": "7166fa8f2d9ef4f4fbbbe7da946c67814553260b89fa71481e6e03a533284a86",
       "remote.signInAccess.invalid": "f7571753e84241b531638ab312bb1b704d261eebae3a05d27f24c02a5ba5061e",
       "remote.signInAccess.note": "ce9c15dc3fe23bbed92cb66d4cd54b8fdf0498f52f6bd2250067134b1ac65783",
-      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d"
+      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d",
+      "sidebar.resizeAria": "243854b4d0c709a06e41005bc74a72d6b49463cc2d9ac5bc2967666f6b988c88",
+      "sidebar.section.renameContext": "d7ef0f1a379aa37491dbc4f72a0ba7a5bf053a6d56307255faf2a2e5eecccbe5",
+      "sidebar.section.renameContextAria": "57c2cb0c15dd1c49d849af217bd482cf3fc9d422caa020bd0e27a4980f566afe",
+      "sidebar.section.deleteContext": "3d33673c8203482e2b03e1b8575d2f96a59199c1c23a0e4b299930cd62d49690",
+      "sidebar.section.deleteTitle": "a4b982a9e0bc24133bce18717f9db74bd70095b79c24ee45c57a8194fb727d4d",
+      "sidebar.section.deleteBody": "0aa93d2dd16e0d39ba61234387432b92d32523867d9eca595ecc83252e827446",
+      "sidebar.bot.moveUp": "c66feb5eb8f217c76bfb0f1b41e3ee73ab41cb9959fae8284911bd3ad3816086",
+      "sidebar.bot.moveDown": "40bb50da160cdc21d6029a927b68f92b07fd450688e609826cbc70d202db96da"
     },
     "pt-br": {
       "noEngines.title": "af88855a5f80377de709995229ba3907df9e8fb3b940fbf7c0d9cbe6eea54afe",
@@ -7230,7 +7265,6 @@
       "sidebar.section.collapse": "19f25826b84b030c2c08c3166fe344167a98e50cc672a669aa5a86397d1f7cae",
       "sidebar.section.expandReorder": "c6fb575f359cde47dd4e5b01cb80e68c3e4bc7681fac74004df1f56e3dc11355",
       "sidebar.section.collapseReorder": "7fedebab5a9fd26cfd13c414017b2aaa190e314183faee83a9625ff4b6970a71",
-      "sidebar.section.dragToReorder": "ef86a0ed928794a4be6a964201fac2fb1d57e1836b14e307e6376ba36ad7a29a",
       "sidebar.profile.you": "08b041935798fbf6fd6ff51099ffedb140a475889986d14f5559ff8e7fc571dd",
       "sidebar.menu.yourPhone": "807163670bbc384df37a2de03c8850b5e9632b6c3344e72699877edf63144bb6",
       "sidebar.menu.getIos": "5f0214a062aca6bcb857c46f03582deda4ca99c92486c61a771815de3f91ee5d",
@@ -8357,7 +8391,15 @@
       "remote.signInAccess.empty": "7166fa8f2d9ef4f4fbbbe7da946c67814553260b89fa71481e6e03a533284a86",
       "remote.signInAccess.invalid": "f7571753e84241b531638ab312bb1b704d261eebae3a05d27f24c02a5ba5061e",
       "remote.signInAccess.note": "ce9c15dc3fe23bbed92cb66d4cd54b8fdf0498f52f6bd2250067134b1ac65783",
-      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d"
+      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d",
+      "sidebar.resizeAria": "243854b4d0c709a06e41005bc74a72d6b49463cc2d9ac5bc2967666f6b988c88",
+      "sidebar.section.renameContext": "d7ef0f1a379aa37491dbc4f72a0ba7a5bf053a6d56307255faf2a2e5eecccbe5",
+      "sidebar.section.renameContextAria": "57c2cb0c15dd1c49d849af217bd482cf3fc9d422caa020bd0e27a4980f566afe",
+      "sidebar.section.deleteContext": "3d33673c8203482e2b03e1b8575d2f96a59199c1c23a0e4b299930cd62d49690",
+      "sidebar.section.deleteTitle": "a4b982a9e0bc24133bce18717f9db74bd70095b79c24ee45c57a8194fb727d4d",
+      "sidebar.section.deleteBody": "0aa93d2dd16e0d39ba61234387432b92d32523867d9eca595ecc83252e827446",
+      "sidebar.bot.moveUp": "c66feb5eb8f217c76bfb0f1b41e3ee73ab41cb9959fae8284911bd3ad3816086",
+      "sidebar.bot.moveDown": "40bb50da160cdc21d6029a927b68f92b07fd450688e609826cbc70d202db96da"
     },
     "zh": {
       "noEngines.title": "af88855a5f80377de709995229ba3907df9e8fb3b940fbf7c0d9cbe6eea54afe",
@@ -8548,7 +8590,6 @@
       "sidebar.section.collapse": "19f25826b84b030c2c08c3166fe344167a98e50cc672a669aa5a86397d1f7cae",
       "sidebar.section.expandReorder": "c6fb575f359cde47dd4e5b01cb80e68c3e4bc7681fac74004df1f56e3dc11355",
       "sidebar.section.collapseReorder": "7fedebab5a9fd26cfd13c414017b2aaa190e314183faee83a9625ff4b6970a71",
-      "sidebar.section.dragToReorder": "ef86a0ed928794a4be6a964201fac2fb1d57e1836b14e307e6376ba36ad7a29a",
       "sidebar.profile.you": "08b041935798fbf6fd6ff51099ffedb140a475889986d14f5559ff8e7fc571dd",
       "sidebar.menu.yourPhone": "807163670bbc384df37a2de03c8850b5e9632b6c3344e72699877edf63144bb6",
       "sidebar.menu.getIos": "5f0214a062aca6bcb857c46f03582deda4ca99c92486c61a771815de3f91ee5d",
@@ -9750,7 +9791,15 @@
       "remote.signInAccess.empty": "7166fa8f2d9ef4f4fbbbe7da946c67814553260b89fa71481e6e03a533284a86",
       "remote.signInAccess.invalid": "f7571753e84241b531638ab312bb1b704d261eebae3a05d27f24c02a5ba5061e",
       "remote.signInAccess.note": "ce9c15dc3fe23bbed92cb66d4cd54b8fdf0498f52f6bd2250067134b1ac65783",
-      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d"
+      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d",
+      "sidebar.resizeAria": "243854b4d0c709a06e41005bc74a72d6b49463cc2d9ac5bc2967666f6b988c88",
+      "sidebar.section.renameContext": "d7ef0f1a379aa37491dbc4f72a0ba7a5bf053a6d56307255faf2a2e5eecccbe5",
+      "sidebar.section.renameContextAria": "57c2cb0c15dd1c49d849af217bd482cf3fc9d422caa020bd0e27a4980f566afe",
+      "sidebar.section.deleteContext": "3d33673c8203482e2b03e1b8575d2f96a59199c1c23a0e4b299930cd62d49690",
+      "sidebar.section.deleteTitle": "a4b982a9e0bc24133bce18717f9db74bd70095b79c24ee45c57a8194fb727d4d",
+      "sidebar.section.deleteBody": "0aa93d2dd16e0d39ba61234387432b92d32523867d9eca595ecc83252e827446",
+      "sidebar.bot.moveUp": "c66feb5eb8f217c76bfb0f1b41e3ee73ab41cb9959fae8284911bd3ad3816086",
+      "sidebar.bot.moveDown": "40bb50da160cdc21d6029a927b68f92b07fd450688e609826cbc70d202db96da"
     },
     "zh-tw": {
       "noEngines.title": "af88855a5f80377de709995229ba3907df9e8fb3b940fbf7c0d9cbe6eea54afe",
@@ -10016,7 +10065,6 @@
       "sidebar.section.collapse": "19f25826b84b030c2c08c3166fe344167a98e50cc672a669aa5a86397d1f7cae",
       "sidebar.section.expandReorder": "c6fb575f359cde47dd4e5b01cb80e68c3e4bc7681fac74004df1f56e3dc11355",
       "sidebar.section.collapseReorder": "7fedebab5a9fd26cfd13c414017b2aaa190e314183faee83a9625ff4b6970a71",
-      "sidebar.section.dragToReorder": "ef86a0ed928794a4be6a964201fac2fb1d57e1836b14e307e6376ba36ad7a29a",
       "sidebar.profile.you": "08b041935798fbf6fd6ff51099ffedb140a475889986d14f5559ff8e7fc571dd",
       "sidebar.menu.yourPhone": "807163670bbc384df37a2de03c8850b5e9632b6c3344e72699877edf63144bb6",
       "sidebar.menu.getIos": "5f0214a062aca6bcb857c46f03582deda4ca99c92486c61a771815de3f91ee5d",

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -262,7 +262,6 @@
   "sidebar.section.collapse": "收合 {name}",
   "sidebar.section.expandReorder": "展開 {name}。按 Alt+上／下鍵可調整順序。",
   "sidebar.section.collapseReorder": "收合 {name}。按 Alt+上／下鍵可調整順序。",
-  "sidebar.section.dragToReorder": "拖曳以調整順序",
   "sidebar.profile.you": "你",
   "sidebar.menu.yourPhone": "你的手機",
   "sidebar.menu.getIos": "取得 iOS 版 OpenMausBot",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -187,7 +187,6 @@
   "sidebar.section.collapse": "收起 {name}",
   "sidebar.section.expandReorder": "展开 {name}。Alt+上/下可调整顺序。",
   "sidebar.section.collapseReorder": "收起 {name}。Alt+上/下可调整顺序。",
-  "sidebar.section.dragToReorder": "拖动以调整顺序",
   "sidebar.profile.you": "你",
   "sidebar.menu.yourPhone": "你的手机",
   "sidebar.menu.getIos": "获取 iOS 版 OpenMausBot",
@@ -1389,5 +1388,13 @@
   "remote.signInAccess.empty": "还没有人。添加一个地址，或用 @yourcompany.com 允许全公司。",
   "remote.signInAccess.invalid": "请输入邮箱地址，或用 @domain 表示该域名下的所有人。",
   "remote.signInAccess.note": "更改立即生效。移除某人会阻止其新的登录；已登录的设备会保留，直到你在上面将其退出。",
-  "remote.signInAccess.error": "无法保存：{error}"
+  "remote.signInAccess.error": "无法保存：{error}",
+  "sidebar.resizeAria": "调整侧边栏宽度",
+  "sidebar.section.renameContext": "重命名情境",
+  "sidebar.section.renameContextAria": "重命名情境 {name}",
+  "sidebar.section.deleteContext": "删除情境",
+  "sidebar.section.deleteTitle": "删除 {name}？",
+  "sidebar.section.deleteBody": "仅标题消失。其中的 {count} 项内容保持不变，回到没有情境的状态，就像新建的机器人一样。",
+  "sidebar.bot.moveUp": "上移",
+  "sidebar.bot.moveDown": "下移"
 }


### PR DESCRIPTION
Closes part of #691 (row reorder; the visual-groups half is not in here).

Three changes that turned out to be one story: the sidebar had three densities
behind a menu, headings that read as dividers, and no way to put a bot where you
want it.

## The divider is dragged, the densities are gone

One number decides everything now. Below 180px the sidebar snaps to the avatar
rail — the old `icons` mode, no longer a mode, just the left end of the drag —
and above it there is a single row shape that truncates as the column narrows.
`comfortable` and `compact` were the same row at two sizes; they are one row.

- A density saved by an older build is migrated once (`icons` → rail,
  `compact` → 272, `comfortable` → 320) rather than reset.
- The drag reuses the pattern `ComputerPanel.tsx` already uses on its own edge:
  pointer capture, one write to storage on release.
- A pointer-only separator is unusable without a mouse, so the collapse button
  stays and arrow keys on the separator step the width — including across the
  dead zone, which a 16px step could never cross on its own.
- Below `md` the drawer keeps a width of its own and the handle is hidden.

## Rows carry their own order

Order is one list of ids in localStorage. **A move is always expressed against a
neighbour taken from the rendered list, never from the saved array**, which is
what keeps a row inside its own section — and sections are team boundaries here:
`list_bots`, `delegate_bot` and the Chief all read them, so a drag must never
change one silently. Dropping onto another section is refused, not silently
accepted.

Drag and drop, or right-click for **Move up / Move down** — for the people who
never discover that a row is draggable. Both work on bots and on channels, and
each move is announced in the existing `aria-live` region.

The ordering helpers are the ones the section order already used
(`orderedSidebarSections`, `placeSection`, `mergeSectionOrder`): they are generic
list operations despite their names, so rows reuse them unchanged.

## Headings are labels, and they have a menu

The rule running from the name to the edge is gone, the chevron appears on
hover, a folded section shows how many rows it is hiding, and the drag moved off
a decorative grip onto the row itself.

Right-clicking a heading opens its own menu: **rename**, **move up / down**,
**delete**. Delete only takes the label off — the bots and channels under it keep
everything and go back to being uncategorised, the way a bot starts, and the
confirmation says exactly that with the row count. Built-in headings (Pinned,
Channels, Bot Chats, Bots) get only the two moves: they are derived from bot
state, not user labels, so there is nothing there to rename or delete.

## Two smaller things the layout made obvious

- **Every row now carries the time of its last message**, not just the selected
  one, at the resolution that is useful at that distance: today the time, then
  "yesterday", then the weekday, then the date. Locale-driven, and counted in
  calendar days so 23:59 → 00:01 reads as yesterday rather than as today. The
  hover **Archive** button that used to occupy that corner is gone — the
  right-click menu already carried the same action, and the button was eating
  the space the timestamp needed.
- **A channel's stacked member avatars measured 66px inside a 40px box**, so the
  first one hung past the left edge of the row. Three slots at 18px now, and a
  channel row lines up with a bot row again (measured: both avatars start at the
  same x).

`ConfirmDialog`'s Cancel button was hardcoded in English — it uses the key that
already existed, which also fixes the archive and delete dialogs.

## Checks

`pnpm typecheck` (both projects), `pnpm lint`, `pnpm i18n:check` (8 languages,
100%), and the suite. New tests cover the width clamp and its migration, the
row order, and the rule that a move cannot leave its list even when the saved
array offers a neighbour from another section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resize the sidebar with pointer or keyboard controls, including rail snapping and saved width preferences.
  * Reorder rooms and bots within sections using drag-and-drop or move actions.
  * Rename, move, and delete custom sidebar sections with confirmation prompts.
  * Access section menus through right-click or keyboard shortcuts.
  * View clearer, localized sidebar timestamps.

* **Accessibility & Localization**
  * Added resize labels, movement announcements, keyboard support, and translations for new sidebar actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->