### PR TITLE
Android: opt-in background connection so scheduled reminders survive the app being closed

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,17 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <!--
+      Opt-in "always on" background connection (Settings toggle, default off).
+      FOREGROUND_SERVICE_CONNECTED_DEVICE rather than dataSync: this service
+      exists to keep the pairing to the paired computer alive, not to move
+      data in bulk, and dataSync foreground services face a ~6h/24h system
+      timeout on Android 15+ that connectedDevice does not.
+    -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <!--
       Pairing QR only, and asked for only when the scanner is opened. The app is
       fully usable without it: the NSD list and a typed address are the other two
       ways in (§6), so a camera the user never grants costs nothing.
@@ -185,6 +196,32 @@
             android:name=".lifecycle.SessionLingerService"
             android:exported="false"
             android:stopWithTask="true" />
+
+        <!--
+          The opt-in "always on" counterpart to SessionLingerService above.
+          stopWithTask="false" is the whole point: this must keep running when
+          the user swipes the app away, which is exactly what the 25-second
+          linger window above does not attempt.
+        -->
+        <service
+            android:name=".lifecycle.AlwaysOnConnectionService"
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice"
+            android:stopWithTask="false" />
+
+        <!--
+          Restarts AlwaysOnConnectionService after a reboot, only when the user
+          left the Settings toggle on. Not exported beyond what BOOT_COMPLETED
+          requires; carries no data and does nothing when the toggle is off.
+        -->
+        <receiver
+            android:name=".lifecycle.AlwaysOnBootReceiver"
+            android:exported="true"
+            android:permission="android.permission.RECEIVE_BOOT_COMPLETED">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
 
         <!--
           Share sheet hand-off for exported transcripts. Not exported, no

--- a/android/app/src/main/kotlin/com/openmausbot/companion/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/MainActivity.kt
@@ -17,10 +17,12 @@ import androidx.compose.runtime.getValue
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import com.openmausbot.companion.dictation.SpeechDictation
+import com.openmausbot.companion.lifecycle.AlwaysOnConnectionService
 import com.openmausbot.companion.notifications.notificationTarget
 import com.openmausbot.companion.browser.CloudDesktopBrowser
 import com.openmausbot.companion.sharing.TranscriptSharing
 import com.openmausbot.companion.storage.ChatPreferences
+import android.os.PowerManager
 import com.openmausbot.companion.ui.CameraPermissionController
 import com.openmausbot.companion.ui.ChatDraftHolder
 import com.openmausbot.companion.ui.CompanionEnvironment
@@ -182,6 +184,8 @@ class MainActivity : ComponentActivity() {
             shareTranscript = sharing::share,
             openCloudDesktop = browser::open,
             shareInbox = app.shareInbox,
+            alwaysOnEnabled = app.alwaysOn.enabled,
+            onToggleAlwaysOn = ::toggleAlwaysOn,
         )
 
         handleIntent(intent)
@@ -266,6 +270,38 @@ class MainActivity : ComponentActivity() {
                 data = Uri.fromParts("package", packageName, null)
             },
         )
+    }
+
+    /**
+     * Flip the setting, start/stop the service to match, and — only when
+     * turning it on — ask once to be exempted from battery optimizations.
+     * Without that exemption Android's Doze/App Standby can still suspend a
+     * foreground service's network access on some OEM skins, which would make
+     * the persistent notification a lie. This is a plain `startActivity`, not a
+     * permission launcher: the system dialog's own Allow/Deny is the answer,
+     * and `onResume`'s refresh (via `NotificationPermissionController` et al.)
+     * already covers "state changed while backgrounded" for the rest of the
+     * screen, so nothing here needs to await a result.
+     */
+    private fun toggleAlwaysOn() {
+        val enabling = !app.alwaysOn.enabled.value
+        app.alwaysOn.setEnabled(enabling)
+        if (enabling) {
+            AlwaysOnConnectionService.start(this)
+            requestIgnoreBatteryOptimizations()
+        } else {
+            AlwaysOnConnectionService.stop(this)
+        }
+    }
+
+    private fun requestIgnoreBatteryOptimizations() {
+        val powerManager = getSystemService(PowerManager::class.java) ?: return
+        if (powerManager.isIgnoringBatteryOptimizations(packageName)) return
+        val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
+            .setData(Uri.parse("package:$packageName"))
+        if (intent.resolveActivity(packageManager) != null) {
+            startActivity(intent)
+        }
     }
 
     private fun preferredLanguageTags(): List<String> {

--- a/android/app/src/main/kotlin/com/openmausbot/companion/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/MainActivity.kt
@@ -29,6 +29,7 @@ import com.openmausbot.companion.ui.CompanionEnvironment
 import com.openmausbot.companion.ui.CompanionRoot
 import com.openmausbot.companion.ui.LocalCompanion
 import com.openmausbot.companion.ui.MicPermissionController
+import com.openmausbot.companion.ui.NotificationAccess
 import com.openmausbot.companion.ui.NotificationPermissionController
 import com.openmausbot.companion.ui.PermissionPreferences
 import com.openmausbot.companion.ui.PermissionRequests
@@ -285,7 +286,14 @@ class MainActivity : ComponentActivity() {
      */
     private fun toggleAlwaysOn() {
         val enabling = !app.alwaysOn.enabled.value
-        app.alwaysOn.setEnabled(enabling)
+        if (enabling && notifications.access.value != NotificationAccess.GRANTED) {
+            // A background connection whose notifications can't post is a
+            // foreground service and battery cost for nothing — send the user
+            // to fix that first instead of turning this on silently broken.
+            notifications.act()
+            return
+        }
+        if (!app.alwaysOn.setEnabled(enabling)) return
         if (enabling) {
             AlwaysOnConnectionService.start(this)
             requestIgnoreBatteryOptimizations()

--- a/android/app/src/main/kotlin/com/openmausbot/companion/OpenMausApp.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/OpenMausApp.kt
@@ -6,12 +6,15 @@ import com.openmausbot.companion.audio.VoicePreviewPlayer
 import com.openmausbot.companion.avatar.AvatarImageStore
 import com.openmausbot.companion.core.Session
 import com.openmausbot.companion.discovery.NsdDiscovery
+import com.openmausbot.companion.lifecycle.AlwaysOnConnectionService
+import com.openmausbot.companion.lifecycle.AlwaysOnConnectionState
 import com.openmausbot.companion.lifecycle.ServiceProcessAnchor
 import com.openmausbot.companion.lifecycle.SessionLingerController
 import com.openmausbot.companion.lifecycle.installSessionLinger
 import com.openmausbot.companion.notifications.LocalNotificationPoster
 import com.openmausbot.companion.permissions.CompanionPermissions
 import com.openmausbot.companion.sharing.ShareInbox
+import com.openmausbot.companion.storage.AlwaysOnPreferences
 import com.openmausbot.companion.storage.DataStoreConnectionStore
 import com.openmausbot.companion.storage.OnboardingPreferences
 import com.openmausbot.companion.storage.KeystoreTokenStore
@@ -54,6 +57,8 @@ class OpenMausApp : Application() {
     lateinit var linger: SessionLingerController
         private set
     lateinit var shareInbox: ShareInbox
+        private set
+    lateinit var alwaysOn: AlwaysOnPreferences
         private set
 
     override fun onCreate() {
@@ -103,6 +108,17 @@ class OpenMausApp : Application() {
             session = session,
             scope = appScope,
             anchor = ServiceProcessAnchor(this),
+            alwaysOn = { AlwaysOnConnectionState.active },
         )
+
+        alwaysOn = AlwaysOnPreferences(this)
+        // Covers the case where the process was relaunched (not booted) while
+        // the setting was on — e.g. the OS killed the whole app under memory
+        // pressure and the user (or a notification tap) reopened it. A device
+        // reboot is covered separately by AlwaysOnBootReceiver, which can run
+        // before anything ever constructs this Application's Activity.
+        if (alwaysOn.enabled.value) {
+            AlwaysOnConnectionService.start(this)
+        }
     }
 }

--- a/android/app/src/main/kotlin/com/openmausbot/companion/lifecycle/AlwaysOnBootReceiver.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/lifecycle/AlwaysOnBootReceiver.kt
@@ -1,0 +1,21 @@
+package com.openmausbot.companion.lifecycle
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.openmausbot.companion.storage.AlwaysOnPreferences
+
+/**
+ * Restarts [AlwaysOnConnectionService] after a reboot, if the user had it
+ * enabled. Android does not carry a running foreground service across a
+ * restart on its own — without this, always-on mode would silently stop
+ * working every time the phone rebooted until the user next opened the app.
+ */
+class AlwaysOnBootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
+        if (AlwaysOnPreferences(context).enabled.value) {
+            AlwaysOnConnectionService.start(context)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/openmausbot/companion/lifecycle/AlwaysOnConnectionService.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/lifecycle/AlwaysOnConnectionService.kt
@@ -46,7 +46,13 @@ class AlwaysOnConnectionService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         startForeground(NOTIFICATION_ID, buildNotification())
         AlwaysOnConnectionState.active = true
-        (application as OpenMausApp).session.connect()
+        val app = application as OpenMausApp
+        // Closes the race where the toggle turns this on and the app
+        // backgrounds before this callback runs: SessionLingerController may
+        // already have opened its own 25s window, whose timer would otherwise
+        // disconnect the session this service now depends on staying open.
+        app.linger.onAlwaysOnStarted()
+        app.session.connect()
         return START_STICKY
     }
 

--- a/android/app/src/main/kotlin/com/openmausbot/companion/lifecycle/AlwaysOnConnectionService.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/lifecycle/AlwaysOnConnectionService.kt
@@ -1,0 +1,99 @@
+package com.openmausbot.companion.lifecycle
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import com.openmausbot.companion.OpenMausApp
+import com.openmausbot.companion.R
+
+/**
+ * The opt-in counterpart to [SessionLingerService]: instead of a short window
+ * after the app leaves the screen, this holds the process out of the `cached`
+ * class indefinitely, so a notify frame that arrives with the app fully closed
+ * still reaches [com.openmausbot.companion.notifications.LocalNotificationPoster].
+ *
+ * Deliberately a real foreground service — `startForeground` with a visible,
+ * silent, ongoing notification — because that is the one supported way to ask
+ * Android for a background process that outlives [SessionLingerController]'s
+ * 25-second grace window. The persistent notification is the cost of that; it
+ * is not a bug to hide.
+ *
+ * `stopWithTask="false"` in the manifest is load-bearing: the whole point is
+ * surviving the user swiping the app away, which is the opposite of
+ * [SessionLingerService]'s `stopWithTask="true"`.
+ *
+ * `START_STICKY`: if the OS still kills this under memory pressure despite the
+ * foreground grant, it restarts with a null Intent and `onStartCommand` runs
+ * the same setup again — connect() is idempotent (`Session.kt` only opens a
+ * stream when `client == null || streamJob == null`), so a restart is a no-op
+ * beyond re-asserting the flag and the notification.
+ */
+class AlwaysOnConnectionService : Service() {
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        ensureChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        startForeground(NOTIFICATION_ID, buildNotification())
+        AlwaysOnConnectionState.active = true
+        (application as OpenMausApp).session.connect()
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        AlwaysOnConnectionState.active = false
+        super.onDestroy()
+    }
+
+    private fun buildNotification(): Notification =
+        NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_maus_mark)
+            .setContentTitle(getString(R.string.always_on_notification_title))
+            .setContentText(getString(R.string.always_on_notification_text))
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOngoing(true)
+            .setSilent(true)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .build()
+
+    private fun ensureChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val system = getSystemService(NotificationManager::class.java) ?: return
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            getString(R.string.notification_channel_always_on),
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            description = getString(R.string.notification_channel_always_on_desc)
+            setShowBadge(false)
+        }
+        system.createNotificationChannel(channel)
+    }
+
+    companion object {
+        const val CHANNEL_ID = "always_on_status"
+        const val NOTIFICATION_ID = 1
+
+        /** Idempotent: `ContextCompat.startForegroundService` is safe to call while already running. */
+        fun start(context: Context) {
+            androidx.core.content.ContextCompat.startForegroundService(
+                context,
+                Intent(context, AlwaysOnConnectionService::class.java),
+            )
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, AlwaysOnConnectionService::class.java))
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/openmausbot/companion/lifecycle/AlwaysOnConnectionState.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/lifecycle/AlwaysOnConnectionState.kt
@@ -1,0 +1,19 @@
+package com.openmausbot.companion.lifecycle
+
+/**
+ * Whether [AlwaysOnConnectionService] is currently the reason the stream stays
+ * open. [SessionLingerController.onStop] reads this before starting its own
+ * 25-second window; when it is true the linger window is skipped entirely —
+ * the service is already holding the process out of the cached class for as
+ * long as the user left always-on enabled, so a 25-second timer racing it
+ * would only ever be redundant or, on the service's own `onDestroy`, premature.
+ *
+ * Both the write (service `onCreate`/`onDestroy`) and the read
+ * ([SessionLingerController], installed on `ProcessLifecycleOwner`) happen on
+ * the main thread, matching [SessionLingerController]'s own "main-thread
+ * confined" invariant — no lock needed.
+ */
+object AlwaysOnConnectionState {
+    var active: Boolean = false
+        internal set
+}

--- a/android/app/src/main/kotlin/com/openmausbot/companion/lifecycle/SessionLingerController.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/lifecycle/SessionLingerController.kt
@@ -141,6 +141,24 @@ class SessionLingerController(
     }
 
     /**
+     * [AlwaysOnConnectionService] just took over holding the process open.
+     * `alwaysOn()` only stops a *new* trip from opening its own window
+     * ([onStop]); it does not reach one already in flight when the service
+     * races it — the toggle can be flipped on and the app backgrounded before
+     * `onStartCommand` runs, opening a window here first. Left alone, that
+     * window's own timer would call `session.disconnect()` at its 25s deadline
+     * out from under the service that now depends on the same connection. Tear
+     * it down without touching the session, which the service owns from here.
+     */
+    fun onAlwaysOnStarted() {
+        val token = openToken ?: return
+        openToken = null
+        timer?.cancel()
+        timer = null
+        anchor.stop(token)
+    }
+
+    /**
      * Whether this background trip can plausibly still receive frames.
      *
      * Status alone is not enough: right after a successful pairing there is a

--- a/android/app/src/main/kotlin/com/openmausbot/companion/lifecycle/SessionLingerController.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/lifecycle/SessionLingerController.kt
@@ -42,6 +42,12 @@ class SessionLingerController(
     private val session: Session,
     private val scope: CoroutineScope,
     private val anchor: ProcessAnchor,
+    /**
+     * True while [AlwaysOnConnectionService] is holding the process open on its
+     * own. Defaults to "never" so every existing caller/test is unaffected;
+     * production wires it to [AlwaysOnConnectionState.active].
+     */
+    private val alwaysOn: () -> Boolean = { false },
 ) : DefaultLifecycleObserver {
 
     /**
@@ -92,6 +98,11 @@ class SessionLingerController(
 
     override fun onStop(owner: LifecycleOwner) {
         foreground = false
+        // AlwaysOnConnectionService is already holding the process open for as
+        // long as the user left it enabled — this window would only ever be
+        // redundant (service still running) or premature (service between
+        // onDestroy and its own restart), so skip it entirely rather than race it.
+        if (alwaysOn()) return
         if (openToken != null) return
         if (!worthHolding()) {
             session.disconnect()
@@ -171,8 +182,9 @@ internal fun installSessionLinger(
     session: Session,
     scope: CoroutineScope,
     anchor: SessionLingerController.ProcessAnchor,
+    alwaysOn: () -> Boolean = { false },
 ): SessionLingerController {
-    val controller = SessionLingerController(session, scope, anchor)
+    val controller = SessionLingerController(session, scope, anchor, alwaysOn)
     anchor.attach(controller)
     lifecycle.addObserver(controller)
     return controller

--- a/android/app/src/main/kotlin/com/openmausbot/companion/notifications/LocalNotificationPoster.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/notifications/LocalNotificationPoster.kt
@@ -98,10 +98,20 @@ class LocalNotificationPoster(
         val done = NotificationChannel(
             NotificationMapping.CHANNEL_DONE,
             appContext.getString(R.string.notification_channel_done),
-            NotificationManager.IMPORTANCE_DEFAULT,
+            // HIGH so this pops up (heads-up banner + lock screen) with sound,
+            // the way a normal messaging app does — DEFAULT only shows quietly
+            // in the shade. Kate's ask (2026-09-08): every bot message, not just
+            // approvals, should read as "interesting app noise" rather than sit
+            // unnoticed until she happens to pull the shade down.
+            NotificationManager.IMPORTANCE_HIGH,
         ).apply {
             description = appContext.getString(R.string.notification_channel_done_desc)
         }
+        // The old channel this replaced. Deleting it (rather than leaving it
+        // orphaned) keeps Settings -> App notifications from showing a dead
+        // "Finished work" entry alongside the new one; harmless no-op if it was
+        // never created on this install.
+        system.deleteNotificationChannel(LEGACY_CHANNEL_DONE)
         val routine = NotificationChannel(
             NotificationMapping.CHANNEL_ROUTINE_FAILED,
             appContext.getString(R.string.notification_channel_routine),
@@ -133,5 +143,8 @@ class LocalNotificationPoster(
 
         /** Permission string for the UI pass's launcher contract. */
         const val POST_NOTIFICATIONS_PERMISSION = Manifest.permission.POST_NOTIFICATIONS
+
+        /** The channel id [NotificationMapping.CHANNEL_DONE] replaced. See its kdoc. */
+        private const val LEGACY_CHANNEL_DONE = "done"
     }
 }

--- a/android/app/src/main/kotlin/com/openmausbot/companion/notifications/LocalNotificationPoster.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/notifications/LocalNotificationPoster.kt
@@ -95,15 +95,30 @@ class LocalNotificationPoster(
         ).apply {
             description = appContext.getString(R.string.notification_channel_blocking_desc)
         }
-        val done = NotificationChannel(
-            NotificationMapping.CHANNEL_DONE,
-            appContext.getString(R.string.notification_channel_done),
+        // The legacy channel could only ever be at DEFAULT or something the
+        // user explicitly lowered it to in system settings (Android caps a
+        // channel at what the app first declared, so DEFAULT is the ceiling).
+        // A lower importance is therefore a deliberate mute, not a default —
+        // deleting the channel and starting fresh at HIGH would silently
+        // override that choice. Carry it forward; only a fresh install or an
+        // untouched legacy channel gets the HIGH bump Kate asked for.
+        val legacyImportance = system.getNotificationChannel(LEGACY_CHANNEL_DONE)?.importance
+        val doneImportance = if (legacyImportance != null &&
+            legacyImportance < NotificationManager.IMPORTANCE_DEFAULT
+        ) {
+            legacyImportance
+        } else {
             // HIGH so this pops up (heads-up banner + lock screen) with sound,
             // the way a normal messaging app does — DEFAULT only shows quietly
             // in the shade. Kate's ask (2026-09-08): every bot message, not just
             // approvals, should read as "interesting app noise" rather than sit
             // unnoticed until she happens to pull the shade down.
-            NotificationManager.IMPORTANCE_HIGH,
+            NotificationManager.IMPORTANCE_HIGH
+        }
+        val done = NotificationChannel(
+            NotificationMapping.CHANNEL_DONE,
+            appContext.getString(R.string.notification_channel_done),
+            doneImportance,
         ).apply {
             description = appContext.getString(R.string.notification_channel_done_desc)
         }

--- a/android/app/src/main/kotlin/com/openmausbot/companion/notifications/LocalNotificationPoster.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/notifications/LocalNotificationPoster.kt
@@ -119,11 +119,11 @@ class LocalNotificationPoster(
             // legacy channel gets the HIGH bump Kate asked for. This whole
             // branch only runs the one time `bot_messages` doesn't exist yet,
             // so it can't re-fire on every launch and re-decide anything.
-            val legacyImportance = system.getNotificationChannel(LEGACY_CHANNEL_DONE)?.importance
-            val doneImportance = if (legacyImportance != null &&
-                legacyImportance < NotificationManager.IMPORTANCE_DEFAULT
+            val legacyDone = system.getNotificationChannel(LEGACY_CHANNEL_DONE)
+            val doneImportance = if (legacyDone != null &&
+                legacyDone.importance < NotificationManager.IMPORTANCE_DEFAULT
             ) {
-                legacyImportance
+                legacyDone.importance
             } else {
                 // HIGH so this pops up (heads-up banner + lock screen) with sound,
                 // the way a normal messaging app does — DEFAULT only shows quietly
@@ -139,6 +139,19 @@ class LocalNotificationPoster(
                     doneImportance,
                 ).apply {
                     description = appContext.getString(R.string.notification_channel_done_desc)
+                    // Importance isn't the only thing a person can customize on a
+                    // channel — a picked sound, an intentionally silent one
+                    // (sound=null), vibration, and lock-screen visibility all
+                    // deserve the same carry-forward as importance above: copy
+                    // them straight off the legacy channel rather than letting
+                    // this constructor's plain defaults silently win. A fresh
+                    // install has no legacy channel, so this is a no-op there.
+                    if (legacyDone != null) {
+                        setSound(legacyDone.sound, legacyDone.audioAttributes)
+                        enableVibration(legacyDone.shouldVibrate())
+                        vibrationPattern = legacyDone.vibrationPattern
+                        lockscreenVisibility = legacyDone.lockscreenVisibility
+                    }
                 },
             )
         }

--- a/android/app/src/main/kotlin/com/openmausbot/companion/notifications/LocalNotificationPoster.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/notifications/LocalNotificationPoster.kt
@@ -88,53 +88,77 @@ class LocalNotificationPoster(
     fun ensureChannels() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
         val system = appContext.getSystemService(NotificationManager::class.java) ?: return
-        val blocking = NotificationChannel(
-            NotificationMapping.CHANNEL_BLOCKING,
-            appContext.getString(R.string.notification_channel_blocking),
-            NotificationManager.IMPORTANCE_HIGH,
-        ).apply {
-            description = appContext.getString(R.string.notification_channel_blocking_desc)
+
+        // Re-creating a channel that already exists is supposed to be a no-op
+        // for anything but name/description, but a plain process restart on
+        // Kate's S26+ (2026-09-09) reset a custom sound she had picked for
+        // `bot_messages` — the channel's own mUserLockedFields showed
+        // visibility+lights locked but *not* sound, so this call's freshly
+        // built (soundless) NotificationChannel object was silently winning.
+        // Only ever create each channel once; leave an existing one alone,
+        // full stop, so nothing this call passes can clobber a real pick.
+        if (system.getNotificationChannel(NotificationMapping.CHANNEL_BLOCKING) == null) {
+            system.createNotificationChannel(
+                NotificationChannel(
+                    NotificationMapping.CHANNEL_BLOCKING,
+                    appContext.getString(R.string.notification_channel_blocking),
+                    NotificationManager.IMPORTANCE_HIGH,
+                ).apply {
+                    description = appContext.getString(R.string.notification_channel_blocking_desc)
+                },
+            )
         }
-        // The legacy channel could only ever be at DEFAULT or something the
-        // user explicitly lowered it to in system settings (Android caps a
-        // channel at what the app first declared, so DEFAULT is the ceiling).
-        // A lower importance is therefore a deliberate mute, not a default —
-        // deleting the channel and starting fresh at HIGH would silently
-        // override that choice. Carry it forward; only a fresh install or an
-        // untouched legacy channel gets the HIGH bump Kate asked for.
-        val legacyImportance = system.getNotificationChannel(LEGACY_CHANNEL_DONE)?.importance
-        val doneImportance = if (legacyImportance != null &&
-            legacyImportance < NotificationManager.IMPORTANCE_DEFAULT
-        ) {
-            legacyImportance
-        } else {
-            // HIGH so this pops up (heads-up banner + lock screen) with sound,
-            // the way a normal messaging app does — DEFAULT only shows quietly
-            // in the shade. Kate's ask (2026-09-08): every bot message, not just
-            // approvals, should read as "interesting app noise" rather than sit
-            // unnoticed until she happens to pull the shade down.
-            NotificationManager.IMPORTANCE_HIGH
-        }
-        val done = NotificationChannel(
-            NotificationMapping.CHANNEL_DONE,
-            appContext.getString(R.string.notification_channel_done),
-            doneImportance,
-        ).apply {
-            description = appContext.getString(R.string.notification_channel_done_desc)
+
+        if (system.getNotificationChannel(NotificationMapping.CHANNEL_DONE) == null) {
+            // The legacy channel could only ever be at DEFAULT or something the
+            // user explicitly lowered it to in system settings (Android caps a
+            // channel at what the app first declared, so DEFAULT is the
+            // ceiling). A lower importance is therefore a deliberate mute, not
+            // a default — starting fresh at HIGH would silently override that
+            // choice. Carry it forward; only a fresh install or an untouched
+            // legacy channel gets the HIGH bump Kate asked for. This whole
+            // branch only runs the one time `bot_messages` doesn't exist yet,
+            // so it can't re-fire on every launch and re-decide anything.
+            val legacyImportance = system.getNotificationChannel(LEGACY_CHANNEL_DONE)?.importance
+            val doneImportance = if (legacyImportance != null &&
+                legacyImportance < NotificationManager.IMPORTANCE_DEFAULT
+            ) {
+                legacyImportance
+            } else {
+                // HIGH so this pops up (heads-up banner + lock screen) with sound,
+                // the way a normal messaging app does — DEFAULT only shows quietly
+                // in the shade. Kate's ask (2026-09-08): every bot message, not just
+                // approvals, should read as "interesting app noise" rather than sit
+                // unnoticed until she happens to pull the shade down.
+                NotificationManager.IMPORTANCE_HIGH
+            }
+            system.createNotificationChannel(
+                NotificationChannel(
+                    NotificationMapping.CHANNEL_DONE,
+                    appContext.getString(R.string.notification_channel_done),
+                    doneImportance,
+                ).apply {
+                    description = appContext.getString(R.string.notification_channel_done_desc)
+                },
+            )
         }
         // The old channel this replaced. Deleting it (rather than leaving it
         // orphaned) keeps Settings -> App notifications from showing a dead
-        // "Finished work" entry alongside the new one; harmless no-op if it was
-        // never created on this install.
+        // "Finished work" entry alongside the new one; harmless no-op once
+        // it's already gone.
         system.deleteNotificationChannel(LEGACY_CHANNEL_DONE)
-        val routine = NotificationChannel(
-            NotificationMapping.CHANNEL_ROUTINE_FAILED,
-            appContext.getString(R.string.notification_channel_routine),
-            NotificationManager.IMPORTANCE_DEFAULT,
-        ).apply {
-            description = appContext.getString(R.string.notification_channel_routine_desc)
+
+        if (system.getNotificationChannel(NotificationMapping.CHANNEL_ROUTINE_FAILED) == null) {
+            system.createNotificationChannel(
+                NotificationChannel(
+                    NotificationMapping.CHANNEL_ROUTINE_FAILED,
+                    appContext.getString(R.string.notification_channel_routine),
+                    NotificationManager.IMPORTANCE_DEFAULT,
+                ).apply {
+                    description = appContext.getString(R.string.notification_channel_routine_desc)
+                },
+            )
         }
-        system.createNotificationChannels(listOf(blocking, done, routine))
     }
 
     /** True when the platform will accept a notification post right now. */

--- a/android/app/src/main/kotlin/com/openmausbot/companion/notifications/NotificationMapping.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/notifications/NotificationMapping.kt
@@ -8,7 +8,15 @@ import com.openmausbot.companion.core.NotificationFrame
  */
 object NotificationMapping {
     const val CHANNEL_BLOCKING = "approval_question"
-    const val CHANNEL_DONE = "done"
+    /**
+     * A new channel id, not "done": Android locks a channel's importance the
+     * moment it is first created on a device — an app can never raise it later,
+     * only the user can, in system Settings. "done" already exists at DEFAULT
+     * importance on every phone with an older build installed, so making bot
+     * replies pop up like a normal message (Kate's ask, 2026-09-08) requires a
+     * fresh channel id rather than reconfiguring this one.
+     */
+    const val CHANNEL_DONE = "bot_messages"
     const val CHANNEL_ROUTINE_FAILED = "routine_failed"
 
     fun channelId(notification: NotificationFrame): String = when (notification.kind) {

--- a/android/app/src/main/kotlin/com/openmausbot/companion/storage/AlwaysOnPreferences.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/storage/AlwaysOnPreferences.kt
@@ -1,0 +1,40 @@
+package com.openmausbot.companion.storage
+
+import android.content.Context
+import android.content.SharedPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * The one durable switch for "keep the stream open even when the app is not
+ * on screen" — off by default, since it trades a persistent notification and
+ * some battery for notifications that survive the app being fully closed.
+ *
+ * Read synchronously at process start ([OpenMausApp.onCreate]) so the boot
+ * receiver and the always-on service can decide whether to run before any
+ * Activity exists. `commit()`, not `apply()`: the toggle in Settings starts or
+ * stops [com.openmausbot.companion.lifecycle.AlwaysOnConnectionService] right
+ * after writing, and that decision must see the value that was just written,
+ * not a write still queued for a background thread.
+ */
+class AlwaysOnPreferences(private val prefs: SharedPreferences) {
+
+    constructor(context: Context) : this(
+        context.applicationContext.getSharedPreferences(NAME, Context.MODE_PRIVATE),
+    )
+
+    private val _enabled = MutableStateFlow(prefs.getBoolean(KEY_ENABLED, false))
+    val enabled: StateFlow<Boolean> = _enabled.asStateFlow()
+
+    fun setEnabled(value: Boolean) {
+        if (_enabled.value == value) return
+        prefs.edit().putBoolean(KEY_ENABLED, value).commit()
+        _enabled.value = value
+    }
+
+    companion object {
+        const val NAME = "openmaus.always_on"
+        const val KEY_ENABLED = "enabled"
+    }
+}

--- a/android/app/src/main/kotlin/com/openmausbot/companion/storage/AlwaysOnPreferences.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/storage/AlwaysOnPreferences.kt
@@ -27,10 +27,12 @@ class AlwaysOnPreferences(private val prefs: SharedPreferences) {
     private val _enabled = MutableStateFlow(prefs.getBoolean(KEY_ENABLED, false))
     val enabled: StateFlow<Boolean> = _enabled.asStateFlow()
 
-    fun setEnabled(value: Boolean) {
-        if (_enabled.value == value) return
-        prefs.edit().putBoolean(KEY_ENABLED, value).commit()
-        _enabled.value = value
+    /** @return false when the write failed — callers must not act as if it took. */
+    fun setEnabled(value: Boolean): Boolean {
+        if (_enabled.value == value) return true
+        val saved = prefs.edit().putBoolean(KEY_ENABLED, value).commit()
+        if (saved) _enabled.value = value
+        return saved
     }
 
     companion object {

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/CompanionEnvironment.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/CompanionEnvironment.kt
@@ -130,6 +130,10 @@ class CompanionEnvironment(
     val openCloudDesktop: (URI) -> String?,
     /** Inbound share copied off the sending app's Intent. */
     val shareInbox: ShareInbox,
+    /** Whether [com.openmausbot.companion.lifecycle.AlwaysOnConnectionService] is enabled. */
+    val alwaysOnEnabled: StateFlow<Boolean>,
+    /** Flips the always-on setting and starts/stops the service to match. */
+    val onToggleAlwaysOn: () -> Unit,
 )
 
 val LocalCompanion = staticCompositionLocalOf<CompanionEnvironment> {

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/SettingsScreen.kt
@@ -209,6 +209,25 @@ fun SettingsScreen(
                 Footnote(SettingsPolicy.NOTIFICATIONS_FOOTER)
             }
 
+            SettingsSection("Background connection") {
+                val alwaysOnEnabled by environment.alwaysOnEnabled.collectAsState()
+                SettingsRow("Status", if (alwaysOnEnabled) "Always on" else "Only while open")
+                SettingsButton(
+                    text = if (alwaysOnEnabled) "Turn off" else "Turn on",
+                    onClick = environment.onToggleAlwaysOn,
+                )
+                Footnote(
+                    if (alwaysOnEnabled) {
+                        "OpenMausBot keeps a permanent notification while this is on, so scheduled " +
+                            "reminders and routine results reach you even with the app fully closed."
+                    } else {
+                        "Notifications only arrive while the app is open or was recently backgrounded. " +
+                            "Turn this on if you rely on scheduled routines to notify you later — it adds " +
+                            "a permanent low-priority notification and uses a little more battery."
+                    },
+                )
+            }
+
             SettingsSection("Chat") {
                 SettingsRow("Activity", activityDetail.label)
                 SettingsButton("Change activity detail") { choosingActivity = true }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -3,8 +3,12 @@
     <string name="app_name">OpenMausMobile</string>
     <string name="notification_channel_blocking">Approvals and questions</string>
     <string name="notification_channel_blocking_desc">Time-sensitive prompts that need an answer</string>
-    <string name="notification_channel_done">Finished work</string>
-    <string name="notification_channel_done_desc">When a bot finishes a turn</string>
+    <string name="notification_channel_done">Bot messages</string>
+    <string name="notification_channel_done_desc">When a bot replies or finishes a turn — pops up with sound, like a normal message</string>
     <string name="notification_channel_routine">Routine failures</string>
     <string name="notification_channel_routine_desc">When a scheduled routine fails</string>
+    <string name="notification_channel_always_on">Background connection</string>
+    <string name="notification_channel_always_on_desc">Shown while OpenMausBot stays connected in the background</string>
+    <string name="always_on_notification_title">MausBot is staying connected</string>
+    <string name="always_on_notification_text">Notifications will reach you even with the app closed</string>
 </resources>

--- a/android/app/src/test/kotlin/com/openmausbot/companion/lifecycle/SessionLingerTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/lifecycle/SessionLingerTest.kt
@@ -331,6 +331,43 @@ class SessionLingerTest {
         assertNull(currentController.openWindow)
     }
 
+    // ------------------------------------------------------- always-on race
+
+    /**
+     * The race CodeRabbit flagged on PR #966: the always-on toggle is turned
+     * on and the app backgrounds before `AlwaysOnConnectionService.onStartCommand`
+     * runs, so this controller opens its own window first. Without the
+     * handoff, that window's 25s timer would call `session.disconnect()` out
+     * from under the service that now depends on the same connection.
+     */
+    @Test
+    fun `always-on starting after ON_STOP cancels the window without disconnecting`() = runTest {
+        val stream = FakeStream()
+        val sink = RecordingSink()
+        val session = session(stream, sink)
+        val owner = live(session, stream)
+
+        owner.registry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+        runCurrent()
+        assertEquals(1, stream.collectors)
+        assertEquals(listOf(1L), currentAnchor.started)
+
+        // AlwaysOnConnectionService won the race and started after this
+        // window was already open.
+        currentController.onAlwaysOnStarted()
+        assertEquals(listOf(1L), currentAnchor.stopped)
+        assertNull(currentController.openWindow)
+
+        // The window's own deadline must not still fire and disconnect what
+        // the service now depends on staying open.
+        advanceTimeBy(30_000)
+        runCurrent()
+        assertEquals(1, stream.collectors)
+        stream.emit(notify("done", seq = 50))
+        runCurrent()
+        assertEquals(1, sink.delivered.size)
+    }
+
     // ---------------------------------------------------------------- §5.7
 
     @Test

--- a/android/app/src/test/kotlin/com/openmausbot/companion/lifecycle/SessionLingerWiringTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/lifecycle/SessionLingerWiringTest.kt
@@ -94,11 +94,16 @@ class SessionLingerWiringTest {
         assertEquals("", service.getAttributeNS(ANDROID, "permission"))
         assertEquals(0, service.getElementsByTagName("intent-filter").length)
 
-        val manifestText = manifestFile.readText()
-        assertFalse(
-            manifestText.contains("FOREGROUND_SERVICE"),
-            "the linger window must never be bought with a foreground service",
-        )
+        // The four assertEquals above are the actual invariant this test name
+        // promises: SessionLingerService itself declares no foregroundServiceType,
+        // no permission, no intent-filter, and stays exported=false/stopWithTask=true.
+        // A manifest-wide "contains FOREGROUND_SERVICE" ban used to stand in for
+        // that, back when this was the only service in the app; it stopped being a
+        // proxy for this test's own claim once AlwaysOnConnectionService — a
+        // separate, user-opt-in, Settings-toggled service for a different job
+        // (surviving the app being fully closed, not a 25s post-background grace
+        // window) — legitimately needed one. See AlwaysOnConnectionService's own
+        // kdoc for why that service does need FOREGROUND_SERVICE.
     }
 
     private val ANDROID = "http://schemas.android.com/apk/res/android"

--- a/android/app/src/test/kotlin/com/openmausbot/companion/onboarding/OnboardingScene.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/onboarding/OnboardingScene.kt
@@ -159,6 +159,8 @@ class OnboardingScene(
         shareTranscript = { _, _ -> null },
         openCloudDesktop = { null },
         shareInbox = ShareInbox(),
+        alwaysOnEnabled = MutableStateFlow(false),
+        onToggleAlwaysOn = {},
     )
 
     init {

--- a/android/app/src/test/kotlin/com/openmausbot/companion/ui/WiringScene.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/ui/WiringScene.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
@@ -114,6 +115,8 @@ internal class WiringScene(
         shareTranscript = { _, _ -> null },
         openCloudDesktop = { null },
         shareInbox = ShareInbox(),
+        alwaysOnEnabled = MutableStateFlow(false),
+        onToggleAlwaysOn = {},
     )
 
     private object SilentDiscovery : CompanionDiscovery {


### PR DESCRIPTION
## Problem

The Android companion has no FCM (confirmed in `LocalNotificationPoster.kt`'s own header comment: "Local-only notifications from live/replayed notify frames. No FCM."). A notify frame only reaches the phone while the app has a live connection, or within the ~25s post-background grace window `SessionLingerService` buys.

That means a **scheduled routine/reminder** meant to notify the user later — the core use case for routines — silently does nothing if the app isn't open (or recently backgrounded) at the moment it fires. There's no error; the routine just runs server-side and nothing reaches the phone. See #963 for the original report.

## What this adds

An opt-in **"Background connection"** toggle in Settings (off by default):

- `AlwaysOnConnectionService`: a real foreground service (`foregroundServiceType="connectedDevice"`, not `dataSync` — that type faces a 6h/24h cap on Android 15+) that holds the SSE stream open indefinitely instead of only the 25s linger window. `stopWithTask="false"` so it survives the app being swiped from Recents; `START_STICKY` so the OS restarts it if it's ever killed under memory pressure.
- `AlwaysOnConnectionState`: a small main-thread-confined flag `SessionLingerController.onStop()` checks so the two mechanisms coordinate instead of racing — when the always-on service is running, the 25s linger timer is skipped entirely rather than potentially disconnecting a stream the service is trying to keep open.
- `AlwaysOnBootReceiver` restarts the service after a reboot if the user left it enabled; `OpenMausApp.onCreate()` covers the "process relaunched, not rebooted" case the same way.
- Battery-optimization exemption is requested once, only when the user turns the toggle on.

This is deliberately **not** a real push (FCM) implementation — it trades a persistent low-priority notification and some battery for reliability using only what the app already has (its own SSE connection over the paired route), no new external dependency. A real FCM implementation would still be the more battery-friendly long-term fix; happy to discuss if that's wanted instead of or alongside this.

## Also included

Bumped the "done" notification channel (bot replies / finished tasks) from `IMPORTANCE_DEFAULT` to `IMPORTANCE_HIGH`, so it pops up with sound like a normal messaging app instead of landing silently in the shade — the same silent-delivery problem as above, just for messages that *do* arrive while the app is reachable. Channel importance can only be set at first creation on a given device, so this ships as a new channel id (`bot_messages`) with the old `done` channel deleted on upgrade rather than trying to reconfigure it in place.

## Test changes

`SessionLingerWiringTest`'s manifest-wide "never contains FOREGROUND_SERVICE" assertion is narrowed to the per-element checks it already had on `SessionLingerService` specifically — that assertion was always a proxy for "the linger *service* doesn't need one," not a blanket ban on the app ever using `FOREGROUND_SERVICE` for a different, user-opted-in purpose. The four `assertEquals` checks on `SessionLingerService`'s own manifest declaration are untouched.

Full `:app` and `:core` unit test suites pass locally (56 tests), `:app:assembleDebug` succeeds, and I've installed and tested this on a real device (Samsung, Android) — service runs in foreground, notification posts, battery-optimization exemption grants correctly, and a test notification delivered to the "bot_messages" channel with the app fully closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional “Background connection” setting to keep the connection active when the app is closed.
  - Background connection can restart automatically after device reboot when enabled.
  - Added guidance about battery usage and persistent notifications.
  - Notification access is required before enabling background connection.

- **Improvements**
  - Completion notifications now use the bot messages notification channel.
  - Existing notification channel settings, including custom sounds, are preserved.
  - Updated notification wording to reflect bot messages more clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->