### PR TITLE
Android: setup checklist on What this bot does

### DIFF
--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/BotOverviewScreen.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/BotOverviewScreen.kt
@@ -9,10 +9,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -29,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.openmausbot.companion.R
 import com.openmausbot.companion.core.BotOverview
+import com.openmausbot.companion.core.Chat
 import kotlinx.coroutines.launch
 
 /**
@@ -112,7 +118,13 @@ fun BotOverviewScreen(botId: String, onBack: () -> Unit) {
                     ) {
                         CircularProgressIndicator(modifier = Modifier.size(28.dp), strokeWidth = 3.dp)
                     }
-                    current != null -> OverviewBody(current)
+                    current != null -> OverviewBody(
+                        overview = current,
+                        onSetup = {
+                            val bot = state.bot(botId) ?: return@OverviewBody
+                            scope.launch { session.send("/setup", Chat.BotChat(bot)) }
+                        },
+                    )
                     failed -> FormSection(header = null) {
                         Text(OverviewRules.FAILED, color = secondaryTint)
                     }
@@ -123,7 +135,36 @@ fun BotOverviewScreen(botId: String, onBack: () -> Unit) {
 }
 
 @Composable
-private fun OverviewBody(overview: BotOverview) {
+private fun OverviewBody(overview: BotOverview, onSetup: () -> Unit) {
+    // The setup checklist the desktop's Overview opens with. The steps point
+    // at desktop settings sections a phone cannot open, so they read as a
+    // list here; the one thing a phone can do is hand the setup to the bot
+    // itself (`ios/App/BotOverviewView.swift`).
+    val steps = overview.setup
+    val remaining = overview.remainingSetup
+    var setupSent by remember(overview) { mutableStateOf(false) }
+    if (steps != null && remaining.isNotEmpty()) {
+        FormSection(header = OverviewRules.setupHeader(steps.size - remaining.size, steps.size)) {
+            steps.forEach { step ->
+                IconNote(
+                    text = step.label,
+                    icon = if (step.done) Icons.Filled.CheckCircle else Icons.Outlined.CheckCircle,
+                    tint = if (step.done) MaterialTheme.colorScheme.primary else secondaryTint,
+                )
+            }
+            TextButton(
+                onClick = {
+                    setupSent = true
+                    onSetup()
+                },
+                enabled = !setupSent,
+            ) {
+                Text(if (setupSent) OverviewRules.SETUP_SENT else OverviewRules.SETUP_ACTION)
+            }
+            Text(OverviewRules.SETUP_FOOTER, color = secondaryTint, fontSize = 12.sp)
+        }
+    }
+
     FormSection(header = OverviewRules.WHO) {
         Text(overview.who.name, fontWeight = FontWeight.SemiBold)
         if (overview.who.title.isNotBlank()) {

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/OverviewRules.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/OverviewRules.kt
@@ -17,6 +17,14 @@ object OverviewRules {
     const val EMPTY_RECENT: String = "No changes recorded yet."
     const val FAILED: String = "Couldn't load the overview."
 
+    /** "Finish setting up · 3 of 5 done" — the checklist header, as iOS words it. */
+    fun setupHeader(done: Int, total: Int): String = "Finish setting up · $done of $total done"
+
+    const val SETUP_ACTION: String = "Set up with the bot"
+    const val SETUP_SENT: String = "Sent — see the chat"
+    const val SETUP_FOOTER: String =
+        "The bot interviews you in the chat and fills these in itself. Folders, apps and instructions are changed on your computer."
+
     const val WHO: String = "Who"
     const val DOES: String = "Does"
     const val REACHES: String = "Can reach"

--- a/android/app/src/test/kotlin/com/openmausbot/companion/ui/OverviewRulesTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/ui/OverviewRulesTest.kt
@@ -13,4 +13,9 @@ class OverviewRulesTest {
     fun `the title names the bot`() {
         assertEquals("What Maus does", OverviewRules.title("Maus"))
     }
+
+    @Test
+    fun `the checklist header counts progress the way iOS does`() {
+        assertEquals("Finish setting up · 3 of 5 done", OverviewRules.setupHeader(3, 5))
+    }
 }

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Models.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Models.kt
@@ -1019,6 +1019,19 @@ data class BotOverviewWho(val name: String, val title: String, val blurb: String
 @Serializable
 data class BotOverviewRecent(val at: Double, val summary: String)
 
+/**
+ * One step of a bot's setup checklist. [section] names the desktop settings
+ * section that finishes it; the phone cannot open that section, so it is
+ * informational here.
+ */
+@Serializable
+data class BotOverviewSetupStep(
+    val id: String,
+    val label: String,
+    val done: Boolean,
+    val section: String? = null,
+)
+
 @Serializable
 data class BotOverview(
     val who: BotOverviewWho,
@@ -1026,4 +1039,10 @@ data class BotOverview(
     val reaches: List<String> = emptyList(),
     val wont: List<String> = emptyList(),
     val recent: List<BotOverviewRecent> = emptyList(),
-)
+    /** Absent from desktops older than the checklist. */
+    val setup: List<BotOverviewSetupStep>? = null,
+) {
+    /** The steps still open, in order; empty without a checklist or when all are done. */
+    val remainingSetup: List<BotOverviewSetupStep>
+        get() = setup.orEmpty().filter { !it.done }
+}

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/DecodingTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/DecodingTest.kt
@@ -442,5 +442,20 @@ class DecodingTest {
         assertEquals("File bugs.", overview.who.soulLead)
         assertTrue(overview.does.isNotEmpty())
         assertTrue(overview.wont.isNotEmpty())
+        // the setup checklist: five steps for a bot whose engine has no
+        // connected-apps tools; "talk" happens in the chat, so no section
+        assertEquals(listOf("identity", "soul", "folder", "schedule", "talk"), overview.setup?.map { it.id })
+        assertEquals(listOf("folder", "talk"), overview.remainingSetup.map { it.id })
+        assertEquals(null, overview.setup?.last()?.section)
+        assertEquals("identity", overview.setup?.first()?.section)
+    }
+
+    @Test
+    fun anOverviewWithoutAChecklistStillDecodes() {
+        val overview = CompanionJson.decodeFromString<BotOverview>(
+            """{"who":{"name":"A","title":"","blurb":"","soulLead":""},"does":[],"reaches":[],"wont":[],"recent":[]}""",
+        )
+        assertEquals(null, overview.setup)
+        assertTrue(overview.remainingSetup.isEmpty())
     }
 }


### PR DESCRIPTION
## In plain language

The Android twin of the iOS checklist PR. "What this bot does" (profile sheet) opens with **Finish setting up · n of m done**, ticked steps for what is done, and **Set up with the bot**, which sends `/setup` to the chat so the bot interviews you and fills the rest in itself. Steps are informational on the phone: they point at desktop settings sections.

## What changed

- `android/core` `Models.kt`: `BotOverviewSetupStep`; `BotOverview.setup` (nullable for older desktops) and `remainingSetup`.
- `android/app` `BotOverviewScreen.kt`: the checklist section and button; `OverviewRules.kt`: header, action, footer copy.
- Tests: decoding the checklist from the shared fixture and an overview without one; the header rule.

## Test plan

- [x] `./gradlew :core:test :app:testDebugUnitTest :app:assembleDebug`
- [ ] On a phone paired to a Mac running #956: profile → What this bot does → Set up with the bot

Stacked on the iOS PR (base `feat/tools-checklist-ios`), which carries the recaptured fixture.

## Platforms
| Platform | Applies? | Status |
|---|---|---|
| macOS     | yes | in #956 |
| Windows   | yes | in #956 |
| iOS       | yes | in the iOS PR |
| Android   | yes | in this PR, debug build and unit tests pass; NOT run on a device |
| Companion | yes | n/a: existing routes only |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
