### PR TITLE
feat(ios): pair with a server's pairing link, not only the companion

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -344,12 +344,17 @@ is the reference implementation.
 ## Using it from your phone
 
 The iOS app pairs with a server the same way a laptop does: scan the QR
-code that `openmausbot serve` (or `openmausbot pair`) prints, or paste the
+code that `openmausbot serve` (or `openmausbot pair`) prints, paste the
 whole `https://host/pair#code=…` link into the address field on the pairing
-screen. The phone gets a session of its own, listed and revocable with
-`openmausbot sessions`. It can chat, approve, and read; creating bots,
-changing models, connecting apps and cloud computers stay with the owner in
-the server's own UI, and the app hides those controls.
+screen, or type the address and then the code. The phone gets a session of
+its own, listed and revocable with `openmausbot sessions`. What it may do is
+the code's scope: a code from `openmausbot pair` carries `admin` and the app
+shows everything; a code from `openmausbot pair --client` (also what the
+guided phone setup mints) can chat, approve and read, and the app hides
+creating bots and sections, changing models, generating avatars, connecting
+apps and cloud desktops — those stay with the owner. A server reinstalled at
+the same address has a new identity; the app then asks to pair again rather
+than present the old session to it.
 
 Older way, still supported: run the companion sidecar next to the harness
 and pair by its own QR. It advertises on your private networks

--- a/ios/App/AgentProfileView.swift
+++ b/ios/App/AgentProfileView.swift
@@ -111,68 +111,72 @@ struct AgentProfileView: View {
     var body: some View {
         NavigationStack {
             Form {
-                Section {
-                    if !modelsLoaded {
-                        HStack {
-                            Text("Loading models")
-                            Spacer()
-                            ProgressView()
-                        }
-                    } else if instanceChoices.isEmpty {
-                        Label("No model providers are available", systemImage: "exclamationmark.triangle")
-                            .foregroundStyle(.secondary)
-                    } else {
-                        Picker("Provider", selection: $selectedInstanceID) {
-                            if !instances.contains(where: { $0.instanceId == selectedInstanceID }) {
-                                Text("Current provider (unavailable)")
-                                    .tag(selectedInstanceID)
-                                    .disabled(true)
+                // Changing the model and generating avatars need the admin scope
+                // on a server; a chat-only phone is not shown either.
+                if session.canAdminister {
+                    Section {
+                        if !modelsLoaded {
+                            HStack {
+                                Text("Loading models")
+                                Spacer()
+                                ProgressView()
                             }
-                            ForEach(instanceChoices) { instance in
-                                Text(instanceLabel(instance))
-                                    .tag(instance.instanceId)
-                                    .disabled(!instance.snapshot.isAvailable)
-                            }
-                        }
-                        .onChange(of: selectedInstanceID) { _, instanceID in
-                            selectDefaults(for: instanceID)
-                        }
-
-                        Picker("Model", selection: $selectedModelID) {
-                            ForEach(selectedModelChoices) { option in
-                                Text(option.label).tag(option.id)
-                            }
-                        }
-                        .disabled(selectedInstance?.snapshot.isAvailable != true)
-
-                        if !effortLevels.isEmpty {
-                            Picker("Reasoning effort", selection: $selectedEffort) {
-                                Text("Default").tag(String?.none)
-                                ForEach(effortLevels, id: \.self) { level in
-                                    Text(effortLabel(level)).tag(Optional(level))
+                        } else if instanceChoices.isEmpty {
+                            Label("No model providers are available", systemImage: "exclamationmark.triangle")
+                                .foregroundStyle(.secondary)
+                        } else {
+                            Picker("Provider", selection: $selectedInstanceID) {
+                                if !instances.contains(where: { $0.instanceId == selectedInstanceID }) {
+                                    Text("Current provider (unavailable)")
+                                        .tag(selectedInstanceID)
+                                        .disabled(true)
+                                }
+                                ForEach(instanceChoices) { instance in
+                                    Text(instanceLabel(instance))
+                                        .tag(instance.instanceId)
+                                        .disabled(!instance.snapshot.isAvailable)
                                 }
                             }
-                        }
+                            .onChange(of: selectedInstanceID) { _, instanceID in
+                                selectDefaults(for: instanceID)
+                            }
 
-                        if current.busy == true {
-                            Label("Stop this bot before changing its model.", systemImage: "hourglass")
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-                        } else if selectedInstance?.snapshot.isAvailable != true {
-                            Label("Choose an available provider to change this bot's model.", systemImage: "info.circle")
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-                        }
+                            Picker("Model", selection: $selectedModelID) {
+                                ForEach(selectedModelChoices) { option in
+                                    Text(option.label).tag(option.id)
+                                }
+                            }
+                            .disabled(selectedInstance?.snapshot.isAvailable != true)
 
-                        Button("Apply model", systemImage: "checkmark") {
-                            Task { await saveModel() }
+                            if !effortLevels.isEmpty {
+                                Picker("Reasoning effort", selection: $selectedEffort) {
+                                    Text("Default").tag(String?.none)
+                                    ForEach(effortLevels, id: \.self) { level in
+                                        Text(effortLabel(level)).tag(Optional(level))
+                                    }
+                                }
+                            }
+
+                            if current.busy == true {
+                                Label("Stop this bot before changing its model.", systemImage: "hourglass")
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                            } else if selectedInstance?.snapshot.isAvailable != true {
+                                Label("Choose an available provider to change this bot's model.", systemImage: "info.circle")
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            Button("Apply model", systemImage: "checkmark") {
+                                Task { await saveModel() }
+                            }
+                            .disabled(busy || !canApplyModel)
                         }
-                        .disabled(busy || !canApplyModel)
+                    } header: {
+                        Text("Model")
+                    } footer: {
+                        Text("Provider accounts and API keys stay on your computer. Default sends no reasoning level and lets the provider decide.")
                     }
-                } header: {
-                    Text("Model")
-                } footer: {
-                    Text("Provider accounts and API keys stay on your computer. Default sends no reasoning level and lets the provider decide.")
                 }
 
                 Section {
@@ -207,19 +211,21 @@ struct AgentProfileView: View {
                     Text("PNG, JPEG, GIF, or WebP, up to 10 MB. Images are stored on your paired computer and loaded with this device's pairing token.")
                 }
 
-                Section {
-                    TextField("Art direction", text: $prompt, axis: .vertical)
-                        .lineLimit(2...5)
-                    Button("Generate on computer", systemImage: "sparkles") {
-                        Task { await generateImage() }
+                if session.canAdminister {
+                    Section {
+                        TextField("Art direction", text: $prompt, axis: .vertical)
+                            .lineLimit(2...5)
+                        Button("Generate on computer", systemImage: "sparkles") {
+                            Task { await generateImage() }
+                        }
+                        .disabled(busy || !imageGenerationReady || prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    } header: {
+                        Text("Generate an avatar")
+                    } footer: {
+                        Text(imageGenerationReady
+                             ? "Generation uses the shared image provider configured on your computer. No provider key is sent to or stored on this device."
+                             : "To generate images, configure the shared image provider in OpenMausBot on your computer. Provider keys cannot be added from this device.")
                     }
-                    .disabled(busy || !imageGenerationReady || prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                } header: {
-                    Text("Generate an avatar")
-                } footer: {
-                    Text(imageGenerationReady
-                         ? "Generation uses the shared image provider configured on your computer. No provider key is sent to or stored on this device."
-                         : "To generate images, configure the shared image provider in OpenMausBot on your computer. Provider keys cannot be added from this device.")
                 }
 
                 Section("Identity") {
@@ -313,7 +319,7 @@ struct AgentProfileView: View {
             .task {
                 async let status = session.configStatus()
                 async let options = session.voiceOptions()
-                async let catalog = session.modelInstances()
+                async let catalog = loadModelCatalog()
                 let (loadedConfig, loadedVoices, loadedInstances) = await (status, options, catalog)
                 config = loadedConfig
                 voices = loadedVoices
@@ -354,6 +360,12 @@ struct AgentProfileView: View {
             synchronizeForm(with: updated)
         }
         busy = false
+    }
+
+    /// The provider list is admin-only on a server: asking without the
+    /// scope would only put a 403 on screen for a picker that is not shown.
+    private func loadModelCatalog() async -> [Instance] {
+        session.canAdminister ? await session.modelInstances() : []
     }
 
     private func saveModel() async {

--- a/ios/App/ChatListView.swift
+++ b/ios/App/ChatListView.swift
@@ -378,8 +378,10 @@ struct ChatListView: View {
             updatesButton
                 .frame(width: 180)
             searchButton
-            sectionButton
-            newBotButton
+            if session.canAdminister {
+                sectionButton
+                newBotButton
+            }
         }
     }
 
@@ -388,23 +390,23 @@ struct ChatListView: View {
             updatesButton
                 .frame(minWidth: 148)
             searchButton
-            // Creating bots and sections is the owner's, on the server's own
-            // UI, when this phone is paired with a server directly.
-            if session.connection?.pairedWithServer != true {
-            Menu {
-                Button("New section", systemImage: "folder.badge.plus", action: openNewSection)
-                    .disabled(!hasVisibleBots)
-                Button("New bot", systemImage: "square.and.pencil", action: createBot)
-            } label: {
-                Image(systemName: "plus")
-                    .font(.system(size: 20, weight: .medium))
-                    .foregroundStyle(Color.primary)
-                    .frame(width: 48, height: 48)
-                    .contentShape(Circle())
-            }
-            .buttonStyle(.plain)
-            .glassCapsule()
-            .accessibilityLabel("Create")
+            // Creating bots and sections needs the admin scope on a server;
+            // a chat-only phone is not shown buttons the server would refuse.
+            if session.canAdminister {
+                Menu {
+                    Button("New section", systemImage: "folder.badge.plus", action: openNewSection)
+                        .disabled(!hasVisibleBots)
+                    Button("New bot", systemImage: "square.and.pencil", action: createBot)
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 20, weight: .medium))
+                        .foregroundStyle(Color.primary)
+                        .frame(width: 48, height: 48)
+                        .contentShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .glassCapsule()
+                .accessibilityLabel("Create")
             }
         }
     }

--- a/ios/App/ComputerView.swift
+++ b/ios/App/ComputerView.swift
@@ -64,7 +64,8 @@ struct ComputerView: View {
             // A VPS-backed bot is "cloud" too, but the server refuses to mint
             // an interactive desktop for it — no button beats a dead one. An
             // older harness never sends cloudBackend, so nil keeps the button.
-            if current.computer == "cloud" && current.cloudBackend != "vps" {
+            // Minting a desktop session is admin-only on a server, too.
+            if current.computer == "cloud" && current.cloudBackend != "vps" && session.canAdminister {
                 VStack(spacing: 8) {
                     if let desktopError {
                         Text(desktopError)

--- a/ios/App/PairingView.swift
+++ b/ios/App/PairingView.swift
@@ -317,7 +317,7 @@ struct PairingView: View {
                 .disabled(pairing)
             } else {
                 VStack(spacing: 12) {
-                    Text("Enter the 6-digit code shown on your computer")
+                    Text("Enter the code shown on your computer")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
 
@@ -335,6 +335,13 @@ struct PairingView: View {
                             // six digits for a computer, ABCD-EFGH-JKLM for a server
                             code = String(value.uppercased().filter { $0.isASCII && ($0.isNumber || $0.isLetter || $0 == "-") }.prefix(14))
                         }
+
+                    if code.count >= 12, !Self.codeLooksComplete(code) {
+                        Text("A server's code is 12 letters and digits, never 0, O, 1 or I.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
 
                     Button {
                         Haptics.selection()

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -53,6 +53,10 @@ final class Session: ObservableObject {
     @Published private(set) var state = CompanionState()
     @Published private(set) var connection: Connection?
     @Published private(set) var connections: [Connection] = []
+    /// Whether the live pairing may administer the workspace — see
+    /// `Connection.canAdminister`. Views hide owner-only controls when this
+    /// is false rather than offer buttons the server would answer 403 to.
+    var canAdminister: Bool { connection?.canAdminister ?? false }
     @Published private(set) var status: Status = .unpaired
     /// Transient, user-facing failures from an action they just took.
     @Published var actionError: String?
@@ -273,8 +277,12 @@ final class Session: ObservableObject {
             invited.establishRoutePolicyFromInvite()
         }
         // A 12-character code pairs with a server directly (its own sessions,
-        // a client-scope bearer); anything else is the companion sidecar's.
+        // a bearer with the code's scopes); anything else is the companion's.
         if let code = PairingInvite.normalizedServerCode(credential) {
+            // Reachability first, on the public descriptor: a wrong address
+            // then fails as an address problem rather than a code problem,
+            // and no attempt is spent against the server's lockout.
+            try await Self.confirmServer(at: invited)
             let paired = try await CompanionClient.pairWithServer(
                 connection: invited,
                 code: code,
@@ -284,6 +292,7 @@ final class Session: ObservableObject {
             var stored = invited
             if !paired.environment.label.isEmpty { stored.name = paired.environment.label }
             stored.serverEnvironmentId = paired.environment.environmentId
+            stored.serverScopes = paired.session.scopes
             stored.companionDeviceId = nil
             if let existing = registry.matchingConnection(for: stored) {
                 stored.id = existing.id
@@ -369,6 +378,21 @@ final class Session: ObservableObject {
         // keychain — the token is in hand, so there is nothing left to retry.
         restorePending = false
         connect()
+    }
+
+    /// `GET /.well-known/openmausbot/environment` on a server about to be
+    /// paired. Nothing there means this address is not a server; the message
+    /// names the address, since that is what the person can fix. Any other
+    /// answer — unreachable, a gateway error — is passed through as it is.
+    private static func confirmServer(at connection: Connection) async throws {
+        let probe = CompanionClient(connection: connection, token: nil, requestTimeout: 8)
+        do {
+            _ = try await probe.environment()
+        } catch APIError.status(404, _) {
+            throw APIError.transport(
+                "\(connection.displayAddress) isn't an OpenMausBot server. Check the address and try again."
+            )
+        }
     }
 
     func receivePairingURL(_ url: URL) {
@@ -669,6 +693,23 @@ final class Session: ObservableObject {
         while !Task.isCancelled {
             guard let client else { return }
             status = .connecting
+            // A server connection first checks it is still the same server.
+            // The descriptor is public, so this spends no credential; a
+            // changed environment id (the address now belongs to another
+            // server, or its data directory was recreated) means "pair
+            // again", exactly like a revoked token — the bearer would be
+            // refused anyway, and a fresh install must not be shown the old
+            // one. Unreachable is not "different": the stream attempt below
+            // reports that the usual way.
+            if let expected = client.connection.serverEnvironmentId {
+                let live = try? await client.environment()
+                if Task.isCancelled { return }
+                if let live, live.environmentId != expected {
+                    log.error("server identity changed: \(expected, privacy: .public) is now \(live.environmentId, privacy: .public)")
+                    status = .unauthorized
+                    return
+                }
+            }
             log.info("opening stream, cursor=\(self.state.cursor ?? "none", privacy: .public)")
             do {
                 // The query is fixed when the connection opens, so changing
@@ -793,7 +834,9 @@ final class Session: ObservableObject {
     /// sidecars return 404 and a transient refresh error must not tear down a
     /// perfectly healthy event stream.
     private func refreshConnectionMetadata(using sourceClient: CompanionClient) {
-        guard let connectionID = connection?.id else { return }
+        // A server has no companion routes to advertise (`/api/companion/*`
+        // is the sidecar's); its one address is the one that was paired.
+        guard connection?.pairedWithServer != true, let connectionID = connection?.id else { return }
         let workingEndpoint = rotation.currentEndpoint ?? sourceClient.connection.activeEndpoint
         endpointRefreshTask?.cancel()
         endpointRefreshTask = Task { [weak self] in

--- a/ios/App/SettingsView.swift
+++ b/ios/App/SettingsView.swift
@@ -132,9 +132,9 @@ struct SettingsView: View {
                         }
                     }
 
-                    // Connecting apps needs the admin scope; on a server the
-                    // owner does it in the server's own UI.
-                    if session.connection?.pairedWithServer != true {
+                    // Connecting apps needs the admin scope; a chat-only
+                    // server session leaves it to the owner, in the server's UI.
+                    if session.canAdminister {
                         NavigationLink {
                             ConnectedAppsView()
                         } label: {

--- a/ios/ShareExtension/ShareViewModel.swift
+++ b/ios/ShareExtension/ShareViewModel.swift
@@ -434,7 +434,10 @@ final class ShareViewModel: ObservableObject {
                 imageCapableInstances = try await withFailover { client in
                     try await client.imageCapableInstanceIDs()
                 }
-            } catch APIError.status(code: 404, message: _) {
+            } catch APIError.status(let code, _) where code == 404 || code == 403 {
+                // 404: a harness from before the capability existed. 403: a
+                // server session without the admin scope, which may not read
+                // the instance list at all. Neither can say where images go.
                 throw ShareExtensionError.imageSupportUnavailable
             }
         } else {

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -47,10 +47,15 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
     public var companionDeviceId: String?
     /// Set when this connection was paired against the server's own sessions
     /// (`openmausbot serve` / the Docker stack) rather than the desktop's
-    /// companion sidecar: the bearer is an `omb_sess_` token with the client
-    /// scope, so what the app may administer differs. Absent on connections
-    /// saved before servers could be paired directly.
+    /// companion sidecar: the bearer is an `omb_sess_` token whose scopes
+    /// say what the app may administer. Absent on connections saved before
+    /// servers could be paired directly.
     public var serverEnvironmentId: String?
+    /// The scopes the server granted this session at pairing, kept so the
+    /// app can tell an owner's phone (`admin`) from a chat-only one
+    /// (`client`) without asking. Absent on server connections saved by
+    /// builds that did not record them, which the app treated as chat-only.
+    public var serverScopes: [String]?
 
     public init(
         id: String = UUID().uuidString,
@@ -64,7 +69,8 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
         allowedLocalRouteURLs: Set<String>? = nil,
         secretPublicKey: String? = nil,
         companionDeviceId: String? = nil,
-        serverEnvironmentId: String? = nil
+        serverEnvironmentId: String? = nil,
+        serverScopes: [String]? = nil
     ) {
         self.id = id
         self.name = name
@@ -78,12 +84,25 @@ public struct Connection: Codable, Hashable, Identifiable, Sendable {
         self.secretPublicKey = secretPublicKey
         self.companionDeviceId = companionDeviceId
         self.serverEnvironmentId = serverEnvironmentId
+        self.serverScopes = serverScopes
     }
 
-    /// Paired with a server directly (client scope): chat, approvals and
-    /// reading are in; creating bots, changing models, connected apps and
-    /// cloud computers are the owner's, done on the server's own UI.
+    /// Paired with a server directly rather than through the companion
+    /// sidecar. What the phone may do there is for the session's scopes to
+    /// say: see `canAdminister`.
     public var pairedWithServer: Bool { serverEnvironmentId != nil }
+
+    /// Whether this pairing may administer the workspace: create bots and
+    /// sections, change models, generate avatars, connect apps, open cloud
+    /// desktops. A companion pairing always may — the sidecar applies its
+    /// own policy to each request. A server session may only with the
+    /// `admin` scope (`openmausbot pair` grants it; `--client` does not);
+    /// the server answers 403 otherwise, so the app hides those controls
+    /// instead of offering buttons that can only fail.
+    public var canAdminister: Bool {
+        guard pairedWithServer else { return true }
+        return serverScopes?.contains("admin") == true
+    }
 
     /// The representation `URLComponents.host` accepts for a literal IPv6
     /// address. It adds brackets exactly once and leaves DNS/IPv4 names alone.
@@ -327,14 +346,30 @@ public struct PairingInvite: Equatable, Sendable {
         return PairingInvite(connection: connection, credential: code)
     }
 
-    /// A server pairing code: 12 characters from a confusion-free alphabet,
-    /// shown as three dashed groups. Only the shape is checked here; a
-    /// mistyped code fails at the server with its own message. Six-digit
-    /// codes and `omb_pair_` tokens are the companion's and return nil.
+    /// The 32 symbols a server draws pairing codes from: digits and capitals
+    /// without 0, O, 1 and I, which read alike in most fonts.
+    public static let serverCodeAlphabet = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ"
+
+    /// What the server does to a typed code before comparing it
+    /// (`normalizePairingCode` in `server/sessions.ts`): uppercase, drop
+    /// dashes, spaces and anything else that is not a letter or digit, then
+    /// read 0 as O and 1 as I. Identical here so the app and the server
+    /// never disagree about which code was entered.
+    public static func normalizePairingCode(_ raw: String) -> String {
+        String(raw.uppercased().filter { $0.isASCII && ($0.isLetter || $0.isNumber) }
+            .map { $0 == "0" ? "O" : $0 == "1" ? "I" : $0 })
+    }
+
+    /// A server pairing code, normalized: exactly 12 symbols from the
+    /// server's alphabet, dashes optional. Six-digit codes and `omb_pair_`
+    /// tokens are the companion's and return nil. So does a code with a
+    /// character the alphabet does not have — the server would refuse it
+    /// and count the attempt towards its lockout, so it is refused here,
+    /// where the person can still fix it.
     public static func normalizedServerCode(_ raw: String) -> String? {
-        let cleaned = raw.uppercased().filter { $0.isASCII && ($0.isLetter || $0.isNumber) }
-        guard cleaned.count == 12, !cleaned.allSatisfy(\.isNumber) else { return nil }
-        return cleaned
+        let code = normalizePairingCode(raw)
+        guard code.count == 12, code.allSatisfy(serverCodeAlphabet.contains) else { return nil }
+        return code
     }
 
     private static func credential(from values: [String: String]) -> String? {
@@ -1502,7 +1537,15 @@ public struct CompanionClient: Sendable {
     /// send a phone on cellular. The computer panel turns it on for exactly
     /// as long as it is open, which costs a reconnect — cheap, because the
     /// stream resumes from its cursor and loses nothing.
-    public func events(since cursor: String?, screens: Bool = false) throws -> AsyncThrowingStream<StreamFrame, Error> {
+    ///
+    /// `streamingSession` is for tests, which need to see the request the
+    /// stream is opened with; the app leaves it nil and gets the session
+    /// tuned above.
+    public func events(
+        since cursor: String?,
+        screens: Bool = false,
+        streamingSession: URLSession? = nil
+    ) throws -> AsyncThrowingStream<StreamFrame, Error> {
         var query = [URLQueryItem(name: "screens", value: screens ? "on" : "off")]
         if let cursor { query.append(URLQueryItem(name: "since", value: cursor)) }
         var streamRequest = try makeRequest("GET", "/api/events", query: query)
@@ -1516,6 +1559,6 @@ public struct CompanionClient: Sendable {
         // first quiet gap and reconnect, forever, looking like a flaky network
         // rather than a number in the wrong place.
         streamRequest.timeoutInterval = 90
-        return eventStream(request: streamRequest, session: Self.streaming)
+        return eventStream(request: streamRequest, session: streamingSession ?? Self.streaming)
     }
 }

--- a/ios/Tests/CompanionCoreTests/Fixtures/auth-pair-response.json
+++ b/ios/Tests/CompanionCoreTests/Fixtures/auth-pair-response.json
@@ -13,6 +13,6 @@
     "label": "cab mini",
     "platform": "linux",
     "version": "0.1.55",
-    "capabilities": { "remoteSessions": true, "selfUpdate": false }
+    "capabilities": { "remoteSessions": true, "selfUpdate": "operator" }
   }
 }

--- a/ios/Tests/CompanionCoreTests/Fixtures/environment.json
+++ b/ios/Tests/CompanionCoreTests/Fixtures/environment.json
@@ -3,5 +3,5 @@
   "label": "cab mini",
   "platform": "linux",
   "version": "0.1.55",
-  "capabilities": { "remoteSessions": true, "selfUpdate": false }
+  "capabilities": { "remoteSessions": true, "selfUpdate": "operator" }
 }

--- a/ios/Tests/CompanionCoreTests/ServerPairingTests.swift
+++ b/ios/Tests/CompanionCoreTests/ServerPairingTests.swift
@@ -179,4 +179,101 @@ final class ServerPairingTests: XCTestCase {
         let round = try JSONDecoder().decode(Connection.self, from: JSONEncoder().encode(server))
         XCTAssertEqual(round.serverEnvironmentId, "env_7f3a9c")
     }
+
+    func testCodeNormalizationMatchesTheServers() throws {
+        // what the server does before comparing: uppercase, strip, 0→O, 1→I
+        XCTAssertEqual(PairingInvite.normalizePairingCode(" abcd-efgh jklm "), "ABCDEFGHJKLM")
+        XCTAssertEqual(PairingInvite.normalizePairingCode("ab0d-1fgh-jklm"), "ABODIFGHJKLM")
+        XCTAssertEqual(PairingInvite.normalizedServerCode("2345-6789-abcd"), "23456789ABCD")
+        // the alphabet has neither O nor I, so a code with 0, 1, O or I can
+        // only be a mistake: refused here, before an attempt is spent
+        XCTAssertNil(PairingInvite.normalizedServerCode("ab0d-1fgh-jklm"))
+        XCTAssertNil(PairingInvite.normalizedServerCode("ABCD-EFGH-JKLO"))
+        XCTAssertNil(PairingInvite.normalizedServerCode("ABCDEFGHJKLMN")) // thirteen
+        // in a link too, whatever case the link came in
+        let invite = PairingInvite.parse(try XCTUnwrap(URL(string: "HTTPS://Mini.Example:8443/pair#code=abcd-efgh-jklm")))
+        XCTAssertEqual(invite?.credential, "ABCDEFGHJKLM")
+        XCTAssertEqual(invite?.connection.activeEndpoint?.url, "https://mini.example:8443")
+        XCTAssertNil(PairingInvite.parse(try XCTUnwrap(URL(string: "https://mini.example/pair#code=ab0d-1fgh-jklm"))))
+    }
+
+    func testEveryRefusalCarriesTheServersStatusAndMessage() async throws {
+        let connection = try XCTUnwrap(Connection.parse("https://c-7f3a9c.openmausbot.com"))
+        for (status, message) in [
+            (415, "send the pairing code as JSON (content-type: application/json)"),
+            (429, "too many failed pairing attempts from your address; try again in 60s"),
+            (400, "bad request"),
+        ] {
+            ServerRequestStub.reset { _ in (status, Data(#"{"error":"\#(message)"}"#.utf8)) }
+            do {
+                _ = try await CompanionClient.pairWithServer(connection: connection, code: "ABCDEFGHJKLM", label: "phone", session: session)
+                XCTFail("expected HTTP \(status) to be refused")
+            } catch let error as APIError {
+                guard case let .status(code, text) = error else { return XCTFail("\(error)") }
+                XCTAssertEqual(code, status)
+                XCTAssertEqual(text, message)
+                XCTAssertEqual(error.localizedDescription, message)
+                XCTAssertFalse(error.isUnauthorized, "only a 401 sends the person back to pairing")
+            }
+            // 415 is what the server answers when this header is missing
+            let request = try XCTUnwrap(ServerRequestStub.captured().first)
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        }
+    }
+
+    func testOnlyAnAdminScopedServerSessionMayAdminister() throws {
+        let companion = Connection(name: "Ada's computer", host: "192.168.1.9", port: 8810)
+        XCTAssertTrue(companion.canAdminister, "the sidecar applies its own policy to each request")
+
+        var chatOnly = try XCTUnwrap(Connection.parse("https://c-7f3a9c.openmausbot.com"))
+        chatOnly.serverEnvironmentId = "env_7f3a9c"
+        chatOnly.serverScopes = ["client"]
+        XCTAssertFalse(chatOnly.canAdminister)
+
+        var owner = chatOnly
+        owner.serverScopes = ["admin", "client"]
+        XCTAssertTrue(owner.canAdminister)
+        let round = try JSONDecoder().decode(Connection.self, from: JSONEncoder().encode(owner))
+        XCTAssertEqual(round.serverScopes, ["admin", "client"])
+        XCTAssertTrue(round.canAdminister)
+
+        // saved by a build that paired with servers but recorded no scopes:
+        // it treated every such pairing as chat-only, and so does this one
+        let earlier = Data(#"{"id":"s1","name":"cab mini","host":"c-7f3a9c.openmausbot.com","port":443,"serverEnvironmentId":"env_7f3a9c"}"#.utf8)
+        let decoded = try JSONDecoder().decode(Connection.self, from: earlier)
+        XCTAssertTrue(decoded.pairedWithServer)
+        XCTAssertNil(decoded.serverScopes)
+        XCTAssertFalse(decoded.canAdminister)
+
+        // the pair response is where the scopes come from
+        let admin = try JSONDecoder().decode(ServerPairResponse.self, from: Data(#"""
+        {"token":"omb_sess_x","session":{"id":"s","label":"iPhone","scopes":["admin","client"],"createdAt":1,"expiresAt":2},
+         "environment":{"environmentId":"env","label":"mini","platform":"darwin","version":"0.1.66",
+                        "capabilities":{"remoteSessions":true,"selfUpdate":"desktop-managed"}}}
+        """#.utf8))
+        XCTAssertTrue(admin.session.isAdmin)
+        XCTAssertEqual(admin.session.scopes, ["admin", "client"])
+    }
+
+    func testAServerConnectionsStreamCarriesTheBearerAndResumesFromTheCursor() async throws {
+        ServerRequestStub.reset { _ in (401, Data(#"{"error":"session revoked"}"#.utf8)) }
+        var connection = try XCTUnwrap(Connection.parse("https://c-7f3a9c.openmausbot.com"))
+        connection.serverEnvironmentId = "env_7f3a9c"
+        connection.serverScopes = ["client"]
+        let client = CompanionClient(connection: connection, token: "omb_sess_Zk3v", session: session)
+        do {
+            for try await _ in try client.events(since: "abc12345:7", streamingSession: session) {}
+            XCTFail("a revoked session must surface as unauthorized, not as an empty stream")
+        } catch let error as APIError {
+            XCTAssertTrue(error.isUnauthorized)
+        }
+        let request = try XCTUnwrap(ServerRequestStub.captured().first)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer omb_sess_Zk3v")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "text/event-stream")
+        let components = try XCTUnwrap(URLComponents(url: XCTUnwrap(request.url), resolvingAgainstBaseURL: false))
+        XCTAssertEqual(components.host, "c-7f3a9c.openmausbot.com")
+        XCTAssertEqual(components.path, "/api/events")
+        XCTAssertEqual(components.queryItems?.first { $0.name == "since" }?.value, "abc12345:7")
+        XCTAssertEqual(components.queryItems?.first { $0.name == "screens" }?.value, "off")
+    }
 }


### PR DESCRIPTION
Follow-up to #819 (merged Sep 5), which taught the app the server's `https://host/pair#code=XXXX-XXXX-XXXX` link and `POST /api/auth/pair`. This PR closes the gaps so a phone paired with a server behaves like a phone paired with the companion — with every companion path unchanged.

## What changes

**Scopes, not a blanket hide.** The pair response's `session.scopes` are persisted on the connection (`Connection.serverScopes`) and `Connection.canAdminister` decides what the app offers: create bot / new section (`ChatListView`), model picker and avatar generation (`AgentProfileView`), Connected Apps (`SettingsView`), live cloud desktop (`ComputerView`). A companion pairing always may; a server session only with `admin`. `openmausbot pair` grants `admin`, `--client` (and the guided phone setup) does not. #819 hid these for *every* server pairing, the owner's phone included. Server records saved without scopes decode as chat-only.

**Same server?** Before each stream open, a server connection reads `GET /.well-known/openmausbot/environment` (public); a changed `environmentId` becomes `.unauthorized` → "pair again", instead of handing the old bearer to a reinstalled server. Unreachable is not "different" and reports the usual way. Pairing probes the descriptor first as well, so a wrong address fails as an address problem and spends no attempt against the 10/min lockout. `refreshConnectionMetadata` is a no-op for server connections (`/api/companion/endpoints` is the sidecar's).

**Codes.** `PairingInvite.normalizePairingCode` mirrors `server/sessions.ts` exactly (uppercase, strip non-alphanumerics, 0→O, 1→I); `normalizedServerCode` then requires 12 symbols from `23456789ABCDEFGHJKLMNPQRSTUVWXYZ`. A lookalike is refused on the phone with a footnote rather than sent to the server. The code screen no longer says "6-digit".

**Share extension.** A 403 on `/api/instances` (client scope) degrades like the 404 an older harness returns.

**Testability.** `events(since:screens:streamingSession:)` accepts an injected session.

## Tests

`swift test --package-path ios`: 341 pass (4 new in `ServerPairingTests`): normalisation incl. 0→O/1→I and mixed-case links; 415/429/400 refusals carry the server's status + message and are not "unauthorized"; scope predicate (companion, client, admin, legacy record without scopes, Codable round trip, `ServerPairResponse` with admin scopes); a server connection's `/api/events` request carries `Authorization: Bearer`, `since` and `screens`, and a 401 surfaces as unauthorized. `xcodegen generate` + simulator build with `CODE_SIGNING_ALLOWED=NO` green locally. Fixtures `environment.json` / `auth-pair-response.json` now carry `selfUpdate: "operator"` (the server never sends `false`); Android does not decode them.

## Not verified here

No real device or live server: the reconnect identity check and the UI gating are app-target code (build-verified only). Note for the server side: `normalizePairingCode` maps 0→O and 1→I, but the alphabet contains neither O nor I, so that mapping can never yield a valid code — harmless, mirrored here for parity, worth a look separately.

## Where the map differed from the code

- A bad or expired code is **401** from `/api/auth/pair` (`sessions.exchange` returns `401 | 429`), not 400.
- `GET /api/auth/session` returns a flat `{kind,id,label,scopes,expiresAt,via,environmentId}`, not `{session:{…}}` (not used by the app).
- Scope denial is **403** (`request-auth.ts:346`), which is why the share extension now treats 403 like 404.
- `kind` is derived from `serverEnvironmentId` (as #819 chose) rather than a separate persisted enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for admin and chat-only pairing permissions.
  * Chat-only sessions can chat, approve requests, and read information, while owner-only controls remain hidden.
  * Admin sessions can access workspace management, app connections, model selection, avatar generation, and live cloud desktop features.
  * Pairing now supports QR codes and clearer code-entry guidance.

* **Bug Fixes**
  * The app now detects when a server’s identity changes and requests pairing again.
  * Improved handling of unavailable features for restricted sessions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->