### PR TITLE
feat(cli): openmausbot access — who may sign in with an emailed code

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -337,6 +337,15 @@ OMB_SIGNIN_EMAILS="her@yourcompany.com, @yourcompany.com"   # full access
 OMB_SIGNIN_MEMBER_EMAILS="freelancer@example.com"          # chat and approvals only
 ```
 
+With the npm package, the same thing from the command line, with the server
+running or not, no restart needed:
+
+```sh
+npx openmausbot access add her@yourcompany.com
+npx openmausbot access add freelancer@example.com --chat-only
+npx openmausbot access list
+```
+
 An entry is an address or `@domain` (everyone at that domain). Admins get
 the same access as a pairing code from `openmausbot serve`; members get the
 chat-only scope, the same as `openmausbot pair --client`. The same lists live

--- a/server/cli.test.ts
+++ b/server/cli.test.ts
@@ -1,11 +1,11 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { applyStartupPreferences, formatSessions, pairingBlock, parseArgs, qrToString, runLogin, runOnboardingCommand, serverEntry, verifyPhoneEndpoint, type CliOptions } from "./cli.ts";
+import { applyStartupPreferences, formatSessions, pairingBlock, parseArgs, qrToString, runAccess, runLogin, runOnboardingCommand, serverEntry, type CliOptions, verifyPhoneEndpoint } from "./cli.ts";
 import { SetupCancelled } from "./cli-prompts.ts";
 import { removeTempDir, waitForExit } from "./testing/cleanup.ts";
 import { startControlPlaneStub } from "./testing/control-plane-stub.ts";
@@ -40,6 +40,10 @@ describe("openmausbot command line", () => {
     expect(parseArgs(["browser", "status"], {})).toMatchObject({ command: "browser", browserAction: "status" });
     expect(parseArgs(["browser"], {})).toEqual({ error: "browser needs an action: install or status" });
     expect(parseArgs(["serve", "--tailscale", "--tunnel"], {})).toEqual({ error: "choose one of --tailscale (your tailnet) and --tunnel (a public address)" });
+    expect(parseArgs(["access", "add", "her@example.test", "--chat-only"], {})).toMatchObject({ command: "access", accessAction: "add", email: "her@example.test", chatOnly: true });
+    expect(parseArgs(["access", "list"], {})).toMatchObject({ command: "access", accessAction: "list" });
+    expect(parseArgs(["access"], {})).toEqual({ error: "access needs one of: list, add EMAIL [--chat-only], remove EMAIL" });
+    expect(parseArgs(["access", "add"], {})).toEqual({ error: "add needs a value" });
   });
 
   it("prints a scannable block with the link, or says where to type the code", () => {
@@ -488,4 +492,35 @@ describe.skipIf(process.platform === "win32")("serve --tunnel", () => {
       expect(dead, url).toBe(true);
     }
   }, 120_000);
+});
+
+describe("openmausbot access", () => {
+  it("edits the sign-in allow-list in config.json without a running server", async () => {
+    const home = mkdtempSync(join(tmpdir(), "omb-cli-access-"));
+    const dataDir = join(home, "data");
+    const out: string[] = [];
+    const err: string[] = [];
+    const io = { log: (line: string) => out.push(line), error: (line: string) => err.push(line), ask: async () => "" };
+    const base = { command: "access" as const, port: 1, dataDir, tailscale: false, tunnel: false, client: false, pair: true, json: false };
+    try {
+      expect(await runAccess({ ...base, accessAction: "list" }, io)).toBe(0);
+      expect(out.at(-1)).toMatch(/pairing codes only/);
+      expect(await runAccess({ ...base, accessAction: "add", email: "Her@Example.test" }, io)).toBe(0);
+      expect(await runAccess({ ...base, accessAction: "add", email: "@agentada.test", chatOnly: true }, io)).toBe(0);
+      expect(await runAccess({ ...base, accessAction: "add", email: "not-an-email" }, io)).toBe(2);
+      const saved = JSON.parse(readFileSync(join(dataDir, "config.json"), "utf8"));
+      expect(saved.signIn).toEqual({ admins: ["her@example.test"], members: ["@agentada.test"] });
+      // moving an entry between lists replaces it rather than duplicating it
+      expect(await runAccess({ ...base, accessAction: "add", email: "her@example.test", chatOnly: true }, io)).toBe(0);
+      expect(JSON.parse(readFileSync(join(dataDir, "config.json"), "utf8")).signIn).toEqual({ admins: [], members: ["@agentada.test", "her@example.test"] });
+      out.length = 0;
+      expect(await runAccess({ ...base, accessAction: "list" }, io)).toBe(0);
+      expect(out.join("\n")).toMatch(/@agentada.test\s+chat and approvals/);
+      expect(await runAccess({ ...base, accessAction: "remove", email: "her@example.test" }, io)).toBe(0);
+      expect(await runAccess({ ...base, accessAction: "remove", email: "her@example.test" }, io)).toBe(1);
+      expect(JSON.parse(readFileSync(join(dataDir, "config.json"), "utf8")).signIn).toEqual({ admins: [], members: ["@agentada.test"] });
+    } finally {
+      await removeTempDir(home);
+    }
+  });
 });

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -30,6 +30,8 @@ import { createInterface } from "node:readline/promises";
 import { fileURLToPath } from "node:url";
 import qrcode from "qrcode-terminal";
 
+import { parseAllowList } from "./account-signin.ts";
+import { writeFileAtomic } from "./atomic.ts";
 import { explainTailscaleFailure, tailscaleServe, tailscaleServeOff, tailscaleStatus, type TailscaleStatus } from "./tailscale.ts";
 import { defaultSetupIo, SetupCancelled, type SetupIo } from "./cli-prompts.ts";
 import { normalizePhoneOrigin, phonePairingInstructions, runPhoneSetup } from "./cli-phone-setup.ts";
@@ -55,7 +57,7 @@ import {
 const HERE = dirname(fileURLToPath(import.meta.url));
 
 export interface CliOptions {
-  command: "setup" | "start" | "serve" | "pair" | "sessions" | "status" | "login" | "logout" | "browser" | "help";
+  command: "setup" | "start" | "serve" | "pair" | "sessions" | "status" | "login" | "logout" | "access" | "browser" | "help";
   port: number;
   dataDir: string;
   label?: string;
@@ -65,6 +67,9 @@ export interface CliOptions {
   client: boolean;
   pair: boolean;
   revoke?: string;
+  /** `access list|add|remove` */
+  accessAction?: "list" | "add" | "remove";
+  chatOnly?: boolean;
   email?: string;
   /** `browser install [--with-deps]` */
   browserAction?: "install" | "status";
@@ -78,7 +83,7 @@ export interface CliOptions {
   phone?: "ios" | "android";
 }
 
-const COMMANDS = ["setup", "start", "serve", "pair", "sessions", "status", "login", "logout", "browser", "help", "--help", "-h"];
+const COMMANDS = ["setup", "start", "serve", "pair", "sessions", "status", "login", "logout", "access", "browser", "help", "--help", "-h"];
 
 export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): CliOptions | { error: string } {
   const implicitStart = !argv.length || (argv[0]!.startsWith("--") && argv[0] !== "--help");
@@ -96,6 +101,7 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
     pair: true,
     withDeps: false,
     json: false,
+    chatOnly: false,
   };
   for (let i = 0; i < rest.length; i += 1) {
     const arg = rest[i];
@@ -119,6 +125,10 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
       else if (arg === "--json") options.json = true;
       else if (arg === "--email") options.email = value();
       else if (options.command === "sessions" && arg === "revoke") options.revoke = value();
+      else if (options.command === "access" && !options.accessAction && (arg === "list" || arg === "add" || arg === "remove")) {
+        options.accessAction = arg;
+        if (arg !== "list") options.email = value();
+      } else if (options.command === "access" && arg === "--chat-only") options.chatOnly = true;
       else if (options.command === "browser" && (arg === "install" || arg === "status")) options.browserAction = arg;
       else if (options.command === "browser" && arg === "--with-deps") options.withDeps = true;
       else return { error: `unknown argument "${arg}"` };
@@ -129,6 +139,7 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
   if (!Number.isInteger(options.port) || options.port < 1 || options.port > 65_535) return { error: "--port must be 1-65535" };
   if (options.publicUrl && !/^https?:\/\//.test(options.publicUrl)) return { error: "--public-url must start with http:// or https://" };
   if (options.tailscale && options.tunnel) return { error: "choose one of --tailscale (your tailnet) and --tunnel (a public address)" };
+  if (options.command === "access" && !options.accessAction) return { error: "access needs one of: list, add EMAIL [--chat-only], remove EMAIL" };
   if (options.local && (options.tailscale || options.tunnel || options.publicUrl)) return { error: "--local cannot be combined with a remote-access option" };
   if (options.command === "browser" && !options.browserAction) return { error: "browser needs an action: install or status" };
   return options;
@@ -146,6 +157,7 @@ export const USAGE = `openmausbot — your team of AI bots, ready in a few steps
   openmausbot status
   openmausbot login [--email you@example.com]
   openmausbot logout
+  openmausbot access list | add EMAIL [--chat-only] | remove EMAIL
   openmausbot browser install [--with-deps] | status
 
 setup   choose AI access and optional phone access; keep existing bots and chats
@@ -157,6 +169,9 @@ status  what the server says about itself
 login   signs this machine in to an OpenMausBot account (an emailed code)
         and reserves its public address for --tunnel
 logout  releases that address and signs out
+access  who may sign in with an emailed code at /pair: an address or
+        @domain; --chat-only gives chat and approvals without settings.
+        Takes effect at once, no restart.
 browser install: the bots' browser engine (agent-browser, pinned) into the
         data dir, and Chrome for Testing into the user's browser cache.
         --with-deps also installs
@@ -441,6 +456,64 @@ export async function runStatus(options: CliOptions, io: CliIo = defaultIo()): P
     else if (account.address) io.log(`public address: ${account.address} (signed in as ${account.email ?? "?"}; serve it with --tunnel)`);
   }
   return code;
+}
+
+/** The sign-in allow-list, edited straight in config.json: the server reads
+ * it per request, so this works with the server running or stopped and
+ * needs no restart. Environment variables (OMB_SIGNIN_EMAILS) win when set.
+ * Written the way the server writes it (atomic, 0600), touching only the
+ * one key, so nothing else in the file moves. */
+export async function runAccess(options: CliOptions, io: CliIo = defaultIo()): Promise<number> {
+  const file = join(options.dataDir, "config.json");
+  let raw: Record<string, unknown> = {};
+  if (existsSync(file)) {
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(file, "utf8"));
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) throw new Error("not an object");
+      raw = Object.fromEntries(Object.entries(parsed));
+    } catch (error) {
+      io.error(`${file} could not be read (${message(error)}); fix it before changing who can sign in`);
+      return 1;
+    }
+  }
+  const current = typeof raw.signIn === "object" && raw.signIn !== null ? Object(raw.signIn) : {};
+  const list = (value: unknown) => parseAllowList(Array.isArray(value) ? value.map(String).join(",") : "");
+  const admins = list(Reflect.get(current, "admins"));
+  const members = list(Reflect.get(current, "members"));
+  const overridden = process.env.OMB_SIGNIN_EMAILS !== undefined || process.env.OMB_SIGNIN_MEMBER_EMAILS !== undefined;
+  const write = (next: { admins: string[]; members: string[] }) => {
+    mkdirSync(options.dataDir, { recursive: true, mode: 0o700 });
+    writeFileAtomic(file, `${JSON.stringify({ ...raw, signIn: next }, null, 2)}\n`, { mode: 0o600 });
+  };
+  if (options.accessAction === "list") {
+    if (!admins.length && !members.length) {
+      io.log("nobody can sign in with an email yet; pairing codes only. Add someone with: openmausbot access add you@example.com");
+      return 0;
+    }
+    for (const entry of admins) io.log(`${entry.padEnd(40)} full access`);
+    for (const entry of members) io.log(`${entry.padEnd(40)} chat and approvals`);
+    if (overridden) io.log("(OMB_SIGNIN_EMAILS / OMB_SIGNIN_MEMBER_EMAILS are set in the environment and win over this list while the server runs)");
+    return 0;
+  }
+  const entry = (options.email ?? "").trim().toLowerCase();
+  if (!entry || (!entry.startsWith("@") && !entry.includes("@")) || /\s/.test(entry)) {
+    io.error("give an email address, or @domain for everyone at that domain");
+    return 2;
+  }
+  const without = (items: string[]) => items.filter((item) => item !== entry);
+  if (options.accessAction === "remove") {
+    if (!admins.includes(entry) && !members.includes(entry)) {
+      io.error(`${entry} is not on the list`);
+      return 1;
+    }
+    write({ admins: without(admins), members: without(members) });
+    io.log(`${entry} can no longer sign in (existing sessions stay until they expire or are revoked with \`openmausbot sessions revoke\`)`);
+    return 0;
+  }
+  write(options.chatOnly ? { admins: without(admins), members: [...without(members), entry] } : { admins: [...without(admins), entry], members: without(members) });
+  io.log(`${entry} can sign in at /pair with an emailed code (${options.chatOnly ? "chat and approvals" : "full access"})`);
+  if (overridden) io.log("note: OMB_SIGNIN_EMAILS / OMB_SIGNIN_MEMBER_EMAILS are set in the environment and win over this list while the server runs");
+  return 0;
 }
 
 export async function runLogin(options: CliOptions, io: CliIo = defaultIo()): Promise<number> {
@@ -875,6 +948,8 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
       return runStatus(options);
     case "login":
       return runLogin(options);
+    case "access":
+      return runAccess(options);
     case "logout":
       return runLogout(options);
     case "browser":


### PR DESCRIPTION
Stacked on #970. For a server installed with the npm package there is no compose file to put the allow-list in, so this adds the command:

```sh
npx openmausbot access list
npx openmausbot access add her@company.com
npx openmausbot access add freelancer@example.com --chat-only
npx openmausbot access remove her@company.com
```

It edits `signIn` in `config.json` straight on disk, the way the server writes it (atomic, 0600, only that key), so it works with the server running or stopped and the change applies on the next request with no restart. Moving an address between the two lists replaces it rather than duplicating it, and the command says so when `OMB_SIGNIN_EMAILS` / `OMB_SIGNIN_MEMBER_EMAILS` are set and win over the file.

Tests: argument parsing, and the full add / move / list / remove cycle against a temp data dir with no server running. 102 tests across the CLI suites; typecheck and lint clean. Docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CLI commands for managing email sign-in access lists without restarting the server.
  - Supports listing, adding, and removing administrator and chat-only email addresses or domains.
  - Added input validation and warnings when environment settings override access-list changes.

- **Documentation**
  - Documented the new access-list management commands for self-hosted deployments.

- **Tests**
  - Added coverage for access-list command parsing, validation, persistence, migration, listing, and removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->