### PR TITLE
fix(self-hosting): support Linux ARM64 cloudflared installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,26 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: pnpm exec vite build
 
+  cloudflared-linux-arm64:
+    name: cloudflared installer (Linux ARM64)
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - name: Install and reuse the pinned connector in an isolated fixture
+        env:
+          OMB_ARM64_FIXTURE: ${{ runner.temp }}/omb-cloudflared-arm64
+        run: |
+          node --input-type=module -e 'import assert from "node:assert/strict"; assert.equal(process.platform, "linux"); assert.equal(process.arch, "arm64");'
+          node scripts/prepare-cloudflared.mjs --current --root "$OMB_ARM64_FIXTURE"
+          node scripts/prepare-cloudflared.mjs --current --root "$OMB_ARM64_FIXTURE"
+          "$OMB_ARM64_FIXTURE/dist-native/cloudflared/linux-arm64/cloudflared" version
+
   control-plane:
     name: control-plane check + workerd tests + dry run
     runs-on: ubuntu-latest

--- a/electron/managed-companion-tunnel.test.mjs
+++ b/electron/managed-companion-tunnel.test.mjs
@@ -137,6 +137,21 @@ describe("managed companion credentials", () => {
 });
 
 describe("cloudflared binary resolution", () => {
+  it.each(["x64", "arm64"])("resolves the staged Linux %s connector for self-hosting", (arch) => {
+    const appPath = temporaryDirectory();
+    const staged = path.join(appPath, "dist-native", "cloudflared", `linux-${arch}`, "cloudflared");
+    expect(
+      resolveCloudflaredBinary({
+        isPackaged: false,
+        appPath,
+        platform: "linux",
+        arch,
+        environment: {},
+        exists: (candidate) => candidate === staged,
+      }),
+    ).toBe(staged);
+  });
+
   it("requires the bundled Resources binary in production", () => {
     const resourcesPath = path.join(
       path.parse(process.cwd()).root,

--- a/scripts/prepare-cloudflared.mjs
+++ b/scripts/prepare-cloudflared.mjs
@@ -1,8 +1,8 @@
 // Stage a pinned Cloudflare Tunnel connector for every desktop architecture
 // electron-builder will package on this host. Pass --current for development
-// to stage only the platform and architecture running this script. The release
-// asset is verified before extraction and the executable is verified again on
-// every reuse.
+// or self-hosting to stage only the platform and architecture running this
+// script. The release asset is verified before extraction and the executable
+// is verified again on every reuse.
 // Nothing is installed globally and cloudflared's own updater stays disabled;
 // OpenMausBot updates this dependency with an ordinary reviewed app release.
 import { spawnSync } from "node:child_process";
@@ -43,6 +43,12 @@ export const CLOUDFLARED_ASSETS = Object.freeze({
     binarySha256: "fcfb02b575a52ca1af2e3267af4e1517bcdeb30ac48c834c69abaed3c0576ad2",
     archive: false,
   }),
+  "linux-arm64": Object.freeze({
+    name: "cloudflared-linux-arm64",
+    sha256: "7747d94570fb390cf47dcb4f9555c193c6355cda9793f0d878d9049e5d6a7790",
+    binarySha256: "7747d94570fb390cf47dcb4f9555c193c6355cda9793f0d878d9049e5d6a7790",
+    archive: false,
+  }),
   "win32-x64": Object.freeze({
     name: "cloudflared-windows-amd64.exe",
     sha256: "c29eee2b121f5436a642eed69fd9767da7e7b8c510fa50aaa130337f931357b5",
@@ -52,6 +58,7 @@ export const CLOUDFLARED_ASSETS = Object.freeze({
 });
 
 export function targetsForHost(platform) {
+  // Desktop package targets only. Self-hosted installs use --current instead.
   if (platform === "darwin") return ["darwin-arm64", "darwin-x64"];
   if (platform === "linux") return ["linux-x64"];
   if (platform === "win32") return ["win32-x64"];
@@ -122,15 +129,16 @@ export function executableTarget(value) {
     throw new Error(`unsupported cloudflared Mach-O CPU type 0x${cpu.toString(16)}`);
   }
 
-  // ELF64, little-endian, AMD64 (e_machine 0x3e).
+  // ELF64, little-endian: AMD64 (EM_X86_64 = 62) or ARM64 (EM_AARCH64 = 183).
   if (
     bytes.length >= 20 &&
     bytes.subarray(0, 4).equals(Buffer.from([0x7f, 0x45, 0x4c, 0x46])) &&
     bytes[4] === 2 &&
-    bytes[5] === 1 &&
-    bytes.readUInt16LE(18) === 0x3e
+    bytes[5] === 1
   ) {
-    return "linux-x64";
+    const machine = bytes.readUInt16LE(18);
+    if (machine === 62) return "linux-x64";
+    if (machine === 183) return "linux-arm64";
   }
 
   // PE32+ AMD64. e_lfanew points from the DOS header to PE\0\0.

--- a/scripts/prepare-cloudflared.test.mjs
+++ b/scripts/prepare-cloudflared.test.mjs
@@ -33,6 +33,12 @@ const PINNED_ASSETS = {
     binarySha256: "fcfb02b575a52ca1af2e3267af4e1517bcdeb30ac48c834c69abaed3c0576ad2",
     archive: false,
   },
+  "linux-arm64": {
+    name: "cloudflared-linux-arm64",
+    sha256: "7747d94570fb390cf47dcb4f9555c193c6355cda9793f0d878d9049e5d6a7790",
+    binarySha256: "7747d94570fb390cf47dcb4f9555c193c6355cda9793f0d878d9049e5d6a7790",
+    archive: false,
+  },
   "win32-x64": {
     name: "cloudflared-windows-amd64.exe",
     sha256: "c29eee2b121f5436a642eed69fd9767da7e7b8c510fa50aaa130337f931357b5",
@@ -48,9 +54,9 @@ function executableFixture(target) {
   if (target === "darwin-arm64" || target === "darwin-x64") {
     bytes.writeUInt32LE(0xfeedfacf, 0);
     bytes.writeUInt32LE(target === "darwin-arm64" ? 0x0100000c : 0x01000007, 4);
-  } else if (target === "linux-x64") {
+  } else if (target === "linux-x64" || target === "linux-arm64") {
     Buffer.from([0x7f, 0x45, 0x4c, 0x46, 2, 1]).copy(bytes);
-    bytes.writeUInt16LE(0x3e, 18);
+    bytes.writeUInt16LE(target === "linux-arm64" ? 183 : 62, 18);
   } else if (target === "win32-x64") {
     bytes.write("MZ", 0, "ascii");
     bytes.writeUInt32LE(0x40, 0x3c);
@@ -68,10 +74,11 @@ describe("pinned cloudflared packaging", () => {
     expect(() => targetsForHost("freebsd")).toThrow(/unsupported/);
   });
 
-  it("stages only the exact current desktop target in development mode", () => {
+  it("stages the exact current target for development and self-hosting", () => {
     expect(targetForCurrentHost("darwin", "arm64")).toBe("darwin-arm64");
     expect(targetForCurrentHost("darwin", "x64")).toBe("darwin-x64");
     expect(targetForCurrentHost("linux", "x64")).toBe("linux-x64");
+    expect(targetForCurrentHost("linux", "arm64")).toBe("linux-arm64");
     expect(targetForCurrentHost("win32", "x64")).toBe("win32-x64");
     expect(targetsForPreparation({ current: true, platform: "darwin", arch: "arm64" })).toEqual([
       "darwin-arm64",
@@ -80,7 +87,10 @@ describe("pinned cloudflared packaging", () => {
       "darwin-arm64",
       "darwin-x64",
     ]);
-    expect(() => targetForCurrentHost("linux", "arm64")).toThrow(/unsupported/);
+    expect(targetsForPreparation({ current: true, platform: "linux", arch: "arm64" })).toEqual([
+      "linux-arm64",
+    ]);
+    expect(() => targetForCurrentHost("linux", "arm")).toThrow(/unsupported/);
   });
 
   it("accepts only the documented current-target CLI option", () => {
@@ -103,7 +113,7 @@ describe("pinned cloudflared packaging", () => {
     );
   });
 
-  it("pins a complete release asset and digest for every packaged target", () => {
+  it("pins a complete release asset and digest for every supported target", () => {
     expect(CLOUDFLARED_VERSION).toBe("2026.8.2");
     expect(CLOUDFLARED_ASSETS).toEqual(PINNED_ASSETS);
   });
@@ -126,5 +136,26 @@ describe("pinned cloudflared packaging", () => {
     const bytes = executableFixture("darwin-arm64");
     expect(() => verifyPinnedBinary(bytes, "darwin-x64")).toThrow(/architecture mismatch/);
     expect(() => verifyPinnedBinary(bytes, "darwin-arm64")).toThrow(/SHA-256 verification/);
+  });
+
+  it.each(["linux-x64", "linux-arm64"])("rejects the wrong architecture and unpinned bytes for %s", (target) => {
+    const bytes = executableFixture(target);
+    const other = target === "linux-arm64" ? "linux-x64" : "linux-arm64";
+    expect(() => verifyPinnedBinary(bytes, other)).toThrow(/architecture mismatch/);
+    expect(() => verifyPinnedBinary(bytes, target)).toThrow(/SHA-256 verification/);
+  });
+
+  it("does not mistake 32-bit, big-endian, truncated or unsupported ELF files for ARM64", () => {
+    const arm32 = executableFixture("linux-arm64");
+    arm32[4] = 1;
+    const bigEndian = executableFixture("linux-arm64");
+    bigEndian[5] = 2;
+    bigEndian.writeUInt16BE(183, 18);
+    const otherMachine = executableFixture("linux-arm64");
+    otherMachine.writeUInt16LE(40, 18); // EM_ARM is not AArch64.
+    const truncated = executableFixture("linux-arm64").subarray(0, 19);
+    for (const bytes of [arm32, bigEndian, otherMachine, truncated]) {
+      expect(() => executableTarget(bytes)).toThrow(/unsupported/);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Fix the self-hosted Managed HTTPS installer failing on Linux ARM64.

- Pin `cloudflared-linux-arm64` from Cloudflare's existing `2026.8.2` release, with the verified asset and executable SHA-256.
- Recognize little-endian ELF64 `EM_AARCH64` (183), retaining x64 support and rejecting unsupported formats, mismatched architectures, and unpinned bytes.
- Cover current-host ARM64 selection and staged connector resolution with regression tests.
- Add a dependency-free Ubuntu ARM64 CI smoke check that downloads, verifies, runs, and reuses the connector in an isolated temporary fixture.

The self-hosted runtime already invokes the installer with `--current`. `targetsForHost()` remains the desktop packaging matrix (Linux desktop packages are still x64); this does not introduce an ARM64 desktop release or change existing workspaces.

## Verification

- Reproduced the current-host rejection and ARM64 executable rejection against unchanged main `600e315c`.
- `pnpm exec vitest run scripts/prepare-cloudflared.test.mjs electron/managed-companion-tunnel.test.mjs server/tunnel.test.ts` — **30 passed**, including the isolated guardian/gateway fixture.
- `pnpm typecheck`, focused Oxlint, `git diff --check`, and CI YAML parsing passed.
- Downloaded the official 37,404,344-byte ARM64 binary; its locally calculated SHA-256 matches the GitHub release API asset digest: `7747d94570fb390cf47dcb4f9555c193c6355cda9793f0d878d9049e5d6a7790`.
- Patched preparation staged the real binary with executable permissions and reused it without rewriting it, in a disposable local fixture on macOS ARM64.
- **Native Linux ARM64 CI passed:** [Ubuntu ARM64 installer smoke](https://github.com/milind-soni/OpenMausBot/actions/runs/34207211227/job/101999407925) downloaded, verified, executed, and reused the connector in an isolated fixture. Other repository CI jobs were still running when this evidence was recorded.

Source: https://github.com/cloudflare/cloudflared/releases/tag/2026.8.2

No live user data or cloud account was touched. This PR verifies the connector installer, not an end-to-end public HTTPS/phone-pairing deployment on an ARM64 VPS. No version bump or release is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Linux ARM64 support for the cloudflared connector.
  * Added CI validation to install and run the Linux ARM64 connector.
* **Bug Fixes**
  * Improved connector binary resolution for Linux x64 and ARM64 development builds.
  * Strengthened validation for architecture mismatches, invalid binaries, truncated files, and unpinned assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->