### PR TITLE
chore: open-core hygiene — licensing note, feature list, delete-the-folder CI, DCO + CLA, code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Maintainer review is required on the open-core boundary, the cloud seam and
+# the licensing files. Enforced when the ruleset requires code-owner review.
+/enterprise/                    @milind-soni
+/server/enterprise.ts           @milind-soni
+/server/enterprise.test.ts      @milind-soni
+/server/brand.ts                @milind-soni
+/server/tunnel.ts               @milind-soni
+/cloudflare/control-plane/      @milind-soni
+/LICENSE                        @milind-soni
+/LICENSING.md                   @milind-soni
+/CLA.md                         @milind-soni
+/.github/                       @milind-soni

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,37 @@ jobs:
           node scripts/prepare-cloudflared.mjs --current --root "$OMB_ARM64_FIXTURE"
           "$OMB_ARM64_FIXTURE/dist-native/cloudflared/linux-arm64/cloudflared" version
 
+  foss:
+    # LICENSING.md promises that deleting enterprise/ leaves a working
+    # open-source edition. Prove it on every change: typecheck, the edition
+    # tests, and a boot that reports "oss" even with a key set.
+    name: open-source edition builds without enterprise/
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Delete the enterprise folder
+        run: rm -rf enterprise
+      - run: pnpm typecheck
+      - run: pnpm exec vitest run server/enterprise.test.ts server/brand.test.ts
+      - name: The server boots and reports the open-source edition
+        run: |
+          mkdir -p /tmp/omb-foss/home
+          HOME=/tmp/omb-foss/home OMB_DATA_DIR=/tmp/omb-foss/data OMB_PORT=18797 OMB_WEBHOOK_PORT=18796 \
+            OMB_BROWSER_CONNECTION=/tmp/omb-foss/browser-connection.json OMB_LICENSE_KEY=omb1.not.real \
+            node --experimental-strip-types server/index.ts > /tmp/omb-foss/server.log 2>&1 &
+          for i in $(seq 1 60); do curl -sf http://127.0.0.1:18797/api/health >/dev/null && break; sleep 1; done
+          curl -sf http://127.0.0.1:18797/api/edition | tee /tmp/omb-foss/edition.json; echo
+          grep -q '"edition":"oss"' /tmp/omb-foss/edition.json
+          grep -q 'no enterprise layer exists' /tmp/omb-foss/edition.json
+          kill %1; wait %1 || true
+
   control-plane:
     name: control-plane check + workerd tests + dry run
     runs-on: ubuntu-latest

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,0 +1,70 @@
+# Sign-off and licensing checks for outside pull requests (LICENSING.md):
+# a DCO sign-off on every commit, and the CLA when enterprise/ changes.
+# Both run on pull_request_target so they can comment and set statuses on
+# fork pull requests; neither checks out or executes pull-request code.
+name: contributors
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  dco:
+    name: DCO sign-off
+    if: github.event_name == 'pull_request_target' && !contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      # The base branch is checked out (trusted); the pull request's commits
+      # are fetched as refs and only their metadata is read.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - run: git fetch --no-tags origin "pull/${{ github.event.pull_request.number }}/head:refs/remotes/pr/head"
+      - run: node scripts/check-dco.mjs "origin/${{ github.event.pull_request.base.ref }}" refs/remotes/pr/head
+
+  cla:
+    name: CLA for enterprise/ changes
+    if: >-
+      (github.event_name == 'pull_request_target' && !contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association))
+      || (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+      statuses: write
+    steps:
+      - name: Does this pull request touch enterprise/?
+        id: changes
+        if: github.event_name == 'pull_request_target'
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            enterprise:
+              - 'enterprise/**'
+      - name: CLA
+        if: github.event_name == 'issue_comment' || steps.changes.outputs.enterprise == 'true'
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: '.github/cla-signatures.json'
+          path-to-document: 'https://github.com/milind-soni/OpenMausBot/blob/main/CLA.md'
+          branch: 'cla-signatures'
+          allowlist: 'milind-soni,dependabot[bot],renovate[bot],github-actions[bot]'
+          custom-notsigned-prcomment: >-
+            This pull request changes files under `enterprise/`, which is under the
+            OpenMausBot Enterprise License (see LICENSING.md). Before it can be merged,
+            please sign the [CLA](https://github.com/milind-soni/OpenMausBot/blob/main/CLA.md)
+            by commenting exactly: **I have read the CLA Document and I hereby sign the CLA**.
+            Changes outside `enterprise/` need only a DCO sign-off (`git commit -s`).
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-allsigned-prcomment: 'Thank you: the CLA is signed for everyone who changed `enterprise/` here.'

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,41 @@
+# OpenMausBot Contributor License Agreement
+
+This agreement covers contributions to the `enterprise/` directory of the
+OpenMausBot repository, which is licensed under the OpenMausBot Enterprise
+License rather than Apache 2.0. Contributions anywhere else need only a
+Developer Certificate of Origin sign-off (see [LICENSING.md](LICENSING.md)).
+
+You sign by commenting on your pull request:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+It applies to every contribution you make to `enterprise/` from then on. It is
+modelled on the Apache Individual Contributor License Agreement, shortened.
+
+1. **Copyright license.** You grant Milind Soni ("the Project Owner") and
+   recipients of software distributed by the Project Owner a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable license to
+   reproduce, prepare derivative works of, publicly display, publicly perform,
+   sublicense, and distribute your contribution and such derivative works,
+   under any license, including the OpenMausBot Enterprise License and the
+   Apache License 2.0.
+2. **Patent license.** You grant the same parties a perpetual, worldwide,
+   non-exclusive, no-charge, royalty-free, irrevocable patent license to make,
+   have made, use, offer to sell, sell, import, and otherwise transfer the
+   work, for patent claims you can license that are necessarily infringed by
+   your contribution alone or by its combination with the work it was
+   submitted to.
+3. **You may grant this.** You are legally entitled to grant the above. If
+   your employer has rights to intellectual property you create, you have
+   permission to make the contribution on its behalf, or it has waived those
+   rights for the contribution.
+4. **Original work.** Each contribution is your original creation. If it
+   includes work that is not yours, you identify it and its license in the
+   pull request.
+5. **No obligation, no warranty.** The Project Owner is not obliged to use
+   your contribution. You provide it as is, without warranty of any kind, and
+   you are not required to support it.
+6. **You keep your rights.** This is a license, not an assignment. You remain
+   the owner of your contribution and may use it for any other purpose.
+
+Questions: soni.mil2001@gmail.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,6 +241,19 @@ An upstream PR should contain only the portable product change. Keep local build
 names, credentials, private endpoints, machine-specific configuration, and fork-only release notes
 out of its commits and screenshots.
 
+## Sign-off and licensing
+
+- Sign off every commit: `git commit -s` adds a `Signed-off-by:` line, which is
+  the [Developer Certificate of Origin](https://developercertificate.org/): you
+  wrote the change or have the right to submit it under the project license.
+  CI checks it on pull requests; `git rebase --signoff` fixes a branch after
+  the fact.
+- Changes under `enterprise/` (source-available, see [LICENSING.md](LICENSING.md))
+  also need the [CLA](CLA.md), signed once by commenting on the pull request
+  when the bot asks. Everything else needs only the sign-off.
+- `enterprise/`, the cloud seam and the licensing files have code owners; a
+  maintainer review is required there.
+
 ## Before you open the PR
 
 - [ ] `pnpm typecheck` and `pnpm test` pass

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,43 @@
+# Licensing
+
+OpenMausBot is open source under the [Apache License 2.0](LICENSE), with one
+carve-out and a few notes.
+
+## The carve-out: `enterprise/`
+
+Everything under `enterprise/` is source-available under the
+[OpenMausBot Enterprise License](enterprise/LICENSE), not Apache 2.0. You may
+read, build, and evaluate it, and run it freely in development and test.
+Running its features in production needs a license key issued for your
+organisation. Hosting it for third parties or white-labelling the product needs
+a partner agreement.
+
+Delete the folder and what remains is the open-source edition: the server
+reports `{"edition":"oss"}` and nothing else changes. CI proves this on every
+change (`open-source edition builds without enterprise/` in `ci.yml`). The list
+of entitlement ids the server understands is in [`enterprise/FEATURES`](enterprise/FEATURES).
+
+The routing rule for new work: could any open-source user want it? Then it goes
+in core, as a public pull request. Organisation-, admin- or tier-flavoured?
+Then it lives in `enterprise/` behind an entitlement. Customer-specific brand,
+skills, packages or connectors belong in that customer's own repository as
+data and configuration, never as a fork.
+
+## Contributions
+
+- Outside `enterprise/`: sign off your commits (`git commit -s`), which is the
+  [Developer Certificate of Origin](https://developercertificate.org/). CI checks it.
+- Inside `enterprise/`: sign the [Contributor License Agreement](CLA.md) once, by
+  commenting on your pull request. It lets the project keep that folder under
+  its own license while still accepting your work.
+- The open-core boundary, the cloud seam and this file are covered by
+  [`CODEOWNERS`](.github/CODEOWNERS): a maintainer reviews changes there.
+
+## Third-party components and trademarks
+
+Bundled third-party software keeps its own licenses; notices, license texts,
+source locations and the SBOM are listed in [NOTICE](NOTICE) and
+[`third_party/`](third_party/). The OpenMausBot name and mascot are trademarks
+of Milind Soni; the Apache License does not grant trademark rights (section 6),
+so a product built on OpenMausBot needs its own name unless a partner agreement
+says otherwise.

--- a/README.md
+++ b/README.md
@@ -384,7 +384,11 @@ AI-provider sign-in. Devices pair once with a short code. The deployment guide i
 
 ## License
 
-[Apache License 2.0](LICENSE) © 2026 Milind Soni and OpenMausBot contributors.
+[Apache License 2.0](LICENSE) © 2026 Milind Soni and OpenMausBot contributors,
+except `enterprise/`, which is source-available under its
+[own license](enterprise/LICENSE); delete that folder and what remains is the
+open-source edition. Details, including how contributions are signed off, are
+in [LICENSING.md](LICENSING.md).
 
 Packaged Cua Driver components retain their upstream MIT, SIL OFL 1.1, MPL-2.0, and other dependency terms;
 the corresponding notices, license texts, source locations, and SBOM are in

--- a/enterprise/FEATURES
+++ b/enterprise/FEATURES
@@ -1,0 +1,10 @@
+# Entitlement ids the server understands (see server/enterprise.ts).
+# id           unlocks                                                            status
+whitelabel     product name, tagline, accent, logo and support link from brand.json shipped
+sso            sign in through an OIDC issuer (a company account) with scope mapping planned
+admin          organisation, members, domains and branding sections in Settings   planned
+budgets        per-bot and per-section spend limits                               planned
+#
+# Keys may carry ids that are not shipped yet; unknown ids grant nothing, so a
+# key can be issued ahead of the feature landing. Add a line here in the same
+# pull request that adds an `entitled("id")` check.

--- a/enterprise/LICENSE
+++ b/enterprise/LICENSE
@@ -7,6 +7,7 @@ Apache License 2.0 that applies to the rest of this repository.
 
 1. Source-available. You may read, build, and evaluate this code, and you may
    modify it for your own evaluation, so that you know exactly what runs.
+   Development, test, and evaluation use is free of charge.
 
 2. Use requires a license key. Running this code with enterprise features
    enabled in production requires a valid, unexpired license key issued by
@@ -15,7 +16,10 @@ Apache License 2.0 that applies to the rest of this repository.
 
 3. No redistribution. You may not redistribute, sublicense, sell, host for
    third parties, or offer as a service this directory or any modified
-   version of it, and you may not remove or circumvent the license check.
+   version of it, and you may not remove, disable, or circumvent the license
+   check. Hosting for third parties, reselling, and white-labelling the
+   product for third parties are permitted only under a written partner
+   agreement with the copyright holder.
 
 4. Everything else is open source. Delete this directory and the remainder
    of the repository builds and runs as the open-source edition under

--- a/scripts/check-dco.mjs
+++ b/scripts/check-dco.mjs
@@ -1,0 +1,55 @@
+// Developer Certificate of Origin check for pull requests: every commit in
+// base..head carries a `Signed-off-by:` trailer whose email matches the
+// author (or the committer). Bot commits are skipped. Runs from the base
+// branch's checkout and reads commit metadata only, so an untrusted pull
+// request never executes anything here.
+//
+//   node scripts/check-dco.mjs <base-ref> <head-ref>
+import { execFileSync } from "node:child_process";
+
+const git = (...args) => execFileSync("git", args, { encoding: "utf8" });
+
+/** Commits in base..head with author, committer and full message. */
+export function commitsBetween(base, head) {
+  return git("log", "--format=%H %ae %ce", `${base}..${head}`)
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [sha, author, committer] = line.split(" ");
+      return { sha, author: author.toLowerCase(), committer: (committer ?? "").toLowerCase(), body: git("log", "-1", "--format=%B", sha) };
+    });
+}
+
+export function signedOff(commit) {
+  if (/\[bot\]/.test(commit.author)) return true;
+  const emails = [...commit.body.matchAll(/^Signed-off-by:\s*.*<([^>]+)>\s*$/gim)].map((match) => match[1].toLowerCase());
+  return emails.includes(commit.author) || emails.includes(commit.committer);
+}
+
+export function main(base, head) {
+  const commits = commitsBetween(base, head);
+  if (!commits.length) {
+    console.log("no commits to check");
+    return 0;
+  }
+  const missing = commits.filter((commit) => !signedOff(commit));
+  if (missing.length) {
+    console.error(`${missing.length} of ${commits.length} commit(s) lack a matching Signed-off-by line:`);
+    for (const commit of missing) console.error(`  ${commit.sha.slice(0, 10)}  ${commit.author}`);
+    console.error("\nfix: `git rebase --signoff <base>` then force-push; for new commits, `git commit -s`");
+    console.error("why: LICENSING.md (Developer Certificate of Origin)");
+    return 1;
+  }
+  console.log(`all ${commits.length} commit(s) signed off`);
+  return 0;
+}
+
+if (process.argv[1] && process.argv[1].endsWith("check-dco.mjs")) {
+  const [base, head] = process.argv.slice(2);
+  if (!base || !head) {
+    console.error("usage: node scripts/check-dco.mjs <base-ref> <head-ref>");
+    process.exit(2);
+  }
+  process.exit(main(base, head));
+}


### PR DESCRIPTION
Makes the open-core boundary explicit and proven, following what Chatwoot, GitLab, PostHog and Coder do with their enterprise folders. No product behaviour changes.

- **LICENSING.md** (linked from README): the `enterprise/` carve-out, the routing rule for new work (core if any OSS user could want it; `enterprise/` if org-, admin- or tier-flavoured; customer repos for customer data), how contributions are signed, trademarks.
- **enterprise/FEATURES**: the entitlement ids and their status, next to the code that checks them.
- **enterprise/LICENSE**: development, test and evaluation are free; hosting for third parties, reselling and white-labelling require a partner agreement. (Reseller deals need that clause to exist; a lawyer should read this and CLA.md once before the first one signs.)
- **CI job `foss`**: deletes `enterprise/`, typechecks, runs the edition and brand tests, boots the server with `OMB_LICENSE_KEY` set and asserts `/api/edition` reports `oss` with the "no enterprise layer" notice. Verified locally the same way (typecheck clean, 12 tests, boot smoke OK).
- **DCO + CLA** (`.github/workflows/contributors.yml`): a DCO sign-off check for every commit from outside contributors, run from the trusted base checkout on `pull_request_target` reading commit metadata only (never executes PR code); a CLA prompt only when a PR touches `enterprise/`, GitLab's split. `scripts/check-dco.mjs` is mutation-checked: a signed commit passes, an unsigned one fails. Owner and member authors are exempt from the DCO job so Codex-driven PRs from this account keep flowing.
- **CODEOWNERS** on `enterprise/`, the enterprise and tunnel seams, the control plane, and the licensing files.

After merge, two repository settings by the owner: require code-owner review on `main`, and (optionally) add `open-source edition builds without enterprise/` and `DCO sign-off` as required checks. The CLA bot stores signatures on a `cla-signatures` branch it creates on first use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the project’s open-source and enterprise licensing model.
  - Added guidance for contribution sign-offs, enterprise agreements, and maintainer review.
  - Documented available and planned enterprise entitlements.
  - Updated the README with licensing and open-source edition details.

- **Chores**
  - Added automated checks for contributor sign-offs and required enterprise agreements.
  - Added validation to confirm the open-source edition builds, starts, and reports the correct edition.
  - Clarified enterprise license permissions and restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->