### PR TITLE
Support audio file uploads in chat

### DIFF
--- a/server/attachments.test.ts
+++ b/server/attachments.test.ts
@@ -282,6 +282,24 @@ describe("shared files", () => {
     }
   });
 
+  it.each([
+    ["audio/opus", ".opus"], ["audio/ogg; codecs=opus", ".ogg"],
+    ["audio/mpeg", ".mp3"], ["audio/mp4", ".m4a"],
+    ["audio/x-wav", ".wav"], ["audio/aac", ".aac"],
+    ["audio/flac", ".flac"], ["audio/webm", ".webm"],
+  ])("stores %s audio privately and retries without duplicating it", async (mime, extension) => {
+    const bytes = Buffer.from([0, 255, 1, 128, 79, 103, 103, 83]);
+    const chunks = async function* () { yield bytes.subarray(0, 3); yield bytes.subarray(3); };
+    const first = await saveFile(chunks(), "Voice note.opus", mime, { uploadId: UPLOAD_A });
+    const again = await saveFile(chunks(), "Voice note.opus", mime, { uploadId: UPLOAD_A });
+    expect(again.path).toBe(first.path);
+    expect(first.path).toBe(join(ATTACHMENTS_DIR, `${UPLOAD_A}${extension}`));
+    expect(first.name).toBe(`Voice note${extension}`);
+    expect(readFileSync(first.path)).toEqual(bytes);
+    if (process.platform !== "win32") expect(statSync(first.path).mode & 0o777).toBe(0o600);
+    expect(readdirSync(ATTACHMENTS_DIR)).toEqual([`${UPLOAD_A}${extension}`]);
+  });
+
   it("rejects empty and oversized streams without leaving partial files", async () => {
     await expect(saveFile((async function* () {})(), "empty.txt", "text/plain")).rejects.toThrow(/empty file/);
     expect(readdirSync(ATTACHMENTS_DIR)).toEqual([]);

--- a/server/attachments.ts
+++ b/server/attachments.ts
@@ -52,12 +52,24 @@ const IMAGE_MIMES: Record<string, string> = {
   "image/webp": ".webp",
 };
 
-/** Useful document formats accepted by the phone share sheet.
+/** Useful document and audio formats accepted by the upload endpoint.
  * Generic archives, binaries, HTML, SVG, and executable/script mimes stay
  * out. Office/OpenDocument packages are allowed because they are documents,
  * despite using ZIP internally. The claimed mime determines the extension;
  * an attacker-controlled filename never does. */
 const FILE_MIMES: Readonly<Record<string, string>> = {
+  "audio/opus": ".opus",
+  "audio/ogg": ".ogg",
+  "audio/mpeg": ".mp3",
+  "audio/mp4": ".m4a",
+  "audio/x-m4a": ".m4a",
+  "audio/aac": ".aac",
+  "audio/wav": ".wav",
+  "audio/x-wav": ".wav",
+  "audio/wave": ".wav",
+  "audio/flac": ".flac",
+  "audio/x-flac": ".flac",
+  "audio/webm": ".webm",
   "text/plain": ".txt",
   "text/markdown": ".md",
   "text/csv": ".csv",
@@ -259,7 +271,7 @@ export function extensionForFileMime(mime: string | undefined): string | null {
  * remain visible as bad requests. */
 export function sanitizeSharedFileName(name: string, mime: string): string {
   const extension = extensionForFileMime(mime);
-  if (!extension) throw statusError(400, "content-type must be a supported document type");
+  if (!extension) throw statusError(400, "content-type must be a supported document or audio type");
 
   const normalized = name.normalize("NFKC").trim();
   if (!normalized) throw statusError(400, "name is required");
@@ -295,7 +307,7 @@ export async function saveFile(
 ): Promise<SavedFile> {
   const normalized = normalizedMime(mime);
   if (!normalized || !extensionForFileMime(normalized)) {
-    throw statusError(400, "content-type must be a supported document type");
+    throw statusError(400, "content-type must be a supported document or audio type");
   }
   const name = sanitizeSharedFileName(originalName, normalized);
   const extension = extensionForFileMime(normalized)!;

--- a/src/lib/composer-attachments.test.ts
+++ b/src/lib/composer-attachments.test.ts
@@ -460,6 +460,38 @@ describe("clipboardHasImages", () => {
 });
 
 describe("private document intake", () => {
+  it.each([
+    ["Voice note.opus", "", "audio/opus"],
+    ["Voice note.opus", "audio/ogg; codecs=opus", "audio/ogg"],
+    ["Recording.M4A", "application/octet-stream", "audio/mp4"],
+    ["recording.wav", "audio/x-wav", "audio/x-wav"],
+  ])("uploads %s as audio without a local path", async (name, type, mime) => {
+    const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      path: "/private/attachments/recording.opus", name, bytes: 3,
+    }), { status: 201, headers: { "content-type": "application/json" } }));
+    try {
+      const file = new File([new Uint8Array([1, 2, 3])], name, { type });
+      await expect(fileAttachmentFromFile(file)).resolves.toMatchObject({
+        kind: "file", name, path: "/private/attachments/recording.opus", size: 3,
+      });
+      expect(fetch).toHaveBeenCalledWith(expect.stringMatching(/^\/api\/files\?/),
+        expect.objectContaining({ method: "POST", body: file, headers: { "content-type": mime } }));
+    } finally {
+      fetch.mockRestore();
+    }
+  });
+
+  it("rejects oversized audio before uploading", async () => {
+    const fetch = vi.spyOn(globalThis, "fetch");
+    try {
+      const file = new File([new Uint8Array(25 * 1024 * 1024 + 1)], "large.opus", { type: "audio/opus" });
+      await expect(fileAttachmentFromFile(file)).rejects.toMatchObject({ status: 413 });
+      expect(fetch).not.toHaveBeenCalled();
+    } finally {
+      fetch.mockRestore();
+    }
+  });
+
   it("recognises supported documents by declared mime or filename", () => {
     expect(documentMime({ name: "notes.bin", type: "text/markdown; charset=utf-8" })).toBe("text/markdown");
     expect(documentMime({ name: "REPORT.PDF", type: "" })).toBe("application/pdf");

--- a/src/lib/composer-attachments.ts
+++ b/src/lib/composer-attachments.ts
@@ -135,6 +135,21 @@ const DOCUMENT_MIMES: Readonly<Record<string, string>> = {
 
 const ACCEPTED_DOCUMENT_MIMES = new Set(Object.values(DOCUMENT_MIMES));
 
+const AUDIO_MIMES_BY_EXTENSION: Readonly<Record<string, string>> = {
+  opus: "audio/opus",
+  ogg: "audio/ogg",
+  mp3: "audio/mpeg",
+  m4a: "audio/mp4",
+  aac: "audio/aac",
+  wav: "audio/wav",
+  flac: "audio/flac",
+  webm: "audio/webm",
+};
+const ACCEPTED_AUDIO_MIMES = new Set([
+  ...Object.values(AUDIO_MIMES_BY_EXTENSION),
+  "audio/x-m4a", "audio/x-wav", "audio/wave", "audio/x-flac",
+]);
+
 export function documentMime(file: Pick<File, "name" | "type">): string | null {
   const declared = file.type.split(";", 1)[0]!.trim().toLowerCase();
   if (ACCEPTED_DOCUMENT_MIMES.has(declared)) return declared;
@@ -321,11 +336,14 @@ export async function imageAttachmentFromFile(
   };
 }
 
-/** Copy a supported document into the private attachment store. The prompt
+/** Copy a supported document or audio file into the private attachment store. The prompt
  * then carries the same durable path for the local agent and paired phones,
  * instead of exposing an arbitrary Finder path to the companion route. */
 export async function fileAttachmentFromFile(file: File): Promise<FileAttachment | null> {
-  const mime = documentMime(file);
+  const declared = file.type.split(";", 1)[0]!.trim().toLowerCase();
+  const extension = file.name.split(".").at(-1)?.toLowerCase() ?? "";
+  const mime = documentMime(file) ??
+    (ACCEPTED_AUDIO_MIMES.has(declared) ? declared : AUDIO_MIMES_BY_EXTENSION[extension]);
   if (!mime) return null;
   if (file.size > FILE_MAX_BYTES) {
     throw Object.assign(new Error(`${file.name} exceeds 25 MB`), { status: 413 });
@@ -789,7 +807,7 @@ export async function intakeFiles<T extends DroppedFile & { type: string }>(
   const rejectedNames = results.flatMap((result) => result.rejectedNames);
   const uploadErrors = results.flatMap((result) => result.uploadError ? [result.uploadError] : []);
   const pathless = rejectedNames.length
-    ? `${rejectedNames.join(", ")} — that file has no path on disk. Save it first, then attach it from Finder.`
+    ? `Unable to attach ${rejectedNames.join(", ")}. Choose a supported image, document, or audio file.`
     : null;
   const failed = uploadErrors.length ? uploadErrors.join("; ") : null;
   return {

--- a/src/lib/intake-files.test.ts
+++ b/src/lib/intake-files.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { intakeFiles, type Attachment } from "./composer-attachments";
 
@@ -20,6 +20,22 @@ const upload = async (f: Fake): Promise<Attachment> => ({
 const onDisk = (f: Fake) => `/Users/me/${f.name}`;
 
 describe("intakeFiles", () => {
+  it("uploads a browser audio drop instead of requiring a Finder path", async () => {
+    const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      path: "/private/attachments/note.ogg", name: "Voice note.ogg", bytes: 4,
+    }), { status: 201, headers: { "content-type": "application/json" } }));
+    const getPath = vi.fn(() => "");
+    try {
+      const out = await intakeFiles([new File(["OggS"], "Voice note.opus", { type: "audio/ogg" })], {
+        allowImages: true, getPath, uploadImage: async () => null,
+      });
+      expect(out.attachments).toEqual([expect.objectContaining({ kind: "file", path: "/private/attachments/note.ogg" })]);
+      expect(out.notice).toBeNull();
+      expect(getPath).not.toHaveBeenCalled();
+    } finally {
+      fetch.mockRestore();
+    }
+  });
   it("uploads images and keeps ordinary files as paths", async () => {
     const out = await intakeFiles([file("shot.png", "image/png"), file("notes.txt", "text/plain")], {
       allowImages: true,
@@ -87,6 +103,7 @@ describe("intakeFiles", () => {
     });
     expect(out.attachments).toHaveLength(0);
     expect(out.notice).toMatch(/ghost\.bin/);
+    expect(out.notice).not.toMatch(/Finder|Save it first/);
   });
 
   it("reports an upload that failed without losing the files that worked", async () => {


### PR DESCRIPTION
Audio selected in the web chat composer currently falls through to a local-path error that tells the user to save the file in Finder. Upload supported audio through the existing private attachment endpoint so the chat receives a durable file reference.

Accept Opus/Ogg, MP3, M4A, AAC, WAV, FLAC and WebM, including common MIME aliases and extension fallback. Keep the existing upload limits, filename normalization and retry behavior. This change stores the original audio; it does not add playback or transcription.

Validation:

- Build and lint passed; 145 Electron Node tests and 8 broker tests passed.
- Full Vitest run: 4,323 passed. One existing installer permission test failed on both this branch and unchanged base; its 27-test file passed with the expected `umask 022`.
- Packaged server and MCP smoke checks passed without dependencies in reach.
- Isolated, paired web fixture: uploaded WAV and Opus/Ogg attachments, sent both in a chat, and verified persisted file references and bytes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for uploading audio attachments alongside images and documents.
  * Supported audio formats include Opus, Ogg, MP3, M4A, WAV, AAC, FLAC, and WebM.
  * Browser-dropped audio files can now upload without requiring a local file path.
  * Audio files larger than 25 MiB are rejected before upload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->