### PR TITLE
feat(cli): serve --tunnel from a fleet credential in the environment

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -92,6 +92,11 @@ is present. Three ways to make the server reachable from elsewhere:
   the server treats as "through a proxy", never as the owner. `npx openmausbot
   logout` releases the address. The account credentials live in
   `~/.openmausbot/tunnel-account.json` (mode 0600).
+  Starting it from a fleet or a container, where nobody can type an emailed
+  code? Set `OMB_INSTALLATION_CREDENTIAL` to the installation credential the
+  fleet issued and skip `login`: the address and connector token are fetched
+  at every start and nothing is written to disk. A rejected credential stops
+  the start with a clear message rather than serving locally.
 - **Behind your own proxy or domain:** `npx openmausbot serve --public-url
   https://maus.example.com`, with the proxy rules from "Putting a proxy in
   front".

--- a/server/cli-lifecycle.test.ts
+++ b/server/cli-lifecycle.test.ts
@@ -7,6 +7,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { isWorkspaceRunning, runOnboardingCommand, runServe, type CliOptions } from "./cli.ts";
 
 const mocks = vi.hoisted(() => ({
+  // the fleet path is off in these tests: no credential in the environment
+  fleetCredential: vi.fn(() => null),
+  fleetAccess: vi.fn(),
+  FLEET_CREDENTIAL_ENV: "OMB_INSTALLATION_CREDENTIAL",
   denyLogOpen: false,
   spawn: vi.fn(),
   tailscaleStatus: vi.fn(), tailscaleServe: vi.fn(), tailscaleServeOff: vi.fn(),

--- a/server/cli.test.ts
+++ b/server/cli.test.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -344,6 +344,67 @@ describe.skipIf(process.platform === "win32")("serve --tunnel", () => {
       await removeTempDir(home);
     }
   }, 30_000);
+
+  it("a fleet credential in the environment serves --tunnel with no account file and no code", async () => {
+    const home = mkdtempSync(join(tmpdir(), "omb-cli-fleet-"));
+    const dataDir = join(home, "data");
+    mkdirSync(dataDir, { recursive: true });
+    const stub = await startControlPlaneStub();
+    const fake = join(home, "cloudflared");
+    writeFileSync(fake, "#!/bin/sh\nexec sleep 300\n", { mode: 0o755 });
+    const port = 21000 + Math.floor(Math.random() * 9000);
+    const originPort = 31000 + Math.floor(Math.random() * 9000);
+    const fleetEnv = {
+      HOME: home,
+      USERPROFILE: home,
+      OMB_WEBHOOK_PORT: String(port + 1),
+      OMB_BROWSER_CONNECTION: join(home, "browser-connection.json"),
+      OMB_CONTROL_PLANE_URL: stub.url,
+      OMB_CLOUDFLARED_PATH: fake,
+      OMB_TUNNEL_ORIGIN_PORT: String(originPort),
+    };
+    // a credential the control plane does not know stops the start; nothing serves
+    const rejected = cli(["serve", "--tunnel", "--no-pair", "--port", String(port), "--data-dir", dataDir], {
+      ...fleetEnv,
+      OMB_INSTALLATION_CREDENTIAL: `omb_install_${"x".repeat(22)}.${"y".repeat(43)}`,
+    });
+    let err = "";
+    rejected.stderr?.on("data", (chunk) => (err += String(chunk)));
+    expect(await exited(rejected)).toBe(1);
+    expect(err).toContain("was rejected");
+
+    const child = cli(["serve", "--tunnel", "--no-pair", "--port", String(port), "--data-dir", dataDir], {
+      ...fleetEnv,
+      OMB_INSTALLATION_CREDENTIAL: stub.seedInstallation("fleet box"),
+    });
+    let out = "";
+    child.stdout?.on("data", (chunk) => (out += String(chunk)));
+    child.stderr?.on("data", (chunk) => (out += String(chunk)));
+    const gateway = `http://127.0.0.1:${originPort}`;
+    try {
+      const deadline = Date.now() + 60_000;
+      while (!out.includes("OpenMausBot is running") && Date.now() < deadline && child.exitCode === null) await new Promise((r) => setTimeout(r, 200));
+      expect(out).toContain("using the installation credential from OMB_INSTALLATION_CREDENTIAL");
+      expect(out).toContain(`reachable at ${stub.endpointUrl}`);
+      expect(existsSync(join(dataDir, "tunnel-account.json"))).toBe(false);
+      let status = 0;
+      const gatewayDeadline = Date.now() + 20_000;
+      while (Date.now() < gatewayDeadline && status !== 200) {
+        try {
+          status = (await fetch(`${gateway}/.well-known/openmausbot/environment`)).status;
+        } catch {
+          status = 0;
+        }
+        if (status !== 200) await new Promise((r) => setTimeout(r, 250));
+      }
+      expect(status).toBe(200);
+    } finally {
+      child.kill("SIGTERM");
+      await exited(child);
+      await stub.close();
+      await removeTempDir(home);
+    }
+  }, 120_000);
 
   it("serves at the account's public address through the gateway, where every request is remote", async () => {
     const home = mkdtempSync(join(tmpdir(), "omb-cli-tunnel-"));

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -41,6 +41,9 @@ import {
   describeTunnelAccount,
   describeTunnelState,
   ensureCloudflared,
+  FLEET_CREDENTIAL_ENV,
+  fleetAccess,
+  fleetCredential,
   guardianEntry,
   startTunnel,
   tunnelAccess,
@@ -434,13 +437,15 @@ export async function runStatus(options: CliOptions, io: CliIo = defaultIo()): P
   }
   if (!options.json) {
     const account = describeTunnelAccount(createTunnelAccount({ dataDir: options.dataDir, version: serverVersion() }).credentials.read());
-    if (account.address) io.log(`public address: ${account.address} (signed in as ${account.email ?? "?"}; serve it with --tunnel)`);
+    if (fleetCredential()) io.log(`public address: managed by the fleet (${FLEET_CREDENTIAL_ENV} is set; the address is fetched when serve --tunnel starts)`);
+    else if (account.address) io.log(`public address: ${account.address} (signed in as ${account.email ?? "?"}; serve it with --tunnel)`);
   }
   return code;
 }
 
 export async function runLogin(options: CliOptions, io: CliIo = defaultIo()): Promise<number> {
   const account = createTunnelAccount({ dataDir: options.dataDir, version: serverVersion() });
+  if (fleetCredential()) io.log(`note: ${FLEET_CREDENTIAL_ENV} is set, so serve --tunnel will use that credential rather than this account`);
   if (account.credentials.status === "unavailable") {
     io.error(`${account.credentials.file} exists but could not be read; fix or remove it, then try again`);
     return 1;
@@ -566,20 +571,32 @@ interface TunnelPlan {
 /** Everything `--tunnel` needs before the server starts, or the one reason
  * it cannot have it. Fails closed: no silent fallback to a local-only server. */
 async function planTunnel(options: CliOptions, log: (line: string) => void): Promise<TunnelPlan | { error: string }> {
-  const account = createTunnelAccount({ dataDir: options.dataDir, version: serverVersion() });
-  if (account.credentials.status === "unavailable") return { error: `${account.credentials.file} exists but could not be read; fix or remove it` };
-  if (!describeTunnelAccount(account.credentials.read()).email) {
-    return { error: "no account on this machine yet: run `openmausbot login` first, then `openmausbot serve --tunnel`" };
+  let access: ManagedTunnelAccess | null = null;
+  const credential = fleetCredential();
+  if (credential) {
+    // A fleet-started container: the credential is the whole identity.
+    log(`tunnel: using the installation credential from ${FLEET_CREDENTIAL_ENV}`);
+    try {
+      access = await fleetAccess({ credential });
+    } catch (error) {
+      return { error: `--tunnel: ${message(error)}` };
+    }
+  } else {
+    const account = createTunnelAccount({ dataDir: options.dataDir, version: serverVersion() });
+    if (account.credentials.status === "unavailable") return { error: `${account.credentials.file} exists but could not be read; fix or remove it` };
+    if (!describeTunnelAccount(account.credentials.read()).email) {
+      return { error: "no account on this machine yet: run `openmausbot login` first, then `openmausbot serve --tunnel`" };
+    }
+    // A fresh connector token when the control plane answers; the saved one otherwise.
+    try {
+      const state = await account.service.retry();
+      if (state.message && !tunnelAccess(account.credentials.read())) log(`tunnel: ${state.message}`);
+    } catch (error) {
+      log(`tunnel: control plane not reachable right now (${message(error)}); using the saved address`);
+    }
+    access = tunnelAccess(account.credentials.read());
+    if (!access) return { error: "this machine has no public address; run `openmausbot login` again" };
   }
-  // A fresh connector token when the control plane answers; the saved one otherwise.
-  try {
-    const state = await account.service.retry();
-    if (state.message && !tunnelAccess(account.credentials.read())) log(`tunnel: ${state.message}`);
-  } catch (error) {
-    log(`tunnel: control plane not reachable right now (${message(error)}); using the saved address`);
-  }
-  const access = tunnelAccess(account.credentials.read());
-  if (!access) return { error: "this machine has no public address; run `openmausbot login` again" };
   let binary: string;
   try {
     binary = await ensureCloudflared({ dataDir: options.dataDir, log });

--- a/server/testing/control-plane-stub.ts
+++ b/server/testing/control-plane-stub.ts
@@ -23,6 +23,9 @@ export interface ControlPlaneStub {
   /** "METHOD /path", in order. */
   calls: string[];
   installations: Map<string, StubInstallation>;
+  /** An installation the control plane already knows, as a fleet would create
+   * one before starting a container: returns its credential. */
+  seedInstallation(name?: string): string;
   close(): Promise<void>;
 }
 
@@ -146,6 +149,11 @@ export async function startControlPlaneStub(options: { otp?: string; endpointUrl
     connectorToken,
     calls,
     installations,
+    seedInstallation: (name = "fleet box") => {
+      const inst: StubInstallation = { id: randomUUID(), clientInstanceId: randomUUID(), name, platform: "linux", appVersion: null, credential: newCredential() };
+      installations.set(inst.id, inst);
+      return inst.credential;
+    },
     close: () => new Promise<void>((done) => server.close(() => done())),
   };
 }

--- a/server/tunnel.test.ts
+++ b/server/tunnel.test.ts
@@ -12,6 +12,8 @@ import {
   createTunnelOrigin,
   describeTunnelAccount,
   describeTunnelState,
+  fleetAccess,
+  fleetCredential,
   guardianEntry,
   openTunnelCredentials,
   platformName,
@@ -200,4 +202,25 @@ describe.skipIf(!posix)("startTunnel: guardian, gateway and connector, verified 
       await removeTempDir(dir);
     }
   }, 30_000);
+});
+
+describe("a fleet's credential in the environment", () => {
+  it("gets the public address with no account file and no emailed code; a rejected credential is a clear error", async () => {
+    const stub = await startControlPlaneStub();
+    try {
+      const env = { ...process.env, OMB_CONTROL_PLANE_URL: stub.url };
+      expect(fleetCredential({})).toBeNull();
+      expect(fleetCredential({ OMB_INSTALLATION_CREDENTIAL: "   " })).toBeNull();
+      const credential = stub.seedInstallation("box-1");
+      expect(fleetCredential({ OMB_INSTALLATION_CREDENTIAL: ` ${credential} ` })).toBe(credential);
+      const access = await fleetAccess({ credential, env });
+      expect(access).toEqual({ endpoint: stub.endpointUrl, token: stub.connectorToken });
+      expect(stub.calls).toContain("POST /v1/installations/self/endpoint");
+      expect(stub.calls.some((call) => call.includes("/api/auth/"))).toBe(false);
+      await expect(fleetAccess({ credential: `omb_install_${"x".repeat(22)}.${"y".repeat(43)}`, env })).rejects.toThrow(/rejected/);
+      await expect(fleetAccess({ credential, env: { ...env, OMB_CONTROL_PLANE_URL: "ftp://nope" } })).rejects.toThrow(/OMB_CONTROL_PLANE_URL/);
+    } finally {
+      await stub.close();
+    }
+  });
 });

--- a/server/tunnel.ts
+++ b/server/tunnel.ts
@@ -40,7 +40,7 @@ import {
   MANAGED_COMPANION_ORIGIN_PORT,
   type CompanionOriginEndpoint,
 } from "../electron/companion-origin-gateway.mjs";
-import { createControlPlaneClient } from "../electron/control-plane-client.mjs";
+import { ControlPlaneError, createControlPlaneClient } from "../electron/control-plane-client.mjs";
 import {
   createManagedCompanionTunnel,
   managedCompanionTunnelAccess,
@@ -165,6 +165,33 @@ export function createTunnelAccount(options: {
     newClientInstanceId: () => randomUUID(),
   });
   return { service, credentials, controlPlane };
+}
+
+// ── a fleet's credential: no account file, no emailed code ───────────────
+export const FLEET_CREDENTIAL_ENV = "OMB_INSTALLATION_CREDENTIAL";
+
+/** A container the fleet starts carries its installation credential in the
+ * environment. Nothing is written to disk and nobody types a code; the
+ * address and connector token are fetched fresh at every start. */
+export function fleetCredential(env: NodeJS.ProcessEnv = process.env): string | null {
+  const value = env[FLEET_CREDENTIAL_ENV]?.trim();
+  return value ? value : null;
+}
+
+export async function fleetAccess(options: { credential: string; env?: NodeJS.ProcessEnv; fetchImpl?: typeof fetch }): Promise<ManagedTunnelAccess> {
+  const env = options.env ?? process.env;
+  const controlPlane = resolveCompanionControlPlaneURL({ isPackaged: true, environment: env });
+  if (!controlPlane) throw new Error("OMB_CONTROL_PLANE_URL is set but is not an https address");
+  const client = createControlPlaneClient({ baseURL: controlPlane, fetchImpl: options.fetchImpl });
+  try {
+    const { endpoint, connectorToken } = await client.ensureEndpoint(options.credential);
+    return { endpoint: endpoint.url, token: connectorToken };
+  } catch (error) {
+    if (error instanceof ControlPlaneError && error.status === 401) {
+      throw new Error(`the installation credential in ${FLEET_CREDENTIAL_ENV} was rejected by ${controlPlane}; the fleet has to issue a new one`);
+    }
+    throw new Error(`could not get this machine's public address from ${controlPlane}: ${error instanceof Error ? error.message : String(error)}`);
+  }
 }
 
 // ── cloudflared and the guardian: where they are, or how to get them ──────


### PR DESCRIPTION
The seam the fleet needs (plan: Phase 0). A container started by the fleet cannot type an emailed code, so `serve --tunnel` now accepts the installation credential from the environment:

```sh
OMB_INSTALLATION_CREDENTIAL=omb_install_… openmausbot serve --tunnel
```

- No account file is read or written; the address and connector token are fetched from the control plane at every start with that credential.
- A rejected credential stops the start with a clear message. It never falls back to a local-only server.
- `status` and `login` say when the environment credential is in charge. Docs updated.

Tests (stub control plane): `fleetAccess` returns the address and token without any sign-in call, a rejected credential and a bad `OMB_CONTROL_PLANE_URL` are clear errors; end to end, a seeded credential serves the public address through the gateway with no `tunnel-account.json` on disk, and a bad one exits 1 with nothing listening. 34 tests across the two files pass; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for starting managed public tunnels with a fleet installation credential.
  * Containers can retrieve their tunnel address and connector token automatically at startup without account files, login, or pairing.
  * Startup clearly reports rejected credentials and does not serve locally when access is denied.

* **Documentation**
  * Added self-hosting guidance for configuring fleet installation credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->