### PR TITLE
perf(attachments): account committed bytes instead of rescanning the directory per MiB

### DIFF
--- a/server/attachments-startup.test.ts
+++ b/server/attachments-startup.test.ts
@@ -1,0 +1,50 @@
+import type { SpawnOptions } from "node:child_process";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, it, vi } from "vitest";
+
+import { launchVerificationServer, runControlOmb } from "../scripts/control-omb.ts";
+
+// Obstruct only the attachments directory in the launcher's disposable home.
+// The real child still boots normally and handles real HTTP requests.
+vi.mock("node:child_process", async (importOriginal) => {
+  const childProcess = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...childProcess,
+    spawn(command: string, args: readonly string[], options: SpawnOptions) {
+      const dataDir = options.env?.OMB_DATA_DIR;
+      if (!dataDir || !args.includes(join(process.cwd(), "server", "index.ts"))) {
+        throw new Error("Expected the isolated verification server");
+      }
+      writeFileSync(join(dataDir, "attachments"), "fixture obstruction");
+      return childProcess.spawn(command, args, options);
+    },
+  };
+});
+
+it("starts despite attachment cleanup failure and initializes quota after the directory is repaired", async () => {
+  const session = await launchVerificationServer();
+  try {
+    await expect(runControlOmb(["doctor", "--url", session.info.url])).resolves.toMatchObject({ ok: true });
+    expect(readFileSync(session.info.logPath, "utf8")).toContain("attachments: startup partial cleanup failed:");
+    const upload = () => fetch(`${session.info.url}/api/files?name=fixture.txt`, {
+      method: "POST",
+      headers: { "content-type": "text/plain" },
+      body: "hello",
+    });
+    const blocked = await upload();
+    expect(blocked.status).toBe(500);
+    await blocked.text();
+
+    unlinkSync(join(session.info.dataDir, "attachments"));
+    const recovered = await upload();
+    expect(recovered.status).toBe(201);
+    const saved = await recovered.json() as { path: string; bytes: number };
+    expect(saved.path.startsWith(join(session.info.dataDir, "attachments"))).toBe(true);
+    expect(saved.bytes).toBe(5);
+    expect(readFileSync(saved.path, "utf8")).toBe("hello");
+  } finally {
+    await session.close();
+  }
+  expect(existsSync(session.info.dataDir)).toBe(false);
+}, 30_000);

--- a/server/attachments.test.ts
+++ b/server/attachments.test.ts
@@ -15,21 +15,23 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { unlink } from "node:fs/promises";
+import { link, unlink } from "node:fs/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("node:fs/promises", async (importOriginal) => {
   const fs = await importOriginal<typeof import("node:fs/promises")>();
-  return { ...fs, unlink: vi.fn(fs.unlink) };
+  return { ...fs, link: vi.fn(fs.link), unlink: vi.fn(fs.unlink) };
 });
 vi.mock("node:fs", async (importOriginal) => {
   const fs = await importOriginal<typeof import("node:fs")>();
   return { ...fs, unlinkSync: vi.fn(fs.unlinkSync) };
 });
 const realUnlink = (await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises")).unlink;
+const realLink = (await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises")).link;
 const realUnlinkSync = (await vi.importActual<typeof import("node:fs")>("node:fs")).unlinkSync;
 afterEach(() => {
   vi.mocked(unlink).mockReset().mockImplementation(realUnlink);
+  vi.mocked(link).mockReset().mockImplementation(realLink);
   vi.mocked(unlinkSync).mockReset().mockImplementation(realUnlinkSync);
 });
 
@@ -308,6 +310,41 @@ describe("aggregate attachment storage", () => {
     await expect(saveImageUpload(Buffer.from("xx"), "image/png", UPLOAD_A)).resolves.toMatchObject({ bytes: 2 });
     expect(readdirSync(ATTACHMENTS_DIR).some((name) => name.endsWith(".partial"))).toBe(false);
     expect(() => saveImage(Buffer.from("y"), "image/png")).not.toThrow();
+    expect(() => saveImage(Buffer.from("z"), "image/png")).toThrow(/storage is full/);
+  });
+
+  it("does not count an in-flight commit twice when cleanup failure causes a rescan", async () => {
+    const existing = saveImage(Buffer.from("x"), "image/png");
+    truncateSync(existing.path, ATTACHMENTS_MAX_BYTES - 5);
+    __resetAttachmentAccountingForTests();
+    let markLinked!: () => void;
+    let finishCommit!: () => void;
+    const linked = new Promise<void>((resolve) => { markLinked = resolve; });
+    const finishing = new Promise<void>((resolve) => { finishCommit = resolve; });
+    vi.mocked(link).mockImplementationOnce(async (...args) => {
+      await realLink(...args);
+      markLinked();
+      await finishing;
+    });
+    const pending = saveFile((async function* () { yield Buffer.from("xx"); })(), "pending.txt", "text/plain", {
+      uploadId: UPLOAD_A, expectedBytes: 2,
+    });
+    try {
+      await linked;
+      for (let attempt = 0; attempt < 2; attempt++) {
+        vi.mocked(unlinkSync).mockImplementationOnce(() => {
+          throw Object.assign(new Error("partial file is locked"), { code: "EPERM" });
+        });
+      }
+      expect(() => saveImage(Buffer.from("x"), "image/png", UPLOAD_B)).toThrow("partial file is locked");
+      // This scan sees the linked file while its commit callback is pending.
+      expect(() => saveImage(Buffer.from("y"), "image/png")).toThrow(/storage is full/);
+    } finally {
+      finishCommit();
+      await pending;
+    }
+    await saveImageUpload(Buffer.from("x"), "image/png", UPLOAD_B);
+    expect(() => saveImage(Buffer.from("yy"), "image/png")).not.toThrow();
     expect(() => saveImage(Buffer.from("z"), "image/png")).toThrow(/storage is full/);
   });
 

--- a/server/attachments.test.ts
+++ b/server/attachments.test.ts
@@ -9,12 +9,29 @@ import {
   rmSync,
   statSync,
   truncateSync,
+  unlinkSync,
   utimesSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { unlink } from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const fs = await importOriginal<typeof import("node:fs/promises")>();
+  return { ...fs, unlink: vi.fn(fs.unlink) };
+});
+vi.mock("node:fs", async (importOriginal) => {
+  const fs = await importOriginal<typeof import("node:fs")>();
+  return { ...fs, unlinkSync: vi.fn(fs.unlinkSync) };
+});
+const realUnlink = (await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises")).unlink;
+const realUnlinkSync = (await vi.importActual<typeof import("node:fs")>("node:fs")).unlinkSync;
+afterEach(() => {
+  vi.mocked(unlink).mockReset().mockImplementation(realUnlink);
+  vi.mocked(unlinkSync).mockReset().mockImplementation(realUnlinkSync);
+});
 
 // The module reads DATA_DIR at import time, so the env var must be set
 // before the import is evaluated.
@@ -251,6 +268,47 @@ describe("aggregate attachment storage", () => {
     const second = saveImage(Buffer.from("yyy"), "image/png");
     expect(second.bytes).toBe(3);
     expect(readdirSync(ATTACHMENTS_DIR)).toEqual([second.path.split(/[\\/]/).pop()!]);
+  });
+
+  it.each([1, 2])("counts a committed upload after %i partial-cleanup failures and an idempotent retry", async (failures) => {
+    const existing = saveImage(Buffer.from("x"), "image/png");
+    truncateSync(existing.path, ATTACHMENTS_MAX_BYTES - 3);
+    __resetAttachmentAccountingForTests();
+    const cleanupError = Object.assign(new Error("partial file is locked"), { code: "EPERM" });
+    for (let attempt = 0; attempt < failures; attempt++) {
+      vi.mocked(unlink).mockRejectedValueOnce(cleanupError);
+    }
+    const chunks = async function* () { yield Buffer.from("xx"); };
+
+    await expect(saveFile(chunks(), "retry.txt", "text/plain", { uploadId: UPLOAD_A }))
+      .rejects.toThrow("partial file is locked");
+    expect(readFileSync(join(ATTACHMENTS_DIR, `${UPLOAD_A}.txt`), "utf8")).toBe("xx");
+    expect(readdirSync(ATTACHMENTS_DIR).filter((name) => name.endsWith(".partial"))).toHaveLength(failures - 1);
+
+    await expect(saveFile(chunks(), "retry.txt", "text/plain", { uploadId: UPLOAD_A }))
+      .resolves.toMatchObject({ bytes: 2 });
+    expect(readdirSync(ATTACHMENTS_DIR).some((name) => name.endsWith(".partial"))).toBe(false);
+    expect(() => saveImage(Buffer.from("y"), "image/png")).not.toThrow();
+    expect(() => saveImage(Buffer.from("z"), "image/png")).toThrow(/storage is full/);
+  });
+
+  it.each([1, 2])("counts an image after %i partial-cleanup failures and an idempotent retry", async (failures) => {
+    const existing = saveImage(Buffer.from("x"), "image/png");
+    truncateSync(existing.path, ATTACHMENTS_MAX_BYTES - 3);
+    __resetAttachmentAccountingForTests();
+    for (let attempt = 0; attempt < failures; attempt++) {
+      vi.mocked(unlinkSync).mockImplementationOnce(() => {
+        throw Object.assign(new Error("partial file is locked"), { code: "EPERM" });
+      });
+    }
+
+    expect(() => saveImage(Buffer.from("xx"), "image/png", UPLOAD_A)).toThrow("partial file is locked");
+    expect(readFileSync(join(ATTACHMENTS_DIR, `${UPLOAD_A}.png`), "utf8")).toBe("xx");
+    expect(readdirSync(ATTACHMENTS_DIR).filter((name) => name.endsWith(".partial"))).toHaveLength(failures - 1);
+    await expect(saveImageUpload(Buffer.from("xx"), "image/png", UPLOAD_A)).resolves.toMatchObject({ bytes: 2 });
+    expect(readdirSync(ATTACHMENTS_DIR).some((name) => name.endsWith(".partial"))).toBe(false);
+    expect(() => saveImage(Buffer.from("y"), "image/png")).not.toThrow();
+    expect(() => saveImage(Buffer.from("z"), "image/png")).toThrow(/storage is full/);
   });
 
   it("initializes correctly on a fresh process against a directory that already has files", () => {

--- a/server/attachments.test.ts
+++ b/server/attachments.test.ts
@@ -2,6 +2,7 @@
 // the name-lock that keeps the serving route inside the attachments dir.
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
@@ -26,7 +27,9 @@ const {
   ATTACHMENT_PARTIAL_MAX_AGE_MS,
   FILE_MAX_BYTES,
   IMAGE_MAX_BYTES,
+  __resetAttachmentAccountingForTests,
   cleanupStaleAttachmentPartials,
+  deleteAttachment,
   extensionForFileMime,
   extensionForMime,
   readAttachment,
@@ -36,6 +39,15 @@ const {
   saveImageUpload,
   validateAttachmentUploadId,
 } = await import("./attachments.ts");
+
+// The cache tracks committed bytes in memory; anything that mutates
+// ATTACHMENTS_DIR directly on disk (rmSync/truncateSync/writeFileSync, all
+// used below to force quota states without a real 512MiB file) must reset it
+// so the next quota check rescans instead of trusting stale counts.
+function resetDir() {
+  rmSync(ATTACHMENTS_DIR, { recursive: true, force: true });
+  __resetAttachmentAccountingForTests();
+}
 
 const UPLOAD_A = "11111111-1111-4111-8111-111111111111";
 const UPLOAD_B = "22222222-2222-4222-8222-222222222222";
@@ -62,10 +74,10 @@ describe("extensionForMime", () => {
 
 describe("saveImage", () => {
   beforeEach(() => {
-    rmSync(ATTACHMENTS_DIR, { recursive: true, force: true });
+    resetDir();
   });
   afterEach(() => {
-    rmSync(ATTACHMENTS_DIR, { recursive: true, force: true });
+    resetDir();
   });
 
   it("persists bytes under the attachments dir with a generated name", () => {
@@ -118,15 +130,16 @@ describe("saveImage", () => {
 
 describe("aggregate attachment storage", () => {
   beforeEach(() => {
-    rmSync(ATTACHMENTS_DIR, { recursive: true, force: true });
+    resetDir();
   });
   afterEach(() => {
-    rmSync(ATTACHMENTS_DIR, { recursive: true, force: true });
+    resetDir();
   });
 
   it("rejects new data at the aggregate ceiling without pruning committed attachments", () => {
     const referenced = saveImage(Buffer.from("x"), "image/png");
     truncateSync(referenced.path, ATTACHMENTS_MAX_BYTES);
+    __resetAttachmentAccountingForTests();
 
     try {
       saveImage(Buffer.from("y"), "image/png");
@@ -143,6 +156,7 @@ describe("aggregate attachment storage", () => {
   it("counts concurrent reservations so uploads cannot race past the ceiling", async () => {
     const existing = saveImage(Buffer.from("x"), "image/png");
     truncateSync(existing.path, ATTACHMENTS_MAX_BYTES - 5);
+    __resetAttachmentAccountingForTests();
 
     const first = saveFile((async function* () {
       yield Buffer.from("four");
@@ -155,6 +169,7 @@ describe("aggregate attachment storage", () => {
   it("lets an unknown-length stream use the exact space left below a reservation increment", async () => {
     const existing = saveImage(Buffer.from("x"), "image/png");
     truncateSync(existing.path, ATTACHMENTS_MAX_BYTES - 2);
+    __resetAttachmentAccountingForTests();
 
     const saved = await saveFile((async function* () {
       yield Buffer.from("a");
@@ -166,6 +181,7 @@ describe("aggregate attachment storage", () => {
   it("releases reservations and removes partials after failed uploads", async () => {
     const existing = saveImage(Buffer.from("x"), "image/png");
     truncateSync(existing.path, ATTACHMENTS_MAX_BYTES - 3);
+    __resetAttachmentAccountingForTests();
 
     await expect(saveFile((async function* () {})(), "empty.txt", "text/plain", { expectedBytes: 3 }))
       .rejects.toThrow(/empty file/);
@@ -192,15 +208,20 @@ describe("aggregate attachment storage", () => {
     expect(existsSync(`${ATTACHMENTS_DIR}/${UPLOAD_A}.png`)).toBe(true);
   });
 
-  it("counts fresh crash leftovers against quota, then reclaims them when stale", () => {
+  it("counts fresh crash leftovers against quota, then reclaims them once a cleanup sweep runs", () => {
     const existing = saveImage(Buffer.from("x"), "image/png");
     truncateSync(existing.path, ATTACHMENTS_MAX_BYTES - 2);
+    __resetAttachmentAccountingForTests();
     const orphan = `${ATTACHMENTS_DIR}/.openmaus-upload-${UPLOAD_A}-${UPLOAD_B}.partial`;
     writeFileSync(orphan, "xx");
 
     expect(() => saveImage(Buffer.from("y"), "image/png")).toThrow(/storage is full/);
     const old = new Date(Date.now() - ATTACHMENT_PARTIAL_MAX_AGE_MS - 1_000);
     utimesSync(orphan, old, old);
+    // Reservation checks no longer rescan the directory on every call (that
+    // was the PERF-03 hot loop); a stale partial is reclaimed by an explicit
+    // cleanup sweep, not automatically on the next quota check.
+    expect(cleanupStaleAttachmentPartials()).toBe(1);
     expect(() => saveImage(Buffer.from("y"), "image/png")).not.toThrow();
     expect(existsSync(orphan)).toBe(false);
   });
@@ -208,6 +229,7 @@ describe("aggregate attachment storage", () => {
   it("reclaims an inactive partial immediately when its upload ID retries", async () => {
     const existing = saveImage(Buffer.from("x"), "image/png");
     truncateSync(existing.path, ATTACHMENTS_MAX_BYTES - 3);
+    __resetAttachmentAccountingForTests();
     const orphan = `${ATTACHMENTS_DIR}/.openmaus-upload-${UPLOAD_A}-${UPLOAD_B}.partial`;
     writeFileSync(orphan, "old");
 
@@ -217,14 +239,41 @@ describe("aggregate attachment storage", () => {
     expect(saved.path.endsWith(`${UPLOAD_A}.txt`)).toBe(true);
     expect(existsSync(orphan)).toBe(false);
   });
+
+  it("frees quota after deleteAttachment, without a rescan, for a file the cache already knows about", () => {
+    const first = saveImage(Buffer.from("x"), "image/png");
+    truncateSync(first.path, ATTACHMENTS_MAX_BYTES - 2);
+    __resetAttachmentAccountingForTests();
+    expect(() => saveImage(Buffer.from("yyy"), "image/png")).toThrow(/storage is full/);
+
+    deleteAttachment(first.path);
+    expect(existsSync(first.path)).toBe(false);
+    const second = saveImage(Buffer.from("yyy"), "image/png");
+    expect(second.bytes).toBe(3);
+    expect(readdirSync(ATTACHMENTS_DIR)).toEqual([second.path.split(/[\\/]/).pop()!]);
+  });
+
+  it("initializes correctly on a fresh process against a directory that already has files", () => {
+    // No saveImage/saveFile call has happened yet in this test, so the cache
+    // is still cold (__resetAttachmentAccountingForTests in the previous
+    // test's afterEach already guaranteed that) — this mirrors a process
+    // restart that finds attachments already on disk from a prior run.
+    mkdirSync(ATTACHMENTS_DIR, { recursive: true });
+    const preexisting = join(ATTACHMENTS_DIR, "11111111-1111-4111-8111-111111111111.png");
+    writeFileSync(preexisting, "x");
+    truncateSync(preexisting, ATTACHMENTS_MAX_BYTES - 2);
+
+    expect(() => saveImage(Buffer.from("yyy"), "image/png")).toThrow(/storage is full/);
+    expect(() => saveImage(Buffer.from("y"), "image/png")).not.toThrow();
+  });
 });
 
 describe("readAttachment name lock", () => {
   beforeEach(() => {
-    rmSync(ATTACHMENTS_DIR, { recursive: true, force: true });
+    resetDir();
   });
   afterEach(() => {
-    rmSync(ATTACHMENTS_DIR, { recursive: true, force: true });
+    resetDir();
   });
 
   it("refuses traversal, dotfiles, and names the saver never writes", () => {
@@ -238,10 +287,10 @@ describe("readAttachment name lock", () => {
 
 describe("shared files", () => {
   beforeEach(() => {
-    rmSync(ATTACHMENTS_DIR, { recursive: true, force: true });
+    resetDir();
   });
   afterEach(() => {
-    rmSync(ATTACHMENTS_DIR, { recursive: true, force: true });
+    resetDir();
   });
 
   it("allows useful document mimes but not executables, archives, or active markup", () => {

--- a/server/attachments.ts
+++ b/server/attachments.ts
@@ -291,6 +291,8 @@ const KNOWN_ATTACHMENT_EXTENSIONS = Array.from(
   new Set([...Object.values(IMAGE_MIMES), ...Object.values(FILE_MIMES)]),
 );
 
+/** Missing or unreadable candidates count as absent here; the atomic link
+ * still detects a collision if a file exists when an upload commits. */
 function statSizeIfFile(path: string): number | null {
   try {
     const stat = statSync(path);
@@ -300,6 +302,8 @@ function statSizeIfFile(path: string): number | null {
   }
 }
 
+/** Find an idempotent retry without listing the directory, rejecting an ID
+ * already committed under a different accepted content type. */
 function committedPathForUpload(uploadId: string, extension: string): string | null {
   ensureAttachmentsDir();
   const exactPath = join(ATTACHMENTS_DIR, `${uploadId}${extension}`);
@@ -434,6 +438,7 @@ export async function saveFile(
     let file: Awaited<ReturnType<typeof open>> | undefined;
     let bytes = 0;
     let closed = false;
+    let partialCleanupFailed = false;
 
     try {
       file = await open(partialPath, "wx", 0o600);
@@ -459,8 +464,8 @@ export async function saveFile(
       closed = true;
       try {
         await link(partialPath, path);
-        await unlink(partialPath);
         addCommittedBytes(bytes);
+        await unlink(partialPath);
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
         if (statSync(path).size !== bytes || await digestFile(path) !== await digestFile(partialPath)) {
@@ -471,10 +476,13 @@ export async function saveFile(
       return { path, name, mime: normalized, bytes };
     } catch (error) {
       if (file && !closed) await file.close().catch(() => undefined);
-      await unlink(partialPath).catch(() => undefined);
+      await unlink(partialPath).catch(() => { partialCleanupFailed = true; });
       throw error;
     } finally {
       activePartials.delete(partialPath);
+      // A leftover partial was excluded from the cache while active. Rescan
+      // after releasing it so a retry cannot subtract bytes never counted.
+      if (partialCleanupFailed) committedAttachmentBytes = null;
       reservation.release();
     }
   });
@@ -508,6 +516,7 @@ export function saveImage(bytes: Buffer, mime: string, requestedUploadId?: strin
   const path = join(ATTACHMENTS_DIR, name);
   const partialPath = join(ATTACHMENTS_DIR, `.openmaus-upload-${id}-${randomUUID()}.partial`);
   activePartials.add(partialPath);
+  let partialCleanupFailed = false;
   try {
     writeFileSync(partialPath, bytes, { mode: 0o600, flag: "wx" });
     try {
@@ -526,11 +535,12 @@ export function saveImage(bytes: Buffer, mime: string, requestedUploadId?: strin
     try {
       unlinkSync(partialPath);
     } catch {
-      // The successful path already removed it, or the write never created it.
+      partialCleanupFailed = true;
     }
     throw error;
   } finally {
     activePartials.delete(partialPath);
+    if (partialCleanupFailed) committedAttachmentBytes = null;
     reservation.release();
   }
 }

--- a/server/attachments.ts
+++ b/server/attachments.ts
@@ -45,8 +45,8 @@ const STREAM_RESERVATION_INCREMENT_BYTES = 1024 * 1024;
 
 /** Cached total of on-disk bytes that count against the quota: committed
  * attachments plus any partial file this process did not itself write (a
- * crash leftover, until it is cleaned up). `null` means "not scanned yet in
- * this process" — the only time a full directory walk happens. Every commit
+ * crash leftover, until it is cleaned up). `null` means a fresh scan is needed
+ * after cold start or a cleanup failure. Every normal commit
  * and delete after that updates it in place instead of rescanning, which is
  * what makes reservation growth O(1) rather than O(directory size).
  *
@@ -55,6 +55,15 @@ const STREAM_RESERVATION_INCREMENT_BYTES = 1024 * 1024;
  * (the app runs one server per data dir; uploadLocks already assumes the
  * same), not a design gap this fix covers. */
 let committedAttachmentBytes: number | null = null;
+// An async link can finish while another upload invalidates or refreshes the
+// cache. Its bytes must not be added again if a scan may already include it.
+let attachmentAccountingVersion = 0;
+
+/** Force a fresh disk total and invalidate any in-flight commit's snapshot. */
+function invalidateAttachmentAccounting(): void {
+  committedAttachmentBytes = null;
+  attachmentAccountingVersion += 1;
+}
 
 /** Mimes the endpoint accepts, mapped to the extension stored on disk.
  * Sniffing is not attempted — a lie here only changes the filename. */
@@ -108,8 +117,8 @@ export function validateAttachmentUploadId(value: string | undefined): string | 
   return normalized;
 }
 
-/** The one full directory walk. Only ever run from cold (committedBytes()
- * the first time in a process) or from an explicit cleanup sweep — never
+/** The one full directory walk. Run from cold or invalidated accounting,
+ * or from an explicit cleanup sweep — never
  * from the per-reservation hot path, which is what made PERF-03 quadratic. */
 function scanAttachmentUsageAndCleanup(now = Date.now()): { bytes: number; removed: number } {
   ensureAttachmentsDir();
@@ -137,33 +146,37 @@ function scanAttachmentUsageAndCleanup(now = Date.now()): { bytes: number; remov
   return { bytes, removed };
 }
 
-/** Lazily initialize (once per process) or return the cached committed-bytes
- * total. Never read `committedAttachmentBytes` directly — always go through
- * this, so a cold process always gets one real scan before trusting it. */
+/** Return cached usage, initializing it from disk after cold start or
+ * invalidation. Reservations must use this rather than trusting a cold cache. */
 function committedBytes(): number {
   if (committedAttachmentBytes === null) {
     committedAttachmentBytes = scanAttachmentUsageAndCleanup().bytes;
+    attachmentAccountingVersion += 1;
   }
   return committedAttachmentBytes;
 }
 
 /** A newly committed file (saveFile/saveImage success path only — never the
  * idempotent-retry branches, which reuse bytes already counted) adds to the
- * cache. Safe to call without forcing a scan first: every caller reserves
- * quota before writing a byte, and reservation already forces committedBytes()
- * to initialize from a scan taken before this file existed. */
-function addCommittedBytes(delta: number): void {
-  committedAttachmentBytes = committedBytes() + delta;
+ * cache. If accounting changed during an async link, a scan may already have
+ * counted that file. Let the next reservation rescan instead of adding twice. */
+function addCommittedBytes(delta: number, version = attachmentAccountingVersion): void {
+  if (version !== attachmentAccountingVersion || committedAttachmentBytes === null) {
+    invalidateAttachmentAccounting();
+    return;
+  }
+  committedAttachmentBytes += delta;
 }
 
 /** Remove only abandoned temporary uploads, and refresh the cached usage
- * total from the same fresh scan. This is the only place a full directory
- * walk still happens after start-up; nothing on the upload path calls it
+ * total from the same fresh scan. Outside accounting recovery, this is the
+ * only full directory walk after start-up; nothing on the upload path calls it
  * per byte or per chunk anymore, so callers that want stale partials
  * reclaimed promptly should invoke it on their own schedule. */
 export function cleanupStaleAttachmentPartials(now = Date.now()): number {
   const { bytes, removed } = scanAttachmentUsageAndCleanup(now);
   committedAttachmentBytes = bytes;
+  attachmentAccountingVersion += 1;
   return removed;
 }
 
@@ -191,7 +204,7 @@ export function deleteAttachment(path: string): void {
  * (truncateSync, rmSync, writeFileSync) to simulate quota states, which the
  * cache can't observe. */
 export function __resetAttachmentAccountingForTests(): void {
-  committedAttachmentBytes = null;
+  invalidateAttachmentAccounting();
 }
 
 /** A retry owns the same UUID namespace as the interrupted attempt. Once it
@@ -463,8 +476,9 @@ export async function saveFile(
       await file.close();
       closed = true;
       try {
+        const accountingVersion = attachmentAccountingVersion;
         await link(partialPath, path);
-        addCommittedBytes(bytes);
+        addCommittedBytes(bytes, accountingVersion);
         await unlink(partialPath);
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
@@ -482,7 +496,7 @@ export async function saveFile(
       activePartials.delete(partialPath);
       // A leftover partial was excluded from the cache while active. Rescan
       // after releasing it so a retry cannot subtract bytes never counted.
-      if (partialCleanupFailed) committedAttachmentBytes = null;
+      if (partialCleanupFailed) invalidateAttachmentAccounting();
       reservation.release();
     }
   });
@@ -540,7 +554,7 @@ export function saveImage(bytes: Buffer, mime: string, requestedUploadId?: strin
     throw error;
   } finally {
     activePartials.delete(partialPath);
-    if (partialCleanupFailed) committedAttachmentBytes = null;
+    if (partialCleanupFailed) invalidateAttachmentAccounting();
     reservation.release();
   }
 }

--- a/server/attachments.ts
+++ b/server/attachments.ts
@@ -43,6 +43,19 @@ const uploadLocks = new Map<string, Promise<void>>();
 let reservedAttachmentBytes = 0;
 const STREAM_RESERVATION_INCREMENT_BYTES = 1024 * 1024;
 
+/** Cached total of on-disk bytes that count against the quota: committed
+ * attachments plus any partial file this process did not itself write (a
+ * crash leftover, until it is cleaned up). `null` means "not scanned yet in
+ * this process" — the only time a full directory walk happens. Every commit
+ * and delete after that updates it in place instead of rescanning, which is
+ * what makes reservation growth O(1) rather than O(directory size).
+ *
+ * This is single-process, in-memory state: it does not see files another
+ * process adds or removes in ATTACHMENTS_DIR. That is an accepted limit
+ * (the app runs one server per data dir; uploadLocks already assumes the
+ * same), not a design gap this fix covers. */
+let committedAttachmentBytes: number | null = null;
+
 /** Mimes the endpoint accepts, mapped to the extension stored on disk.
  * Sniffing is not attempted — a lie here only changes the filename. */
 const IMAGE_MIMES: Record<string, string> = {
@@ -95,7 +108,10 @@ export function validateAttachmentUploadId(value: string | undefined): string | 
   return normalized;
 }
 
-function attachmentUsageAndCleanup(now = Date.now()): { bytes: number; removed: number } {
+/** The one full directory walk. Only ever run from cold (committedBytes()
+ * the first time in a process) or from an explicit cleanup sweep — never
+ * from the per-reservation hot path, which is what made PERF-03 quadratic. */
+function scanAttachmentUsageAndCleanup(now = Date.now()): { bytes: number; removed: number } {
   ensureAttachmentsDir();
   let bytes = 0;
   let removed = 0;
@@ -121,10 +137,61 @@ function attachmentUsageAndCleanup(now = Date.now()): { bytes: number; removed: 
   return { bytes, removed };
 }
 
-/** Remove only abandoned temporary uploads. Active partials are protected
- * even if a very slow request crosses the age threshold. */
+/** Lazily initialize (once per process) or return the cached committed-bytes
+ * total. Never read `committedAttachmentBytes` directly — always go through
+ * this, so a cold process always gets one real scan before trusting it. */
+function committedBytes(): number {
+  if (committedAttachmentBytes === null) {
+    committedAttachmentBytes = scanAttachmentUsageAndCleanup().bytes;
+  }
+  return committedAttachmentBytes;
+}
+
+/** A newly committed file (saveFile/saveImage success path only — never the
+ * idempotent-retry branches, which reuse bytes already counted) adds to the
+ * cache. Safe to call without forcing a scan first: every caller reserves
+ * quota before writing a byte, and reservation already forces committedBytes()
+ * to initialize from a scan taken before this file existed. */
+function addCommittedBytes(delta: number): void {
+  committedAttachmentBytes = committedBytes() + delta;
+}
+
+/** Remove only abandoned temporary uploads, and refresh the cached usage
+ * total from the same fresh scan. This is the only place a full directory
+ * walk still happens after start-up; nothing on the upload path calls it
+ * per byte or per chunk anymore, so callers that want stale partials
+ * reclaimed promptly should invoke it on their own schedule. */
 export function cleanupStaleAttachmentPartials(now = Date.now()): number {
-  return attachmentUsageAndCleanup(now).removed;
+  const { bytes, removed } = scanAttachmentUsageAndCleanup(now);
+  committedAttachmentBytes = bytes;
+  return removed;
+}
+
+/** Delete a committed attachment (e.g. a generated image whose owning
+ * message/turn was retired) and keep the quota cache in sync. Every caller
+ * outside this module that removes a file saveImage/saveFile created must
+ * route through here instead of a raw unlink, or the cache will overcount
+ * forever and eventually reject uploads that should fit. */
+export function deleteAttachment(path: string): void {
+  try {
+    // Only bother sizing it if the cache is already warm — if it isn't, the
+    // eventual first scan just won't see this file, which is correct.
+    const size = committedAttachmentBytes !== null ? statSync(path).size : 0;
+    unlinkSync(path);
+    if (committedAttachmentBytes !== null) {
+      committedAttachmentBytes = Math.max(0, committedAttachmentBytes - size);
+    }
+  } catch {
+    // Already gone, or never existed — nothing to reconcile.
+  }
+}
+
+/** Test-only: force the next quota check to rescan the directory instead of
+ * trusting the cache. Needed because tests mutate ATTACHMENTS_DIR directly
+ * (truncateSync, rmSync, writeFileSync) to simulate quota states, which the
+ * cache can't observe. */
+export function __resetAttachmentAccountingForTests(): void {
+  committedAttachmentBytes = null;
 }
 
 /** A retry owns the same UUID namespace as the interrupted attempt. Once it
@@ -139,7 +206,14 @@ function cleanupAttachmentPartialsForUpload(uploadId: string): void {
     const path = join(ATTACHMENTS_DIR, entry.name);
     if (activePartials.has(path)) continue;
     try {
+      // Only bother sizing it if the cache is already warm — if it isn't,
+      // the eventual first scan runs after this unlink and simply never
+      // sees the file, so there is nothing to reconcile.
+      const size = committedAttachmentBytes !== null ? statSync(path).size : 0;
       unlinkSync(path);
+      if (committedAttachmentBytes !== null) {
+        committedAttachmentBytes = Math.max(0, committedAttachmentBytes - size);
+      }
     } catch {
       // A concurrent cleanup already removed the abandoned attempt.
     }
@@ -156,7 +230,7 @@ class AttachmentReservation {
   }
 
   private reserveAtLeast(required: number, preferred: number): void {
-    const used = attachmentUsageAndCleanup().bytes;
+    const used = committedBytes();
     const available = ATTACHMENTS_MAX_BYTES - used - reservedAttachmentBytes;
     if (available < required) {
       throw statusError(
@@ -208,13 +282,31 @@ async function withUploadLock<T>(uploadId: string | undefined, operation: () => 
   }
 }
 
+/** Every committed attachment name is `${uuid}${extension}` for one of these
+ * fixed extensions — saveFile/saveImage never write any other suffix — so
+ * whether a given upload ID is already committed, and under which content
+ * type, can be answered with a handful of direct stats instead of a scan
+ * over every file in the directory. */
+const KNOWN_ATTACHMENT_EXTENSIONS = Array.from(
+  new Set([...Object.values(IMAGE_MIMES), ...Object.values(FILE_MIMES)]),
+);
+
+function statSizeIfFile(path: string): number | null {
+  try {
+    const stat = statSync(path);
+    return stat.isFile() ? stat.size : null;
+  } catch {
+    return null;
+  }
+}
+
 function committedPathForUpload(uploadId: string, extension: string): string | null {
   ensureAttachmentsDir();
-  const exact = `${uploadId}${extension}`;
-  for (const entry of readdirSync(ATTACHMENTS_DIR, { withFileTypes: true })) {
-    if (!entry.isFile() || PARTIAL_NAME.test(entry.name)) continue;
-    if (entry.name === exact) return join(ATTACHMENTS_DIR, entry.name);
-    if (entry.name.startsWith(`${uploadId}.`)) {
+  const exactPath = join(ATTACHMENTS_DIR, `${uploadId}${extension}`);
+  if (statSizeIfFile(exactPath) !== null) return exactPath;
+  for (const other of KNOWN_ATTACHMENT_EXTENSIONS) {
+    if (other === extension) continue;
+    if (statSizeIfFile(join(ATTACHMENTS_DIR, `${uploadId}${other}`)) !== null) {
       throw statusError(409, "uploadId was already used for another content type");
     }
   }
@@ -368,6 +460,7 @@ export async function saveFile(
       try {
         await link(partialPath, path);
         await unlink(partialPath);
+        addCommittedBytes(bytes);
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
         if (statSync(path).size !== bytes || await digestFile(path) !== await digestFile(partialPath)) {
@@ -419,6 +512,7 @@ export function saveImage(bytes: Buffer, mime: string, requestedUploadId?: strin
     writeFileSync(partialPath, bytes, { mode: 0o600, flag: "wx" });
     try {
       linkSync(partialPath, path);
+      addCommittedBytes(bytes.byteLength);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       const saved = readFileSync(path);

--- a/server/index.ts
+++ b/server/index.ts
@@ -12935,12 +12935,16 @@ console.log(describeBrand(loadBrand()));
 // Reclaim upload partials a previous run crashed out of, and warm the
 // attachment quota cache off the same scan. This used to happen implicitly on
 // every reservation, which is exactly what made uploads quadratic in
-// directory size; start-up is the one place it costs nothing.
+// directory size; do the initial sweep before accepting requests.
 // ponytail: once per boot, not periodic. A partial orphaned while this
 // process is up survives until the next restart — add a timer only if that
 // shows up as real quota pressure.
-const reclaimedPartials = cleanupStaleAttachmentPartials();
-if (reclaimedPartials > 0) console.log(`reclaimed ${reclaimedPartials} abandoned upload partial(s)`);
+try {
+  const reclaimedPartials = cleanupStaleAttachmentPartials();
+  if (reclaimedPartials > 0) console.log(`reclaimed ${reclaimedPartials} abandoned upload partial(s)`);
+} catch (error) {
+  console.warn(`attachments: startup partial cleanup failed: ${error instanceof Error ? error.message : String(error)}`);
+}
 
 server.listen(PORT, "127.0.0.1", () => {
   console.log(`openmausbot server on http://127.0.0.1:${PORT}`);

--- a/server/index.ts
+++ b/server/index.ts
@@ -43,6 +43,8 @@ import { validateBotCwd } from "./bot-cwd.ts";
 import {
   ATTACHMENTS_DIR,
   attachmentExists,
+  cleanupStaleAttachmentPartials,
+  deleteAttachment,
   extensionForMime,
   FILE_MAX_BYTES,
   IMAGE_MAX_BYTES,
@@ -704,7 +706,7 @@ function purgeGeneratedImagesForThread(threadId: string): void {
     if (!key.startsWith(`${threadId}:`)) continue;
     generatedImagesByTurn.delete(key);
     for (const attachment of attachments) {
-      try { unlinkSync(attachment.path); } catch {}
+      deleteAttachment(attachment.path);
     }
   }
 }
@@ -726,7 +728,7 @@ function retireProviderTurn(turnId: string): void {
     if (!key.endsWith(`:${turnId}`)) continue;
     generatedImagesByTurn.delete(key);
     for (const attachment of attachments) {
-      try { unlinkSync(attachment.path); } catch {}
+      deleteAttachment(attachment.path);
     }
   }
 }
@@ -10199,7 +10201,7 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
       if (!bot) {
         // There are no awaits between the refreshed lookup and this patch, but
         // keep the attachment invariant explicit if the store ever changes.
-        try { unlinkSync(saved.path); } catch {}
+        deleteAttachment(saved.path);
         return json(res, 404, { error: "no such bot" });
       }
       const visible = wireBot(bot);
@@ -12929,6 +12931,16 @@ calendarCalls.start();
 // Resolve the edition before accepting requests so /api/edition is never a guess.
 console.log(describeEdition(await loadEnterpriseLayer()));
 console.log(describeBrand(loadBrand()));
+
+// Reclaim upload partials a previous run crashed out of, and warm the
+// attachment quota cache off the same scan. This used to happen implicitly on
+// every reservation, which is exactly what made uploads quadratic in
+// directory size; start-up is the one place it costs nothing.
+// ponytail: once per boot, not periodic. A partial orphaned while this
+// process is up survives until the next restart — add a timer only if that
+// shows up as real quota pressure.
+const reclaimedPartials = cleanupStaleAttachmentPartials();
+if (reclaimedPartials > 0) console.log(`reclaimed ${reclaimedPartials} abandoned upload partial(s)`);
 
 server.listen(PORT, "127.0.0.1", () => {
   console.log(`openmausbot server on http://127.0.0.1:${PORT}`);


### PR DESCRIPTION
Unknown-length uploads previously rescanned the entire attachments directory whenever their reservation grew by 1 MiB. This change caches committed byte usage, updates it on commit and deletion, and checks known upload extensions directly. Startup performs the initial cleanup; successful reservation growth no longer scans the directory.

Quota accounting remains correct when cleanup fails: a successful link is counted before removing the temporary name, and an unrecoverable partial-cleanup failure invalidates the cache after the partial becomes inactive. This prevents retries from subtracting leftover bytes that were never counted. A cache version also prevents a concurrently completed link from being counted twice after a rescan. Startup cleanup errors produce a warning and allow the server to start; the first later upload retries initialization.

Existing attachment deletion paths use the accounting helper. The cache retains the existing single-server-per-data-directory assumption. Quota remains based on directory entries, including fresh abandoned partials until cleanup. The follow-up suggestion to deduplicate physical inodes is not included: it changes existing quota semantics and would also require coordinated deletion accounting so removing one hard link cannot incorrectly free the bytes of another.

Validation:
- 30 attachment and startup checks pass, including fault injection for transient and repeated cleanup failures, idempotent retries, exact quota boundaries, concurrent commits during a rescan, and startup recovery after a broken attachment directory is repaired.
- Typecheck and changed-code lint pass (one existing unrelated lint warning in server/index.ts).
- An isolated fake-engine server accepted a 25 MiB chunked upload without Content-Length, preserved its bytes, reused the same file on retry, rejected changed content with 409, and left no temporary or duplicate files. A normal chat turn subsequently settled.
- Both original CodeRabbit findings are addressed; the new attachment lookup helpers are documented.
- All eight jobs in [CI run 34216223642](https://github.com/milind-soni/OpenMausBot/actions/runs/34216223642) pass, including the required macOS, Linux, and Windows checks.
