### PR TITLE
fix(electron): prove a data-directory lease dead across a reboot

### DIFF
--- a/electron/data-dir-lease.mjs
+++ b/electron/data-dir-lease.mjs
@@ -1,6 +1,7 @@
+import { execFileSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { existsSync, linkSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
-import { hostname } from "node:os";
+import { hostname, uptime } from "node:os";
 import { join } from "node:path";
 
 const LEASE_NAME = "openmausbot-server.lease";
@@ -11,6 +12,7 @@ const DELEGATED_CHILD_DIR = ".openmausbot-server-child";
 const CHILD_LEASE_ENV = "OPENMAUSBOT_INTERNAL_DATA_DIR_LEASE";
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const MAX_PID = 0x7fffffff;
+const MAX_BOOT_ID = 128;
 const MAX_REAPER_GENERATIONS = 128;
 
 export class DataDirLeaseError extends Error {
@@ -25,6 +27,77 @@ function isPid(value) {
   return Number.isInteger(value) && value > 0 && value <= MAX_PID;
 }
 
+/**
+ * A pid does not identify a process across a reboot. The kernel restarts pid
+ * allocation, so the low pid a login-item launch recorded is typically reused
+ * by a root-owned daemon on the next boot; process.kill(pid, 0) then answers
+ * EPERM, which reads as alive, and the desktop refuses to start forever with
+ * no instance for anyone to close. Recording which boot wrote the lease turns
+ * that guess into proof.
+ *
+ * Both signals below may only ever prove a lease DEAD, never alive, and both
+ * are exact rather than heuristic: a wrong "stale" verdict would let two
+ * instances share one data directory, which is the harm this module exists to
+ * prevent. Nothing here is derived from the wall clock, which NTP can move.
+ */
+let cachedBootSession;
+
+function readBootSession() {
+  try {
+    if (process.platform === "linux") {
+      return normalizeBootId(readFileSync("/proc/sys/kernel/random/boot_id", "utf8"));
+    }
+    if (process.platform === "darwin") {
+      return normalizeBootId(execFileSync("/usr/sbin/sysctl", ["-n", "kern.bootsessionuuid"], {
+        encoding: "utf8",
+        timeout: 5_000,
+        stdio: ["ignore", "pipe", "ignore"],
+      }));
+    }
+  } catch {
+    // An unreadable boot id is not a startup failure. The lease simply falls
+    // back to the pid-only protocol this module has always used.
+  }
+  return null;
+}
+
+function normalizeBootId(value) {
+  const id = String(value).trim();
+  return id.length > 0 && id.length <= MAX_BOOT_ID && !/[^0-9A-Za-z:_.-]/.test(id) ? id : null;
+}
+
+/** Stable for one boot; Windows has no equivalent, so it reports null there. */
+function bootSession() {
+  if (cachedBootSession === undefined) cachedBootSession = readBootSession();
+  return cachedBootSession;
+}
+
+function uptimeMs() {
+  const seconds = uptime();
+  return Number.isFinite(seconds) && seconds >= 0 ? Math.floor(seconds * 1000) : 0;
+}
+
+function isBootIdentity(value) {
+  return value === null || (typeof value === "string" && normalizeBootId(value) === value);
+}
+
+function ownerPredatesThisBoot(owner) {
+  const current = bootSession();
+  if (current !== null && typeof owner.boot === "string") return owner.boot !== current;
+  // Without a boot id, a since-boot clock is still one-directional: it cannot
+  // run backwards within a single boot, so a larger recorded value can only
+  // have been written before a reboot.
+  if (Number.isInteger(owner.uptime)) return uptimeMs() < owner.uptime;
+  // A record written by an older build carries neither signal. Treating it as
+  // current preserves the previous behaviour exactly.
+  return false;
+}
+
+/** The only liveness question this module should ever ask about a record. */
+function ownerIsAlive(owner) {
+  return !ownerPredatesThisBoot(owner) && processIsAlive(owner.pid);
+}
+
 function isLeaseOwner(value) {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   return value.version === 1
@@ -37,7 +110,11 @@ function isLeaseOwner(value) {
     && UUID.test(value.token)
     && typeof value.createdAt === "number"
     && Number.isFinite(value.createdAt)
-    && value.createdAt > 0;
+    && value.createdAt > 0
+    // Optional so a lease written by an older build stays readable rather
+    // than bricking startup on an "invalid lease" during the upgrade.
+    && (value.boot === undefined || isBootIdentity(value.boot))
+    && (value.uptime === undefined || (Number.isInteger(value.uptime) && value.uptime >= 0));
 }
 
 function isReaperOwner(value, targetToken) {
@@ -143,6 +220,8 @@ function claimReaperAuthority(leasePath, expected) {
       host: hostname(),
       token: randomUUID(),
       createdAt: Date.now(),
+      boot: bootSession(),
+      uptime: uptimeMs(),
       targetToken: expected.token,
     };
     if (publishRecord(
@@ -159,7 +238,7 @@ function claimReaperAuthority(leasePath, expected) {
         `A stale OpenMausBot data-directory lease is being recovered on another machine. Recovery record: ${JSON.stringify(reaperPath)}.`,
       );
     }
-    if (processIsAlive(current.pid)) return false;
+    if (ownerIsAlive(current)) return false;
     reaperPath = successorReaperPath(leasePath, expected.token, current.token);
   }
   throw leaseError("OpenMausBot could not recover the stale data-directory lease after repeated interrupted attempts.");
@@ -174,7 +253,7 @@ function retireDeadOwner(leasePath, expected) {
       `The stale OpenMausBot data-directory lease changed ownership to another machine. Lease record: ${JSON.stringify(leasePath)}.`,
     );
   }
-  if (processIsAlive(current.pid)) return false;
+  if (ownerIsAlive(current)) return false;
   unlinkExact(leasePath, "OpenMausBot could not retire the stale data-directory lease.");
   return true;
 }
@@ -219,7 +298,7 @@ function assertNoLiveDelegatedChild(dataDir) {
       `This OpenMausBot data directory still has a delegated server on another machine. Delegated server lease: ${JSON.stringify(childLeasePath)}.`,
     );
   }
-  if (processIsAlive(child.pid)) {
+  if (ownerIsAlive(child)) {
     throw leaseError(
       `OpenMausBot's previous server process ${child.pid} is still shutting down. Try again shortly.`,
     );
@@ -262,7 +341,7 @@ function validateChildDelegation(dataDir, encoded) {
     && owner.pid === capability.pid
     && owner.token === capability.token
     && owner.host === hostname()
-    && processIsAlive(owner.pid));
+    && ownerIsAlive(owner));
   if (!matchesLiveParent(readOwner(parentLeasePath))) {
     throw invalid();
   }
@@ -297,6 +376,8 @@ function acquireDataDirLeaseInternal(dataDir, options = {}) {
     host: hostname(),
     token: randomUUID(),
     createdAt: Date.now(),
+    boot: bootSession(),
+    uptime: uptimeMs(),
   };
   const candidatePath = `${leasePath}.candidate-${owner.pid}-${owner.token}`;
   try {
@@ -325,9 +406,9 @@ function acquireDataDirLeaseInternal(dataDir, options = {}) {
           `This OpenMausBot data directory is already owned by a process on another machine. Lease record: ${JSON.stringify(leasePath)}.`,
         );
       }
-      if (processIsAlive(current.pid)) {
+      if (ownerIsAlive(current)) {
         throw leaseError(
-          `OpenMausBot is already using this data directory (process ${current.pid}). Close the other instance first.`,
+          `OpenMausBot is already using this data directory (process ${current.pid}). Close the other instance first. If no OpenMausBot is running, delete this lease record and start again: ${JSON.stringify(leasePath)}.`,
         );
       }
       if (!retireDeadOwner(leasePath, current)) {

--- a/electron/data-dir-lease.node-test.mjs
+++ b/electron/data-dir-lease.node-test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { hostname, tmpdir } from "node:os";
+import { hostname, tmpdir, uptime as osUptime } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
@@ -387,4 +387,121 @@ test("process entry API remains compatible with a standalone server", () => {
   assert.equal(lease.delegated, false);
   assert.equal(lease.ownerPid, process.pid);
   assert.equal(lease.release(), true);
+});
+
+/**
+ * Read the lease record this build actually writes, so the boot-identity tests
+ * assert against the real on-disk shape instead of a hand-copied duplicate.
+ */
+function recordWrittenByThisProcess(dataDir) {
+  const lease = acquireDataDirLease(dataDir);
+  const record = JSON.parse(readFileSync(path.join(dataDir, LEASE_NAME), "utf8"));
+  lease.release();
+  return record;
+}
+
+function plantOwner(dataDir, overrides) {
+  const leasePath = path.join(dataDir, LEASE_NAME);
+  const owner = { ...recordWrittenByThisProcess(dataDir), ...overrides };
+  writeFileSync(leasePath, `${JSON.stringify(owner)}\n`, { mode: 0o600 });
+  return leasePath;
+}
+
+test("a lease left behind by an earlier boot is retired even though its pid is live", () => {
+  const { dataDir } = temporaryDirectory();
+  if (recordWrittenByThisProcess(dataDir).boot === null) return; // no boot identity on this platform
+  // The reported failure: a restart force-kills the desktop, the pid it
+  // recorded is reused by a root-owned daemon on the next boot, and kill(0)
+  // answers EPERM. Our own live pid reproduces that "owner looks alive" state
+  // exactly, without depending on which daemon holds a recycled pid.
+  plantOwner(dataDir, { boot: randomUUID(), pid: process.pid, token: randomUUID() });
+
+  const lease = acquireDataDirLease(dataDir);
+  assert.equal(lease.ownerPid, process.pid);
+  assert.equal(lease.release(), true);
+});
+
+test("a live owner from the current boot still blocks a second instance", () => {
+  const { dataDir } = temporaryDirectory();
+  plantOwner(dataDir, { pid: process.pid, token: randomUUID() });
+
+  assert.throws(() => acquireDataDirLease(dataDir), /already using this data directory/i);
+});
+
+test("a lease recorded above the machine's current uptime is retired", () => {
+  const { dataDir } = temporaryDirectory();
+  // Windows has no boot session id, so a reboot is proven by the only
+  // one-directional signal available: a since-boot clock cannot run backwards
+  // within a single boot.
+  plantOwner(dataDir, {
+    boot: null,
+    uptime: Math.floor(osUptime() * 1000) + 3_600_000,
+    pid: process.pid,
+    token: randomUUID(),
+  });
+
+  const lease = acquireDataDirLease(dataDir);
+  assert.equal(lease.ownerPid, process.pid);
+  assert.equal(lease.release(), true);
+});
+
+test("the contention error names the lease record so a stuck owner is recoverable", () => {
+  const { dataDir } = temporaryDirectory();
+  const leasePath = plantOwner(dataDir, { pid: process.pid, token: randomUUID() });
+
+  assert.throws(
+    () => acquireDataDirLease(dataDir),
+    (error) => {
+      assert.ok(error.message.includes(JSON.stringify(leasePath)), error.message);
+      return true;
+    },
+  );
+});
+
+test("a stale lease whose pid was recycled by a root-owned daemon no longer blocks startup", () => {
+  const { dataDir } = temporaryDirectory();
+  if (recordWrittenByThisProcess(dataDir).boot === null) return; // no boot identity on this platform
+  // The exact reported failure. pid 1 is always live and always root-owned, so
+  // kill(0) answers EPERM here just as it did for the recycled pid 459 in the
+  // user's report -- the case that made the desktop unstartable forever.
+  assert.throws(() => process.kill(1, 0), { code: "EPERM" });
+  plantOwner(dataDir, { boot: randomUUID(), pid: 1, token: randomUUID() });
+
+  const lease = acquireDataDirLease(dataDir);
+  assert.equal(lease.ownerPid, process.pid);
+  assert.equal(lease.release(), true);
+});
+
+test("boot identity does not weaken exclusion: only one of many live racers wins", async () => {
+  const { dataDir } = temporaryDirectory();
+  // The guarantee this module exists to provide. Boot identity may only ever
+  // prove a record dead, so concurrent live claimants must still serialize to
+  // exactly one owner -- a stale-detection bug that let two in would corrupt
+  // the very state the lease protects.
+  const racers = await Promise.all(Array.from({ length: 8 }, () => runNode(`
+    const { acquireDataDirLease } = await import(${JSON.stringify(MODULE_URL)});
+    try {
+      const lease = acquireDataDirLease(${JSON.stringify(dataDir)});
+      // Hold it long enough that every sibling overlaps this owner.
+      await new Promise((resolve) => setTimeout(resolve, 750));
+      process.stdout.write(JSON.stringify({ acquired: true, released: lease.release() }));
+    } catch (error) {
+      process.stdout.write(JSON.stringify({ acquired: false, error: String(error?.message ?? error) }));
+    }
+  `)));
+
+  const results = racers.map((racer) => {
+    assert.equal(racer.stderr, "");
+    return JSON.parse(racer.stdout);
+  });
+  const winners = results.filter((result) => result.acquired);
+  assert.equal(winners.length, 1, JSON.stringify(results, null, 2));
+  assert.equal(winners[0].released, true);
+  for (const loser of results.filter((result) => !result.acquired)) {
+    assert.match(loser.error, /already using this data directory|being recovered/i);
+  }
+
+  // And the directory is left usable rather than wedged by the contention.
+  const after = acquireDataDirLease(dataDir);
+  assert.equal(after.release(), true);
 });

--- a/electron/data-dir-lease.node-test.mjs
+++ b/electron/data-dir-lease.node-test.mjs
@@ -407,9 +407,9 @@ function plantOwner(dataDir, overrides) {
   return leasePath;
 }
 
-test("a lease left behind by an earlier boot is retired even though its pid is live", () => {
+test("a lease left behind by an earlier boot is retired even though its pid is live", (t) => {
   const { dataDir } = temporaryDirectory();
-  if (recordWrittenByThisProcess(dataDir).boot === null) return; // no boot identity on this platform
+  if (recordWrittenByThisProcess(dataDir).boot === null) return t.skip("no boot identity on this platform");
   // The reported failure: a restart force-kills the desktop, the pid it
   // recorded is reused by a root-owned daemon on the next boot, and kill(0)
   // answers EPERM. Our own live pid reproduces that "owner looks alive" state
@@ -426,6 +426,39 @@ test("a live owner from the current boot still blocks a second instance", () => 
   plantOwner(dataDir, { pid: process.pid, token: randomUUID() });
 
   assert.throws(() => acquireDataDirLease(dataDir), /already using this data directory/i);
+});
+
+test("a reaper from an earlier boot is succeeded even when its pid is live", (t) => {
+  const { dataDir } = temporaryDirectory();
+  const current = recordWrittenByThisProcess(dataDir);
+  if (current.boot === null) return t.skip("no boot identity on this platform");
+  const stale = { ...current, boot: randomUUID() };
+  const leasePath = path.join(dataDir, LEASE_NAME);
+  const reaper = { ...stale, token: randomUUID(), targetToken: stale.token };
+  writeFileSync(leasePath, JSON.stringify(stale));
+  writeFileSync(`${leasePath}.reap-${stale.token}`, JSON.stringify(reaper));
+
+  const lease = acquireDataDirLease(dataDir);
+  const successor = createHash("sha256").update(reaper.token).digest("hex").slice(0, 32);
+  const record = JSON.parse(readFileSync(`${leasePath}.reap-${stale.token}-${successor}`, "utf8"));
+  assert.equal(record.boot, current.boot);
+  assert.equal(record.pid, process.pid);
+  assert.equal(lease.release(), true);
+});
+
+test("a delegated child from an earlier boot cannot block a new parent", (t) => {
+  const { dataDir } = temporaryDirectory();
+  const current = recordWrittenByThisProcess(dataDir);
+  if (current.boot === null) return t.skip("no boot identity on this platform");
+  const childPath = path.join(dataDir, ".openmausbot-server-child", LEASE_NAME);
+  mkdirSync(path.dirname(childPath));
+  writeFileSync(childPath, JSON.stringify({ ...current, boot: randomUUID() }));
+
+  const parent = acquireDataDirLease(dataDir);
+  const child = acquireDataDirLeaseForProcess(dataDir, { ...parent.utilityServerLeaseEnvironment() });
+  assert.equal(child.delegated, true);
+  assert.equal(child.release(), true);
+  assert.equal(parent.release(), true);
 });
 
 test("a lease recorded above the machine's current uptime is retired", () => {
@@ -458,13 +491,17 @@ test("the contention error names the lease record so a stuck owner is recoverabl
   );
 });
 
-test("a stale lease whose pid was recycled by a root-owned daemon no longer blocks startup", () => {
+test("a stale lease whose pid was recycled by a root-owned daemon no longer blocks startup", (t) => {
   const { dataDir } = temporaryDirectory();
-  if (recordWrittenByThisProcess(dataDir).boot === null) return; // no boot identity on this platform
-  // The exact reported failure. pid 1 is always live and always root-owned, so
-  // kill(0) answers EPERM here just as it did for the recycled pid 459 in the
-  // user's report -- the case that made the desktop unstartable forever.
-  assert.throws(() => process.kill(1, 0), { code: "EPERM" });
+  if (recordWrittenByThisProcess(dataDir).boot === null) return t.skip("no boot identity on this platform");
+  // Root/container runners may be allowed to signal PID 1. Only run this
+  // fixture when it reproduces the reported EPERM failure.
+  try {
+    process.kill(1, 0);
+    return t.skip("this runner can signal PID 1");
+  } catch (error) {
+    assert.equal(error.code, "EPERM");
+  }
   plantOwner(dataDir, { boot: randomUUID(), pid: 1, token: randomUUID() });
 
   const lease = acquireDataDirLease(dataDir);
@@ -478,19 +515,37 @@ test("boot identity does not weaken exclusion: only one of many live racers wins
   // prove a record dead, so concurrent live claimants must still serialize to
   // exactly one owner -- a stale-detection bug that let two in would corrupt
   // the very state the lease protects.
-  const racers = await Promise.all(Array.from({ length: 8 }, () => runNode(`
+  const racers = await Promise.all(Array.from({ length: 8 }, (_, index) => runNode(`
+    const { existsSync, writeFileSync } = await import("node:fs");
     const { acquireDataDirLease } = await import(${JSON.stringify(MODULE_URL)});
+    const prefix = ${JSON.stringify(path.join(dataDir, "racer-"))};
+    const deadline = Date.now() + 10_000;
+    async function waitForAll(stage) {
+      while (!Array.from({ length: 8 }, (_, i) => existsSync(prefix + i + stage)).every(Boolean)) {
+        if (Date.now() > deadline) throw new Error("racer barrier timed out: " + stage);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+    }
+    writeFileSync(prefix + ${index} + ".ready", "");
+    await waitForAll(".ready");
+    let lease;
     try {
-      const lease = acquireDataDirLease(${JSON.stringify(dataDir)});
-      // Hold it long enough that every sibling overlaps this owner.
-      await new Promise((resolve) => setTimeout(resolve, 750));
+      lease = acquireDataDirLease(${JSON.stringify(dataDir)});
+      writeFileSync(prefix + ${index} + ".attempted", "");
+      // Keep the winner live until every sibling has attempted acquisition,
+      // even when a runner is paused or much slower than its siblings.
+      await waitForAll(".attempted");
       process.stdout.write(JSON.stringify({ acquired: true, released: lease.release() }));
     } catch (error) {
+      writeFileSync(prefix + ${index} + ".attempted", "");
       process.stdout.write(JSON.stringify({ acquired: false, error: String(error?.message ?? error) }));
+    } finally {
+      lease?.release();
     }
   `)));
 
   const results = racers.map((racer) => {
+    assert.equal(racer.code, 0, racer.stderr);
     assert.equal(racer.stderr, "");
     return JSON.parse(racer.stdout);
   });

--- a/server/data-dir-lease.test.ts
+++ b/server/data-dir-lease.test.ts
@@ -59,14 +59,22 @@ describe("OpenMausBot data-directory lease", () => {
     const lease = acquireDataDirLease(dir);
     const stored = JSON.parse(readFileSync(join(dir, "openmausbot-server.lease"), "utf8"));
 
-    expect(stored).toEqual({
+    // boot/uptime identify which boot wrote the record, so a pid recycled
+    // across a restart cannot be mistaken for a live owner. boot is null on
+    // platforms that expose no boot id, so it is checked separately.
+    const { boot, ...rest } = stored;
+    expect(rest).toEqual({
       version: 1,
       pid: process.pid,
       host: hostname(),
       token: expect.stringMatching(/^[0-9a-f-]{36}$/),
       createdAt: expect.any(Number),
+      uptime: expect.any(Number),
     });
-    expect(Object.keys(stored).sort()).toEqual(["createdAt", "host", "pid", "token", "version"]);
+    expect(boot === null || (typeof boot === "string" && boot.length > 0)).toBe(true);
+    expect(Object.keys(stored).sort()).toEqual(
+      ["boot", "createdAt", "host", "pid", "token", "uptime", "version"],
+    );
     expect(() => acquireDataDirLease(dir)).toThrow(/already using this data directory/i);
 
     expect(lease.release()).toBe(true);


### PR DESCRIPTION
## The bug

A user could not launch OpenMausBot after a restart:

> **OpenMausBot could not start safely**
> OpenMausBot is already using this data directory (process 459). Close the other instance first.

There was no other instance to close, and no in-app recovery — the app was bricked on every launch.

## Root cause

The data-directory lease identified its owner by **pid alone**:

```js
const owner = { version: 1, pid: process.pid, host: hostname(), token, createdAt };
```

Three things combine into a permanent failure:

1. **The lease survives an unclean exit.** `release()` runs on `will-quit` / `process exit`. A macOS restart force-kills apps that miss the shutdown deadline, and the desktop does async CUA + utility-server teardown before quitting. The lease is left holding the old pid.
2. **Pids reset on reboot and get recycled.** A login-item launch records a low pid; after the next boot that pid belongs to a root-owned daemon.
3. **`EPERM` counts as alive** (`processIsAlive`, by design — the pid exists but this account cannot signal it). So a recycled pid reads as a live owner, the stale-lease reaper never fires, and startup fails forever.

Both pids in the user's report — **459** and **400** — sit squarely in the range macOS assigns during boot, consistent with the app being launched at login.

## The fix

Record which boot wrote the lease, and require a match before believing the owner is alive.

```js
function ownerIsAlive(owner) {
  return !ownerPredatesThisBoot(owner) && processIsAlive(owner.pid);
}
```

**The pid check is unchanged and still required.** Boot identity is an added *necessary* condition for declaring a record dead — it can never make a record look alive, and it never relaxes exclusion. A wrong "stale" verdict would let two instances share one data directory, which is the exact harm this module exists to prevent, so both signals are exact rather than heuristic, and neither is derived from the wall clock (NTP can move it):

- **macOS / Linux** — the kernel's boot session id (`kern.bootsessionuuid`, `/proc/sys/kernel/random/boot_id`), fixed for the life of one boot. Complete coverage.
- **Everywhere else** — a since-boot clock cannot run backwards within a boot, so a recorded uptime above the machine's current uptime can only have been written before a reboot.

Records written by older builds carry neither field and keep the previous pid-only behaviour exactly, so an in-place upgrade cannot fail on an "invalid lease".

The contention message now names the lease record, so anyone still stuck can recover without contacting support:

> OpenMausBot is already using this data directory (process 459). Close the other instance first. If no OpenMausBot is running, delete this lease record and start again: "/Users/…/.openmausbot/openmausbot-server.lease".

### Known limit

Windows has no cheap synchronous boot id, so it relies on the uptime-regression check. That is **sound** (it cannot produce a false "stale") and it catches the common launch-at-login case that caused this report, but it misses one shape: machine up a long time, app launched later in the session than the previous session's uptime. That case degrades to today's behaviour, now with a recoverable error message. Closing it fully would need either a ~300-500ms PowerShell spawn at startup or a wall-clock age comparison that an NTP correction could turn into a false "stale" — deliberately not taken.

## Test plan

Written test-first; every new test was watched fail against the pre-fix module.

- `node --test electron/data-dir-lease.node-test.mjs` — **17/17 pass** (11 pre-existing + 6 new)
  - `a stale lease whose pid was recycled by a root-owned daemon no longer blocks startup` — reproduces the report exactly using pid 1 (always live, always root-owned, so `kill(0)` answers `EPERM`). **Fails on `origin/main`, passes here.**
  - `a lease left behind by an earlier boot is retired even though its pid is live`
  - `a lease recorded above the machine's current uptime is retired` — the Windows path
  - `a live owner from the current boot still blocks a second instance` — guards against a false "stale"
  - `boot identity does not weaken exclusion: only one of many live racers wins` — 8 concurrent live claimants, exactly one wins, directory left usable
  - `the contention error names the lease record so a stuck owner is recoverable`
  - The 6 pre-existing tests that plant old-format records still pass unchanged, proving the upgrade path.
- `vitest run server/data-dir-lease.test.ts` — 5/5. The record-shape guard was updated to pin the two new fields rather than loosened.
- `vitest run server/index.test.ts` — 198/198.
- `node --test "electron/*.node-test.mjs"` — 140 pass, 0 fail. The 11 cancellations in `approval-trusted-mode` / `server-boot-probe` are present on pristine `origin/main` and unrelated.
- `tsc -b && tsc -p tsconfig.server.json` — clean. `oxlint` on changed files — clean.

Not yet exercised on a real reboot or on Windows hardware.

## Platforms
| Platform | Applies? | Status |
|---|---|---|
| macOS     | yes | in this PR — exact fix via `kern.bootsessionuuid`; reported bug reproduced pre-fix and fixed |
| Windows   | yes | in this PR — the non-darwin/linux branch *is* the Windows path, no separate win32 gate needed; sound but partial (see Known limit); NOT built on Windows |
| iOS       | no  | n/a: no data-directory lease on the phone clients |
| Android   | no  | n/a: no data-directory lease on the phone clients |
| Companion | no  | n/a: no phone-called route changed |

## For the affected user, before this ships

Quit OpenMausBot, then:

```bash
rm -f ~/.openmausbot/openmausbot-server.lease \
      ~/.openmausbot/.openmausbot-server-child/openmausbot-server.lease
```

Lock state only — no chats, bots, or settings are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection and recovery of stale data-directory leases after system reboots or process ID reuse.
  - Strengthened handling for lease contention and concurrent acquisition.
  - Updated already-in-use errors with guidance for removing stale lease records.
  - Preserved compatibility with older lease records while recording additional boot-session and uptime details.
  - Improved recovery after interrupted or competing lease-acquisition attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->