### PR TITLE
feat(ios): answer a structured ask with the model's own questions

### DIFF
--- a/ios/App/Cards/QuestionCardView.swift
+++ b/ios/App/Cards/QuestionCardView.swift
@@ -1,0 +1,308 @@
+import CompanionCore
+import SwiftUI
+
+/// The question card: what the bot actually asked, and its own answers.
+///
+/// A structured ask (Claude's `AskUserQuestion`) reaches the harness through
+/// the permission channel, so before this it drew the ordinary card — a flat
+/// row of buttons over "which model should this bot run on?". One tap could
+/// not say WHICH question it answered, so a multi-question ask had nothing
+/// tappable at all and the phone could only watch it time out.
+///
+/// The desktop's `src/components/QuestionCard.tsx`, in SwiftUI: a tab per
+/// question, the model's options with their glosses, an "Other" row for a
+/// reply it did not think of, and one submit that sends every answer at once.
+/// The answer text is built by `AskQuestionAnswer.format`, so an answer given
+/// here is byte-for-byte the one the Mac would have sent.
+struct QuestionCardView: View {
+    let chat: Chat
+    let message: Message
+    @EnvironmentObject private var session: Session
+
+    /// Per question: the option labels ticked, and the free-text reply.
+    @State private var picked: [Int: Set<String>] = [:]
+    @State private var custom: [Int: String] = [:]
+    @State private var other: Set<Int> = []
+    @State private var active = 0
+    @State private var answering = false
+    /// The harness settles the card, but only after a round trip. Holding the
+    /// sent answer closes the window where the buttons are still live.
+    @State private var sent: String?
+    @FocusState private var otherFocused: Bool
+
+    private var tint: Color { MausPalette.color(chat.color) }
+
+    private var card: OptionCard? { message.card }
+    private var questions: [AskQuestion] { card?.questions ?? [] }
+
+    private var index: Int { min(active, max(questions.count - 1, 0)) }
+    private var current: AskQuestion? { questions.indices.contains(index) ? questions[index] : nil }
+
+    /// An open "Other" field with nothing in it is not an answer.
+    private func answers(for position: Int) -> [String] {
+        var chosen = Array(picked[position] ?? []).sorted()
+        if other.contains(position) {
+            let typed = (custom[position] ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            if !typed.isEmpty { chosen.append(typed) }
+        }
+        return chosen
+    }
+
+    private func isAnswered(_ position: Int) -> Bool { !answers(for: position).isEmpty }
+    private var complete: Bool { questions.indices.allSatisfy(isAnswered) }
+    private var answeredCount: Int { questions.indices.filter(isAnswered).count }
+    private var settled: Bool { (card?.answered != nil) || sent != nil }
+
+    var body: some View {
+        if let card, !questions.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                header(card)
+                if questions.count > 1 { tabs }
+                if let current {
+                    Text(current.question)
+                        .font(.system(size: 15))
+                        .foregroundStyle(Color.primary)
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                    if !settled {
+                        if current.allowsMultiple {
+                            Text("Choose all that apply")
+                                .font(.system(size: 12))
+                                .foregroundStyle(Color.secondary)
+                        }
+                        choices(current)
+                    }
+                }
+                if settled {
+                    answeredSummary(card)
+                } else {
+                    submit
+                }
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 22, style: .continuous)
+                    .fill(settled ? Color.secondary.opacity(0.13) : tint.opacity(0.12))
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 22, style: .continuous)
+                    .strokeBorder(settled ? .clear : tint, lineWidth: 1.5)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func header(_ card: OptionCard) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Label("\(chat.name) has a question", systemImage: "questionmark.bubble.fill")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(settled ? Color.secondary : tint)
+            Spacer(minLength: 8)
+            if questions.count > 1, !settled {
+                Text("\(answeredCount) of \(questions.count)")
+                    .font(.system(size: 12).monospacedDigit())
+                    .foregroundStyle(Color.secondary)
+            }
+        }
+    }
+
+    private var tabs: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(Array(questions.enumerated()), id: \.offset) { position, question in
+                    Button {
+                        Haptics.selection()
+                        active = position
+                    } label: {
+                        HStack(spacing: 4) {
+                            if isAnswered(position) {
+                                Image(systemName: "checkmark")
+                                    .font(.system(size: 10, weight: .bold))
+                            }
+                            Text(question.tabLabel(position: position + 1))
+                                .font(.system(size: 13, weight: position == index ? .semibold : .regular))
+                        }
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(
+                            Capsule().fill(position == index ? Color.secondary.opacity(0.22) : Color.clear)
+                        )
+                        .foregroundStyle(position == index ? Color.primary : Color.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(settled)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func choices(_ question: AskQuestion) -> some View {
+        VStack(spacing: 0) {
+            ForEach(Array(question.options.enumerated()), id: \.offset) { position, option in
+                if position > 0 { Divider().opacity(0.4) }
+                row(
+                    label: option.label,
+                    detail: option.detail,
+                    checked: picked[index]?.contains(option.label) == true,
+                    multi: question.allowsMultiple
+                ) { choose(option.label, in: question) }
+            }
+            if !question.options.isEmpty { Divider().opacity(0.4) }
+            row(
+                label: String(localized: "Other"),
+                detail: nil,
+                checked: other.contains(index),
+                multi: question.allowsMultiple
+            ) { toggleOther(question) }
+            if other.contains(index) {
+                Divider().opacity(0.4)
+                TextField("Type your own answer", text: binding(forCustom: index), axis: .vertical)
+                    .font(.system(size: 15))
+                    .lineLimit(1...4)
+                    .focused($otherFocused)
+                    .textFieldStyle(.plain)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+            }
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous).fill(Color.secondary.opacity(0.10))
+        )
+    }
+
+    @ViewBuilder
+    private func row(
+        label: String,
+        detail: String?,
+        checked: Bool,
+        multi: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: {
+            Haptics.selection()
+            action()
+        }) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: marker(checked: checked, multi: multi))
+                    .font(.system(size: 17))
+                    .foregroundStyle(checked ? tint : Color.secondary)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(label)
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(Color.primary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    if let detail, !detail.isEmpty {
+                        Text(detail)
+                            .font(.system(size: 13))
+                            .foregroundStyle(Color.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(answering)
+        .accessibilityAddTraits(checked ? [.isSelected] : [])
+    }
+
+    private func marker(checked: Bool, multi: Bool) -> String {
+        if multi { return checked ? "checkmark.square.fill" : "square" }
+        return checked ? "largecircle.fill.circle" : "circle"
+    }
+
+    private var submit: some View {
+        Button {
+            Haptics.selection()
+            send()
+        } label: {
+            Text(questions.count > 1 ? "Submit answers" : "Submit answer")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity)
+                .frame(height: 40)
+                .background(Capsule().fill(complete ? tint : Color.secondary.opacity(0.35)))
+        }
+        .buttonStyle(.plain)
+        .disabled(!complete || answering)
+        .padding(.top, 2)
+    }
+
+    @ViewBuilder
+    private func answeredSummary(_ card: OptionCard) -> some View {
+        let answer = card.answeredText ?? sent
+        Label {
+            Text(answer.map(AskQuestionAnswer.withoutPreamble) ?? String(localized: "Answered"))
+                .font(.system(size: 14))
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+        } icon: {
+            Image(systemName: "checkmark.circle")
+        }
+        .foregroundStyle(Color.secondary)
+    }
+
+    private func binding(forCustom position: Int) -> Binding<String> {
+        Binding(get: { custom[position] ?? "" }, set: { custom[position] = $0 })
+    }
+
+    private func choose(_ label: String, in question: AskQuestion) {
+        guard !settled else { return }
+        var chosen = picked[index] ?? []
+        if question.allowsMultiple {
+            if chosen.contains(label) { chosen.remove(label) } else { chosen.insert(label) }
+            picked[index] = chosen
+            return
+        }
+        // Single-select is a radio group: picking replaces, and picking an
+        // option means the free-text answer was not the one they wanted.
+        picked[index] = [label]
+        other.remove(index)
+        otherFocused = false
+        // Move to the next question they still owe an answer to. The last one
+        // stays put so the submit button is under the thumb that just chose.
+        if let next = questions.indices.first(where: { $0 != index && !isAnswered($0) }) {
+            active = next
+        }
+    }
+
+    private func toggleOther(_ question: AskQuestion) {
+        guard !settled else { return }
+        if other.contains(index) {
+            other.remove(index)
+            otherFocused = false
+            return
+        }
+        other.insert(index)
+        if !question.allowsMultiple { picked[index] = [] }
+        otherFocused = true
+    }
+
+    private func send() {
+        guard !settled, complete, let card, let requestId = card.requestId else { return }
+        let answer = AskQuestionAnswer.format(
+            questions: questions,
+            answers: questions.indices.map(answers(for:))
+        )
+        guard !answer.isEmpty else { return }
+        sent = answer
+        answering = true
+        otherFocused = false
+        Task {
+            // A question only ever answers with text; the harness rejects an
+            // allow/deny on one, so this never takes the permission path.
+            await session.answer(
+                threadId: chat.threadId,
+                requestId: requestId,
+                choice: answer,
+                isPermission: false
+            )
+            answering = false
+        }
+    }
+}

--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -1317,7 +1317,13 @@ struct MessageRow: View {
         case .text:
             TextBubble(message: message, chat: chat, tailed: endsRun, openLink: openLink)
         case .options:
-            CardView(chat: chat, message: message)
+            // A structured ask draws its own card: its answers are the
+            // model's questions, not an allow/deny a tap could stand for.
+            if message.card?.questions.isEmpty == false {
+                QuestionCardView(chat: chat, message: message)
+            } else {
+                CardView(chat: chat, message: message)
+            }
         case .secret:
             if let secret = message.secret {
                 CredentialRequestCardView(chat: chat, message: message, secret: secret)

--- a/ios/Sources/CompanionCore/AskQuestion.swift
+++ b/ios/Sources/CompanionCore/AskQuestion.swift
@@ -1,0 +1,109 @@
+/// Structured questions raised by a provider's own "ask the human" tool —
+/// Claude's built-in `AskUserQuestion`.
+///
+/// A port of `shared/ask-question.ts`. The desktop re-reads that tool's input
+/// into these questions and puts them on the card; the phone renders them and
+/// sends back the same answer text the desktop would, so a question answered
+/// here is indistinguishable from one answered on the Mac.
+///
+/// Decoding is deliberately forgiving. These payloads are bot-authored and
+/// arrive inside a transcript: a question whose shape surprises us must cost
+/// one card, never the whole conversation.
+
+public struct AskQuestionOption: Codable, Hashable, Sendable {
+    public var label: String
+    /// The model's one-line gloss under the label. Named `detail` because
+    /// `description` is Swift's own printing hook.
+    public var detail: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case label
+        case detail = "description"
+    }
+
+    public init(label: String, detail: String? = nil) {
+        self.label = label
+        self.detail = detail
+    }
+}
+
+public struct AskQuestion: Codable, Hashable, Sendable {
+    public var question: String
+    /// The short tab label the model gave this question ("Schedule", "Model").
+    public var header: String?
+    public var multiSelect: Bool?
+    public var options: [AskQuestionOption]
+
+    public init(question: String, header: String? = nil, multiSelect: Bool? = nil, options: [AskQuestionOption]) {
+        self.question = question
+        self.header = header
+        self.multiSelect = multiSelect
+        self.options = options
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        question = try container.decode(String.self, forKey: .question)
+        header = try container.decodeIfPresent(String.self, forKey: .header)
+        multiSelect = try container.decodeIfPresent(Bool.self, forKey: .multiSelect)
+        // A question with no options is still answerable — the card always
+        // offers free text — so a missing list is empty, not a failure.
+        options = try container.decodeIfPresent([AskQuestionOption].self, forKey: .options) ?? []
+    }
+
+    /// What the tab shows. The model names most questions; a numbered
+    /// fallback keeps the tabs distinguishable when it does not.
+    public func tabLabel(position: Int) -> String {
+        if let header, !header.isEmpty { return header }
+        return "Question \(position)"
+    }
+
+    public var allowsMultiple: Bool { multiSelect == true }
+}
+
+public struct QuestionRequestCardData: Codable, Hashable, Sendable {
+    public var version: Int
+    public var questions: [AskQuestion]
+
+    public init(version: Int = 1, questions: [AskQuestion]) {
+        self.version = version
+        self.questions = questions
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        version = try container.decodeIfPresent(Int.self, forKey: .version) ?? 1
+        questions = try container.decodeIfPresent([AskQuestion].self, forKey: .questions) ?? []
+    }
+}
+
+/// The answer text, byte-for-byte what `shared/ask-question.ts` produces.
+///
+/// It reaches the model as the tool's own result, so it has to stand on its
+/// own: name each question, then what was picked for it.
+public enum AskQuestionAnswer {
+    /// The lead-in exists for the model — the answer is delivered on the
+    /// permission contract's deny channel, so it has to say what it is. The
+    /// card strips it back off when it shows a person what they sent.
+    public static let preamble = "The user answered your questions."
+
+    public static func format(questions: [AskQuestion], answers: [[String]]) -> String {
+        var blocks: [String] = []
+        for (index, question) in questions.enumerated() {
+            let picked = (index < answers.count ? answers[index] : [])
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+            guard !picked.isEmpty else { continue }
+            blocks.append("Q: \(question.question)\nA: \(picked.joined(separator: ", "))")
+        }
+        guard !blocks.isEmpty else { return "" }
+        return "\(preamble)\n\n\(blocks.joined(separator: "\n\n"))"
+    }
+
+    /// The same answer without the model-facing lead-in, for a settled card.
+    public static func withoutPreamble(_ answer: String) -> String {
+        let lead = "\(preamble)\n\n"
+        guard answer.hasPrefix(lead) else { return answer }
+        return String(answer.dropFirst(lead.count))
+    }
+}

--- a/ios/Sources/CompanionCore/Models.swift
+++ b/ios/Sources/CompanionCore/Models.swift
@@ -57,6 +57,13 @@ public struct OptionCard: Codable, Hashable, Sendable {
     /// Learned skills must show their complete reviewed contents before an
     /// approval button is offered on a compact companion surface.
     public var skillRequest: SkillRequestCardData? = nil
+    /// The model's own questions and options (Claude's `AskUserQuestion`).
+    /// Present only on a structured ask; every other card leaves it nil.
+    public var questionRequest: QuestionRequestCardData? = nil
+    /// What an answered question was answered WITH. `answered` only records
+    /// the behavior once the harness settles a live ask, so without this a
+    /// settled question card would read "answer" instead of the reply.
+    public var answeredText: String? = nil
 
     /// A card is actionable while it is unanswered and still has a request
     /// behind it. Everything else is transcript.
@@ -66,6 +73,14 @@ public struct OptionCard: Codable, Hashable, Sendable {
 
     /// Permission cards carry a tool; questions do not.
     public var isPermission: Bool { tool != nil }
+
+    /// A structured ask draws its own card: the model posed real questions
+    /// with real options, and a flat row of buttons cannot say which
+    /// question a tap answered.
+    public var questions: [AskQuestion] {
+        guard let questionRequest, !questionRequest.questions.isEmpty else { return [] }
+        return questionRequest.questions
+    }
 
     /// The wire API accepts an approval behavior rather than the button's
     /// display text. Treat the one refusal as deny and every other offered

--- a/ios/Tests/CompanionCoreTests/AskQuestionTests.swift
+++ b/ios/Tests/CompanionCoreTests/AskQuestionTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+
+@testable import CompanionCore
+
+/// A structured ask (Claude's `AskUserQuestion`) as the harness puts it on a
+/// card, and the answer text the phone sends back for it.
+///
+/// The answer format is pinned against `shared/ask-question.ts` rather than
+/// invented here: the model receives this text as its tool result, and an
+/// answer given on the phone must be indistinguishable from one given on the
+/// Mac. If the two ever disagree, this test is the one that says so.
+final class AskQuestionTests: XCTestCase {
+    private let payload = #"""
+    {
+      "title": "Your bot has a question",
+      "subtitle": "Which model should Hazelnut run on by default?",
+      "options": ["Claude Opus 5", "Gemini"],
+      "requestId": "req-1",
+      "questionRequest": {
+        "version": 1,
+        "questions": [
+          {
+            "question": "Which model should Hazelnut run on by default?",
+            "header": "Model",
+            "multiSelect": false,
+            "options": [
+              {"label": "Claude Opus 5", "description": "What the bot had before."},
+              {"label": "Gemini"}
+            ]
+          },
+          {
+            "question": "Which stores may it order from?",
+            "header": "Stores",
+            "multiSelect": true,
+            "options": [{"label": "Instamart"}, {"label": "Blinkit"}]
+          }
+        ]
+      }
+    }
+    """#
+
+    private func card() throws -> OptionCard {
+        try JSONDecoder().decode(OptionCard.self, from: Data(payload.utf8))
+    }
+
+    func testDecodesTheModelsQuestionsAndTheirOptions() throws {
+        let card = try card()
+        XCTAssertEqual(card.questions.count, 2)
+        XCTAssertEqual(card.questions.first?.header, "Model")
+        XCTAssertEqual(card.questions.first?.options.first?.label, "Claude Opus 5")
+        XCTAssertEqual(card.questions.first?.options.first?.detail, "What the bot had before.")
+        XCTAssertNil(card.questions.first?.options.last?.detail)
+        XCTAssertFalse(card.questions[0].allowsMultiple)
+        XCTAssertTrue(card.questions[1].allowsMultiple)
+    }
+
+    func testAStructuredAskIsAQuestion() throws {
+        let card = try card()
+        // `tool` is what tells a permission from a question, and the harness
+        // leaves it off a structured ask precisely so no allow/deny is
+        // offered for one. The broker rejects any behavior but "answer".
+        XCTAssertFalse(card.isPermission)
+        XCTAssertEqual(OptionCard.responseBehavior(for: "anything", isPermission: card.isPermission), "answer")
+    }
+
+    func testAnOrdinaryCardHasNoQuestions() throws {
+        let approval = #"""
+        {"title": "Approval needed", "subtitle": "git push", "options": ["Allow", "Deny"],
+         "requestId": "req-2", "tool": "Bash"}
+        """#
+        let card = try JSONDecoder().decode(OptionCard.self, from: Data(approval.utf8))
+        XCTAssertTrue(card.questions.isEmpty, "an approval must keep the ordinary card")
+        XCTAssertTrue(card.isPermission)
+    }
+
+    func testDecodesAQuestionThatOffersNoOptions() throws {
+        // Free text still answers it, so a missing list must not fail the
+        // whole transcript decode.
+        let sparse = #"""
+        {"title": "t", "subtitle": "s", "options": [], "requestId": "r",
+         "questionRequest": {"questions": [{"question": "Which account?"}]}}
+        """#
+        let card = try JSONDecoder().decode(OptionCard.self, from: Data(sparse.utf8))
+        XCTAssertEqual(card.questions.first?.options, [])
+        XCTAssertEqual(card.questions.first?.tabLabel(position: 1), "Question 1")
+    }
+
+    func testFormatsTheAnswerTheModelWillRead() throws {
+        let card = try card()
+        let answer = AskQuestionAnswer.format(
+            questions: card.questions,
+            answers: [["Claude Opus 5"], ["Instamart", "Blinkit"]]
+        )
+        XCTAssertEqual(
+            answer,
+            """
+            The user answered your questions.
+
+            Q: Which model should Hazelnut run on by default?
+            A: Claude Opus 5
+
+            Q: Which stores may it order from?
+            A: Instamart, Blinkit
+            """
+        )
+    }
+
+    func testOmitsAnUnansweredQuestionRatherThanImplyingOne() throws {
+        let card = try card()
+        let answer = AskQuestionAnswer.format(questions: card.questions, answers: [["Gemini"], ["   "]])
+        XCTAssertEqual(answer, "The user answered your questions.\n\nQ: Which model should Hazelnut run on by default?\nA: Gemini")
+        XCTAssertEqual(AskQuestionAnswer.format(questions: card.questions, answers: [[], []]), "",
+                       "nothing answered means nothing is sent")
+    }
+
+    func testSettledCardDropsTheModelFacingLeadIn() throws {
+        let card = try card()
+        let answer = AskQuestionAnswer.format(questions: card.questions, answers: [["Gemini"], ["Instamart"]])
+        XCTAssertFalse(AskQuestionAnswer.withoutPreamble(answer).hasPrefix(AskQuestionAnswer.preamble))
+        XCTAssertTrue(AskQuestionAnswer.withoutPreamble(answer).hasPrefix("Q: "))
+        XCTAssertEqual(AskQuestionAnswer.withoutPreamble("Tea"), "Tea")
+    }
+
+    func testCarriesTheAnsweredTextTheHarnessRecords() throws {
+        let settled = #"""
+        {"title": "t", "subtitle": "s", "options": [], "requestId": "r", "answered": "answer",
+         "answeredText": "The user answered your questions.\n\nQ: Which model?\nA: Gemini",
+         "questionRequest": {"version": 1, "questions": [{"question": "Which model?", "options": []}]}}
+        """#
+        let card = try JSONDecoder().decode(OptionCard.self, from: Data(settled.utf8))
+        XCTAssertFalse(card.isPending)
+        XCTAssertEqual(AskQuestionAnswer.withoutPreamble(try XCTUnwrap(card.answeredText)),
+                       "Q: Which model?\nA: Gemini")
+    }
+}


### PR DESCRIPTION
Stacked on #953 (base is `fix/ask-user-question-card`, so this diff is iOS only).

#953 turned Claude's `AskUserQuestion` into a real question card on the desktop. The phone got the **single-question** path for free — the harness also sends flat option labels, which drive the buttons `ios/App/ChatView.swift` already draws — but a **multi-question** ask arrived with nothing tappable. One flat button cannot say *which* question it answered, so the card just sat there until the ask timed out into "use your best judgment".

`QuestionCardView` is the desktop's card in SwiftUI: a tab per question, the model's options with their glosses, an "Other" row for a reply the model did not think of, and one submit that sends every answer at once.

## The part worth reviewing

`AskQuestionAnswer.format` is a port of the formatter in `shared/ask-question.ts`, and it has to be exact: that string reaches the model as the tool's own result, so an answer given on the phone must be indistinguishable from one given on the Mac. `AskQuestionTests` pins it against the same literal strings the TypeScript test uses rather than trusting the two to stay in step. If they ever drift, that test says so.

Decoding is deliberately forgiving — a question with no options, a missing `version`. These payloads are bot-authored and arrive inside a transcript, so a surprising shape must cost one card and never the whole conversation.

## Platforms

| Platform | Applies? | Status |
|---|---|---|
| macOS     | n/a | #953 |
| Windows   | n/a | #953 |
| iOS       | yes | in this PR |
| Android   | yes | #955 (the Kotlin twin, same commit shape) |
| Companion | n/a | no new `/api/*` route — the answer goes through the existing `POST /api/threads/:id/respond` with `behavior: "answer"` |

## Test plan

- `cd ios && swift build && swift test` — 345 tests pass, including 7 new in `AskQuestionTests`: decoding a real card payload, an ordinary approval keeping the ordinary card, a question with no options, the exact answer text, an unanswered question being omitted rather than implied, and the settled card dropping the model-facing lead-in.
- `xcodebuild -project OpenMausCompanion.xcodeproj -scheme OpenMausCompanion -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' CODE_SIGNING_ALLOWED=NO build` — **BUILD SUCCEEDED** (after `xcodegen generate`, which this PR's new `App/` file requires).
- **Not yet seen on a device.** Stages 1 and 3 of `ios/TESTING.md` pass; stage 4 needs a paired phone and a bot that asks, which is a person's hands. The card's shape is the desktop one, which was tested on a real bot in an OMB2 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
