### PR TITLE
feat(android): Activity and Team memory screens, mirroring iOS

### DIFF
--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/ActivityRules.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/ActivityRules.kt
@@ -1,0 +1,73 @@
+package com.openmausbot.companion.ui
+
+import com.openmausbot.companion.core.ActivityRow
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+
+/**
+ * A bot's activity log, as rules — the copy and the grouping behind
+ * [BotActivityScreen]. Rows arrive newest first from the computer; the
+ * screen shows them under day headings with an outcome chip, matching
+ * `ios/App/BotActivityView.swift` and the desktop's Activity panel.
+ */
+object ActivityRules {
+    const val PROFILE_ROW: String = "Activity"
+    const val FAILED: String = "Couldn't load the activity log."
+
+    fun title(name: String): String = "$name activity"
+
+    fun empty(name: String): String = "Nothing yet. Once $name runs a tool or asks for an approval, it shows up here."
+
+    /** One short word per outcome, and whether it reads as good, bad, live, or waiting. */
+    enum class Tone { GOOD, BAD, LIVE, WAITING, PLAIN }
+
+    data class Chip(val text: String, val tone: Tone)
+
+    fun chip(outcome: String): Chip = when (outcome) {
+        "ran" -> Chip("Ran", Tone.GOOD)
+        "allowed" -> Chip("Allowed", Tone.GOOD)
+        "failed" -> Chip("Failed", Tone.BAD)
+        "denied" -> Chip("Denied", Tone.BAD)
+        "running" -> Chip("Running", Tone.LIVE)
+        "waiting" -> Chip("Needs you", Tone.WAITING)
+        else -> Chip(outcome, Tone.PLAIN)
+    }
+
+    data class Day(val key: LocalDate, val label: String, val rows: List<ActivityRow>)
+
+    private val dayFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("EEE d MMM")
+    private val timeFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+
+    fun instant(iso: String): Instant? = try {
+        Instant.parse(iso)
+    } catch (_: DateTimeParseException) {
+        null
+    }
+
+    /** "09:00" in the viewer's zone, or nothing when the stamp is unreadable. */
+    fun time(iso: String, zone: ZoneId = ZoneId.systemDefault()): String =
+        instant(iso)?.atZone(zone)?.toLocalTime()?.format(timeFormat).orEmpty()
+
+    /** Group newest-first rows under their local day, keeping that order. */
+    fun days(rows: List<ActivityRow>, today: LocalDate = LocalDate.now(), zone: ZoneId = ZoneId.systemDefault()): List<Day> {
+        val result = mutableListOf<Day>()
+        for (row in rows) {
+            val date = instant(row.at)?.atZone(zone)?.toLocalDate() ?: today
+            val last = result.lastOrNull()
+            if (last != null && last.key == date) {
+                result[result.lastIndex] = last.copy(rows = last.rows + row)
+            } else {
+                val label = when (date) {
+                    today -> "Today"
+                    today.minusDays(1) -> "Yesterday"
+                    else -> date.format(dayFormat)
+                }
+                result += Day(date, label, listOf(row))
+            }
+        }
+        return result
+    }
+}

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/AgentProfileSheet.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/AgentProfileSheet.kt
@@ -19,6 +19,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AddCircle
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Face
+import androidx.compose.material.icons.filled.List
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.CircularProgressIndicator
@@ -90,7 +92,13 @@ import kotlinx.coroutines.withContext
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-internal fun AgentProfileSheet(bot: Bot, onDismiss: () -> Unit, onOpenOverview: (String) -> Unit) {
+internal fun AgentProfileSheet(
+    bot: Bot,
+    onDismiss: () -> Unit,
+    onOpenOverview: (String) -> Unit,
+    onOpenActivity: (String) -> Unit = {},
+    onOpenTeamMemory: (String) -> Unit = {},
+) {
     val environment = LocalCompanion.current
     val session = environment.session
     val state by session.state.collectAsState()
@@ -218,6 +226,16 @@ internal fun AgentProfileSheet(bot: Bot, onDismiss: () -> Unit, onOpenOverview: 
                         text = "What this bot does",
                         icon = Icons.Filled.Info,
                         onClick = { onOpenOverview(bot.id) },
+                    )
+                    ActionRow(
+                        text = ActivityRules.PROFILE_ROW,
+                        icon = Icons.Filled.List,
+                        onClick = { onOpenActivity(bot.id) },
+                    )
+                    ActionRow(
+                        text = TeamMemoryRules.PROFILE_ROW,
+                        icon = Icons.Filled.Face,
+                        onClick = { onOpenTeamMemory(bot.section.orEmpty()) },
                     )
                 }
 

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/BotActivityScreen.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/BotActivityScreen.kt
@@ -1,0 +1,170 @@
+package com.openmausbot.companion.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.openmausbot.companion.core.ActivityRow
+import kotlinx.coroutines.launch
+
+/**
+ * What one bot did, newest first, grouped by day: every tool it used and
+ * every approval it asked for, each with the outcome. The phone twin of the
+ * desktop's Activity panel and of `ios/App/BotActivityView.swift`;
+ * read-only, like [BotOverviewScreen] beside it.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BotActivityScreen(botId: String, onBack: () -> Unit) {
+    val environment = LocalCompanion.current
+    val session = environment.session
+    val state by session.state.collectAsState()
+    val connection by session.connection.collectAsState()
+    val connectionId = connection?.id
+    val scope = rememberCoroutineScope()
+
+    var rows by remember(botId, connectionId) { mutableStateOf<List<ActivityRow>?>(null) }
+    var loading by remember(botId, connectionId) { mutableStateOf(true) }
+    var refreshing by remember(botId, connectionId) { mutableStateOf(false) }
+    var failed by remember(botId, connectionId) { mutableStateOf(false) }
+
+    suspend fun refresh(showProgress: Boolean = false) {
+        if (showProgress) refreshing = true
+        try {
+            val loaded = session.loadActivity(botId)
+            failed = loaded == null
+            if (loaded != null) rows = loaded
+        } finally {
+            if (showProgress) refreshing = false
+        }
+    }
+
+    LaunchedEffect(botId, connectionId) {
+        loading = true
+        try {
+            refresh()
+        } finally {
+            loading = false
+        }
+    }
+
+    val name = state.bot(botId)?.name.orEmpty()
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 10.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            HeaderBackButton(onBack)
+            Text(ActivityRules.title(name), fontSize = 17.sp, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
+        }
+        HorizontalDivider()
+
+        PullToRefreshBox(
+            isRefreshing = refreshing,
+            onRefresh = { scope.launch { refresh(showProgress = true) } },
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(vertical = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                val current = rows
+                when {
+                    loading -> Row(
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp),
+                        horizontalArrangement = Arrangement.Center,
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(28.dp), strokeWidth = 3.dp)
+                    }
+                    current != null && current.isEmpty() -> FormSection(header = null) {
+                        Text(ActivityRules.empty(name), color = secondaryTint)
+                    }
+                    current != null -> ActivityRules.days(current).forEach { day ->
+                        FormSection(header = day.label) {
+                            day.rows.forEach { ActivityLine(it) }
+                        }
+                    }
+                    failed -> FormSection(header = null) {
+                        Text(ActivityRules.FAILED, color = secondaryTint)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActivityLine(row: ActivityRow) {
+    val chip = ActivityRules.chip(row.outcome)
+    val chipColor = when (chip.tone) {
+        ActivityRules.Tone.GOOD -> MaterialTheme.colorScheme.primary
+        ActivityRules.Tone.BAD -> MaterialTheme.colorScheme.error
+        ActivityRules.Tone.LIVE -> MaterialTheme.colorScheme.primary
+        ActivityRules.Tone.WAITING -> MaterialTheme.colorScheme.tertiary
+        ActivityRules.Tone.PLAIN -> secondaryTint
+    }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        Text(ActivityRules.time(row.at), fontSize = 12.sp, color = secondaryTint, modifier = Modifier.width(44.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                row.app?.let {
+                    Text(it, fontSize = 15.sp, fontWeight = FontWeight.Medium)
+                    Text("·", fontSize = 15.sp, color = secondaryTint)
+                }
+                Text(row.label, fontSize = 15.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            }
+            row.summary?.takeIf { it.isNotBlank() }?.let {
+                Text(it, fontSize = 12.sp, fontFamily = FontFamily.Monospace, color = secondaryTint, maxLines = 2, overflow = TextOverflow.Ellipsis)
+            }
+        }
+        Text(
+            chip.text,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Medium,
+            color = chipColor,
+            modifier = Modifier
+                .background(chipColor.copy(alpha = 0.15f), RoundedCornerShape(999.dp))
+                .padding(horizontal = 6.dp, vertical = 2.dp),
+        )
+    }
+}

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/ChatScreen.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/ChatScreen.kt
@@ -139,6 +139,8 @@ fun ChatScreen(
     onBack: () -> Unit,
     onOpenComputer: (String) -> Unit,
     onOpenOverview: (String) -> Unit,
+    onOpenActivity: (String) -> Unit,
+    onOpenTeamMemory: (String) -> Unit,
     /**
      * True while this conversation is still on the navigator stack (including
      * under Computer). Used on dispose to keep the in-memory draft across a
@@ -166,7 +168,7 @@ fun ChatScreen(
             // that is open is the one deleted.
             val resolved = (destination as? Destination.Thread)?.let { resolution.chat.target }
             LaunchedEffect(resolved) { if (resolved != null) onResolved(resolved) }
-            LoadedChat(resolution.chat, state, onBack, onOpenComputer, onOpenOverview, retainsDraft)
+            LoadedChat(resolution.chat, state, onBack, onOpenComputer, onOpenOverview, onOpenActivity, onOpenTeamMemory, retainsDraft)
         }
     }
 }
@@ -196,6 +198,8 @@ private fun LoadedChat(
     onBack: () -> Unit,
     onOpenComputer: (String) -> Unit,
     onOpenOverview: (String) -> Unit,
+    onOpenActivity: (String) -> Unit,
+    onOpenTeamMemory: (String) -> Unit,
     retainsDraft: (chatId: String) -> Boolean,
 ) {
     // The bot's *current* thread, not the one the destination named. Switching or
@@ -970,6 +974,14 @@ private fun LoadedChat(
             onDismiss = { showingProfile = false },
             onOpenOverview = {
                 onOpenOverview(it)
+                showingProfile = false
+            },
+            onOpenActivity = {
+                onOpenActivity(it)
+                showingProfile = false
+            },
+            onOpenTeamMemory = {
+                onOpenTeamMemory(it)
                 showingProfile = false
             },
         )

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/Navigation.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/Navigation.kt
@@ -46,6 +46,15 @@ sealed interface Destination {
      */
     data class Overview(val botId: String) : Destination
 
+    /** A bot's activity log: what it did, with the outcome. Read-only. */
+    data class Activity(val botId: String) : Destination
+
+    /**
+     * A section's team memory — the people, places, decisions and terms every
+     * bot there shares. Addressed by the section key; "" is General.
+     */
+    data class TeamMemory(val section: String) : Destination
+
     /**
      * A conversation, in one of the two ways something can name one.
      *
@@ -138,6 +147,8 @@ class CompanionNavigator(initial: List<Destination> = listOf(Destination.Roster)
         private const val THREAD = "thread:"
         private const val COMPUTER = "computer:"
         private const val OVERVIEW = "overview:"
+        private const val ACTIVITY = "activity:"
+        private const val TEAM_MEMORY = "teammemory:"
         private const val BOT_CHAT = "botchat:"
         private const val ROOM_CHAT = "roomchat:"
 
@@ -150,6 +161,8 @@ class CompanionNavigator(initial: List<Destination> = listOf(Destination.Roster)
                 is Destination.Thread -> THREAD + it.threadId
                 is Destination.Computer -> COMPUTER + it.botId
                 is Destination.Overview -> OVERVIEW + it.botId
+                is Destination.Activity -> ACTIVITY + it.botId
+                is Destination.TeamMemory -> TEAM_MEMORY + it.section
                 is Destination.Chat -> when (val target = it.target) {
                     is ChatTarget.Bot -> BOT_CHAT + join(target.botId, target.threadId)
                     is ChatTarget.Room -> ROOM_CHAT + join(target.roomId, target.threadId)
@@ -166,6 +179,8 @@ class CompanionNavigator(initial: List<Destination> = listOf(Destination.Roster)
                 it.startsWith(THREAD) -> Destination.Thread(it.removePrefix(THREAD))
                 it.startsWith(COMPUTER) -> Destination.Computer(it.removePrefix(COMPUTER))
                 it.startsWith(OVERVIEW) -> Destination.Overview(it.removePrefix(OVERVIEW))
+                it.startsWith(ACTIVITY) -> Destination.Activity(it.removePrefix(ACTIVITY))
+                it.startsWith(TEAM_MEMORY) -> Destination.TeamMemory(it.removePrefix(TEAM_MEMORY))
                 it.startsWith(BOT_CHAT) -> split(it.removePrefix(BOT_CHAT))
                     ?.let { (owner, thread) -> Destination.Chat(ChatTarget.Bot(owner, thread)) }
                 it.startsWith(ROOM_CHAT) -> split(it.removePrefix(ROOM_CHAT))

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/RootScreen.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/RootScreen.kt
@@ -387,6 +387,8 @@ private fun PairedScreen(
             onBack = navigator::pop,
             onOpenComputer = { navigator.push(Destination.Computer(it)) },
             onOpenOverview = { navigator.push(Destination.Overview(it)) },
+            onOpenActivity = { navigator.push(Destination.Activity(it)) },
+            onOpenTeamMemory = { navigator.push(Destination.TeamMemory(it)) },
             // Push Computer keeps the chat under the top; pop to roster does not.
             retainsDraft = navigator::retainsChatDraft,
         )
@@ -396,6 +398,14 @@ private fun PairedScreen(
         )
         is Destination.Overview -> BotOverviewScreen(
             botId = destination.botId,
+            onBack = navigator::pop,
+        )
+        is Destination.Activity -> BotActivityScreen(
+            botId = destination.botId,
+            onBack = navigator::pop,
+        )
+        is Destination.TeamMemory -> TeamMemoryScreen(
+            section = destination.section,
             onBack = navigator::pop,
         )
     }

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/TeamMemoryRules.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/TeamMemoryRules.kt
@@ -1,0 +1,41 @@
+package com.openmausbot.companion.ui
+
+import com.openmausbot.companion.core.TeamMemoryEntry
+
+/**
+ * Team memory, as rules — the copy behind [TeamMemoryScreen]. The screen
+ * shows what the computer stores: proposals waiting for a tap, then the
+ * accepted entries by kind. Matches `ios/App/TeamMemoryView.swift`.
+ */
+object TeamMemoryRules {
+    const val PROFILE_ROW: String = "Team memory"
+    const val WAITING: String = "Waiting for you"
+    const val REMEMBER: String = "Remember"
+    const val SKIP: String = "Skip"
+    const val ADD: String = "Add an entry"
+    const val FAILED: String = "Couldn't load team memory."
+    const val EMPTY: String =
+        "Nothing shared yet. Bots add entries as they learn who is who and where things live, or add one below."
+
+    /** Section order and titles, one per kind the computer knows. */
+    val KINDS: List<Pair<String, String>> = listOf(
+        "person" to "People",
+        "place" to "Places",
+        "decision" to "Decisions",
+        "term" to "Terms",
+    )
+
+    fun title(label: String?): String = if (label.isNullOrBlank()) "Team memory" else "$label team memory"
+
+    fun proposed(entries: List<TeamMemoryEntry>): List<TeamMemoryEntry> = entries.filter { it.status == "proposed" }
+
+    fun accepted(entries: List<TeamMemoryEntry>, kind: String): List<TeamMemoryEntry> =
+        entries.filter { it.status == "accepted" && it.kind == kind }
+
+    /** "Ada Lovelace (also Ada)" */
+    fun heading(entry: TeamMemoryEntry): String =
+        if (entry.aliases.isEmpty()) entry.name else "${entry.name} (also ${entry.aliases.joinToString(", ")})"
+
+    /** Who said it: the bot, or "you" for an entry added by hand. */
+    fun attribution(entry: TeamMemoryEntry): String = entry.source.botName.ifBlank { "you" }
+}

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/TeamMemoryScreen.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/TeamMemoryScreen.kt
@@ -1,0 +1,240 @@
+package com.openmausbot.companion.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddCircle
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.openmausbot.companion.core.TeamMemoryEntry
+import com.openmausbot.companion.core.TeamMemoryPage
+import kotlinx.coroutines.launch
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+/**
+ * The people, places, decisions and terms every bot in a section shares.
+ * Bots add what they learn (places and terms land at once; people and
+ * decisions wait here for a tap); the person answers, adds, and removes.
+ * The phone twin of Team map → Memory and of `ios/App/TeamMemoryView.swift`.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TeamMemoryScreen(section: String, onBack: () -> Unit) {
+    val environment = LocalCompanion.current
+    val session = environment.session
+    val connection by session.connection.collectAsState()
+    val connectionId = connection?.id
+    val scope = rememberCoroutineScope()
+
+    var page by remember(section, connectionId) { mutableStateOf<TeamMemoryPage?>(null) }
+    var loading by remember(section, connectionId) { mutableStateOf(true) }
+    var refreshing by remember(section, connectionId) { mutableStateOf(false) }
+    var failed by remember(section, connectionId) { mutableStateOf(false) }
+    var busyId by remember { mutableStateOf<String?>(null) }
+    var adding by remember { mutableStateOf(false) }
+    var draftKind by remember { mutableStateOf("term") }
+    var draftName by remember { mutableStateOf("") }
+    var draftDetail by remember { mutableStateOf("") }
+
+    suspend fun refresh(showProgress: Boolean = false) {
+        if (showProgress) refreshing = true
+        try {
+            val loaded = session.loadTeamMemory(section)
+            failed = loaded == null
+            if (loaded != null) page = loaded
+        } finally {
+            if (showProgress) refreshing = false
+        }
+    }
+
+    LaunchedEffect(section, connectionId) {
+        loading = true
+        try {
+            refresh()
+        } finally {
+            loading = false
+        }
+    }
+
+    fun apply(entries: List<TeamMemoryEntry>?) {
+        val current = page ?: return
+        if (entries != null) page = current.copy(entries = entries)
+    }
+
+    fun edit(id: String, action: suspend () -> List<TeamMemoryEntry>?) {
+        scope.launch {
+            busyId = id
+            try {
+                apply(action())
+            } finally {
+                busyId = null
+            }
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 10.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            HeaderBackButton(onBack)
+            Text(TeamMemoryRules.title(page?.label), fontSize = 17.sp, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
+        }
+        HorizontalDivider()
+
+        PullToRefreshBox(
+            isRefreshing = refreshing,
+            onRefresh = { scope.launch { refresh(showProgress = true) } },
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(vertical = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                val entries = page?.entries
+                when {
+                    loading -> Row(
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp),
+                        horizontalArrangement = Arrangement.Center,
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(28.dp), strokeWidth = 3.dp)
+                    }
+                    entries != null -> {
+                        val proposed = TeamMemoryRules.proposed(entries)
+                        if (proposed.isNotEmpty()) {
+                            FormSection(header = TeamMemoryRules.WAITING) {
+                                proposed.forEach { entry ->
+                                    EntryLine(entry)
+                                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                        Button(
+                                            onClick = { edit(entry.id) { session.editTeamMemory { it.answerTeamMemory(section, entry.id, remember = true) } } },
+                                            enabled = busyId != entry.id,
+                                        ) { Text(TeamMemoryRules.REMEMBER) }
+                                        OutlinedButton(
+                                            onClick = { edit(entry.id) { session.editTeamMemory { it.answerTeamMemory(section, entry.id, remember = false) } } },
+                                            enabled = busyId != entry.id,
+                                        ) { Text(TeamMemoryRules.SKIP) }
+                                    }
+                                }
+                            }
+                        }
+                        val anyAccepted = TeamMemoryRules.KINDS.any { (kind, _) -> TeamMemoryRules.accepted(entries, kind).isNotEmpty() }
+                        if (!anyAccepted && proposed.isEmpty()) {
+                            FormSection(header = null) { Text(TeamMemoryRules.EMPTY, color = secondaryTint) }
+                        }
+                        TeamMemoryRules.KINDS.forEach { (kind, title) ->
+                            val rows = TeamMemoryRules.accepted(entries, kind)
+                            if (rows.isNotEmpty()) {
+                                FormSection(header = title) {
+                                    rows.forEach { entry ->
+                                        Row(verticalAlignment = Alignment.Top) {
+                                            Column(modifier = Modifier.weight(1f)) { EntryLine(entry) }
+                                            ActionRow(
+                                                text = "",
+                                                icon = Icons.Filled.Delete,
+                                                destructive = true,
+                                                enabled = busyId != entry.id,
+                                                onClick = { edit(entry.id) { session.editTeamMemory { it.removeTeamMemory(section, entry.id) } } },
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        FormSection(header = null) {
+                            if (adding) {
+                                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                                    TeamMemoryRules.KINDS.forEach { (kind, title) ->
+                                        FilterChip(
+                                            selected = draftKind == kind,
+                                            onClick = { draftKind = kind },
+                                            label = { Text(title.removeSuffix("s")) },
+                                        )
+                                    }
+                                }
+                                OutlinedTextField(value = draftName, onValueChange = { draftName = it }, label = { Text("Name") }, modifier = Modifier.fillMaxWidth())
+                                OutlinedTextField(
+                                    value = draftDetail,
+                                    onValueChange = { draftDetail = it },
+                                    label = { Text("What every bot should know about it") },
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    Button(
+                                        onClick = {
+                                            val name = draftName.trim()
+                                            val detail = draftDetail.trim()
+                                            edit("new") {
+                                                val result = session.editTeamMemory { it.addTeamMemory(section, draftKind, name, detail) }
+                                                if (result != null) {
+                                                    draftName = ""
+                                                    draftDetail = ""
+                                                    adding = false
+                                                }
+                                                result
+                                            }
+                                        },
+                                        enabled = busyId != "new" && draftName.isNotBlank() && draftDetail.isNotBlank(),
+                                    ) { Text("Add") }
+                                    OutlinedButton(onClick = { adding = false }) { Text("Cancel") }
+                                }
+                            } else {
+                                ActionRow(text = TeamMemoryRules.ADD, icon = Icons.Filled.AddCircle, onClick = { adding = true })
+                            }
+                        }
+                    }
+                    failed -> FormSection(header = null) { Text(TeamMemoryRules.FAILED, color = secondaryTint) }
+                }
+            }
+        }
+    }
+}
+
+private val dateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("d MMM yyyy")
+
+@Composable
+private fun EntryLine(entry: TeamMemoryEntry) {
+    Column {
+        Text(TeamMemoryRules.heading(entry), fontSize = 15.sp, fontWeight = FontWeight.Medium)
+        Text(entry.detail, fontSize = 15.sp)
+        val date = Instant.ofEpochMilli(entry.updatedAt.toLong()).atZone(ZoneId.systemDefault()).toLocalDate().format(dateFormat)
+        Text("${TeamMemoryRules.attribution(entry)} · $date", fontSize = 12.sp, color = secondaryTint)
+    }
+}

--- a/android/app/src/test/kotlin/com/openmausbot/companion/ui/ActivityRulesTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/ui/ActivityRulesTest.kt
@@ -1,0 +1,40 @@
+package com.openmausbot.companion.ui
+
+import com.openmausbot.companion.core.ActivityRow
+import java.time.LocalDate
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ActivityRulesTest {
+    private fun row(at: String, outcome: String = "ran") =
+        ActivityRow(at = at, threadId = "t1", tool = "Bash", app = null, label = "Ran a command", outcome = outcome)
+
+    @Test
+    fun groupsNewestFirstRowsUnderTheirDayWithTodayAndYesterdayNamed() {
+        val today = LocalDate.of(2026, 9, 7)
+        val days = ActivityRules.days(
+            listOf(row("2026-09-07T18:00:00.000Z"), row("2026-09-07T09:00:00.000Z"), row("2026-09-06T12:00:00.000Z"), row("2026-09-05T12:00:00.000Z")),
+            today,
+            ZoneOffset.UTC,
+        )
+        assertEquals(listOf("Today" to 2, "Yesterday" to 1, "Sat 5 Sep" to 1), days.map { it.label to it.rows.size })
+    }
+
+    @Test
+    fun givesEveryOutcomeAWordAndAToneMatchingIos() {
+        assertEquals(ActivityRules.Chip("Ran", ActivityRules.Tone.GOOD), ActivityRules.chip("ran"))
+        assertEquals(ActivityRules.Chip("Allowed", ActivityRules.Tone.GOOD), ActivityRules.chip("allowed"))
+        assertEquals(ActivityRules.Chip("Failed", ActivityRules.Tone.BAD), ActivityRules.chip("failed"))
+        assertEquals(ActivityRules.Chip("Denied", ActivityRules.Tone.BAD), ActivityRules.chip("denied"))
+        assertEquals(ActivityRules.Chip("Running", ActivityRules.Tone.LIVE), ActivityRules.chip("running"))
+        assertEquals(ActivityRules.Chip("Needs you", ActivityRules.Tone.WAITING), ActivityRules.chip("waiting"))
+    }
+
+    @Test
+    fun formatsTimesInTheViewersZoneAndShrugsAtJunk() {
+        assertEquals("09:05", ActivityRules.time("2026-09-07T09:05:00.000Z", ZoneOffset.UTC))
+        assertEquals("", ActivityRules.time("not a time", ZoneOffset.UTC))
+        assertEquals("Maus activity", ActivityRules.title("Maus"))
+    }
+}

--- a/android/app/src/test/kotlin/com/openmausbot/companion/ui/NavigationTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/ui/NavigationTest.kt
@@ -111,6 +111,9 @@ class NavigationTest {
             Destination.Thread("thread:with:colons"),
             Destination.Computer("bot:with:colons"),
             Destination.Overview("bot:with:colons"),
+            Destination.Activity("bot:with:colons"),
+            Destination.TeamMemory(""),
+            Destination.TeamMemory("Work: clients"),
             Destination.Chat(ChatTarget.Bot("bot:1:x", "thread:1:y")),
             Destination.Chat(ChatTarget.Room("room::9", "")),
         )
@@ -194,12 +197,14 @@ class NavigationTest {
     }
 
     @Test
-    fun `the five addressable destinations do not collide in saved state`() {
+    fun `the addressable destinations do not collide in saved state`() {
         val encoded = CompanionNavigator.encode(
             listOf(
                 Destination.Thread("x"),
                 Destination.Computer("x"),
                 Destination.Overview("x"),
+                Destination.Activity("x"),
+                Destination.TeamMemory("x"),
                 Destination.Chat(ChatTarget.Bot("x", "x")),
                 Destination.Chat(ChatTarget.Room("x", "x")),
             ),

--- a/android/app/src/test/kotlin/com/openmausbot/companion/ui/TeamMemoryRulesTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/ui/TeamMemoryRulesTest.kt
@@ -1,0 +1,32 @@
+package com.openmausbot.companion.ui
+
+import com.openmausbot.companion.core.TeamMemoryEntry
+import com.openmausbot.companion.core.TeamMemorySource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TeamMemoryRulesTest {
+    private fun entry(kind: String, name: String, status: String = "accepted", aliases: List<String> = emptyList(), bot: String = "") =
+        TeamMemoryEntry(
+            id = name.lowercase(), kind = kind, name = name, detail = "d", aliases = aliases, status = status,
+            source = TeamMemorySource(botId = "", botName = bot, threadId = "", at = 1.0), updatedAt = 1.0,
+        )
+
+    @Test
+    fun splitsProposalsFromAcceptedEntriesByKind() {
+        val entries = listOf(entry("person", "Ada", status = "proposed"), entry("term", "MCHQ"), entry("place", "Plan"))
+        assertEquals(listOf("Ada"), TeamMemoryRules.proposed(entries).map { it.name })
+        assertEquals(listOf("MCHQ"), TeamMemoryRules.accepted(entries, "term").map { it.name })
+        assertEquals(emptyList(), TeamMemoryRules.accepted(entries, "decision"))
+    }
+
+    @Test
+    fun namesTheSectionAndTheSpeakerLikeIos() {
+        assertEquals("Work team memory", TeamMemoryRules.title("Work"))
+        assertEquals("Team memory", TeamMemoryRules.title(null))
+        assertEquals("Ada Lovelace (also Ada)", TeamMemoryRules.heading(entry("person", "Ada Lovelace", aliases = listOf("Ada"))))
+        assertEquals("you", TeamMemoryRules.attribution(entry("term", "MCHQ")))
+        assertEquals("Scout", TeamMemoryRules.attribution(entry("term", "MCHQ", bot = "Scout")))
+        assertEquals(listOf("person", "place", "decision", "term"), TeamMemoryRules.KINDS.map { it.first })
+    }
+}

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Client.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Client.kt
@@ -287,6 +287,57 @@ class CompanionClient(
     suspend fun overview(botId: String): BotOverview =
         send(makeRequest("GET", "/api/bots/${segment(botId)}/overview"))
 
+    /**
+     * What the bot did, newest first: every tool it used and every approval it
+     * asked for, with the outcome. Read-only, like the overview.
+     */
+    suspend fun activity(botId: String, limit: Int = 200): List<ActivityRow> = send<ActivityPage>(
+        makeRequest("GET", "/api/bots/${segment(botId)}/activity", query = listOf("limit" to limit.toString())),
+    ).rows
+
+    /**
+     * The section's shared people, places, decisions and terms. The section is
+     * a query parameter, empty for General, and always sent.
+     */
+    suspend fun teamMemory(section: String): TeamMemoryPage =
+        send(makeRequest("GET", "/api/team-memory", query = listOf("section" to section)))
+
+    /** Add an entry by hand. The person's own entry never waits on the person. */
+    suspend fun addTeamMemory(section: String, kind: String, name: String, detail: String): List<TeamMemoryEntry> =
+        send<TeamMemoryEdit>(
+            makeRequest(
+                "POST",
+                "/api/team-memory",
+                query = listOf("section" to section),
+                body = buildJsonObject {
+                    put("kind", kind)
+                    put("name", name)
+                    put("detail", detail)
+                },
+            ),
+        ).entries
+
+    /** Answer a proposal: remember it, or drop it. */
+    suspend fun answerTeamMemory(section: String, id: String, remember: Boolean): List<TeamMemoryEntry> {
+        val query = listOf("section" to section)
+        return if (remember) {
+            send<TeamMemoryEdit>(
+                makeRequest("PATCH", "/api/team-memory/${segment(id)}", query = query, body = buildJsonObject { put("accept", true) }),
+            ).entries
+        } else {
+            send<TeamMemoryEdit>(makeRequest("DELETE", "/api/team-memory/${segment(id)}", query = query)).entries
+        }
+    }
+
+    /** Change what an entry says. Editing a proposal accepts it. */
+    suspend fun updateTeamMemory(section: String, id: String, detail: String): List<TeamMemoryEntry> =
+        send<TeamMemoryEdit>(
+            makeRequest("PATCH", "/api/team-memory/${segment(id)}", query = listOf("section" to section), body = buildJsonObject { put("detail", detail) }),
+        ).entries
+
+    suspend fun removeTeamMemory(section: String, id: String): List<TeamMemoryEntry> =
+        send<TeamMemoryEdit>(makeRequest("DELETE", "/api/team-memory/${segment(id)}", query = listOf("section" to section))).entries
+
     suspend fun createBot(): Bot = send<CreatedBot>(makeRequest("POST", "/api/bots")).bot
 
     /**

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Models.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Models.kt
@@ -1027,3 +1027,59 @@ data class BotOverview(
     val wont: List<String> = emptyList(),
     val recent: List<BotOverviewRecent> = emptyList(),
 )
+
+/**
+ * One line of a bot's activity log: what ran, in words, and how it ended.
+ * Built on the computer from logs that already exist; the phone only reads
+ * it. Port of `ActivityRow` in `ios/Sources/CompanionCore/Models.swift`.
+ */
+@Serializable
+data class ActivityRow(
+    /** ISO 8601, when it started (a tool) or was asked (a request) */
+    val at: String,
+    val threadId: String,
+    val turnId: String? = null,
+    val requestId: String? = null,
+    /** the raw tool name */
+    val tool: String,
+    /** the connected app or surface it touched, when there is one */
+    val app: String? = null,
+    /** the action, in words */
+    val label: String,
+    /** the arguments the decision log recorded, already redacted */
+    val summary: String? = null,
+    /** ran | failed | running | allowed | denied | waiting */
+    val outcome: String,
+)
+
+@Serializable
+data class ActivityPage(val rows: List<ActivityRow> = emptyList())
+
+@Serializable
+data class TeamMemorySource(val botId: String, val botName: String, val threadId: String, val at: Double)
+
+/**
+ * One thing every bot in a section shares: a person, a place, a decision, or
+ * a term. `proposed` waits for the person; `accepted` rides the prompt.
+ */
+@Serializable
+data class TeamMemoryEntry(
+    val id: String,
+    /** person | place | decision | term */
+    val kind: String,
+    val name: String,
+    val detail: String,
+    val aliases: List<String> = emptyList(),
+    /** accepted | proposed */
+    val status: String,
+    val source: TeamMemorySource,
+    /** epoch milliseconds */
+    val updatedAt: Double,
+)
+
+@Serializable
+data class TeamMemoryPage(val section: String, val label: String, val entries: List<TeamMemoryEntry> = emptyList())
+
+/** What an edit answers with: the edited entry and the whole page. */
+@Serializable
+data class TeamMemoryEdit(val entry: TeamMemoryEntry? = null, val entries: List<TeamMemoryEntry> = emptyList())

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Session.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Session.kt
@@ -1890,6 +1890,51 @@ class Session(
         }
     }
 
+    /** What the bot did, with the outcome. Read-only, like the overview. */
+    suspend fun loadActivity(botId: String): List<ActivityRow>? {
+        val activeClient = client ?: return null
+        val connectionId = _connection.value?.id
+        return try {
+            val rows = activeClient.activity(botId)
+            currentCoroutineContext().ensureActive()
+            rows.takeIf { _connection.value?.id == connectionId }
+        } catch (error: Throwable) {
+            if (error is CancellationException) throw error
+            if (_connection.value?.id == connectionId) _actionError.value = error.message
+            null
+        }
+    }
+
+    /** The section's shared people, places, decisions and terms. */
+    suspend fun loadTeamMemory(section: String): TeamMemoryPage? {
+        val activeClient = client ?: return null
+        val connectionId = _connection.value?.id
+        return try {
+            val page = activeClient.teamMemory(section)
+            currentCoroutineContext().ensureActive()
+            page.takeIf { _connection.value?.id == connectionId }
+        } catch (error: Throwable) {
+            if (error is CancellationException) throw error
+            if (_connection.value?.id == connectionId) _actionError.value = error.message
+            null
+        }
+    }
+
+    /**
+     * One team-memory edit, and the page as it is afterwards; null when it
+     * failed, with the failure already shown.
+     */
+    suspend fun editTeamMemory(edit: suspend (CompanionClient) -> List<TeamMemoryEntry>): List<TeamMemoryEntry>? {
+        val activeClient = client ?: return null
+        return try {
+            edit(activeClient)
+        } catch (error: Throwable) {
+            if (error is CancellationException) throw error
+            _actionError.value = error.message
+            null
+        }
+    }
+
     suspend fun loadRoutineRunAvailability(): RoutineRunAvailability? {
         val activeClient = client ?: return null
         return try {

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/ActivityClientTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/ActivityClientTest.kt
@@ -1,0 +1,89 @@
+package com.openmausbot.companion.core
+
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The activity log and team memory calls: the paths and queries the sidecar
+ * allowlist expects, and the bodies the harness routes parse. Mirrors
+ * `ios/Tests/CompanionCoreTests/ActivityClientTests.swift`.
+ */
+class ActivityClientTest {
+    private lateinit var server: MockWebServer
+    private lateinit var client: CompanionClient
+
+    @BeforeTest
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        val connection = requireNotNull(Connection.parse(server.url("/").toString()))
+        client = CompanionClient(connection, "paired-token")
+    }
+
+    @AfterTest
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun json(body: String) = MockResponse().setHeader("Content-Type", "application/json").setBody(body)
+
+    @Test
+    fun readsTheActivityLogWithALimit() = runBlocking {
+        server.enqueue(json("""{"rows":[{"at":"2026-09-07T09:00:00.000Z","threadId":"t1","tool":"GMAIL_SEND_EMAIL","app":"Gmail","label":"Send email","summary":"to finance@","outcome":"waiting"}]}"""))
+
+        val rows = client.activity("bot_1", limit = 50)
+
+        val request = server.takeRequest()
+        assertEquals("/api/bots/bot_1/activity?limit=50", request.path)
+        assertEquals(1, rows.size)
+        assertEquals("Gmail", rows[0].app)
+        assertEquals("waiting", rows[0].outcome)
+    }
+
+    @Test
+    fun readsTeamMemoryForTheGeneralSection() = runBlocking {
+        server.enqueue(json("""{"section":"","label":"General","entries":[]}"""))
+
+        val page = client.teamMemory("")
+
+        // the harness requires the parameter even when it is empty
+        assertEquals("/api/team-memory?section=", server.takeRequest().path)
+        assertEquals("General", page.label)
+    }
+
+    @Test
+    fun remembersAProposalWithAnAcceptPatchAndSkipsWithADelete() = runBlocking {
+        server.enqueue(json("""{"entries":[]}"""))
+        server.enqueue(json("""{"entries":[]}"""))
+
+        client.answerTeamMemory("Work", "entry_1", remember = true)
+        val patch = server.takeRequest()
+        assertEquals("PATCH", patch.method)
+        assertEquals("/api/team-memory/entry_1?section=Work", patch.path)
+        assertTrue(patch.body.readUtf8().contains("\"accept\":true"))
+
+        client.answerTeamMemory("", "entry_1", remember = false)
+        val delete = server.takeRequest()
+        assertEquals("DELETE", delete.method)
+        assertEquals("/api/team-memory/entry_1?section=", delete.path)
+    }
+
+    @Test
+    fun addsAnEntryByHand() = runBlocking {
+        server.enqueue(json("""{"entries":[{"id":"e1","kind":"term","name":"MCHQ","detail":"MissionControlHQ","aliases":[],"status":"accepted","source":{"botId":"","botName":"you","threadId":"","at":1},"updatedAt":1}]}"""))
+
+        val entries = client.addTeamMemory("", kind = "term", name = "MCHQ", detail = "MissionControlHQ")
+
+        val request = server.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/api/team-memory?section=", request.path)
+        assertTrue(request.body.readUtf8().contains("\"kind\":\"term\""))
+        assertEquals("MCHQ", entries.first().name)
+    }
+}

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/DecodingTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/DecodingTest.kt
@@ -436,6 +436,29 @@ class DecodingTest {
     }
 
     @Test
+    fun decodesAnActivityPage() {
+        // A fixture harness has run no tools, so the page is empty; the shape
+        // is what matters, and an empty list must decode, not fail.
+        val page = decodeFixture<ActivityPage>("bot-activity")
+        assertTrue(page.rows.isEmpty())
+    }
+
+    @Test
+    fun decodesTeamMemory() {
+        val page = decodeFixture<TeamMemoryPage>("team-memory")
+        assertEquals("", page.section)
+        assertEquals("General", page.label)
+        assertEquals(listOf("person", "place", "decision", "term"), page.entries.map { it.kind })
+        val ada = page.entries.first()
+        assertEquals("Ada Lovelace", ada.name)
+        assertEquals(listOf("Ada"), ada.aliases)
+        assertEquals("accepted", ada.status)
+        // the person's own entries carry no bot
+        assertEquals("you", ada.source.botName)
+        assertTrue(ada.updatedAt > 0)
+    }
+
+    @Test
     fun decodesTheBotOverview() {
         val overview = decodeFixture<BotOverview>("bot-overview")
         assertEquals("Kiwi", overview.who.name)


### PR DESCRIPTION
## In plain language

The Android twin of the iOS PR: two screens, reached from a bot's profile sheet.

- **Activity** — what the bot did, newest first by day, each row with the app and action in words, the recorded arguments, and an outcome chip (ran, failed, running, allowed, denied, needs you). Read-only, like "What this bot does" beside it.
- **Team memory** — the bot's section's shared people, places, decisions and terms: proposals waiting for a tap with Remember / Skip, accepted entries by kind with a remove button, and a form to add one by hand.

The sending policy, app scopes, and fallback chain from #903 are not ported, on purpose: a paired phone may change a bot's model and profile but no other bot settings, so execution policy stays on the desktop.

## What changed

- `android/core`: `ActivityRow`, `ActivityPage`, `TeamMemoryEntry`, `TeamMemoryPage`, `TeamMemoryEdit`; client calls mirroring `CompanionCore`; session loaders `loadActivity`, `loadTeamMemory`, `editTeamMemory`.
- `android/app`: `BotActivityScreen`, `TeamMemoryScreen`, `ActivityRules`, `TeamMemoryRules`; two new destinations (`Activity`, `TeamMemory`) through the navigator, root screen, chat screen and profile sheet.
- Tests: decoding both shared fixtures, the client paths and bodies, day grouping and outcome chips, navigation round trips.

## Test plan

- [x] `./gradlew :core:test :app:testDebugUnitTest :app:assembleDebug`
- [ ] On a phone paired to a Mac running #903: bot profile → Activity, → Team memory; answer a proposal from a bot

Stacked on the iOS PR (base `feat/trust-ios`), which carries the companion allowlist and the fixtures.

## Platforms
| Platform | Applies? | Status |
|---|---|---|
| macOS     | yes | in #903 |
| Windows   | yes | in #903 |
| iOS       | yes | in the iOS PR |
| Android   | yes | in this PR, debug build and unit tests pass; NOT run on a device |
| Companion | yes | in the iOS PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
