### PR TITLE
feat(android): answer a structured ask with the model's own questions

### DIFF
--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/MessageRow.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/MessageRow.kt
@@ -393,7 +393,13 @@ private fun MessageContent(
 ) {
     when (message.kind) {
         Message.Kind.TEXT -> TextBubble(chat.threadId, message, endsRun, openLink, openAttachment)
-        Message.Kind.OPTIONS -> CardView(chat, message, haptics)
+        // A structured ask draws its own card: its answers are the model's
+        // questions, not an allow/deny a tap could stand for.
+        Message.Kind.OPTIONS -> if (QuestionCardRules.drawsQuestionCard(message)) {
+            QuestionCardView(chat, message, haptics)
+        } else {
+            CardView(chat, message, haptics)
+        }
         Message.Kind.ACTIVITY -> ActivityChip(message.tool)
         Message.Kind.SCREEN -> ScreenShot(chat.threadId, message)
         // A message kind from a newer computer. Almost everything the harness

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/QuestionCard.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/QuestionCard.kt
@@ -1,0 +1,371 @@
+package com.openmausbot.companion.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.openmausbot.companion.core.AskQuestion
+import com.openmausbot.companion.core.AskQuestionAnswer
+import com.openmausbot.companion.core.Chat
+import com.openmausbot.companion.core.Message
+import kotlinx.coroutines.launch
+
+/**
+ * The question card: what the bot actually asked, and its own answers.
+ *
+ * A structured ask (Claude's `AskUserQuestion`) reaches the harness through
+ * the permission channel, so before this it drew the ordinary card — a flat
+ * row of buttons over "which model should this bot run on?". One tap could not
+ * say WHICH question it answered, so a multi-question ask had nothing tappable
+ * at all and the phone could only watch it time out.
+ *
+ * The desktop's `src/components/QuestionCard.tsx` and its Swift twin
+ * `ios/App/Cards/QuestionCardView.swift`, in Compose: a tab per question, the
+ * model's options with their glosses, an "Other" row for a reply it did not
+ * think of, and one submit that sends every answer at once. The answer text is
+ * built by [AskQuestionAnswer.format], so an answer given here is
+ * byte-for-byte the one the Mac would have sent.
+ */
+@Composable
+internal fun QuestionCardView(chat: Chat, message: Message, haptics: Haptics) {
+    val card = message.card ?: return
+    val questions = card.questions
+    if (questions.isEmpty()) return
+
+    val session = LocalCompanion.current.session
+    val scope = rememberCoroutineScope()
+    // Per question: the option labels ticked, the free-text reply, and whether
+    // "Other" is open. An open field with nothing in it is not an answer.
+    val picked = remember(message.id) { mutableStateMapOf<Int, Set<String>>() }
+    val custom = remember(message.id) { mutableStateMapOf<Int, String>() }
+    val other = remember(message.id) { mutableStateMapOf<Int, Boolean>() }
+    var active by remember(message.id) { mutableStateOf(0) }
+    var answering by remember(message.id) { mutableStateOf(false) }
+    // The harness settles the card, but only after a round trip. Holding the
+    // sent answer closes the window where the buttons are still live.
+    var sent by remember(message.id) { mutableStateOf<String?>(null) }
+
+    fun answersFor(position: Int): List<String> {
+        val chosen = picked[position].orEmpty().sorted().toMutableList()
+        if (other[position] == true) {
+            custom[position]?.trim()?.takeIf { it.isNotEmpty() }?.let(chosen::add)
+        }
+        return chosen
+    }
+
+    val index = active.coerceIn(0, questions.lastIndex)
+    val current = questions[index]
+    val answeredCount = questions.indices.count { answersFor(it).isNotEmpty() }
+    val complete = answeredCount == questions.size
+    val settled = card.answered != null || sent != null
+
+    fun choose(label: String) {
+        if (settled) return
+        if (current.allowsMultiple) {
+            val chosen = picked[index].orEmpty()
+            picked[index] = if (label in chosen) chosen - label else chosen + label
+            return
+        }
+        // Single-select is a radio group: picking replaces, and picking an
+        // option means the free-text answer was not the one they wanted.
+        picked[index] = setOf(label)
+        other[index] = false
+        // Move to the next question they still owe an answer to. The last one
+        // stays put so the submit button is under the thumb that just chose.
+        questions.indices
+            .firstOrNull { it != index && answersFor(it).isEmpty() }
+            ?.let { active = it }
+    }
+
+    fun toggleOther() {
+        if (settled) return
+        if (other[index] == true) {
+            other[index] = false
+            return
+        }
+        other[index] = true
+        if (!current.allowsMultiple) picked[index] = emptySet()
+    }
+
+    fun send() {
+        val requestId = card.requestId
+        if (settled || !complete || requestId == null) return
+        val answer = AskQuestionAnswer.format(questions, questions.indices.map(::answersFor))
+        if (answer.isEmpty()) return
+        sent = answer
+        answering = true
+        scope.launch {
+            // A question only ever answers with text; the harness rejects an
+            // allow/deny on one, so this never takes the permission path.
+            session.answer(
+                threadId = chat.threadId,
+                requestId = requestId,
+                choice = answer,
+                isPermission = false,
+            )
+            answering = false
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(secondaryTint.copy(alpha = 0.13f), RoundedCornerShape(22.dp))
+            .then(
+                if (settled) {
+                    Modifier
+                } else {
+                    Modifier.border(1.5.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(22.dp))
+                },
+            )
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                "${chat.name} has a question",
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.weight(1f),
+            )
+            if (questions.size > 1 && !settled) {
+                Text("$answeredCount of ${questions.size}", fontSize = 12.sp, color = secondaryTint)
+            }
+        }
+
+        if (questions.size > 1) {
+            Row(
+                modifier = Modifier.horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                questions.forEachIndexed { position, question ->
+                    val chosen = position == index
+                    Row(
+                        modifier = Modifier
+                            .background(
+                                if (chosen) secondaryTint.copy(alpha = 0.22f) else Color.Transparent,
+                                RoundedCornerShape(14.dp),
+                            )
+                            .clickable(enabled = !settled) {
+                                haptics.play(TactileAction.CHOOSE_APPROVAL)
+                                active = position
+                            }
+                            .padding(horizontal = 10.dp, vertical = 5.dp),
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        if (answersFor(position).isNotEmpty()) {
+                            Icon(
+                                imageVector = Icons.Filled.Check,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(12.dp),
+                            )
+                        }
+                        Text(
+                            question.tabLabel(position + 1),
+                            fontSize = 13.sp,
+                            fontWeight = if (chosen) FontWeight.SemiBold else FontWeight.Normal,
+                            color = if (chosen) MaterialTheme.colorScheme.onSurface else secondaryTint,
+                        )
+                    }
+                }
+            }
+        }
+
+        SelectionContainer {
+            Text(current.question, fontSize = 15.sp)
+        }
+
+        if (settled) {
+            val answer = card.answeredText ?: sent
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.Top,
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Check,
+                    contentDescription = null,
+                    tint = secondaryTint,
+                    modifier = Modifier.size(16.dp),
+                )
+                SelectionContainer {
+                    Text(
+                        answer?.let(AskQuestionAnswer::withoutPreamble) ?: "Answered",
+                        fontSize = 14.sp,
+                        color = secondaryTint,
+                    )
+                }
+            }
+            return@Column
+        }
+
+        if (current.allowsMultiple) {
+            Text("Choose all that apply", fontSize = 12.sp, color = secondaryTint)
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(secondaryTint.copy(alpha = 0.10f), RoundedCornerShape(14.dp)),
+        ) {
+            current.options.forEachIndexed { position, option ->
+                if (position > 0) HorizontalDivider()
+                ChoiceRow(
+                    label = option.label,
+                    detail = option.detail,
+                    checked = option.label in picked[index].orEmpty(),
+                    multi = current.allowsMultiple,
+                    enabled = !answering,
+                ) {
+                    haptics.play(TactileAction.CHOOSE_APPROVAL)
+                    choose(option.label)
+                }
+            }
+            if (current.options.isNotEmpty()) HorizontalDivider()
+            ChoiceRow(
+                label = "Other",
+                detail = null,
+                checked = other[index] == true,
+                multi = current.allowsMultiple,
+                enabled = !answering,
+            ) {
+                haptics.play(TactileAction.CHOOSE_APPROVAL)
+                toggleOther()
+            }
+            if (other[index] == true) {
+                HorizontalDivider()
+                OutlinedTextField(
+                    value = custom[index].orEmpty(),
+                    onValueChange = { custom[index] = it },
+                    placeholder = { Text("Type your own answer") },
+                    singleLine = false,
+                    maxLines = 4,
+                    enabled = !answering,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(10.dp),
+                )
+            }
+        }
+
+        Button(
+            onClick = ::send,
+            enabled = complete && !answering,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(if (questions.size > 1) "Submit answers" else "Submit answer")
+        }
+    }
+}
+
+/** One option row. The whole row is the target, not the 16 dp glyph on it. */
+@Composable
+private fun ChoiceRow(
+    label: String,
+    detail: String?,
+    checked: Boolean,
+    multi: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = enabled, onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        Marker(checked = checked, multi = multi)
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(label, fontSize = 15.sp, fontWeight = FontWeight.Medium)
+            if (!detail.isNullOrEmpty()) {
+                Text(detail, fontSize = 13.sp, color = secondaryTint)
+            }
+        }
+    }
+}
+
+/** What the tabs and the answer share, kept here so a test can reach it. */
+internal object QuestionCardRules {
+    /** A structured ask draws the question card; everything else the ordinary one. */
+    fun drawsQuestionCard(message: Message): Boolean =
+        message.kind == Message.Kind.OPTIONS && message.card?.questions?.isNotEmpty() == true
+
+    /** The tab labels, in order, exactly as the card shows them. */
+    fun tabLabels(questions: List<AskQuestion>): List<String> =
+        questions.mapIndexed { index, question -> question.tabLabel(index + 1) }
+}
+
+/**
+ * The radio dot / checkbox tick, drawn rather than taken from the icon set:
+ * the app bundles material-icons-core only, and pulling in the extended pack
+ * for four glyphs would cost more than the twelve lines below.
+ */
+@Composable
+private fun Marker(checked: Boolean, multi: Boolean) {
+    val accent = MaterialTheme.colorScheme.primary
+    val shape = if (multi) RoundedCornerShape(5.dp) else CircleShape
+    Box(
+        modifier = Modifier
+            .size(20.dp)
+            .then(
+                if (checked) {
+                    Modifier.background(accent, shape)
+                } else {
+                    Modifier.border(1.5.dp, secondaryTint, shape)
+                },
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (!checked) return@Box
+        if (multi) {
+            Icon(
+                imageVector = Icons.Filled.Check,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimary,
+                modifier = Modifier.size(14.dp),
+            )
+        } else {
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .background(MaterialTheme.colorScheme.onPrimary, CircleShape),
+            )
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/openmausbot/companion/ui/QuestionCardRulesTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/ui/QuestionCardRulesTest.kt
@@ -1,0 +1,70 @@
+package com.openmausbot.companion.ui
+
+import com.openmausbot.companion.core.AskQuestion
+import com.openmausbot.companion.core.AskQuestionOption
+import com.openmausbot.companion.core.Message
+import com.openmausbot.companion.core.OptionCard
+import com.openmausbot.companion.core.QuestionRequestCardData
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Which card a transcript row draws.
+ *
+ * The mistake this guards is the one the desktop shipped: a structured ask
+ * routed to the approval card, offering Deny / Always allow / Allow once over
+ * a question that has no such answer.
+ */
+class QuestionCardRulesTest {
+    private fun message(card: OptionCard?): Message = Message(
+        id = "m-1",
+        role = Message.Role.BOT,
+        kind = Message.Kind.OPTIONS,
+        at = 1.0,
+        card = card,
+    )
+
+    private val questions = listOf(
+        AskQuestion(
+            question = "Which model?",
+            header = "Model",
+            options = listOf(AskQuestionOption("Opus"), AskQuestionOption("Gemini")),
+        ),
+        AskQuestion(question = "Which style?", options = listOf(AskQuestionOption("Terse"))),
+    )
+
+    private fun card(questionRequest: QuestionRequestCardData?, tool: String? = null) = OptionCard(
+        title = "t",
+        subtitle = "s",
+        options = emptyList(),
+        requestId = "req-1",
+        tool = tool,
+        questionRequest = questionRequest,
+    )
+
+    @Test
+    fun `a structured ask draws the question card`() {
+        assertTrue(
+            QuestionCardRules.drawsQuestionCard(
+                message(card(QuestionRequestCardData(questions = questions))),
+            ),
+        )
+    }
+
+    @Test
+    fun `an approval keeps the ordinary card`() {
+        assertFalse(QuestionCardRules.drawsQuestionCard(message(card(null, tool = "Bash"))))
+        assertFalse(QuestionCardRules.drawsQuestionCard(message(null)))
+        assertFalse(
+            QuestionCardRules.drawsQuestionCard(message(card(QuestionRequestCardData(questions = emptyList())))),
+            "a payload with no questions has nothing to draw",
+        )
+    }
+
+    @Test
+    fun `tabs fall back to a number only where the model named nothing`() {
+        assertEquals(listOf("Model", "Question 2"), QuestionCardRules.tabLabels(questions))
+    }
+}

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/AskQuestion.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/AskQuestion.kt
@@ -1,0 +1,88 @@
+package com.openmausbot.companion.core
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Structured questions raised by a provider's own "ask the human" tool —
+ * Claude's built-in `AskUserQuestion`.
+ *
+ * A port of `shared/ask-question.ts`, kept in step with
+ * `ios/Sources/CompanionCore/AskQuestion.swift`. The desktop re-reads that
+ * tool's input into these questions and puts them on the card; the phone
+ * renders them and sends back the same answer text the desktop would, so a
+ * question answered here is indistinguishable from one answered on the Mac.
+ *
+ * Every field but the question itself is optional. These payloads are
+ * bot-authored and arrive inside a transcript: a question whose shape
+ * surprises us must cost one card, never the whole conversation.
+ */
+@Serializable
+data class AskQuestionOption(
+    val label: String,
+    /**
+     * The model's one-line gloss under the label. Named `detail` because
+     * `description` collides with nothing here but reads as a Kotlin
+     * `toString` hook to anyone arriving from the Swift twin.
+     */
+    @SerialName("description") val detail: String? = null,
+)
+
+@Serializable
+data class AskQuestion(
+    val question: String,
+    /** The short tab label the model gave this question ("Schedule", "Model"). */
+    val header: String? = null,
+    val multiSelect: Boolean? = null,
+    /**
+     * A question with no options is still answerable — the card always offers
+     * free text — so a missing list is empty, not a failure.
+     */
+    val options: List<AskQuestionOption> = emptyList(),
+) {
+    val allowsMultiple: Boolean get() = multiSelect == true
+
+    /**
+     * What the tab shows. The model names most questions; a numbered fallback
+     * keeps the tabs distinguishable when it does not.
+     */
+    fun tabLabel(position: Int): String = header?.takeIf { it.isNotEmpty() } ?: "Question $position"
+}
+
+@Serializable
+data class QuestionRequestCardData(
+    val version: Int = 1,
+    val questions: List<AskQuestion> = emptyList(),
+)
+
+/**
+ * The answer text, byte-for-byte what `shared/ask-question.ts` produces.
+ *
+ * It reaches the model as the tool's own result, so it has to stand on its
+ * own: name each question, then what was picked for it.
+ */
+object AskQuestionAnswer {
+    /**
+     * The lead-in exists for the model — the answer is delivered on the
+     * permission contract's deny channel, so it has to say what it is. The
+     * card strips it back off when it shows a person what they sent.
+     */
+    const val PREAMBLE = "The user answered your questions."
+
+    fun format(questions: List<AskQuestion>, answers: List<List<String>>): String {
+        val blocks = questions.mapIndexedNotNull { index, question ->
+            val picked = answers.getOrElse(index) { emptyList() }
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+            if (picked.isEmpty()) null else "Q: ${question.question}\nA: ${picked.joinToString(", ")}"
+        }
+        if (blocks.isEmpty()) return ""
+        return "$PREAMBLE\n\n${blocks.joinToString("\n\n")}"
+    }
+
+    /** The same answer without the model-facing lead-in, for a settled card. */
+    fun withoutPreamble(answer: String): String {
+        val lead = "$PREAMBLE\n\n"
+        return if (answer.startsWith(lead)) answer.removePrefix(lead) else answer
+    }
+}

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Models.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Models.kt
@@ -76,9 +76,27 @@ data class OptionCard(
     val allowKey: String? = null,
     /** Learned skills require a complete, hash-bound review before approval. */
     val skillRequest: SkillRequestCardData? = null,
+    /**
+     * The model's own questions and options (Claude's `AskUserQuestion`).
+     * Present only on a structured ask; every other card leaves it null.
+     */
+    val questionRequest: QuestionRequestCardData? = null,
+    /**
+     * What an answered question was answered WITH. `answered` only records the
+     * behavior once the harness settles a live ask, so without this a settled
+     * question card would read "answer" instead of the reply.
+     */
+    val answeredText: String? = null,
 ) {
     val isPending: Boolean get() = requestId != null && answered == null && dismissed != true
     val isPermission: Boolean get() = tool != null
+
+    /**
+     * A structured ask draws its own card: the model posed real questions with
+     * real options, and a flat row of buttons cannot say which question a tap
+     * answered.
+     */
+    val questions: List<AskQuestion> get() = questionRequest?.questions.orEmpty()
 
     fun responseBehavior(choice: String): String = responseBehavior(choice, isPermission)
 

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/AskQuestionTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/AskQuestionTest.kt
@@ -1,0 +1,152 @@
+package com.openmausbot.companion.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * A structured ask (Claude's `AskUserQuestion`) as the harness puts it on a
+ * card, and the answer text the phone sends back for it.
+ *
+ * The expectations come from the desktop, not from the Kotlin under them:
+ * `shared/ask-question.ts` builds this exact string and the model receives it
+ * as its tool result, so an answer given on Android has to be
+ * indistinguishable from one given on the Mac or in
+ * `ios/Sources/CompanionCore/AskQuestion.swift`. If the three ever disagree,
+ * this test is the one that says so.
+ */
+class AskQuestionTest {
+    private val payload = """
+        {
+          "title": "Your bot has a question",
+          "subtitle": "Which model should Hazelnut run on by default?",
+          "options": ["Claude Opus 5", "Gemini"],
+          "requestId": "req-1",
+          "questionRequest": {
+            "version": 1,
+            "questions": [
+              {
+                "question": "Which model should Hazelnut run on by default?",
+                "header": "Model",
+                "multiSelect": false,
+                "options": [
+                  {"label": "Claude Opus 5", "description": "What the bot had before."},
+                  {"label": "Gemini"}
+                ]
+              },
+              {
+                "question": "Which stores may it order from?",
+                "header": "Stores",
+                "multiSelect": true,
+                "options": [{"label": "Instamart"}, {"label": "Blinkit"}]
+              }
+            ]
+          }
+        }
+    """.trimIndent()
+
+    private fun card(json: String = payload): OptionCard =
+        CompanionJson.decodeFromString(OptionCard.serializer(), json)
+
+    @Test
+    fun `decodes the model's questions and their options`() {
+        val card = card()
+        assertEquals(2, card.questions.size)
+        assertEquals("Model", card.questions[0].header)
+        assertEquals("Claude Opus 5", card.questions[0].options[0].label)
+        assertEquals("What the bot had before.", card.questions[0].options[0].detail)
+        assertEquals(null, card.questions[0].options[1].detail)
+        assertFalse(card.questions[0].allowsMultiple)
+        assertTrue(card.questions[1].allowsMultiple)
+    }
+
+    @Test
+    fun `a structured ask is a question, so only an answer settles it`() {
+        val card = card()
+        // `tool` is what tells a permission from a question, and the harness
+        // leaves it off a structured ask precisely so no allow/deny is offered
+        // for one. The broker rejects any behavior but "answer".
+        assertFalse(card.isPermission)
+        assertEquals("answer", OptionCard.responseBehavior("anything", card.isPermission))
+    }
+
+    @Test
+    fun `an ordinary approval keeps the ordinary card`() {
+        val approval = card(
+            """{"title":"Approval needed","subtitle":"git push","options":["Allow","Deny"],
+               "requestId":"req-2","tool":"Bash"}""",
+        )
+        assertTrue(approval.questions.isEmpty())
+        assertTrue(approval.isPermission)
+    }
+
+    @Test
+    fun `a question that offers no options still decodes`() {
+        // Free text answers it, so a missing list must never fail the whole
+        // transcript decode.
+        val sparse = card(
+            """{"title":"t","subtitle":"s","options":[],"requestId":"r",
+               "questionRequest":{"questions":[{"question":"Which account?"}]}}""",
+        )
+        assertEquals(emptyList(), sparse.questions[0].options)
+        assertEquals("Question 1", sparse.questions[0].tabLabel(1))
+    }
+
+    @Test
+    fun `formats the answer the model will read`() {
+        val answer = AskQuestionAnswer.format(
+            card().questions,
+            listOf(listOf("Claude Opus 5"), listOf("Instamart", "Blinkit")),
+        )
+        assertEquals(
+            """
+            The user answered your questions.
+
+            Q: Which model should Hazelnut run on by default?
+            A: Claude Opus 5
+
+            Q: Which stores may it order from?
+            A: Instamart, Blinkit
+            """.trimIndent(),
+            answer,
+        )
+    }
+
+    @Test
+    fun `omits an unanswered question rather than implying one`() {
+        val questions = card().questions
+        assertEquals(
+            "The user answered your questions.\n\n" +
+                "Q: Which model should Hazelnut run on by default?\nA: Gemini",
+            AskQuestionAnswer.format(questions, listOf(listOf("Gemini"), listOf("   "))),
+        )
+        assertEquals(
+            "",
+            AskQuestionAnswer.format(questions, listOf(emptyList(), emptyList())),
+            "nothing answered means nothing is sent",
+        )
+    }
+
+    @Test
+    fun `a settled card drops the model-facing lead-in`() {
+        val answer = AskQuestionAnswer.format(card().questions, listOf(listOf("Gemini"), listOf("Instamart")))
+        assertFalse(AskQuestionAnswer.withoutPreamble(answer).startsWith(AskQuestionAnswer.PREAMBLE))
+        assertTrue(AskQuestionAnswer.withoutPreamble(answer).startsWith("Q: "))
+        assertEquals("Tea", AskQuestionAnswer.withoutPreamble("Tea"))
+    }
+
+    @Test
+    fun `an answered question keeps the words it was answered with`() {
+        val settled = card(
+            """{"title":"t","subtitle":"s","options":[],"requestId":"r","answered":"answer",
+               "answeredText":"The user answered your questions.\n\nQ: Which model?\nA: Gemini",
+               "questionRequest":{"version":1,"questions":[{"question":"Which model?","options":[]}]}}""",
+        )
+        assertFalse(settled.isPending)
+        assertEquals(
+            "Q: Which model?\nA: Gemini",
+            AskQuestionAnswer.withoutPreamble(settled.answeredText!!),
+        )
+    }
+}


### PR DESCRIPTION
Stacked on #953 (base is `fix/ask-user-question-card`, so this diff is Android only). The Kotlin twin of #954.

#953 turned Claude's `AskUserQuestion` into a real question card on the desktop. The phone got the **single-question** path for free — the harness also sends flat option labels, which drive the buttons `MessageRow.kt` already draws — but a **multi-question** ask arrived with nothing tappable. One flat button cannot say *which* question it answered, so the card just sat there until the ask timed out into "use your best judgment".

`QuestionCardView` is the desktop's card in Compose: a tab per question, the model's options with their glosses, an "Other" row for a reply the model did not think of, and one submit that sends every answer at once.

## The parts worth reviewing

`AskQuestionAnswer.format` is a port of the formatter in `shared/ask-question.ts`, and it has to be exact: that string reaches the model as the tool's own result, so an answer given here must be indistinguishable from one given on the Mac or the iPhone. `AskQuestionTest` pins it against the same literal strings the TypeScript and Swift tests use rather than trusting the three to stay in step.

The radio/checkbox markers are drawn with `Box` rather than taken from the icon set — the app bundles `material-icons-core` only, and `CheckBox`/`RadioButtonChecked` live in the extended pack. Twelve lines beat a new dependency for four glyphs.

`QuestionCardRules` exists so the routing decision — which card a transcript row draws — is testable without a Compose harness. The mistake it guards is exactly the one the desktop shipped: a structured ask routed to the approval card, offering Deny / Always allow / Allow once over a question that has no such answer.

## Platforms

| Platform | Applies? | Status |
|---|---|---|
| macOS     | n/a | #953 |
| Windows   | n/a | #953 |
| iOS       | yes | #954 |
| Android   | yes | in this PR |
| Companion | n/a | no new `/api/*` route — the answer goes through the existing `POST /api/threads/:id/respond` with `behavior: "answer"` |

## Test plan

- `cd android && ./gradlew cleanTest :core:test :app:testDebugUnitTest :app:assembleDebug` — **BUILD SUCCESSFUL**; 493 core and 863 app tests, 0 failures. New: 8 in `AskQuestionTest` (decoding, the exact answer text, an unanswered question omitted rather than implied, the settled card's lead-in) and 3 in `QuestionCardRulesTest` (which card a row draws, and the tab labels).
- **Not yet seen on a device or emulator.** Compile and unit gates pass; putting it in front of a real bot needs a paired phone and a person to answer, and the card's shape is the desktop one, which was tested on a real bot in an OMB2 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
