### PR TITLE
feat(auth): sign in with your email on a hosted server

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -5,3 +5,9 @@ DOMAIN=maus.example.com
 # Engine CLIs baked into the image at build time (space-separated npm packages).
 # Sign in afterwards with:  docker compose exec omb claude   (etc.)
 ENGINES=@anthropic-ai/claude-code
+
+# Optional: let people sign in with an emailed code instead of a pairing
+# code. Addresses or @domain entries, comma-separated. Admins get full
+# access; members get chat and approvals only.
+OMB_SIGNIN_EMAILS=
+OMB_SIGNIN_MEMBER_EMAILS=

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -28,6 +28,10 @@ services:
       OMB_WEBHOOK_PUBLIC_URL: https://${DOMAIN}
       # pairing links for remote clients point here (docs/self-hosting.md)
       OMB_PUBLIC_URL: https://${DOMAIN}
+      # Who may sign in with an emailed code at /pair (docs/self-hosting.md,
+      # "Sign in with your email"). Empty means pairing codes only.
+      OMB_SIGNIN_EMAILS: ${OMB_SIGNIN_EMAILS:-}
+      OMB_SIGNIN_MEMBER_EMAILS: ${OMB_SIGNIN_MEMBER_EMAILS:-}
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://127.0.0.1:8799/api/health | grep -q openmausbot"]
       interval: 30s

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -321,6 +321,32 @@ ssh -L 8799:localhost:8799 you@your-server
 # then open http://localhost:8799 — loopback, so no pairing needed
 ```
 
+## Sign in with your email
+
+A pairing code is fine for the owner's own devices. For a workspace other
+people use every day, let them sign in with an emailed code instead: set an
+allow-list, and `/pair` on your server offers "Sign in with your email" first.
+
+```sh
+OMB_SIGNIN_EMAILS="her@yourcompany.com, @yourcompany.com"   # full access
+OMB_SIGNIN_MEMBER_EMAILS="freelancer@example.com"          # chat and approvals only
+```
+
+An entry is an address or `@domain` (everyone at that domain). Admins get
+the same access as a pairing code from `openmausbot serve`; members get the
+chat-only scope, the same as `openmausbot pair --client`. The same lists live
+in `config.json` under `signIn.admins` and `signIn.members` and can be changed
+through the settings API without a restart; the environment variables win
+when set, which is how a container or a service unit is bootstrapped.
+
+The code itself comes from `accounts.openmausbot.com`, the OpenMausBot
+account service, so your server needs no email credentials. Your server asks
+it to send the code, checks the answer, and then issues its own session
+cookie: the browser only ever talks to your server, and who is welcome is
+decided only by your allow-list. Wrong codes count against the same lockout
+as pairing codes. Sessions from a sign-in show the email in
+`openmausbot sessions` and can be revoked the same way.
+
 ## Putting a proxy in front
 
 Any reverse proxy works, given three things:

--- a/server/account-signin.test.ts
+++ b/server/account-signin.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { allowedScopes, createEmailSignIn, parseAllowList, signInEnabled } from "./account-signin.ts";
+import { startControlPlaneStub } from "./testing/control-plane-stub.ts";
+
+describe("the sign-in allow-list", () => {
+  it("splits on commas, spaces and newlines and ignores case", () => {
+    expect(parseAllowList(" Her@Example.test, @Agentada.test\nstaff@example.test ")).toEqual(["her@example.test", "@agentada.test", "staff@example.test"]);
+    expect(parseAllowList(undefined)).toEqual([]);
+  });
+
+  it("maps addresses and @domains to scopes, and never matches a look-alike domain", () => {
+    const list = { admins: ["her@example.test", "@agentada.test"], members: ["staff@example.test", "@partner.test"] };
+    expect(allowedScopes("HER@example.test", list)).toEqual(["admin", "client"]);
+    expect(allowedScopes("anyone@agentada.test", list)).toEqual(["admin", "client"]);
+    expect(allowedScopes("staff@example.test", list)).toEqual(["client"]);
+    expect(allowedScopes("x@partner.test", list)).toEqual(["client"]);
+    expect(allowedScopes("x@evilagentada.test", list)).toBeNull();
+    expect(allowedScopes("x@agentada.test.evil", list)).toBeNull();
+    expect(allowedScopes("@agentada.test", list)).toBeNull();
+    expect(allowedScopes("stranger@example.test", list)).toBeNull();
+    expect(signInEnabled(list)).toBe(true);
+    expect(signInEnabled({ admins: [], members: [] })).toBe(false);
+  });
+});
+
+describe("the exchange with the control plane", () => {
+  it("sends a code only to welcome addresses, turns the right code into scopes, and explains the wrong one", async () => {
+    const stub = await startControlPlaneStub();
+    try {
+      const signIn = createEmailSignIn({
+        allow: { admins: ["her@example.test"], members: ["@team.test"] },
+        env: { ...process.env, OMB_CONTROL_PLANE_URL: stub.url },
+      });
+      expect(signIn.enabled()).toBe(true);
+      expect(await signIn.start("nobody@example.test")).toMatchObject({ ok: false, status: 403 });
+      expect(await signIn.start("not an email")).toMatchObject({ ok: false, status: 400 });
+      expect(stub.calls).not.toContain("POST /api/auth/email-otp/send-verification-otp");
+      expect(await signIn.start("Her@Example.test")).toEqual({ ok: true });
+      expect(stub.calls).toContain("POST /api/auth/email-otp/send-verification-otp");
+
+      const wrong = await signIn.verify("her@example.test", "00000000");
+      expect(wrong).toMatchObject({ ok: false, status: 401 });
+      expect(wrong.ok ? "" : wrong.error).toMatch(/wrong or has expired/);
+      expect(await signIn.verify("her@example.test", "12")).toMatchObject({ ok: false, status: 400 });
+      expect(await signIn.verify("nobody@example.test", stub.otp)).toMatchObject({ ok: false, status: 403 });
+
+      const admin = await signIn.verify("her@example.test", stub.otp);
+      expect(admin).toEqual({ ok: true, email: "her@example.test", userId: "user_stub", scopes: ["admin", "client"] });
+      const member = await signIn.verify("someone@team.test", stub.otp);
+      expect(member).toMatchObject({ ok: true, scopes: ["client"] });
+      await new Promise((r) => setTimeout(r, 50));
+      expect(stub.calls.filter((call) => call === "POST /api/auth/sign-out").length).toBe(2);
+    } finally {
+      await stub.close();
+    }
+  });
+
+  it("is off with an empty allow-list and says so when the sign-in service is down", async () => {
+    const off = createEmailSignIn({ allow: () => ({ admins: [], members: [] }) });
+    expect(off.enabled()).toBe(false);
+    const down = createEmailSignIn({ allow: { admins: ["a@b.test"], members: [] }, env: { ...process.env, OMB_CONTROL_PLANE_URL: "http://127.0.0.1:9" } });
+    expect(await down.start("a@b.test")).toMatchObject({ ok: false, status: 502 });
+  });
+});

--- a/server/account-signin.ts
+++ b/server/account-signin.ts
@@ -1,0 +1,119 @@
+// Sign in with your email on a hosted server. The emailed code comes from the
+// OpenMausBot control plane (the account service the desktop companion and
+// `openmausbot login` already use), and this server decides who is welcome
+// with an allow-list its owner controls. The result is an ordinary local
+// session, the same thing a pairing code produces, so every gate applies.
+//
+// Why through the control plane rather than a mail provider per server: a
+// self-hoster then needs no email credentials at all; the code arrives from
+// accounts.openmausbot.com. The exchange happens server-side, so a browser
+// only ever talks to this server, and a server with an empty allow-list does
+// not expose the routes.
+import { resolveCompanionControlPlaneURL } from "../electron/companion-account-service.mjs";
+import { ControlPlaneError, createControlPlaneClient, normalizeAccountEmail, type ControlPlaneClient } from "../electron/control-plane-client.mjs";
+import type { Scope } from "./sessions.ts";
+
+/** Who may sign in. `a@b.com` is that address; `@b.com` is everyone at b.com. */
+export interface SignInAllowList {
+  admins: string[];
+  members: string[];
+}
+
+export const ADMIN_EMAILS_ENV = "OMB_SIGNIN_EMAILS";
+export const MEMBER_EMAILS_ENV = "OMB_SIGNIN_MEMBER_EMAILS";
+
+/** Commas, spaces or newlines between entries; case does not matter. */
+export function parseAllowList(value: string | undefined | null): string[] {
+  return (value ?? "")
+    .split(/[,\s]+/)
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function allowedScopes(rawEmail: string, list: SignInAllowList): Scope[] | null {
+  const email = rawEmail.trim().toLowerCase();
+  if (!email.includes("@")) return null;
+  const matches = (entry: string) => (entry.startsWith("@") ? email.endsWith(entry) && email.length > entry.length : entry === email);
+  if (list.admins.some(matches)) return ["admin", "client"];
+  if (list.members.some(matches)) return ["client"];
+  return null;
+}
+
+export function signInEnabled(list: SignInAllowList): boolean {
+  return list.admins.length + list.members.length > 0;
+}
+
+export type SignInFailure = { ok: false; status: number; error: string };
+
+export interface EmailSignIn {
+  enabled(): boolean;
+  start(email: string): Promise<{ ok: true } | SignInFailure>;
+  verify(email: string, code: string): Promise<{ ok: true; email: string; userId: string; scopes: Scope[] } | SignInFailure>;
+}
+
+const NOT_WELCOME: SignInFailure = { ok: false, status: 403, error: "this email is not on this server's sign-in list; ask the server's owner to add it" };
+
+export function createEmailSignIn(options: {
+  allow: SignInAllowList | (() => SignInAllowList);
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  client?: ControlPlaneClient;
+}): EmailSignIn {
+  const env = options.env ?? process.env;
+  const allow = () => (typeof options.allow === "function" ? options.allow() : options.allow);
+  let client: ControlPlaneClient | null = options.client ?? null;
+  const controlPlane = (): ControlPlaneClient => {
+    if (client) return client;
+    const url = resolveCompanionControlPlaneURL({ isPackaged: true, environment: env });
+    if (!url) throw new Error("OMB_CONTROL_PLANE_URL is set but is not an https address");
+    client = createControlPlaneClient({ baseURL: url, fetchImpl: options.fetchImpl });
+    return client;
+  };
+  return {
+    enabled: () => signInEnabled(allow()),
+    async start(rawEmail) {
+      const email = normalizeAccountEmail(rawEmail);
+      if (!email) return { ok: false, status: 400, error: "enter a valid email address" };
+      if (!allowedScopes(email, allow())) return NOT_WELCOME;
+      try {
+        await controlPlane().requestOTP(email);
+      } catch (error) {
+        return unavailable(error);
+      }
+      return { ok: true };
+    },
+    async verify(rawEmail, code) {
+      const email = normalizeAccountEmail(rawEmail);
+      if (!email || !allowedScopes(email, allow())) return NOT_WELCOME;
+      let verified: { accountToken: string; user: { id: string; email: string } };
+      try {
+        verified = await controlPlane().verifyOTP(email, code);
+      } catch (error) {
+        // The client refuses a malformed code before any request (status 0);
+        // the control plane's own "invalid_otp" is a wrong or expired code.
+        if (error instanceof ControlPlaneError && error.code === "invalid_otp" && !error.status) {
+          return { ok: false, status: 400, error: "enter the 8-digit code from the email" };
+        }
+        if (error instanceof ControlPlaneError && error.status === 429) {
+          return { ok: false, status: 429, error: "too many attempts; wait a minute and request a new code" };
+        }
+        if (error instanceof ControlPlaneError && (error.status === 400 || error.status === 401 || error.status === 403)) {
+          return { ok: false, status: 401, error: "that code is wrong or has expired; request a new one" };
+        }
+        return unavailable(error);
+      }
+      // The account session on the control plane has done its job.
+      void controlPlane()
+        .signOut(verified.accountToken)
+        .catch(() => undefined);
+      const scopes = allowedScopes(verified.user.email, allow());
+      if (!scopes) return NOT_WELCOME;
+      return { ok: true, email: verified.user.email, userId: verified.user.id, scopes };
+    },
+  };
+}
+
+function unavailable(error: unknown): SignInFailure {
+  const detail = error instanceof ControlPlaneError ? `${error.code}${error.status ? ` (${error.status})` : ""}` : error instanceof Error ? error.message : String(error);
+  return { ok: false, status: 502, error: `the sign-in service could not be reached (${detail}); try again in a moment` };
+}

--- a/server/config.ts
+++ b/server/config.ts
@@ -238,6 +238,9 @@ const defaultModelSelectionSchema = z.object({
 const appConfigSchema = z.object({
   /** Verified by the dedicated domain endpoint, never a generic config patch. */
   customDomain: z.string().optional(),
+  /** Who may sign in with an emailed code (server/account-signin.ts):
+   * addresses or `@domain` entries; admins get every scope, members chat only. */
+  signIn: z.object({ admins: z.array(z.string().max(320)).max(500).optional(), members: z.array(z.string().max(320)).max(5000).optional() }).optional(),
   defaultModelSelection: defaultModelSelectionSchema.optional(),
   /** CLI-only launch preferences. Never enable remote access implicitly. */
   cliStartup: z.object({
@@ -288,6 +291,7 @@ const jsonObjectSchema = z.record(z.string(), z.json());
 
 export interface AppConfig {
   customDomain?: string;
+  signIn?: { admins?: string[]; members?: string[] };
   /** Preferred selection for newly created bots; existing bots keep theirs. */
   defaultModelSelection?: ModelSelection;
   cliStartup?: {
@@ -502,6 +506,14 @@ export function loadConfig(): AppConfig {
   if (process.env.OMB_TTS_KEY !== undefined) cfg.tts.key = process.env.OMB_TTS_KEY;
   cfg.imageGen = { ...cfg.imageGen };
   if (process.env.OMB_OPENAI_IMAGE_KEY !== undefined) cfg.imageGen.key = process.env.OMB_OPENAI_IMAGE_KEY;
+  // The sign-in allow-list: env is how a headless box or a container is
+  // bootstrapped before anyone can reach Settings.
+  const splitEmails = (value: string) => value.split(/[,\s]+/).map((entry) => entry.trim().toLowerCase()).filter(Boolean);
+  if (process.env.OMB_SIGNIN_EMAILS !== undefined || process.env.OMB_SIGNIN_MEMBER_EMAILS !== undefined) {
+    cfg.signIn = { ...cfg.signIn };
+    if (process.env.OMB_SIGNIN_EMAILS !== undefined) cfg.signIn.admins = splitEmails(process.env.OMB_SIGNIN_EMAILS);
+    if (process.env.OMB_SIGNIN_MEMBER_EMAILS !== undefined) cfg.signIn.members = splitEmails(process.env.OMB_SIGNIN_MEMBER_EMAILS);
+  }
   return cfg;
 }
 
@@ -616,6 +628,7 @@ export function saveConfig(patch: Partial<AppConfig>, options: { replaceInstance
   // scalar, not a section: the merge loop above only walks objects
   if (checkedPatch.language !== undefined) disk.language = checkedPatch.language;
   if (checkedPatch.customDomain !== undefined) disk.customDomain = checkedPatch.customDomain;
+  if (checkedPatch.signIn !== undefined) disk.signIn = checkedPatch.signIn;
   // A selection is replaced as one value, so changing engines also clears
   // an effort level omitted from the new selection.
   if (checkedPatch.defaultModelSelection !== undefined) {

--- a/server/email-signin.test.ts
+++ b/server/email-signin.test.ts
@@ -1,0 +1,205 @@
+// End to end: a hosted server with a sign-in allow-list lets a remote browser
+// sign in with an emailed code from the control plane (stubbed here) and
+// ends up with the same cookie session a pairing code would give.
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { request as httpRequest } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { removeTempDir, waitForExit } from "./testing/cleanup.ts";
+import { startControlPlaneStub, type ControlPlaneStub } from "./testing/control-plane-stub.ts";
+
+const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(SERVER_DIR, "..");
+const PORT = 24000 + Math.floor(Math.random() * 5000);
+const HOST = "agentada.test";
+
+let home: string;
+let child: ChildProcess;
+let stub: ControlPlaneStub;
+let stderr = "";
+
+interface Reply {
+  status: number;
+  headers: Record<string, string | string[] | undefined>;
+  body: any;
+}
+
+/** A remote browser: a foreign Host and a forwarded address, like a proxy or tunnel hands us. */
+function call(path: string, init: { method?: string; body?: unknown; headers?: Record<string, string>; from?: string } = {}): Promise<Reply> {
+  return new Promise((resolve, reject) => {
+    const payload = init.body === undefined ? undefined : JSON.stringify(init.body);
+    const req = httpRequest(
+      {
+        hostname: "127.0.0.1",
+        port: PORT,
+        path,
+        method: init.method ?? (payload ? "POST" : "GET"),
+        headers: {
+          host: HOST,
+          "x-forwarded-for": init.from ?? "203.0.113.7",
+          "x-forwarded-proto": "https",
+          ...(payload ? { "content-type": "application/json" } : {}),
+          ...init.headers,
+        },
+      },
+      (res) => {
+        let raw = "";
+        res.on("data", (chunk) => (raw += chunk));
+        res.on("end", () => {
+          let body: unknown = raw;
+          try {
+            body = JSON.parse(raw);
+          } catch {
+            /* not json */
+          }
+          resolve({ status: res.statusCode ?? 0, headers: res.headers, body });
+        });
+      },
+    );
+    req.on("error", reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+const cookieOf = (reply: Reply): string => {
+  const raw = reply.headers["set-cookie"];
+  const first = Array.isArray(raw) ? raw[0] : raw;
+  return (first ?? "").split(";")[0];
+};
+
+beforeAll(async () => {
+  stub = await startControlPlaneStub();
+  home = mkdtempSync(join(tmpdir(), "omb-email-signin-"));
+  const staticDir = join(home, "static");
+  mkdirSync(join(home, ".openmausbot"), { recursive: true });
+  mkdirSync(join(staticDir, "assets"), { recursive: true });
+  writeFileSync(join(staticDir, "index.html"), "<!doctype html><title>Served UI</title>");
+  writeFileSync(join(home, ".openmausbot", "config.json"), JSON.stringify({ instances: { fixture: { driver: "email-signin-test-shadow" } } }));
+  child = spawn(process.execPath, [join(SERVER_DIR, "index.ts")], {
+    cwd: ROOT,
+    env: {
+      ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
+      ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
+      HOME: home,
+      USERPROFILE: home,
+      OMB_PORT: String(PORT),
+      OMB_WEBHOOK_PORT: String(PORT + 1),
+      OMB_STATIC_DIR: staticDir,
+      OMB_PUBLIC_URL: `https://${HOST}`,
+      OMB_ENVIRONMENT_LABEL: "agentada",
+      OMB_BROWSER_CONNECTION: join(home, "browser-test-connection.json"),
+      OMB_CONTROL_PLANE_URL: stub.url,
+      OMB_SIGNIN_EMAILS: "Her@Example.test, @agentada.test",
+      OMB_SIGNIN_MEMBER_EMAILS: "staff@example.test",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stderr?.on("data", (chunk) => (stderr += String(chunk)));
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${PORT}/api/health`);
+      if (res.ok) return;
+    } catch {
+      /* not up yet */
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`server did not start:\n${stderr}`);
+}, 30_000);
+
+afterAll(async () => {
+  await waitForExit(child, { signal: "SIGTERM" });
+  await stub.close();
+  await removeTempDir(home);
+});
+
+describe("sign in with your email on a hosted server", () => {
+  it("advertises the option in the public descriptor", async () => {
+    const descriptor = await call("/.well-known/openmausbot/environment");
+    expect(descriptor.status).toBe(200);
+    expect(descriptor.body.capabilities.emailSignIn).toBe(true);
+  });
+
+  it("is JSON-only and refuses addresses that are not on the list", async () => {
+    const form = await new Promise<Reply>((resolve, reject) => {
+      const req = httpRequest({ hostname: "127.0.0.1", port: PORT, path: "/api/auth/email/start", method: "POST", headers: { host: HOST, "x-forwarded-for": "203.0.113.9", "content-type": "application/x-www-form-urlencoded" } }, (res) => {
+        let raw = "";
+        res.on("data", (c) => (raw += c));
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, headers: res.headers, body: raw }));
+      });
+      req.on("error", reject);
+      req.end("email=her%40example.test");
+    });
+    expect(form.status).toBe(415);
+    const stranger = await call("/api/auth/email/start", { body: { email: "stranger@example.test" } });
+    expect(stranger.status).toBe(403);
+    expect(stranger.body.error).toMatch(/not on this server's sign-in list/);
+    expect(stub.calls).not.toContain("POST /api/auth/email-otp/send-verification-otp");
+  });
+
+  it("emails a code to a welcome address, then turns the code into an admin cookie session that shows its email", async () => {
+    const started = await call("/api/auth/email/start", { body: { email: "her@example.test" } });
+    expect(started.status).toBe(200);
+    expect(stub.calls).toContain("POST /api/auth/email-otp/send-verification-otp");
+
+    const wrong = await call("/api/auth/email/verify", { body: { email: "her@example.test", code: "00000000", label: "Her iPad" } });
+    expect(wrong.status).toBe(401);
+    expect(cookieOf(wrong)).toBe("");
+
+    const right = await call("/api/auth/email/verify", { body: { email: "her@example.test", code: stub.otp, label: "Her iPad" } });
+    expect(right.status).toBe(200);
+    expect(right.body.session).toMatchObject({ label: "Her iPad", scopes: ["admin", "client"], email: "her@example.test" });
+    expect(right.body.environment.environmentId).toBeTruthy();
+    const cookie = cookieOf(right);
+    expect(cookie).toMatch(/^omb_session_/);
+    expect(String(right.headers["set-cookie"])).toMatch(/HttpOnly/);
+
+    const me = await call("/api/auth/session", { headers: { cookie, origin: `https://${HOST}` } });
+    expect(me.status).toBe(200);
+    expect(me.body).toMatchObject({ kind: "session", email: "her@example.test", scopes: ["admin", "client"], via: "cookie" });
+    // admin scope: settings are hers to change
+    const config = await call("/api/config", { method: "PUT", body: { language: "en" }, headers: { cookie, origin: `https://${HOST}` } });
+    expect(config.status).toBe(200);
+    const listed = await call("/api/auth/sessions", { headers: { cookie, origin: `https://${HOST}` } });
+    expect(listed.status).toBe(200);
+    expect(listed.body.sessions.some((s: { email?: string }) => s.email === "her@example.test")).toBe(true);
+  });
+
+  it("a member address gets a chat-only session; a domain entry welcomes the whole company", async () => {
+    await call("/api/auth/email/start", { body: { email: "staff@example.test" } });
+    const member = await call("/api/auth/email/verify", { body: { email: "staff@example.test", code: stub.otp, label: "Staff phone" } });
+    expect(member.status).toBe(200);
+    expect(member.body.session.scopes).toEqual(["client"]);
+    const cookie = cookieOf(member);
+    const bots = await call("/api/bots", { headers: { cookie, origin: `https://${HOST}` } });
+    expect(bots.status).toBe(200);
+    const config = await call("/api/config", { method: "PUT", body: { language: "en" }, headers: { cookie, origin: `https://${HOST}` } });
+    expect(config.status).toBe(403);
+
+    await call("/api/auth/email/start", { body: { email: "anyone@agentada.test" } });
+    const colleague = await call("/api/auth/email/verify", { body: { email: "anyone@agentada.test", code: stub.otp } });
+    expect(colleague.status).toBe(200);
+    expect(colleague.body.session.scopes).toEqual(["admin", "client"]);
+    // no label and no browser user agent in this test client: the generic fallback
+    expect(colleague.body.session.label).toBe("Unnamed device");
+  });
+
+  it("locks a source out after repeated wrong codes, like pairing does", async () => {
+    let last = 0;
+    for (let i = 0; i < 12; i += 1) {
+      const reply = await call("/api/auth/email/verify", { body: { email: "her@example.test", code: "99999999" }, from: "198.51.100.42" });
+      last = reply.status;
+      if (last === 429) break;
+    }
+    expect(last).toBe(429);
+    // the lockout is per source: someone else still gets in
+    const other = await call("/api/auth/email/verify", { body: { email: "her@example.test", code: stub.otp }, from: "198.51.100.43" });
+    expect(other.status).toBe(200);
+  });
+});

--- a/server/environment.test.ts
+++ b/server/environment.test.ts
@@ -123,7 +123,7 @@ describe("environment identity", () => {
       label: "cab mini",
       platform: process.platform,
       version: "0.1.99",
-      capabilities: { remoteSessions: true, selfUpdate: "desktop-managed" },
+      capabilities: { remoteSessions: true, selfUpdate: "desktop-managed", emailSignIn: false },
     });
     expect(environmentDescriptor({ environmentId: "abc", desktopManaged: false }).capabilities.selfUpdate).toBe("operator");
   });

--- a/server/environment.ts
+++ b/server/environment.ts
@@ -28,6 +28,8 @@ export interface EnvironmentDescriptor {
     remoteSessions: true;
     /** Who can update the server: the desktop app that runs it, or the operator. */
     selfUpdate: "desktop-managed" | "operator";
+    /** Whether /pair offers "sign in with your email" (an allow-list is set). */
+    emailSignIn?: boolean;
   };
 }
 
@@ -113,7 +115,7 @@ export function serverVersion(): string {
   return "unknown";
 }
 
-export function environmentDescriptor(input: { environmentId: string; desktopManaged: boolean }): EnvironmentDescriptor {
+export function environmentDescriptor(input: { environmentId: string; desktopManaged: boolean; emailSignIn?: boolean }): EnvironmentDescriptor {
   return {
     environmentId: input.environmentId,
     label: process.env.OMB_ENVIRONMENT_LABEL?.trim() || hostname(),
@@ -122,6 +124,7 @@ export function environmentDescriptor(input: { environmentId: string; desktopMan
     capabilities: {
       remoteSessions: true,
       selfUpdate: input.desktopManaged ? "desktop-managed" : "operator",
+      emailSignIn: input.emailSignIn === true,
     },
   };
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -326,6 +326,7 @@ import { acquireDataDirLeaseForProcess } from "./data-dir-lease.ts";
 import { describeEdition, editionStatus, loadEnterpriseLayer } from "./enterprise.ts";
 import { environmentDescriptor, loadEnvironmentId } from "./environment.ts";
 import { createCustomDomainVerifier, customDomainIpv4, normalizeCustomDomain } from "./custom-domain.ts";
+import { createEmailSignIn, parseAllowList } from "./account-signin.ts";
 import { ProviderAuthSessions } from "./provider-auth-sessions.ts";
 import {
   clearSessionCookie,
@@ -402,6 +403,14 @@ let companionMutationToken: string | undefined = DESKTOP_MANAGED ? "" : undefine
 const FALLBACK_PUBLIC_URL = process.env.OMB_PUBLIC_URL?.trim().replace(/\/+$/, "") || null;
 const cfg = loadConfig();
 const customDomainVerifier = createCustomDomainVerifier({ environmentId: ENVIRONMENT_ID });
+// "Sign in with your email" on /pair: the allow-list is read per call so a
+// Settings change or an env bootstrap applies without a restart.
+const emailSignIn = createEmailSignIn({
+  allow: () => {
+    const current = loadConfig().signIn;
+    return { admins: parseAllowList(current?.admins?.join(",")), members: parseAllowList(current?.members?.join(",")) };
+  },
+});
 let customDomainRevision = 0;
 function savedCustomDomain(): string | null {
   if (DESKTOP_MANAGED || !cfg.customDomain) return null;
@@ -7459,15 +7468,19 @@ function configStatus() {
     // show the same durable session as an agent, but config PATCH validation
     // keeps it read-only and rejects callers that try to choose it.
     browserProfiles: cfg.browserProfiles ?? [],
+    // who may sign in with an emailed code (server/account-signin.ts)
+    signIn: { admins: cfg.signIn?.admins ?? [], members: cfg.signIn?.members ?? [] },
   };
 }
 
 function configForAccess(status: ReturnType<typeof configStatus>, admin: boolean) {
   if (admin) return status;
-  // Configured-or-not is fine; an SSH alias, an email, and a browser
-  // partition id are not a client's business. Preserve the source objects.
+  // Configured-or-not is fine; an SSH alias, an email, a browser partition
+  // id, and the sign-in list are not a client's business. Preserve the
+  // source objects.
   return {
     ...status,
+    signIn: { admins: [], members: [] },
     vps: { configured: status.vps.configured, sshAlias: "" },
     profile: { name: status.profile.name, email: "" },
     browserProfiles: status.browserProfiles.map((profile) => Object.fromEntries(Object.entries(profile).filter(([key]) => key !== "partitionId"))),
@@ -7669,13 +7682,49 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
     // paired session with the right scope.
     if (method === "GET" && !path.startsWith("/api/") && !path.startsWith("/.well-known/") && serveStatic(res, path)) return;
     if (method === "GET" && path === "/.well-known/openmausbot/environment") {
-      return json(res, 200, environmentDescriptor({ environmentId: ENVIRONMENT_ID, desktopManaged: DESKTOP_MANAGED }));
+      return json(res, 200, environmentDescriptor({ environmentId: ENVIRONMENT_ID, desktopManaged: DESKTOP_MANAGED, emailSignIn: emailSignIn.enabled() }));
     }
     const domainCheck = /^\/\.well-known\/openmausbot\/domain-check\/([a-f0-9]{64})$/.exec(path);
     if (method === "GET" && domainCheck) {
       res.setHeader("cache-control", "no-store");
       const challenge = customDomainVerifier.challenge(domainCheck[1]);
       return json(res, challenge ? 200 : 404, challenge ?? { error: "No active domain check." });
+    }
+    // Sign in with an emailed code (server/account-signin.ts). Public like
+    // /api/auth/pair, JSON-only for the same reason, and counted against the
+    // same per-source lockout so a code cannot be guessed.
+    if (method === "POST" && (path === "/api/auth/email/start" || path === "/api/auth/email/verify")) {
+      if (!/^application\/json\b/i.test(String(req.headers["content-type"] ?? ""))) {
+        return json(res, 415, { error: "send the sign-in request as JSON (content-type: application/json)" });
+      }
+      if (!emailSignIn.enabled()) return json(res, 404, { error: "email sign-in is not set up on this server; use a pairing code" });
+      const source = requestSource(req);
+      const allowed = sessions.attemptAllowed(source);
+      if (!allowed.ok) return json(res, 429, { error: `too many failed sign-in attempts from your address; try again in ${Math.ceil(allowed.retryAfterMs / 1000)}s` });
+      const body = await readBody(req);
+      const email = typeof body?.email === "string" ? body.email : "";
+      if (path === "/api/auth/email/start") {
+        const started = await emailSignIn.start(email);
+        if (!started.ok) {
+          if (started.status === 403) sessions.noteFailure(source);
+          return json(res, started.status, { error: started.error });
+        }
+        return json(res, 200, { ok: true });
+      }
+      const code = typeof body?.code === "string" ? body.code : "";
+      const label = typeof body?.label === "string" ? body.label : "";
+      const verified = await emailSignIn.verify(email, code);
+      if (!verified.ok) {
+        if (verified.status === 401 || verified.status === 403) sessions.noteFailure(source);
+        console.warn(`email sign-in refused from ${source}: ${verified.error}`);
+        return json(res, verified.status, { error: verified.error });
+      }
+      sessions.clearFailures(source);
+      const issued = sessions.issue({ label: label.trim() || labelFromUserAgent(req.headers["user-agent"]), scopes: verified.scopes, userId: verified.userId, email: verified.email });
+      const environment = environmentDescriptor({ environmentId: ENVIRONMENT_ID, desktopManaged: DESKTOP_MANAGED, emailSignIn: true });
+      const secure = requestOrigin(req)?.startsWith("https://") === true;
+      res.setHeader("set-cookie", serializeSessionCookie(SESSION_COOKIE, issued.token, { secure, maxAgeSeconds: cookieMaxAgeSeconds(issued.session) }));
+      return json(res, 200, { session: issued.session, environment });
     }
     if (method === "POST" && path === "/api/auth/pair") {
       // JSON only: a cross-site HTML form cannot send this content type
@@ -7694,7 +7743,7 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
         console.warn(`pairing refused from ${requestSource(req)}: ${result.error}`);
         return json(res, result.status, { error: result.error });
       }
-      const environment = environmentDescriptor({ environmentId: ENVIRONMENT_ID, desktopManaged: DESKTOP_MANAGED });
+      const environment = environmentDescriptor({ environmentId: ENVIRONMENT_ID, desktopManaged: DESKTOP_MANAGED, emailSignIn: emailSignIn.enabled() });
       if (wantsCookie) {
         const secure = requestOrigin(req)?.startsWith("https://") === true;
         res.setHeader("set-cookie", serializeSessionCookie(SESSION_COOKIE, result.token, { secure, maxAgeSeconds: cookieMaxAgeSeconds(result.session) }));
@@ -7748,6 +7797,8 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
               expiresAt: auth.session.expiresAt,
               via: auth.via,
               environmentId: ENVIRONMENT_ID,
+              // the account behind the session, when it came from a sign-in
+              ...(auth.session.email ? { email: auth.session.email } : {}),
             },
       );
     }

--- a/server/remote-sessions.test.ts
+++ b/server/remote-sessions.test.ts
@@ -140,7 +140,7 @@ describe("before pairing", () => {
     expect(descriptor.body.environmentId).toMatch(/^[0-9a-f-]{36}$/);
     expect(descriptor.body.label).toBe("cab mini");
     expect(descriptor.body.version).toBe("9.9.9-test");
-    expect(descriptor.body.capabilities).toEqual({ remoteSessions: true, selfUpdate: "operator" });
+    expect(descriptor.body.capabilities).toEqual({ remoteSessions: true, selfUpdate: "operator", emailSignIn: false });
     const refused = await call("/api/bots", { headers: remote("10.0.0.1") });
     expect(refused.status).toBe(403);
     expect(refused.body.error).toMatch(/pair this device/);

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -72,6 +72,9 @@ const sessionSchema = z.object({
   createdAt: z.number(),
   lastSeenAt: z.number(),
   expiresAt: z.number(),
+  /** Set when the session came from an account sign-in rather than a code. */
+  userId: z.string().max(256).optional(),
+  email: z.string().max(320).optional(),
 });
 
 const fileSchema = z.object({ version: z.literal(1), sessions: z.array(sessionSchema) });
@@ -86,6 +89,8 @@ export interface PublicSession {
   createdAt: number;
   lastSeenAt: number;
   expiresAt: number;
+  /** The account that signed in, when it was an account and not a code. */
+  email?: string;
 }
 
 export interface PairingCode {
@@ -146,7 +151,7 @@ export function formatPairingCode(code: string): string {
 }
 
 function publicSession(record: SessionRecord): PublicSession {
-  return {
+  const view: PublicSession = {
     id: record.id,
     label: record.label,
     scopes: [...record.scopes],
@@ -154,6 +159,8 @@ function publicSession(record: SessionRecord): PublicSession {
     lastSeenAt: record.lastSeenAt,
     expiresAt: record.expiresAt,
   };
+  if (record.email) view.email = record.email;
+  return view;
 }
 
 export class SessionRegistry {
@@ -328,6 +335,43 @@ export class SessionRegistry {
     const result: ExchangeResult = { ok: true, token, session: publicSession(record) };
     if (attemptId) this.replays.push({ codeHash: presented, attemptId, result, expiresAt: now + EXCHANGE_REPLAY_MS });
     return result;
+  }
+
+  /** A session from a verified account sign-in (server/account-signin.ts)
+   * rather than a pairing code: same token, same term, same gates. */
+  issue(input: { label: string; scopes: Scope[]; userId?: string; email?: string }): { token: string; session: PublicSession } {
+    this.prune();
+    const now = this.now();
+    const token = `omb_sess_${randomBytes(32).toString("base64url")}`;
+    const record: SessionRecord = {
+      id: randomUUID(),
+      tokenHash: sha256(token),
+      label: (input.label.trim() || "Unnamed device").slice(0, 80),
+      scopes: [...new Set(input.scopes)],
+      createdAt: now,
+      lastSeenAt: now,
+      expiresAt: now + Math.min(SESSION_TTL_MS, SESSION_MAX_AGE_MS),
+    };
+    if (input.userId) record.userId = input.userId;
+    if (input.email) record.email = input.email;
+    this.sessions.push(record);
+    this.lastSeenWrites.set(record.id, now);
+    this.persist();
+    return { token, session: publicSession(record) };
+  }
+
+  /** The pairing lockout, for other code-like exchanges on the same source. */
+  attemptAllowed(source: string): { ok: true } | { ok: false; retryAfterMs: number } {
+    const lock = this.lockState(source);
+    return lock.locked ? { ok: false, retryAfterMs: lock.retryAfterMs } : { ok: true };
+  }
+
+  noteFailure(source: string): void {
+    this.recordFailure(source);
+  }
+
+  clearFailures(source: string): void {
+    this.failures.delete(source);
   }
 
   // ── sessions ───────────────────────────────────────────────────────────

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -7,7 +7,7 @@ export interface EnvironmentDescriptor {
   label: string;
   platform: string;
   version: string;
-  capabilities: { remoteSessions: true; selfUpdate: "desktop-managed" | "operator" };
+  capabilities: { remoteSessions: true; selfUpdate: "desktop-managed" | "operator"; emailSignIn?: boolean };
 }
 
 export type SessionState =
@@ -84,4 +84,28 @@ export async function pairWithCode(
   if (res.ok) return { ok: true };
   const error = Reflect.get(Object(body), "error");
   return { ok: false, error: typeof error === "string" ? error : `${res.status} ${res.statusText}` };
+}
+
+/** Server-side JSON exchanges that end in a session cookie. */
+async function postAuth(path: string, body: Record<string, unknown>, fetchImpl: typeof fetch): Promise<{ ok: true } | { ok: false; error: string }> {
+  let res: Response;
+  try {
+    res = await fetchImpl(path, { method: "POST", credentials: "same-origin", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+  } catch (error) {
+    return { ok: false, error: `could not reach the server (${error instanceof Error ? error.message : String(error)})` };
+  }
+  const parsed: unknown = await res.json().catch(() => ({}));
+  if (res.ok) return { ok: true };
+  const error = Reflect.get(Object(parsed), "error");
+  return { ok: false, error: typeof error === "string" ? error : `${res.status} ${res.statusText}` };
+}
+
+/** Ask the server to email a sign-in code (the server checks its allow-list first). */
+export function startEmailSignIn(email: string, fetchImpl: typeof fetch = fetch): Promise<{ ok: true } | { ok: false; error: string }> {
+  return postAuth("/api/auth/email/start", { email }, fetchImpl);
+}
+
+/** Exchange the emailed code for a session cookie. */
+export function verifyEmailSignIn(input: { email: string; code: string; label: string }, fetchImpl: typeof fetch = fetch): Promise<{ ok: true } | { ok: false; error: string }> {
+  return postAuth("/api/auth/email/verify", { email: input.email, code: input.code, label: input.label }, fetchImpl);
 }

--- a/src/pair/PairPage.tsx
+++ b/src/pair/PairPage.tsx
@@ -1,9 +1,24 @@
 import { useEffect, useState } from "react";
 
-import { defaultDeviceLabel, newAttemptId, pairWithCode, readSessionState, type EnvironmentDescriptor, type SessionState } from "../lib/session";
+import {
+  defaultDeviceLabel,
+  newAttemptId,
+  pairWithCode,
+  readSessionState,
+  startEmailSignIn,
+  verifyEmailSignIn,
+  type EnvironmentDescriptor,
+  type SessionState,
+} from "../lib/session";
+
+const input = "mt-1 w-full rounded-md border border-line bg-surface px-3 py-2 text-[14px] text-ink outline-none focus:border-accent-border";
+const button = "mt-5 w-full rounded-md bg-accent px-4 py-2 text-[14px] font-medium text-accent-ink disabled:opacity-50";
+const fieldLabel = "mt-4 block text-[12px] font-medium text-ink-secondary";
 
 /** The page a pairing link opens: /pair#code=XXXX-XXXX-XXXX. Also what the
- * app shows instead of itself when a remote browser has no session yet. */
+ * app shows instead of itself when a remote browser has no session yet.
+ * When the server has a sign-in allow-list, "sign in with your email" comes
+ * first and the pairing code stays one link away. */
 export function PairPage({ initialCode, reason }: { initialCode: string | null; reason?: string }) {
   const [code, setCode] = useState(initialCode ?? "");
   const [label, setLabel] = useState(defaultDeviceLabel());
@@ -13,18 +28,29 @@ export function PairPage({ initialCode, reason }: { initialCode: string | null; 
   const [error, setError] = useState<string | null>(null);
   // one id per code typed: a retry after a lost response reuses it, a new code gets a new one
   const [attemptId, setAttemptId] = useState(() => newAttemptId());
+  const [mode, setMode] = useState<"email" | "code" | null>(initialCode ? "code" : null);
+  const [email, setEmail] = useState("");
+  const [otp, setOtp] = useState("");
+  const [sent, setSent] = useState(false);
 
   useEffect(() => {
     void fetch("/.well-known/openmausbot/environment")
       .then((r) => (r.ok ? r.json() : null))
-      .then((d: EnvironmentDescriptor | null) => setEnvironment(d))
-      .catch(() => setEnvironment(null));
+      .then((d: EnvironmentDescriptor | null) => {
+        setEnvironment(d);
+        setMode((current) => current ?? (d?.capabilities.emailSignIn ? "email" : "code"));
+      })
+      .catch(() => {
+        setEnvironment(null);
+        setMode((current) => current ?? "code");
+      });
     void readSessionState().then(setSession);
   }, []);
 
   const connected = session?.kind === "loopback" || session?.kind === "session";
+  const emailOffered = environment?.capabilities.emailSignIn === true;
 
-  async function submit(e: React.FormEvent) {
+  async function submitCode(e: React.FormEvent) {
     e.preventDefault();
     setBusy(true);
     setError(null);
@@ -37,13 +63,39 @@ export function PairPage({ initialCode, reason }: { initialCode: string | null; 
     setError(result.error);
   }
 
+  async function submitEmail(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+    const result = sent ? await verifyEmailSignIn({ email, code: otp, label }) : await startEmailSignIn(email);
+    setBusy(false);
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+    if (sent) {
+      location.replace("/");
+      return;
+    }
+    setSent(true);
+  }
+
+  function switchMode(next: "email" | "code") {
+    setMode(next);
+    setError(null);
+  }
+
   return (
     <main className="flex min-h-screen items-center justify-center bg-app px-6 text-ink">
-      <form onSubmit={submit} className="w-full max-w-[420px]">
-        <h1 className="text-[20px] font-semibold">Connect to {environment?.label ?? "this OpenMausBot"}</h1>
+      <div className="w-full max-w-[420px]">
+        <h1 className="text-[20px] font-semibold">{mode === "email" ? "Sign in to" : "Connect to"} {environment?.label ?? "this OpenMausBot"}</h1>
         <p className="mt-1.5 text-[13.5px] leading-relaxed text-ink-secondary">
           {environment ? `Version ${environment.version} on ${environment.platform}. ` : ""}
-          Enter the pairing code shown on the server. Codes work once and expire after five minutes.
+          {mode === "email"
+            ? sent
+              ? `We emailed an 8-digit code to ${email}. It works once and expires in ten minutes.`
+              : "Enter your email and we will send you a one-time code."
+            : "Enter the pairing code shown on the server. Codes work once and expire after five minutes."}
         </p>
         {reason && !connected ? <p className="mt-3 text-[13px] text-ink-secondary">{reason}</p> : null}
         {connected ? (
@@ -53,9 +105,62 @@ export function PairPage({ initialCode, reason }: { initialCode: string | null; 
               Open the app
             </a>
           </p>
+        ) : mode === "email" ? (
+          <form onSubmit={submitEmail}>
+            <label className={fieldLabel} htmlFor="signin-email">
+              Email
+            </label>
+            <input
+              id="signin-email"
+              type="email"
+              value={email}
+              onChange={(e) => {
+                setEmail(e.target.value);
+                setSent(false);
+                setOtp("");
+              }}
+              autoComplete="email"
+              inputMode="email"
+              spellCheck={false}
+              className={input}
+            />
+            {sent ? (
+              <>
+                <label className={fieldLabel} htmlFor="signin-code">
+                  Code from the email
+                </label>
+                <input
+                  id="signin-code"
+                  value={otp}
+                  onChange={(e) => setOtp(e.target.value)}
+                  placeholder="12345678"
+                  autoComplete="one-time-code"
+                  inputMode="numeric"
+                  spellCheck={false}
+                  className={`${input} font-mono text-[15px] tracking-[0.12em]`}
+                />
+                <label className={fieldLabel} htmlFor="signin-label">
+                  This device
+                </label>
+                <input id="signin-label" value={label} onChange={(e) => setLabel(e.target.value)} maxLength={80} className={input} />
+              </>
+            ) : null}
+            {error ? <p className="mt-3 text-[13px] text-danger">{error}</p> : null}
+            <button type="submit" disabled={busy || !email.includes("@") || (sent && otp.replace(/\D/g, "").length < 8)} className={button}>
+              {busy ? (sent ? "Signing in…" : "Sending…") : sent ? "Sign in" : "Send code"}
+            </button>
+            {sent ? (
+              <button type="button" onClick={() => setSent(false)} className="mt-3 w-full text-[13px] text-ink-secondary underline">
+                Send a new code
+              </button>
+            ) : null}
+            <button type="button" onClick={() => switchMode("code")} className="mt-3 w-full text-[13px] text-ink-secondary underline">
+              Have a pairing code instead?
+            </button>
+          </form>
         ) : (
-          <>
-            <label className="mt-5 block text-[12px] font-medium text-ink-secondary" htmlFor="pair-code">
+          <form onSubmit={submitCode}>
+            <label className={fieldLabel} htmlFor="pair-code">
               Pairing code
             </label>
             <input
@@ -69,29 +174,24 @@ export function PairPage({ initialCode, reason }: { initialCode: string | null; 
               autoComplete="one-time-code"
               autoCapitalize="characters"
               spellCheck={false}
-              className="mt-1 w-full rounded-md border border-line bg-surface px-3 py-2 font-mono text-[15px] tracking-[0.12em] text-ink outline-none focus:border-accent-border"
+              className={`${input} font-mono text-[15px] tracking-[0.12em]`}
             />
-            <label className="mt-4 block text-[12px] font-medium text-ink-secondary" htmlFor="pair-label">
+            <label className={fieldLabel} htmlFor="pair-label">
               This device
             </label>
-            <input
-              id="pair-label"
-              value={label}
-              onChange={(e) => setLabel(e.target.value)}
-              maxLength={80}
-              className="mt-1 w-full rounded-md border border-line bg-surface px-3 py-2 text-[14px] text-ink outline-none focus:border-accent-border"
-            />
+            <input id="pair-label" value={label} onChange={(e) => setLabel(e.target.value)} maxLength={80} className={input} />
             {error ? <p className="mt-3 text-[13px] text-danger">{error}</p> : null}
-            <button
-              type="submit"
-              disabled={busy || code.replace(/[^a-z0-9]/gi, "").length < 12}
-              className="mt-5 w-full rounded-md bg-accent px-4 py-2 text-[14px] font-medium text-accent-ink disabled:opacity-50"
-            >
+            <button type="submit" disabled={busy || code.replace(/[^a-z0-9]/gi, "").length < 12} className={button}>
               {busy ? "Connecting…" : "Connect"}
             </button>
-          </>
+            {emailOffered ? (
+              <button type="button" onClick={() => switchMode("email")} className="mt-3 w-full text-[13px] text-ink-secondary underline">
+                Sign in with your email instead
+              </button>
+            ) : null}
+          </form>
         )}
-      </form>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
For a hosted workspace that other people use every day (the first client is live on her own box), the pairing code is the wrong front door: it needs the owner each time. This adds **Sign in with your email** to `/pair`, shown first when the server has an allow-list.

```sh
OMB_SIGNIN_EMAILS="her@yourcompany.com, @yourcompany.com"   # full access
OMB_SIGNIN_MEMBER_EMAILS="freelancer@example.com"          # chat and approvals only
```

- Entries are addresses or `@domain`; admins get everything a `serve` pairing code gives, members get the chat-only scope of `pair --client`. Also `signIn.admins` / `signIn.members` in `config.json` (admin-only in `GET /api/config`, writable through `PUT /api/config`), read per request so no restart is needed; env wins when set.
- The emailed code comes from `accounts.openmausbot.com`, the account service the companion and `openmausbot login` already use, so a self-hoster needs no email credentials. The exchange is server-side: `POST /api/auth/email/start` and `/verify`, JSON-only like `/api/auth/pair`, counted against the same per-source lockout. The browser only ever talks to this server; who is welcome is decided only by the allow-list.
- The server issues its own cookie session with `email` and the granted scopes. Everything downstream is unchanged: client allow-list, revocation, stream tickets, sessions list (which now shows the email), `GET /api/auth/session` (now includes `email`).
- The public descriptor gains `capabilities.emailSignIn`; the pair page offers email first when true, with "Have a pairing code instead?" one link away. Servers without an allow-list are unchanged.

**Tests**: allow-list parsing and matching incl. no look-alike domains; the exchange against the stub control plane (welcome and unwelcome, wrong and malformed code, sign-out afterwards, service down); end to end on a booted server reached as a remote browser (descriptor flag, 415 for forms, 403 for strangers, admin session with email, member scope limited, `@domain`, per-source lockout). 127 tests across the touched suites; typecheck (server and UI) and lint clean.

**Not in this PR**: a Settings screen to edit the list (env or the config API for now), and the phone app (in progress separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional “Sign in with your email” using one-time verification codes.
  - Supports separate administrator and member email or domain allow-lists.
  - Administrators receive full access; members receive chat-only access.
  - Added sign-in status reporting and session visibility for signed-in email addresses.
  - Pairing now offers email sign-in when supported, while retaining pairing-code access.
  - Added rate limiting, lockout protection, and handling for invalid or expired codes.

- **Documentation**
  - Added self-hosting guidance for configuring and using email sign-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->