### PR TITLE
perf(sse): stop buffering screen frames for a client that cannot drain

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -331,6 +331,7 @@ import {
 } from "./request-auth.ts";
 import { cookieMaxAgeSeconds, formatPairingCode, SessionRegistry, type Scope } from "./sessions.ts";
 import { describeBrand, loadBrand } from "./brand.ts";
+import { deliverSseFrame } from "./sse-fanout.ts";
 import {
   PHONE_SECRET_PROTOCOL_VERSION,
   PhoneSecretBridge,
@@ -2060,6 +2061,10 @@ interface SseClient {
   /** The paired session behind this stream, when there is one: revoking or
    * expiring it must end the stream, not just future requests. */
   sessionId?: string;
+  /** Set once this client's socket has signalled it can't keep up (write()
+   * returned false); cleared implicitly once it's disconnected. See
+   * ./sse-fanout.ts for what this does to fan-out. */
+  backpressured: boolean;
 }
 const sseClients = new Set<SseClient>();
 sessions.onSessionRevoked((sessionId) => {
@@ -2124,9 +2129,9 @@ function broadcast(payload: Record<string, unknown>) {
   if (replayBuffer.length > REPLAY_MAX) replayBuffer.shift();
   for (const client of [...sseClients]) {
     if (!wants(client, kind)) continue;
-    try {
-      client.res.write(client.admin ? frame : clientFrame);
-    } catch {
+    // Screen frames are replaceable and durable events are not: see
+    // ./sse-fanout.ts for the backpressure/bound decision this makes.
+    if (deliverSseFrame(client, kind, client.admin ? frame : clientFrame) === "disconnected") {
       sseClients.delete(client);
     }
   }
@@ -8854,7 +8859,12 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
 
     // ── events stream ──
     if (method === "GET" && path === "/api/events") {
-      const client: SseClient = { res, admin: auth.scopes.includes("admin"), screens: url.searchParams.get("screens") !== "off" };
+      const client: SseClient = {
+        res,
+        admin: auth.scopes.includes("admin"),
+        screens: url.searchParams.get("screens") !== "off",
+        backpressured: false,
+      };
       if (auth.kind === "session") client.sessionId = auth.session.id;
       res.writeHead(200, {
         "content-type": "text/event-stream",

--- a/server/sse-fanout.test.ts
+++ b/server/sse-fanout.test.ts
@@ -1,0 +1,116 @@
+// Unit test for the SSE backpressure decision (PERF-02). This drives a fake
+// response object directly instead of the real HTTP harness index.test.ts
+// uses elsewhere: index.ts starts a real server on import, so it can't be
+// imported into a unit test, which is why this logic lives in its own file.
+import { describe, expect, it } from "vitest";
+
+import { deliverSseFrame, SSE_MAX_BUFFERED_BYTES, type SseFanoutClient } from "./sse-fanout.ts";
+
+/** A fake client plus a handle on the drain listeners it queued. */
+type TestClient = SseFanoutClient & { drains: (() => void)[] };
+
+function fakeClient(resOverrides: Partial<SseFanoutClient["res"]> = {}): TestClient {
+  const drains: (() => void)[] = [];
+  return {
+    backpressured: false,
+    drains,
+    res: {
+      writableLength: 0,
+      write: () => true,
+      end: () => {},
+      once: (_event: "drain", listener: () => void) => drains.push(listener),
+      ...resOverrides,
+    },
+  };
+}
+
+describe("deliverSseFrame", () => {
+  it("sends normally while write() returns true", () => {
+    const client = fakeClient();
+    expect(deliverSseFrame(client, "message", "frame-a")).toBe("sent");
+    expect(client.backpressured).toBe(false);
+  });
+
+  it("marks the client backpressured when write() returns false, without dropping that frame", () => {
+    const client = fakeClient({ write: () => false });
+    expect(deliverSseFrame(client, "message", "frame-a")).toBe("sent");
+    expect(client.backpressured).toBe(true);
+  });
+
+  it("drops a replaceable screen frame once backpressured, but never drops a durable event", () => {
+    const written: string[] = [];
+    const client = fakeClient({
+      write: (chunk: string) => {
+        written.push(chunk);
+        return false; // stays backpressured for every subsequent frame
+      },
+    });
+
+    // First screen frame: not backpressured yet, so it's sent — and that
+    // write's false return is what sets the flag.
+    expect(deliverSseFrame(client, "screen", "screen-1")).toBe("sent");
+    expect(client.backpressured).toBe(true);
+
+    // Now backpressured: the next screen capture is replaceable, so it's
+    // dropped rather than queued behind the stalled socket.
+    expect(deliverSseFrame(client, "screen", "screen-2")).toBe("dropped");
+
+    // A durable event is not droppable — it still goes out even while
+    // backpressured.
+    expect(deliverSseFrame(client, "message", "message-1")).toBe("sent");
+
+    expect(written).toEqual(["screen-1", "message-1"]);
+  });
+
+  it("disconnects a client once buffered bytes exceed the bound, even for a durable event", () => {
+    let ended = false;
+    const client = fakeClient({
+      writableLength: SSE_MAX_BUFFERED_BYTES + 1,
+      end: () => {
+        ended = true;
+      },
+    });
+    expect(deliverSseFrame(client, "message", "message-1")).toBe("disconnected");
+    expect(ended).toBe(true);
+  });
+
+  it("resumes screen frames once the socket drains", () => {
+    // A single screen frame is bigger than the 16 KB highWaterMark, so a
+    // perfectly healthy client's write() returns false too. If the flag
+    // latched on for the life of the connection, that client would never see
+    // another screen frame.
+    let full = true;
+    const client = fakeClient({ write: () => !full });
+
+    expect(deliverSseFrame(client, "screen", "screen-1")).toBe("sent");
+    expect(client.backpressured).toBe(true);
+    expect(deliverSseFrame(client, "screen", "screen-2")).toBe("dropped");
+    expect(client.drains).toHaveLength(1);
+
+    full = false;
+    for (const drain of client.drains) drain();
+
+    expect(client.backpressured).toBe(false);
+    expect(deliverSseFrame(client, "screen", "screen-3")).toBe("sent");
+  });
+
+  it("queues one drain listener per backpressure episode, not per frame", () => {
+    const client = fakeClient({ write: () => false });
+
+    deliverSseFrame(client, "message", "message-1");
+    deliverSseFrame(client, "message", "message-2");
+    deliverSseFrame(client, "message", "message-3");
+
+    expect(client.backpressured).toBe(true);
+    expect(client.drains).toHaveLength(1);
+  });
+
+  it("treats a throwing write() as a dead connection", () => {
+    const client = fakeClient({
+      write: () => {
+        throw new Error("socket hang up");
+      },
+    });
+    expect(deliverSseFrame(client, "message", "message-1")).toBe("disconnected");
+  });
+});

--- a/server/sse-fanout.ts
+++ b/server/sse-fanout.ts
@@ -1,0 +1,67 @@
+// Per-client delivery decision for the SSE broadcast fan-out in index.ts.
+// Pulled into its own file — not just its own function — because index.ts
+// starts the real HTTP server as an import-time side effect (see the bottom
+// of index.ts: `server.listen(...)` runs unconditionally on import), so it
+// can never be imported from a plain unit test. This one function has no
+// dependency on that module and can be driven directly with a fake response.
+
+/** Shape broadcast() needs from an SSE client: a writable response, and the
+ * one flag that survives across frames — whether its socket already told us
+ * it can't keep up. */
+export interface SseFanoutClient {
+  res: {
+    write(chunk: string): boolean;
+    end(): void;
+    writableLength: number;
+    once(event: "drain", listener: () => void): unknown;
+  };
+  backpressured: boolean;
+}
+
+/** Past this many buffered bytes, the client isn't draining on any useful
+ * timeframe: cut it loose rather than let Node's per-connection write buffer
+ * grow without bound. Its own EventSource reconnects and replays via
+ * Last-Event-ID (server/index.ts's existing replayBuffer/cursorSeq). */
+// ponytail: fixed byte bound, not adaptive. Retune from real writableLength
+// telemetry (see the audit's validation step) if it trips too eager or late.
+export const SSE_MAX_BUFFERED_BYTES = 4 * 1024 * 1024;
+
+export type SseFanoutOutcome = "sent" | "dropped" | "disconnected";
+
+/** One client's fate for one frame.
+ *
+ * Screen captures are replaceable: once a client is backpressured, skip them
+ * until it drains, since the next capture supersedes whatever was dropped.
+ * Durable events (messages, bot/group state, config, ...) are never
+ * silently dropped here — they're written regardless of the backpressure
+ * flag. The only way a durable event goes missing is the bound below, which
+ * disconnects the client outright so its next reconnect replays what it
+ * missed instead of silently losing it. */
+export function deliverSseFrame(client: SseFanoutClient, kind: string, frame: string): SseFanoutOutcome {
+  if (client.res.writableLength > SSE_MAX_BUFFERED_BYTES) {
+    try {
+      client.res.end();
+    } catch {
+      /* already gone */
+    }
+    return "disconnected";
+  }
+  if (client.backpressured && kind === "screen") return "dropped";
+  try {
+    if (!client.res.write(frame) && !client.backpressured) {
+      // write() returns false as soon as buffered bytes pass the socket's
+      // 16 KB highWaterMark, which a single screen frame clears on its own —
+      // so this says "hasn't drained yet", not "is a slow client". Without
+      // the drain listener the flag latches on for the life of the
+      // connection and screen streaming never resumes. One listener per
+      // transition into backpressure, never one per frame.
+      client.backpressured = true;
+      client.res.once("drain", () => {
+        client.backpressured = false;
+      });
+    }
+    return "sent";
+  } catch {
+    return "disconnected";
+  }
+}


### PR DESCRIPTION
## The problem

`broadcast()` writes every SSE frame with `client.res.write(frame)` and discards the boolean return. Nothing consults backpressure, so a slow or stalled remote client has every subsequent frame queued in Node's per-connection write buffer, growing RSS and event-loop pressure until it disconnects.

Screen captures are the exposed path: hundreds of kilobytes each, broadcast through the same fan-out, and on by default.

## The change

`deliverSseFrame()` makes one decision per client per frame:

- over 4 MB buffered → end the connection. Its `EventSource` reconnects and replays through the existing `Last-Event-ID` / `replayBuffer` path, so nothing is silently lost.
- backpressured and the frame is a screen capture → drop it. The next capture supersedes whatever was dropped.
- otherwise write it. **Durable events are never dropped on the backpressure flag alone** — losing one would silently corrupt a client's view of the conversation.

The flag clears on the socket's `drain` event, which matters more than it looks: `write()` returns false as soon as buffered bytes pass the socket's 16 KB high-water mark, and a single screen frame clears that on its own. Without the drain listener the flag latches for the life of the connection and a perfectly healthy client stops receiving screen frames after its first one. One listener per backpressure episode, not per frame.

No new dependencies, and no new replay mechanism — this reuses `STREAM_ID`/`lastSeq`/`replayBuffer`/`cursorSeq()` exactly as they are.

## Why it is a separate file

`server/index.ts` calls `server.listen()` as an import-time side effect, so it can never be imported into a unit test — which is why the existing SSE coverage in `index.test.ts` spawns the server as a subprocess. Pulling this one decision into a dependency-free module makes it drivable with a fake response object. It is a function extraction, not a new layer: no class, no queue, no abstraction over the transport.

## Measured

I could not read the real spawned server's internal `writableLength` from the test process — there is no introspection endpoint, and adding one seemed out of scope. So this is a simulation of `deliverSseFrame` against a mock response that never drains, 500 frames of 200 KB:

- before (unconditional `write()`): buffered grows to 97.7 MB, unbounded.
- after: stays at 0.195 MB — the first write reveals backpressure, then screen frames are dropped rather than queued.
- an unthrottled client receives all 500 either way.

Stating plainly that this models the mechanism rather than measuring the live server. An end-to-end test with a real throttled TCP consumer would be the natural next increment.

## Tests

`server/sse-fanout.test.ts`, 7 cases: normal send, the flag set on `write() === false`, a replaceable screen frame dropped while a durable event still goes out, resumption after `drain`, one listener per episode, disconnect over the byte bound, and a throwing `write()` treated as dead.

`server/index.test.ts`: 198 passed, 1 skipped, including `resumable event stream` and `computer control API`, so the replay path and the broadcast-heavy suites are unaffected.

`pnpm typecheck` clean.

## Full suite, honestly

`pnpm test` on this branch: **4,195 passed, 4 failed** of 4,327. None of the four is attributable to this change, and each was checked rather than assumed:

- 2 × `EPERM` on `renameSync` inside `writeFileAtomic` against Windows temp paths (`routines.json`, `bots.json`) — a known Windows filesystem flake, unrelated code.
- `server/peer-allowlist.e2e.test.ts > refuses to loosen a bot from a bare loopback call while any bot is working` — fails identically on unmodified `main` on this machine.
- `server/group-goal-run.e2e.test.ts` — passes 12/12 on this branch when run alone, twice. It only failed in a fully parallel run, i.e. load-sensitive.

Also excluded: `electron/updater-handoff.electron.test.mjs`, which cannot load here at all (`ERR_DLOPEN_FAILED`, "An Application Control policy has blocked this file") and fails the same way on unmodified `main` — a local machine policy blocking Electron's native binary.

Tested on Windows 11 with Node 24.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of live event updates for clients with slow or unstable connections.
  * Prevented temporary screen updates from overwhelming a connection when it cannot keep up.
  * Ensured important message events continue to be delivered during temporary connection slowdowns.
  * Automatically removes disconnected or excessively backed-up connections to help maintain server stability.
  * Live updates resume automatically once a previously delayed connection catches up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->