### PR TITLE
feat(engines): sign Claude Code in from Settings on a hosted server

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -262,6 +262,20 @@ WantedBy=multi-user.target
 Engine CLIs read their logins from the service user's home — sign in as
 that user (`sudo -u maus claude` etc.) before starting the service.
 
+## Signing the engines in without a terminal
+
+On a hosted server, the engine CLIs sign in from Settings → Engines:
+
+- **Codex**: "Connect ChatGPT" shows a one-time code to enter on OpenAI's
+  device page.
+- **Claude Code**: "Sign in to Claude" opens Anthropic's own sign-in page in
+  your browser; after you sign in it shows a code, which you paste back into
+  Settings. The server hands that code to the unmodified `claude` CLI once and
+  never stores it; the login lands where Claude Code keeps it for the account
+  that runs your bots. This is the sign-in Anthropic permits for a hosted,
+  unmodified Claude Code with your own subscription; the bots then share that
+  subscription's usage limits.
+
 ## Using it from your computer
 
 Pair once, then use the server from any browser on any machine that can

--- a/server/drivers/claude-login-auth.test.ts
+++ b/server/drivers/claude-login-auth.test.ts
@@ -1,0 +1,161 @@
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { removeTempDir } from "../testing/cleanup.ts";
+import { ClaudeLoginController, claudeLoginCode, claudeLoginPrompt, claudeSignInLink } from "./claude-login-auth.ts";
+
+// A stand-in for the Claude CLI: prints what `claude auth login` prints,
+// waits for the pasted code on stdin, and answers `auth status --json`. It
+// never touches the network or any real credential.
+const FAKE = `#!/usr/bin/env node
+import { appendFileSync, existsSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+const home = process.env.HOME;
+const mode = process.env.FAKE_AUTH_MODE || 'success';
+const args = process.argv.slice(2);
+appendFileSync(join(home, 'calls.jsonl'), JSON.stringify({ args, home, configDir: process.env.CLAUDE_CONFIG_DIR, browser: process.env.BROWSER }) + '\\n');
+if (args.join(' ') === 'auth status --json') {
+  const signedIn = mode === 'already' || existsSync(join(home, 'authenticated'));
+  process.stdout.write(JSON.stringify({ loggedIn: signedIn, authMethod: signedIn ? 'claude.ai' : undefined }) + '\\n');
+  process.exit(signedIn ? 0 : 1);
+} else if (args.join(' ') === 'auth login') {
+  writeFileSync(join(home, 'pid'), String(process.pid));
+  if (mode === 'no-url') { setInterval(() => {}, 1000); }
+  else {
+    process.stdout.write('Opening browser to sign in…\\n');
+    const link = mode === 'evil' ? 'https://evil.example/oauth/authorize?code=true' : 'https://claude.com/cai/oauth/authorize?code=true&client_id=fixture&state=abc';
+    process.stdout.write('If the browser didn\\'t open, visit: ' + link + '\\n');
+    process.stdout.write('Paste code here if prompted > ');
+    let buffered = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      buffered += chunk;
+      if (!buffered.includes('\\n')) return;
+      const code = buffered.split('\\n')[0].trim();
+      if (code === 'GOODCODE#abc') {
+        writeFileSync(join(home, 'authenticated'), 'fixture only');
+        process.stdout.write('Login successful\\n');
+        process.exit(0);
+      }
+      process.stderr.write('Invalid authorization code\\n');
+      process.exit(1);
+    });
+  }
+} else {
+  process.stderr.write('unsupported fixture command\\n');
+  process.exit(2);
+}
+`;
+
+describe("the sign-in link and code checks", () => {
+  it("accepts only Anthropic's own https pages and complete lines", () => {
+    expect(claudeSignInLink("https://claude.com/cai/oauth/authorize?code=true&state=x")).toContain("claude.com");
+    expect(claudeSignInLink("https://platform.claude.com/oauth/code/callback")).toBeTruthy();
+    expect(claudeSignInLink("https://console.anthropic.com/oauth/authorize")).toBeTruthy();
+    expect(claudeSignInLink("http://claude.com/x")).toBeNull();
+    expect(claudeSignInLink("https://evil.example/claude.com")).toBeNull();
+    expect(claudeSignInLink("https://claude.com.evil.example/x")).toBeNull();
+    expect(claudeSignInLink("https://user:pw@claude.com/x")).toBeNull();
+    expect(claudeLoginPrompt("Opening browser…\nIf the browser didn't open, visit: https://claude.com/cai/oauth/authorize?code=true")).toBeNull();
+    expect(claudeLoginPrompt("Opening browser…\nIf the browser didn't open, visit: https://claude.com/cai/oauth/authorize?code=true\nPaste code")).toEqual({ authorizationUrl: "https://claude.com/cai/oauth/authorize?code=true" });
+    expect(claudeLoginPrompt("visit: https://evil.example/x\n")).toBeNull();
+    expect(claudeLoginCode("  GOODCODE#abc ")).toBe("GOODCODE#abc");
+    expect(claudeLoginCode("short")).toBeNull();
+    expect(claudeLoginCode("has spaces in it here")).toBeNull();
+  });
+});
+
+describe("Claude server-owned sign-in", () => {
+  let home: string;
+  let cli: string;
+  let controllers: ClaudeLoginController[];
+  const create = (mode = "success", overrides: Partial<ConstructorParameters<typeof ClaudeLoginController>[0]> = {}) => {
+    const controller = new ClaudeLoginController({
+      cli,
+      environment: () => ({ ...process.env, HOME: home, CLAUDE_CONFIG_DIR: join(home, ".claude"), FAKE_AUTH_MODE: mode }),
+      startupTimeoutMs: 1000,
+      lifetimeMs: 3000,
+      completeTimeoutMs: 3000,
+      terminateTimeoutMs: 50,
+      ...overrides,
+    });
+    controllers.push(controller);
+    return controller;
+  };
+  const calls = () => readFileSync(join(home, "calls.jsonl"), "utf8").trim().split("\n").map((line) => JSON.parse(line));
+  const alive = (pid: number) => {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "omb-claude-login-"));
+    cli = join(home, "fake-claude.mjs");
+    writeFileSync(cli, FAKE, { mode: 0o700 });
+    chmodSync(cli, 0o700);
+    controllers = [];
+  });
+  afterEach(async () => {
+    await Promise.all(controllers.map((controller) => controller.dispose()));
+    await removeTempDir(home);
+  });
+
+  it("shows the link, takes the pasted code once, and confirms the login with the status command", async () => {
+    let refreshed = 0;
+    const controller = create("success", { onAuthenticated: async () => { refreshed++; } });
+    const start = await controller.start();
+    expect(start).toMatchObject({ phase: "waiting", authorizationUrl: "https://claude.com/cai/oauth/authorize?code=true&client_id=fixture&state=abc" });
+    expect(start.userCode).toBeUndefined();
+    expect(start.flowId).toMatch(/^[0-9a-f-]{36}$/);
+    // a second click while waiting returns the same link, no second process
+    expect((await controller.start()).flowId).toBe(start.flowId);
+    await controller.complete(start.flowId!, " GOODCODE#abc\n");
+    expect(await controller.get(start.flowId!)).toEqual({ phase: "succeeded", flowId: start.flowId, authorizationUrl: null, expiresAt: null });
+    expect(refreshed).toBe(1);
+    expect(calls().map((call) => call.args)).toEqual([["auth", "status", "--json"], ["auth", "login"], ["auth", "status", "--json"]]);
+    expect(calls().every((call) => call.home === home && call.configDir === join(home, ".claude"))).toBe(true);
+    expect(calls()[1].browser).toBe(process.platform === "win32" ? undefined : "true");
+    await expect(controller.complete(start.flowId!, "GOODCODE#abc")).rejects.toThrow(/no longer available/);
+  });
+
+  it("reports a rejected code without keeping the process, and refuses malformed codes before sending", async () => {
+    const controller = create();
+    const start = await controller.start();
+    await expect(controller.complete(start.flowId!, "bad")).rejects.toThrow(/whole code/);
+    await expect(controller.complete(start.flowId!, "WRONGCODE#abc")).rejects.toThrow(/did not accept that code/);
+    expect(await controller.get(start.flowId!)).toMatchObject({ phase: "failed" });
+    const pid = Number(readFileSync(join(home, "pid"), "utf8"));
+    await expect.poll(() => alive(pid)).toBe(false);
+  });
+
+  it("does not replace a working login", async () => {
+    const controller = create("already");
+    expect((await controller.start()).phase).toBe("succeeded");
+    expect(calls().map((call) => call.args)).toEqual([["auth", "status", "--json"]]);
+  });
+
+  it("never shows a link that is not Anthropic's, and times out instead", async () => {
+    const controller = create("evil");
+    await expect(controller.start()).rejects.toThrow(/did not show a sign-in link/);
+  });
+
+  it("times out when the CLI prints no link, and cancel kills the process", async () => {
+    const controller = create("no-url", { startupTimeoutMs: 20_000 });
+    const started = controller.start();
+    await expect.poll(() => { try { return readFileSync(join(home, "pid"), "utf8").length > 0; } catch { return false; } }).toBe(true);
+    const pid = Number(readFileSync(join(home, "pid"), "utf8"));
+    await controller.cancel();
+    await expect(started).rejects.toThrow(/cancelled/);
+    await expect.poll(() => alive(pid)).toBe(false);
+  });
+
+  it("fails safely when the configured executable is missing", async () => {
+    const controller = create("success", { cli: join(home, "missing-claude") });
+    await expect(controller.start()).rejects.toThrow(/not installed|could not start|did not show/);
+  });
+});

--- a/server/drivers/claude-login-auth.test.ts
+++ b/server/drivers/claude-login-auth.test.ts
@@ -146,11 +146,12 @@ describe("Claude server-owned sign-in", () => {
 
   it("times out when the CLI prints no link, and cancel kills the process", async () => {
     const controller = create("no-url", { startupTimeoutMs: 20_000 });
-    const started = controller.start();
+    // the rejection lands during cancel(); the expectation must already be listening
+    const started = expect(controller.start()).rejects.toThrow(/cancelled/);
     await expect.poll(() => { try { return readFileSync(join(home, "pid"), "utf8").length > 0; } catch { return false; } }).toBe(true);
     const pid = Number(readFileSync(join(home, "pid"), "utf8"));
     await controller.cancel();
-    await expect(started).rejects.toThrow(/cancelled/);
+    await started;
     await expect.poll(() => alive(pid)).toBe(false);
   });
 

--- a/server/drivers/claude-login-auth.ts
+++ b/server/drivers/claude-login-auth.ts
@@ -1,0 +1,359 @@
+// Sign the server's Claude Code CLI in from Settings, with the user's own
+// Claude subscription, without a terminal on the server.
+//
+// The unmodified `claude auth login` is spawned with pipes. It prints the
+// sign-in link (Anthropic's own page, with this login's one-time PKCE
+// challenge in the query) and then waits on stdin for the code that page
+// shows once the user has signed in. We surface only that link, accept the
+// pasted code once, write it to the CLI's stdin, and confirm the result with
+// `claude auth status --json`. Nothing about the sign-in is stored here: the
+// credential lands where Claude Code keeps it for the account that will run
+// the bots. Anthropic permits exactly this — an end user signing in to the
+// unmodified binary with their own subscription, including where a platform
+// hosts it — and forbids any flow that intermediates claude.ai credentials
+// itself, which is why there is no OAuth client code in this repository.
+import type { ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { realpathSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { stripVTControlCharacters } from "node:util";
+import type { ProviderAuthenticationStart, ProviderAuthenticationStatus } from "../contracts.ts";
+import { killCliTree, spawnCli } from "../procs.ts";
+
+const MAX_OUTPUT = 32_768;
+/** Where Anthropic's sign-in lives. Anything else in the CLI's output is not a link we show. */
+const SIGN_IN_HOSTS = ["claude.com", "claude.ai", "console.anthropic.com", "platform.claude.com"];
+// One login per credential home at a time; turns are never blocked by this.
+const authenticatingHomes = new Set<string>();
+
+function canonicalPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    const parent = dirname(path);
+    return parent === path ? path : join(canonicalPath(parent), basename(path));
+  }
+}
+
+/** The sign-in link, or null for anything that is not Anthropic's own page over https. */
+export function claudeSignInLink(value: string | null | undefined): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    const host = url.hostname.toLowerCase();
+    const trusted = SIGN_IN_HOSTS.some((allowed) => host === allowed || host.endsWith(`.${allowed}`));
+    return url.protocol === "https:" && trusted && !url.username && !url.password ? url.href : null;
+  } catch {
+    return null;
+  }
+}
+
+/** The link from the CLI's output, once its line is complete. */
+export function claudeLoginPrompt(output: string): { authorizationUrl: string } | null {
+  const lines = stripVTControlCharacters(output).split(/\r?\n/).slice(0, -1);
+  for (const line of lines) {
+    const match = /(https:\/\/\S+)/.exec(line.trim());
+    const link = match ? claudeSignInLink(match[1].replace(/[),.;]+$/, "")) : null;
+    if (link) return { authorizationUrl: link };
+  }
+  return null;
+}
+
+/** What Anthropic's page shows after sign-in: a code, sometimes with `#state`. */
+export function claudeLoginCode(value: string): string | null {
+  const code = value.trim();
+  return /^[A-Za-z0-9_\-#.:]{8,1024}$/.test(code) ? code : null;
+}
+
+type Flow = {
+  status: ProviderAuthenticationStatus;
+  child: ChildProcess | null;
+  ready: boolean;
+  codeSent: boolean;
+  output: string;
+  resolve: (value: ProviderAuthenticationStart) => void;
+  reject: (error: Error) => void;
+  startupTimer: NodeJS.Timeout;
+  expiryTimer: NodeJS.Timeout;
+  homeKey: string;
+  env: NodeJS.ProcessEnv;
+  completion?: { resolve: () => void; reject: (error: Error) => void };
+  stopping?: Promise<void>;
+  terminationFailed?: boolean;
+};
+
+interface ClaudeLoginOptions {
+  cli: string;
+  environment: () => NodeJS.ProcessEnv;
+  onAuthenticated?: () => Promise<void>;
+  startupTimeoutMs?: number;
+  lifetimeMs?: number;
+  completeTimeoutMs?: number;
+  terminateTimeoutMs?: number;
+}
+
+const NOT_AVAILABLE = "This sign-in is no longer available. Start sign-in again.";
+
+export class ClaudeLoginController {
+  private flow: Flow | null = null;
+  private disposed = false;
+  private readonly options: ClaudeLoginOptions;
+
+  constructor(options: ClaudeLoginOptions) {
+    this.options = options;
+  }
+
+  async start(): Promise<ProviderAuthenticationStart> {
+    if (this.disposed) throw new Error("This provider was removed. Refresh Settings before signing in.");
+    if (this.flow?.status.phase === "waiting") {
+      if (this.flow.ready) return { ...this.flow.status, phase: "waiting" };
+      throw new Error("A Claude sign-in is already starting. Please wait for the link.");
+    }
+    await this.flow?.stopping;
+    if (this.disposed) throw new Error("This provider was removed. Refresh Settings before signing in.");
+    const env = this.options.environment();
+    const home = env.HOME || env.USERPROFILE || homedir();
+    if (!isAbsolute(home) || (env.CLAUDE_CONFIG_DIR && !isAbsolute(env.CLAUDE_CONFIG_DIR))) {
+      throw new Error("Use an absolute HOME and CLAUDE_CONFIG_DIR path for this server's Claude provider before signing in.");
+    }
+    const homeKey = canonicalPath(resolve(env.CLAUDE_CONFIG_DIR || join(home, ".claude")));
+    if (authenticatingHomes.has(homeKey)) {
+      throw new Error("A Claude sign-in is already running for this server account. Finish or cancel it before starting another.");
+    }
+    authenticatingHomes.add(homeKey);
+    return new Promise<ProviderAuthenticationStart>((resolveStart, reject) => {
+      const flow: Flow = {
+        status: {
+          phase: "waiting",
+          flowId: randomUUID(),
+          authorizationUrl: null,
+          expiresAt: new Date(Date.now() + (this.options.lifetimeMs ?? 15 * 60_000)).toISOString(),
+        },
+        child: null,
+        ready: false,
+        codeSent: false,
+        output: "",
+        resolve: resolveStart,
+        reject,
+        homeKey,
+        env,
+        startupTimer: setTimeout(
+          () => this.finish(flow, "failed", "Claude Code did not show a sign-in link in time. Check that it is installed and up to date on the server, then try again."),
+          this.options.startupTimeoutMs ?? 30_000,
+        ),
+        expiryTimer: setTimeout(() => this.finish(flow, "expired", "The Claude sign-in link expired. Start sign-in again."), this.options.lifetimeMs ?? 15 * 60_000),
+      };
+      flow.startupTimer.unref();
+      flow.expiryTimer.unref();
+      this.flow = flow;
+      // Never replace a working login because the button was clicked twice.
+      void this.signedIn(env).then((already) => {
+        if (flow.status.phase !== "waiting") return;
+        if (already) {
+          this.finish(flow, "succeeded");
+          return;
+        }
+        this.login(flow);
+      });
+    });
+  }
+
+  /** The pasted code goes to the CLI once; the CLI's exit decides the outcome. */
+  async complete(flowId: string, pasted: string): Promise<void> {
+    const flow = this.flow;
+    if (!flowId || flow?.status.flowId !== flowId) throw new Error(NOT_AVAILABLE);
+    if (flow.status.phase !== "waiting" || !flow.ready) throw new Error(NOT_AVAILABLE);
+    if (flow.codeSent) throw new Error("A code was already sent for this sign-in. Wait for the result, or cancel and start again.");
+    const code = claudeLoginCode(pasted);
+    if (!code) throw new Error("Paste the whole code shown on Anthropic's page after signing in.");
+    const child = flow.child;
+    const stdin = child?.stdin;
+    if (!child || !stdin || child.exitCode !== null || child.signalCode !== null) throw new Error(NOT_AVAILABLE);
+    flow.codeSent = true;
+    await new Promise<void>((resolveDone, rejectDone) => {
+      flow.completion = { resolve: resolveDone, reject: rejectDone };
+      const timer = setTimeout(
+        () => this.finish(flow, "failed", "Claude Code did not finish the sign-in after the code was entered. Start sign-in again."),
+        this.options.completeTimeoutMs ?? 60_000,
+      );
+      timer.unref();
+      stdin.write(`${code}\n`, (error) => {
+        if (error) this.finish(flow, "failed", "The code could not be handed to Claude Code on the server. Start sign-in again.");
+      });
+    });
+  }
+
+  async get(flowId: string): Promise<ProviderAuthenticationStatus> {
+    if (!flowId || this.flow?.status.flowId !== flowId) throw new Error(NOT_AVAILABLE);
+    return { ...this.flow.status };
+  }
+
+  async cancel(): Promise<void> {
+    if (this.flow?.status.phase === "waiting") this.finish(this.flow, "cancelled", "Claude sign-in cancelled.");
+    await this.flow?.stopping;
+    if (this.flow?.terminationFailed) throw new Error(this.flow.status.message);
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed = true;
+    await this.cancel();
+    this.flow = null;
+  }
+
+  private signedIn(env: NodeJS.ProcessEnv): Promise<boolean> {
+    return new Promise((resolveStatus) => {
+      let child: ReturnType<typeof spawnCli>;
+      try {
+        child = spawnCli(this.options.cli, ["auth", "status", "--json"], { env: { ...env, NO_COLOR: "1" }, stdio: ["ignore", "pipe", "pipe"] });
+      } catch {
+        resolveStatus(false);
+        return;
+      }
+      let stdout = "";
+      child.stdout.on("data", (chunk: Buffer) => {
+        if (stdout.length < MAX_OUTPUT) stdout += chunk.toString("utf8");
+      });
+      child.stderr.on("data", () => {});
+      const timer = setTimeout(() => {
+        child.kill("SIGKILL");
+        resolveStatus(false);
+      }, 8_000);
+      timer.unref();
+      child.once("error", () => {
+        clearTimeout(timer);
+        resolveStatus(false);
+      });
+      child.once("close", () => {
+        clearTimeout(timer);
+        try {
+          const status: unknown = JSON.parse(stdout);
+          resolveStatus(typeof status === "object" && status !== null && Reflect.get(status, "loggedIn") === true);
+        } catch {
+          resolveStatus(false);
+        }
+      });
+    });
+  }
+
+  private login(flow: Flow): void {
+    if (flow.status.phase !== "waiting") return;
+    let child: ReturnType<typeof spawnCli>;
+    try {
+      // No browser on a server: the CLI then prints the link instead of opening it.
+      const browserless = process.platform === "win32" ? {} : { BROWSER: "true" };
+      child = spawnCli(this.options.cli, ["auth", "login"], {
+        env: { ...flow.env, ...browserless, NO_COLOR: "1" },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch {
+      this.finish(flow, "failed", "Claude Code could not start on this server. Install or update the configured Claude CLI, then try again.");
+      return;
+    }
+    flow.child = child;
+    const receive = (chunk: Buffer) => {
+      if (flow.status.phase !== "waiting") return;
+      if (flow.output.length + chunk.length > MAX_OUTPUT) {
+        this.finish(flow, "failed", "Claude Code returned an unexpected sign-in response. Update the server's Claude CLI and try again.");
+        return;
+      }
+      flow.output += chunk.toString("utf8");
+      if (flow.ready) return;
+      const prompt = claudeLoginPrompt(flow.output);
+      if (!prompt) return;
+      flow.status = { ...flow.status, authorizationUrl: prompt.authorizationUrl };
+      flow.ready = true;
+      clearTimeout(flow.startupTimer);
+      flow.resolve({ ...flow.status, phase: "waiting" });
+    };
+    child.stdout.on("data", receive);
+    child.stderr.on("data", receive);
+    child.once("error", (error: NodeJS.ErrnoException) => {
+      const message = error.code === "ENOENT"
+        ? "Claude Code is not installed on this server. Install it on the server, then try again."
+        : "Claude Code could not start on this server. Check the configured CLI path and its executable permissions.";
+      this.finish(flow, "failed", message);
+    });
+    child.once("close", (code) => {
+      if (flow.child === child) flow.child = null;
+      if (flow.status.phase !== "waiting") return;
+      const output = stripVTControlCharacters(flow.output);
+      flow.output = "";
+      // The CLI's exit is the verdict; the login status command is the proof.
+      void this.signedIn(flow.env).then((signedIn) => {
+        if (flow.status.phase !== "waiting") return;
+        if (signedIn) {
+          this.finish(flow, "succeeded");
+          return;
+        }
+        this.finish(flow, "failed", flow.codeSent
+          ? /invalid|expired|denied|rejected/i.test(output)
+            ? "Anthropic did not accept that code. Start sign-in again and paste the whole code it shows."
+            : "Claude Code finished but is not signed in. Start sign-in again."
+          : code === 0
+            ? "Claude Code finished but is not signed in. Start sign-in again."
+            : "Claude Code stopped before the sign-in finished. Check the server's connection and try again.");
+      });
+    });
+  }
+
+  private finish(flow: Flow, phase: Exclude<ProviderAuthenticationStatus["phase"], "waiting">, message?: string): void {
+    if (flow.status.phase !== "waiting") return;
+    clearTimeout(flow.startupTimer);
+    clearTimeout(flow.expiryTimer);
+    flow.status = {
+      phase,
+      flowId: flow.status.flowId,
+      authorizationUrl: null,
+      expiresAt: null,
+      ...(phase !== "succeeded" && message ? { message } : {}),
+    };
+    flow.output = "";
+    if (!flow.ready) {
+      if (phase === "succeeded") flow.resolve({ ...flow.status, phase });
+      else flow.reject(new Error(message ?? "Claude sign-in did not finish."));
+    }
+    if (flow.completion) {
+      if (phase === "succeeded") flow.completion.resolve();
+      else flow.completion.reject(new Error(message ?? "Claude sign-in did not finish."));
+      flow.completion = undefined;
+    }
+    flow.stopping = this.stopChild(flow)
+      .catch(() => false)
+      .then((stopped) => {
+        const release = () => authenticatingHomes.delete(flow.homeKey);
+        if (stopped) {
+          release();
+          return;
+        }
+        flow.terminationFailed = true;
+        flow.status = { ...flow.status, phase: "failed", message: "Claude Code could not be stopped on this server. Ask the server administrator to stop the login process before trying again." };
+        const child = flow.child;
+        if (!child || child.exitCode !== null || child.signalCode !== null) release();
+        else child.once("close", release);
+      });
+    if (phase === "succeeded") void this.options.onAuthenticated?.().catch(() => {});
+  }
+
+  private async stopChild(flow: Flow): Promise<boolean> {
+    const child = flow.child;
+    if (!child || (await killCliTree(child, this.options.terminateTimeoutMs ?? 1500))) return true;
+    if (process.platform !== "win32" && child.pid) {
+      try {
+        process.kill(-child.pid, "SIGKILL");
+      } catch {
+        child.kill("SIGKILL");
+      }
+    } else child.kill("SIGKILL");
+    await new Promise<void>((resolveStop) => {
+      if (child.exitCode !== null || child.signalCode !== null) return resolveStop();
+      const timer = setTimeout(resolveStop, 1500);
+      timer.unref();
+      child.once("close", () => {
+        clearTimeout(timer);
+        resolveStop();
+      });
+    });
+    return child.exitCode !== null || child.signalCode !== null;
+  }
+}

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -17,6 +17,7 @@ import { join, dirname, isAbsolute, normalize } from "node:path";
 import { DATA_DIR, stripWorkspaceCredentialEnv } from "../config.ts";
 import { augmentedPath } from "../env-path.ts";
 import { brokerSocketPath, describeSpawnFailure, execCli, killCliTree, spawnCli } from "../procs.ts";
+import { ClaudeLoginController } from "./claude-login-auth.ts";
 
 import type {
   DriverCreateInput,
@@ -1382,6 +1383,10 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       return writeUser(s, threadId, claudeUserMessage(text, undefined));
     };
 
+    // Sign in from Settings: the unmodified CLI's own login, driven over pipes
+    // (server/drivers/claude-login-auth.ts). Same environment as every turn.
+    const login = new ClaudeLoginController({ cli: config.cli, environment, onAuthenticated: async () => { await refreshModels(); } });
+
     const snapshot = async (): Promise<ProviderSnapshot> => {
       const env = environment();
       const version = await new Promise<string | null>((resolve) => {
@@ -1465,6 +1470,10 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       },
       refreshModels,
       snapshot,
+      startAuthentication: () => login.start(),
+      getAuthentication: (flowId) => login.get(flowId),
+      completeAuthentication: (flowId, code) => login.complete(flowId, code),
+      cancelAuthentication: () => login.cancel(),
       adapter: {
         provider: DRIVER_KIND,
         capabilities: {

--- a/server/harness/registry.ts
+++ b/server/harness/registry.ts
@@ -235,7 +235,13 @@ export class ProviderRegistry {
           access: driver?.metadata.access ?? "subscription",
           install: driver?.install,
           authentication: inst.startAuthentication
-            ? { method: inst.getAuthentication ? "device-code" as const : "browser" as const }
+            ? {
+                method: inst.getAuthentication && inst.completeAuthentication
+                  ? "paste-code" as const // a link to open, then a code pasted back (Claude)
+                  : inst.getAuthentication
+                    ? "device-code" as const // a code to enter at the provider's page (Codex)
+                    : "browser" as const, // a link and a callback URL (managed engines)
+              }
             : undefined,
           cli: this.cliByInstance.get(inst.instanceId),
           cliDefault: cliDefaultOf(driver),

--- a/server/index.ts
+++ b/server/index.ts
@@ -12197,8 +12197,9 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
         if (action === "auth/complete") {
           const body = await readBody(req);
           const flowId = typeof body?.flowId === "string" ? body.flowId : "";
-          const callbackUrl = typeof body?.callbackUrl === "string" ? body.callbackUrl : "";
-          if (!flowId || !callbackUrl) return json(res, 400, { error: "flowId and callbackUrl are required" });
+          // `code` for a pasted sign-in code (Claude), `callbackUrl` for a browser callback
+          const callbackUrl = typeof body?.callbackUrl === "string" ? body.callbackUrl : typeof body?.code === "string" ? body.code : "";
+          if (!flowId || !callbackUrl) return json(res, 400, { error: "flowId and a code or callbackUrl are required" });
           await providerAuthSessions.complete(instanceId, owner, flowId, callbackUrl);
           return json(res, 200, { ok: true });
         }

--- a/src/components/ClaudeSignIn.test.ts
+++ b/src/components/ClaudeSignIn.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { claudeSignInLink } from "./ClaudeSignIn";
+
+describe("the Claude sign-in link shown in Settings", () => {
+  it("is only ever Anthropic's own page over https", () => {
+    expect(claudeSignInLink("https://claude.com/cai/oauth/authorize?code=true&state=x")).toBe("https://claude.com/cai/oauth/authorize?code=true&state=x");
+    expect(claudeSignInLink("https://console.anthropic.com/oauth/authorize")).toBeTruthy();
+    expect(claudeSignInLink("https://sub.claude.ai/x")).toBeTruthy();
+    expect(claudeSignInLink("http://claude.com/x")).toBeNull();
+    expect(claudeSignInLink("https://claude.com.evil.example/x")).toBeNull();
+    expect(claudeSignInLink("https://evil.example/?u=https://claude.com")).toBeNull();
+    expect(claudeSignInLink("https://a:b@claude.com/x")).toBeNull();
+    expect(claudeSignInLink(null)).toBeNull();
+    expect(claudeSignInLink("not a url")).toBeNull();
+  });
+});

--- a/src/components/ClaudeSignIn.tsx
+++ b/src/components/ClaudeSignIn.tsx
@@ -1,0 +1,185 @@
+import { useEffect, useState } from "react";
+import { ExternalLink, Loader2, LogIn } from "lucide-react";
+import { api } from "@/state/store";
+import { useStore } from "@/state/store";
+import { t } from "@/lib/i18n";
+import { deviceFlowUnavailable, type DeviceSignInStatus } from "./CodexDeviceSignIn";
+
+const SIGN_IN_HOSTS = ["claude.com", "claude.ai", "console.anthropic.com", "platform.claude.com"];
+
+/** Never turn arbitrary process output into a link: only Anthropic's own
+ * sign-in pages over https. The server applies the same rule first. */
+export function claudeSignInLink(value: string | null | undefined): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    const host = url.hostname.toLowerCase();
+    const trusted = SIGN_IN_HOSTS.some((allowed) => host === allowed || host.endsWith(`.${allowed}`));
+    return url.protocol === "https:" && trusted && !url.username && !url.password ? url.href : null;
+  } catch {
+    return null;
+  }
+}
+
+function endedFlow(phase: "expired" | "failed"): DeviceSignInStatus {
+  return { phase, flowId: null, authorizationUrl: null, expiresAt: null, ...(phase === "failed" ? { message: t("engineSetup.device.flowEnded") } : {}) };
+}
+
+/** Settings → Engines → Claude on a hosted server: open Anthropic's sign-in
+ * page, paste the code it shows, done. The server drives the unmodified CLI. */
+export function ClaudeSignIn({ instanceId }: { instanceId: string }) {
+  const { refreshInstances, refreshModels } = useStore();
+  const [auth, setAuth] = useState<DeviceSignInStatus | null>(null);
+  const [code, setCode] = useState("");
+  const [busy, setBusy] = useState<"start" | "finish" | "cancel" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const base = `/api/instances/${encodeURIComponent(instanceId)}/auth`;
+  const link = claudeSignInLink(auth?.authorizationUrl);
+
+  const refresh = async () => {
+    await refreshInstances();
+    await refreshModels(instanceId);
+  };
+
+  // Expire the link locally when the server says it does, and poll the
+  // outcome while a code is being checked.
+  useEffect(() => {
+    if (auth?.phase !== "waiting" || !auth.flowId) return;
+    const remaining = auth.expiresAt ? Date.parse(auth.expiresAt) - Date.now() : Number.NaN;
+    const expiryTimer = Number.isFinite(remaining)
+      ? window.setTimeout(() => {
+          setAuth(endedFlow("expired"));
+          setError(null);
+        }, Math.max(0, remaining))
+      : null;
+    return () => {
+      if (expiryTimer !== null) window.clearTimeout(expiryTimer);
+    };
+  }, [auth]);
+
+  const start = async () => {
+    setBusy("start");
+    setError(null);
+    try {
+      const { auth: next }: { auth: DeviceSignInStatus } = await api(`${base}/start`, { method: "POST" });
+      setAuth(next);
+      setCode("");
+      if (next.phase === "succeeded") await refresh();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : t("engineSetup.device.failed"));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const finish = async () => {
+    if (!auth?.flowId) return;
+    setBusy("finish");
+    setError(null);
+    try {
+      await api(`${base}/complete`, { method: "POST", body: JSON.stringify({ flowId: auth.flowId, code: code.trim() }) });
+      const { auth: next }: { auth: DeviceSignInStatus } = await api(`${base}/status?flowId=${encodeURIComponent(auth.flowId)}`);
+      setAuth(next);
+      setCode("");
+      if (next.phase === "succeeded") await refresh();
+    } catch (cause) {
+      if (deviceFlowUnavailable(cause)) {
+        // the server already knows the outcome; ask it rather than guess
+        try {
+          const { auth: next }: { auth: DeviceSignInStatus } = await api(`${base}/status?flowId=${encodeURIComponent(auth.flowId)}`);
+          setAuth(next);
+          if (next.phase === "succeeded") await refresh();
+          return;
+        } catch {
+          setAuth(endedFlow("failed"));
+          return;
+        }
+      }
+      setError(cause instanceof Error ? cause.message : t("engineSetup.device.failed"));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const cancel = async () => {
+    if (!auth?.flowId) return;
+    setBusy("cancel");
+    setError(null);
+    try {
+      await api(`${base}/cancel`, { method: "POST", body: JSON.stringify({ flowId: auth.flowId }) });
+      setAuth({ phase: "cancelled", flowId: null, authorizationUrl: null, expiresAt: null });
+    } catch (cause) {
+      if (deviceFlowUnavailable(cause)) setAuth(endedFlow("failed"));
+      else setError(cause instanceof Error ? cause.message : t("engineSetup.device.failed"));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const outcome = auth && auth.phase !== "waiting"
+    ? auth.phase === "succeeded"
+      ? t("engineSetup.claude.connected")
+      : auth.phase === "cancelled"
+        ? t("engineSetup.device.cancelled")
+        : auth.phase === "expired"
+          ? t("engineSetup.device.expired")
+          : auth.message || t("engineSetup.device.failed")
+    : null;
+
+  return (
+    <div className="mt-3 space-y-2" data-claude-sign-in>
+      {outcome ? (
+        <p role="status" className={auth?.phase === "succeeded" ? "text-[12px] text-success" : "text-[12px] text-ink-secondary"}>{outcome}</p>
+      ) : null}
+      {auth?.phase === "waiting" ? (
+        link ? (
+          <div className="space-y-2 rounded-lg border border-hairline/50 bg-app p-3">
+            <a href={link} target="_blank" rel="noopener noreferrer" className="flex items-center justify-center gap-2 rounded-lg bg-accent px-3 py-2 text-[12.5px] font-semibold text-white hover:brightness-110">
+              {t("engineSetup.claude.open")} <ExternalLink size={13} />
+            </a>
+            <label className="block text-[12px] text-ink-secondary" htmlFor={`claude-code-${instanceId}`}>
+              {t("engineSetup.claude.codeLabel")}
+            </label>
+            <input
+              id={`claude-code-${instanceId}`}
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              autoComplete="off"
+              spellCheck={false}
+              className="w-full rounded-md border border-line bg-surface px-3 py-2 font-mono text-[13px] text-ink outline-none focus:border-accent-border"
+            />
+            <button
+              type="button"
+              disabled={busy !== null || code.trim().length < 8}
+              onClick={() => void finish()}
+              className="flex w-full items-center justify-center gap-2 rounded-lg bg-accent px-3 py-2 text-[12.5px] font-semibold text-white hover:brightness-110 disabled:opacity-50"
+            >
+              {busy === "finish" ? <Loader2 size={14} className="animate-spin" /> : <LogIn size={14} />}
+              {busy === "finish" ? t("engineSetup.claude.finishing") : t("engineSetup.claude.finish")}
+            </button>
+            {auth.expiresAt && Number.isFinite(Date.parse(auth.expiresAt)) ? (
+              <p className="text-[11px] text-ink-secondary">{t("engineSetup.device.expires", { time: new Date(auth.expiresAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }) })}</p>
+            ) : null}
+            <p className="text-[11px] leading-relaxed text-ink-secondary">{t("engineSetup.claude.security")}</p>
+            <button type="button" disabled={busy !== null} onClick={() => void cancel()} className="w-full rounded-lg bg-control px-3 py-2 text-[12px] font-medium text-ink disabled:opacity-50">
+              {busy === "cancel" ? t("engineSetup.device.cancelling") : t("engineSetup.device.cancel")}
+            </button>
+          </div>
+        ) : (
+          <p role="alert" className="text-[12px] text-danger">{t("engineSetup.claude.invalidChallenge")}</p>
+        )
+      ) : auth?.phase !== "succeeded" ? (
+        <button
+          type="button"
+          disabled={busy !== null}
+          onClick={() => void start()}
+          className="flex w-full items-center justify-center gap-2 rounded-lg bg-accent px-3 py-2 text-[12.5px] font-semibold text-white hover:brightness-110 disabled:opacity-50"
+        >
+          {busy === "start" ? <Loader2 size={14} className="animate-spin" /> : <LogIn size={14} />}
+          {busy === "start" ? t("engineSetup.claude.starting") : t("engineSetup.claude.start")}
+        </button>
+      ) : null}
+      {error ? <p role="alert" className="text-[12px] text-danger">{error}</p> : null}
+    </div>
+  );
+}

--- a/src/components/EngineSetup.tsx
+++ b/src/components/EngineSetup.tsx
@@ -7,6 +7,7 @@ import { api, type EngineInstall, type InstanceInfo, useStore } from "@/state/st
 import { cn } from "@/lib/cn";
 import { t } from "@/lib/i18n";
 import { CodexDeviceSignIn } from "./CodexDeviceSignIn";
+import { ClaudeSignIn } from "./ClaudeSignIn";
 
 type Platform = "darwin" | "win32" | "linux";
 
@@ -316,6 +317,7 @@ export function EngineSetup({
   const signInCommand = install?.signInCommand;
   const signInOnly = intent === "cloud" && needsSignIn(instance);
   const deviceSignIn = signInOnly && instance.authentication?.method === "device-code";
+  const pasteSignIn = signInOnly && instance.authentication?.method === "paste-code";
   const command = signInOnly ? signInCommand : installCommand;
   const title = signInOnly
     ? t("engineSetup.signInTitle", { name: instance.displayName })
@@ -323,6 +325,8 @@ export function EngineSetup({
   const description = signInOnly
     ? deviceSignIn
       ? t("engineSetup.device.description")
+      : pasteSignIn
+      ? t("engineSetup.claude.description")
       : install?.managed
       ? t("engineSetup.managedSignIn")
       : t("engineSetup.terminalSignIn")
@@ -367,6 +371,8 @@ export function EngineSetup({
 
       {deviceSignIn ? (
         <CodexDeviceSignIn key={instance.instanceId} instanceId={instance.instanceId} />
+      ) : pasteSignIn ? (
+        <ClaudeSignIn key={instance.instanceId} instanceId={instance.instanceId} />
       ) : install.managed ? (
         <ManagedEngineSetup instance={instance} signInOnly={signInOnly} />
       ) : command ? (

--- a/src/components/EnginesSettings.tsx
+++ b/src/components/EnginesSettings.tsx
@@ -308,10 +308,15 @@ function EngineRow({ instance }: { instance: InstanceInfo }) {
       )}
       {error && <div role="alert" className="mt-1 text-[12px] text-danger">{error}</div>}
       {instance.claudeAccount && <ClaudeAccountSettings instance={instance} />}
-      {instance.authentication?.method === "device-code" && (
+      {(instance.authentication?.method === "device-code" || instance.authentication?.method === "paste-code") && (
         needsCli(instance) || needsSignIn(instance)
           ? <EngineSetup instance={instance} className="mt-3" />
-          : instance.snapshot.authenticated && <p className="mt-2 flex items-center gap-1.5 text-[12px] text-success"><Check size={13} />{t("engineSetup.device.connectedAccount")}</p>
+          : instance.snapshot.authenticated && (
+            <p className="mt-2 flex items-center gap-1.5 text-[12px] text-success">
+              <Check size={13} />
+              {instance.authentication.method === "paste-code" ? t("engineSetup.claude.connectedAccount") : t("engineSetup.device.connectedAccount")}
+            </p>
+          )
       )}
       {open && (
         <CustomPicker

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1376,5 +1376,16 @@
   "remote.serverPairing.minutesAgo": "vor {minutes} Min.",
   "remote.serverPairing.hoursAgo": "vor {hours} Std.",
   "remote.serverPairing.daysAgo": "vor {days} Tagen",
-  "remote.serverPairing.error": "Der Server antwortet nicht: {error}"
+  "remote.serverPairing.error": "Der Server antwortet nicht: {error}",
+  "engineSetup.claude.description": "Melde Claude Code auf diesem Server mit deinem eigenen Claude-Abo an. Öffne die Anmeldeseite von Anthropic im Browser, melde dich an und füge den angezeigten Code hier ein. Kein Terminal, kein Teilen von Passwörtern.",
+  "engineSetup.claude.start": "Bei Claude anmelden",
+  "engineSetup.claude.starting": "Anmeldung wird vorbereitet…",
+  "engineSetup.claude.open": "Claude-Anmeldeseite öffnen",
+  "engineSetup.claude.codeLabel": "Code von dieser Seite einfügen",
+  "engineSetup.claude.finish": "Anmeldung abschließen",
+  "engineSetup.claude.finishing": "Wird mit Claude Code geprüft…",
+  "engineSetup.claude.security": "Füge nur einen Code ein, den du über eine hier gestartete Anmeldung erhalten hast. Er wird einmal an Claude Code auf diesem Server übergeben und nie gespeichert; dein Passwort bleibt bei Anthropic. Bots auf diesem Server teilen sich das Nutzungslimit deines Abos.",
+  "engineSetup.claude.connected": "Claude verbunden. Deine Modelle werden aktualisiert.",
+  "engineSetup.claude.connectedAccount": "Claude auf diesem Server verbunden",
+  "engineSetup.claude.invalidChallenge": "Claude Code hat keinen gültigen Anmeldelink von Anthropic zurückgegeben. Abbrechen und erneut versuchen."
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1482,5 +1482,16 @@
   "remote.serverPairing.minutesAgo": "{minutes} min ago",
   "remote.serverPairing.hoursAgo": "{hours} h ago",
   "remote.serverPairing.daysAgo": "{days} d ago",
-  "remote.serverPairing.error": "Could not talk to the server: {error}"
+  "remote.serverPairing.error": "Could not talk to the server: {error}",
+  "engineSetup.claude.description": "Sign in to Claude Code on this server with your own Claude subscription. Open Anthropic's sign-in page in your browser, sign in, then paste the code it shows you here. No terminal and no password sharing.",
+  "engineSetup.claude.start": "Sign in to Claude",
+  "engineSetup.claude.starting": "Preparing sign-in…",
+  "engineSetup.claude.open": "Open the Claude sign-in page",
+  "engineSetup.claude.codeLabel": "Paste the code from that page",
+  "engineSetup.claude.finish": "Finish sign-in",
+  "engineSetup.claude.finishing": "Checking with Claude Code…",
+  "engineSetup.claude.security": "Only paste a code from a sign-in you started here. It is handed to Claude Code on this server once and never stored; your password stays with Anthropic. Bots on this server share your subscription's usage limits.",
+  "engineSetup.claude.connected": "Claude connected. Your models are being refreshed.",
+  "engineSetup.claude.connectedAccount": "Claude connected on this server",
+  "engineSetup.claude.invalidChallenge": "Claude Code did not return a valid Anthropic sign-in link. Cancel and try again."
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1376,5 +1376,16 @@
   "remote.serverPairing.minutesAgo": "hace {minutes} min",
   "remote.serverPairing.hoursAgo": "hace {hours} h",
   "remote.serverPairing.daysAgo": "hace {days} d",
-  "remote.serverPairing.error": "No se pudo hablar con el servidor: {error}"
+  "remote.serverPairing.error": "No se pudo hablar con el servidor: {error}",
+  "engineSetup.claude.description": "Inicia sesión en Claude Code en este servidor con tu propia suscripción a Claude. Abre la página de inicio de sesión de Anthropic en tu navegador, inicia sesión y pega aquí el código que te muestra. Sin terminal ni compartir contraseñas.",
+  "engineSetup.claude.start": "Iniciar sesión en Claude",
+  "engineSetup.claude.starting": "Preparando el inicio de sesión…",
+  "engineSetup.claude.open": "Abrir la página de inicio de sesión de Claude",
+  "engineSetup.claude.codeLabel": "Pega el código de esa página",
+  "engineSetup.claude.finish": "Terminar el inicio de sesión",
+  "engineSetup.claude.finishing": "Comprobando con Claude Code…",
+  "engineSetup.claude.security": "Pega solo un código de un inicio de sesión que hayas empezado aquí. Se entrega una vez a Claude Code en este servidor y nunca se guarda; tu contraseña se queda en Anthropic. Los bots de este servidor comparten los límites de uso de tu suscripción.",
+  "engineSetup.claude.connected": "Claude conectado. Tus modelos se están actualizando.",
+  "engineSetup.claude.connectedAccount": "Claude conectado en este servidor",
+  "engineSetup.claude.invalidChallenge": "Claude Code no devolvió un enlace de inicio de sesión válido de Anthropic. Cancela e inténtalo de nuevo."
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1376,5 +1376,16 @@
   "remote.serverPairing.minutesAgo": "il y a {minutes} min",
   "remote.serverPairing.hoursAgo": "il y a {hours} h",
   "remote.serverPairing.daysAgo": "il y a {days} j",
-  "remote.serverPairing.error": "Impossible de joindre le serveur : {error}"
+  "remote.serverPairing.error": "Impossible de joindre le serveur : {error}",
+  "engineSetup.claude.description": "Connectez Claude Code sur ce serveur avec votre propre abonnement Claude. Ouvrez la page de connexion d’Anthropic dans votre navigateur, connectez-vous, puis collez ici le code affiché. Ni terminal ni partage de mot de passe.",
+  "engineSetup.claude.start": "Se connecter à Claude",
+  "engineSetup.claude.starting": "Préparation de la connexion…",
+  "engineSetup.claude.open": "Ouvrir la page de connexion Claude",
+  "engineSetup.claude.codeLabel": "Collez le code affiché sur cette page",
+  "engineSetup.claude.finish": "Terminer la connexion",
+  "engineSetup.claude.finishing": "Vérification avec Claude Code…",
+  "engineSetup.claude.security": "Ne collez qu’un code issu d’une connexion lancée ici. Il est transmis une seule fois à Claude Code sur ce serveur et jamais stocké ; votre mot de passe reste chez Anthropic. Les bots de ce serveur partagent les limites d’usage de votre abonnement.",
+  "engineSetup.claude.connected": "Claude connecté. Vos modèles sont en cours d’actualisation.",
+  "engineSetup.claude.connectedAccount": "Claude connecté sur ce serveur",
+  "engineSetup.claude.invalidChallenge": "Claude Code n’a pas renvoyé de lien de connexion Anthropic valide. Annulez et réessayez."
 }

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -1376,5 +1376,16 @@
   "remote.serverPairing.minutesAgo": "{minutes} मिनट पहले",
   "remote.serverPairing.hoursAgo": "{hours} घंटे पहले",
   "remote.serverPairing.daysAgo": "{days} दिन पहले",
-  "remote.serverPairing.error": "सर्वर से बात नहीं हो सकी: {error}"
+  "remote.serverPairing.error": "सर्वर से बात नहीं हो सकी: {error}",
+  "engineSetup.claude.description": "अपनी Claude सदस्यता से इस सर्वर पर Claude Code में साइन इन करें। ब्राउज़र में Anthropic का साइन-इन पेज खोलें, साइन इन करें, फिर वहाँ दिखा कोड यहाँ पेस्ट करें। न टर्मिनल, न पासवर्ड साझा करना।",
+  "engineSetup.claude.start": "Claude में साइन इन करें",
+  "engineSetup.claude.starting": "साइन-इन तैयार हो रहा है…",
+  "engineSetup.claude.open": "Claude साइन-इन पेज खोलें",
+  "engineSetup.claude.codeLabel": "उस पेज का कोड यहाँ पेस्ट करें",
+  "engineSetup.claude.finish": "साइन-इन पूरा करें",
+  "engineSetup.claude.finishing": "Claude Code से जाँच हो रही है…",
+  "engineSetup.claude.security": "केवल वही कोड पेस्ट करें जो यहाँ शुरू किए गए साइन-इन से मिला हो। यह इस सर्वर पर Claude Code को एक बार दिया जाता है और कभी सहेजा नहीं जाता; आपका पासवर्ड Anthropic के पास ही रहता है। इस सर्वर के बॉट आपकी सदस्यता की उपयोग सीमा साझा करते हैं।",
+  "engineSetup.claude.connected": "Claude जुड़ गया। आपके मॉडल ताज़ा हो रहे हैं।",
+  "engineSetup.claude.connectedAccount": "इस सर्वर पर Claude जुड़ा है",
+  "engineSetup.claude.invalidChallenge": "Claude Code ने Anthropic का मान्य साइन-इन लिंक नहीं दिया। रद्द करके फिर से प्रयास करें।"
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1376,5 +1376,16 @@
   "remote.serverPairing.minutesAgo": "{minutes} 分前",
   "remote.serverPairing.hoursAgo": "{hours} 時間前",
   "remote.serverPairing.daysAgo": "{days} 日前",
-  "remote.serverPairing.error": "サーバーと通信できませんでした: {error}"
+  "remote.serverPairing.error": "サーバーと通信できませんでした: {error}",
+  "engineSetup.claude.description": "自分の Claude サブスクリプションで、このサーバーの Claude Code にサインインします。ブラウザで Anthropic のサインインページを開いてサインインし、表示されたコードをここに貼り付けてください。ターミナルもパスワードの共有も不要です。",
+  "engineSetup.claude.start": "Claude にサインイン",
+  "engineSetup.claude.starting": "サインインを準備中…",
+  "engineSetup.claude.open": "Claude のサインインページを開く",
+  "engineSetup.claude.codeLabel": "そのページのコードを貼り付け",
+  "engineSetup.claude.finish": "サインインを完了",
+  "engineSetup.claude.finishing": "Claude Code で確認中…",
+  "engineSetup.claude.security": "ここで開始したサインインで得たコードだけを貼り付けてください。コードはこのサーバーの Claude Code に一度だけ渡され、保存されません。パスワードは Anthropic にのみ残ります。このサーバーのボットはあなたのサブスクリプションの利用上限を共有します。",
+  "engineSetup.claude.connected": "Claude に接続しました。モデルを更新しています。",
+  "engineSetup.claude.connectedAccount": "このサーバーで Claude に接続済み",
+  "engineSetup.claude.invalidChallenge": "Claude Code が有効な Anthropic のサインインリンクを返しませんでした。キャンセルしてやり直してください。"
 }

--- a/src/locales/pt-br.json
+++ b/src/locales/pt-br.json
@@ -1376,5 +1376,16 @@
   "remote.serverPairing.minutesAgo": "há {minutes} min",
   "remote.serverPairing.hoursAgo": "há {hours} h",
   "remote.serverPairing.daysAgo": "há {days} d",
-  "remote.serverPairing.error": "Não foi possível falar com o servidor: {error}"
+  "remote.serverPairing.error": "Não foi possível falar com o servidor: {error}",
+  "engineSetup.claude.description": "Entre no Claude Code neste servidor com a sua própria assinatura do Claude. Abra a página de login da Anthropic no navegador, entre e cole aqui o código exibido. Sem terminal e sem compartilhar senha.",
+  "engineSetup.claude.start": "Entrar no Claude",
+  "engineSetup.claude.starting": "Preparando o login…",
+  "engineSetup.claude.open": "Abrir a página de login do Claude",
+  "engineSetup.claude.codeLabel": "Cole o código daquela página",
+  "engineSetup.claude.finish": "Concluir o login",
+  "engineSetup.claude.finishing": "Verificando com o Claude Code…",
+  "engineSetup.claude.security": "Cole apenas um código de um login iniciado aqui. Ele é entregue uma vez ao Claude Code neste servidor e nunca é armazenado; sua senha fica com a Anthropic. Os bots deste servidor compartilham os limites de uso da sua assinatura.",
+  "engineSetup.claude.connected": "Claude conectado. Seus modelos estão sendo atualizados.",
+  "engineSetup.claude.connectedAccount": "Claude conectado neste servidor",
+  "engineSetup.claude.invalidChallenge": "O Claude Code não retornou um link de login válido da Anthropic. Cancele e tente novamente."
 }

--- a/src/locales/source-hashes.json
+++ b/src/locales/source-hashes.json
@@ -1379,7 +1379,18 @@
       "remote.serverPairing.minutesAgo": "5a0d9752dcc98ad174b74fb774137062709188753404e9337d7271c0b0120765",
       "remote.serverPairing.hoursAgo": "15c7928eb8c8a23a031fa4285a389f713d67fa26262565c0574801cb3f3dc0c1",
       "remote.serverPairing.daysAgo": "de3a2d58e357b552aa9c313bfbda543e0e98eea4a23fe65dcc257ca6ea06514c",
-      "remote.serverPairing.error": "45037f1c0212f956e66bb6e3bc627c6be2880a1c09afb973ea238225a7ab38ac"
+      "remote.serverPairing.error": "45037f1c0212f956e66bb6e3bc627c6be2880a1c09afb973ea238225a7ab38ac",
+      "engineSetup.claude.description": "b36c19aa9140ffea9171b6b7525513c4e9653d00726c242d673e998c1fd7dea5",
+      "engineSetup.claude.start": "168e2c1b9cf37745b05a14f30c971f8f1a047e83f300b4205db74c9fdca7c29e",
+      "engineSetup.claude.starting": "cdca9524ec00f4e3f6a911f36d30c6a460a5bd6ec96e5803ee25fd08ba805c7e",
+      "engineSetup.claude.open": "2026f9f179ebe3aa4afdb35e276e93503c7a80ef8f44becf7ab02df0c2b2f49c",
+      "engineSetup.claude.codeLabel": "a96080b9680863fc258b3eff690a46bebfb012f381b9c445111a0f6d395ec920",
+      "engineSetup.claude.finish": "ab9b21071bf9a3adddadd2b3b8580cc37916d3854913fa87fb85a86d06e10c5b",
+      "engineSetup.claude.finishing": "e3384d33d9a29df0adfef9bc707cec43fad3267b48dd853af43d4a60039d1597",
+      "engineSetup.claude.security": "34ee9beac3350e3ba101e25b69d2c80996a2f263e1291a48decc19a302a2b207",
+      "engineSetup.claude.connected": "426ba959753edfbe38d7a030bd5d094ecbb418206304e58afcc91307a00b44ab",
+      "engineSetup.claude.connectedAccount": "7c74fb2ecc04b81046affe78b7d74dde6fe3e5dad50ba4ba02492620d8451e13",
+      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe"
     },
     "es": {
       "noEngines.title": "af88855a5f80377de709995229ba3907df9e8fb3b940fbf7c0d9cbe6eea54afe",
@@ -2759,7 +2770,18 @@
       "remote.serverPairing.minutesAgo": "5a0d9752dcc98ad174b74fb774137062709188753404e9337d7271c0b0120765",
       "remote.serverPairing.hoursAgo": "15c7928eb8c8a23a031fa4285a389f713d67fa26262565c0574801cb3f3dc0c1",
       "remote.serverPairing.daysAgo": "de3a2d58e357b552aa9c313bfbda543e0e98eea4a23fe65dcc257ca6ea06514c",
-      "remote.serverPairing.error": "45037f1c0212f956e66bb6e3bc627c6be2880a1c09afb973ea238225a7ab38ac"
+      "remote.serverPairing.error": "45037f1c0212f956e66bb6e3bc627c6be2880a1c09afb973ea238225a7ab38ac",
+      "engineSetup.claude.description": "b36c19aa9140ffea9171b6b7525513c4e9653d00726c242d673e998c1fd7dea5",
+      "engineSetup.claude.start": "168e2c1b9cf37745b05a14f30c971f8f1a047e83f300b4205db74c9fdca7c29e",
+      "engineSetup.claude.starting": "cdca9524ec00f4e3f6a911f36d30c6a460a5bd6ec96e5803ee25fd08ba805c7e",
+      "engineSetup.claude.open": "2026f9f179ebe3aa4afdb35e276e93503c7a80ef8f44becf7ab02df0c2b2f49c",
+      "engineSetup.claude.codeLabel": "a96080b9680863fc258b3eff690a46bebfb012f381b9c445111a0f6d395ec920",
+      "engineSetup.claude.finish": "ab9b21071bf9a3adddadd2b3b8580cc37916d3854913fa87fb85a86d06e10c5b",
+      "engineSetup.claude.finishing": "e3384d33d9a29df0adfef9bc707cec43fad3267b48dd853af43d4a60039d1597",
+      "engineSetup.claude.security": "34ee9beac3350e3ba101e25b69d2c80996a2f263e1291a48decc19a302a2b207",
+      "engineSetup.claude.connected": "426ba959753edfbe38d7a030bd5d094ecbb418206304e58afcc91307a00b44ab",
+      "engineSetup.claude.connectedAccount": "7c74fb2ecc04b81046affe78b7d74dde6fe3e5dad50ba4ba02492620d8451e13",
+      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe"
     },
     "fr": {
       "noEngines.title": "af88855a5f80377de709995229ba3907df9e8fb3b940fbf7c0d9cbe6eea54afe",
@@ -4139,7 +4161,18 @@
       "remote.serverPairing.minutesAgo": "5a0d9752dcc98ad174b74fb774137062709188753404e9337d7271c0b0120765",
       "remote.serverPairing.hoursAgo": "15c7928eb8c8a23a031fa4285a389f713d67fa26262565c0574801cb3f3dc0c1",
       "remote.serverPairing.daysAgo": "de3a2d58e357b552aa9c313bfbda543e0e98eea4a23fe65dcc257ca6ea06514c",
-      "remote.serverPairing.error": "45037f1c0212f956e66bb6e3bc627c6be2880a1c09afb973ea238225a7ab38ac"
+      "remote.serverPairing.error": "45037f1c0212f956e66bb6e3bc627c6be2880a1c09afb973ea238225a7ab38ac",
+      "engineSetup.claude.description": "b36c19aa9140ffea9171b6b7525513c4e9653d00726c242d673e998c1fd7dea5",
+      "engineSetup.claude.start": "168e2c1b9cf37745b05a14f30c971f8f1a047e83f300b4205db74c9fdca7c29e",
+      "engineSetup.claude.starting": "cdca9524ec00f4e3f6a911f36d30c6a460a5bd6ec96e5803ee25fd08ba805c7e",
+      "engineSetup.claude.open": "2026f9f179ebe3aa4afdb35e276e93503c7a80ef8f44becf7ab02df0c2b2f49c",
+      "engineSetup.claude.codeLabel": "a96080b9680863fc258b3eff690a46bebfb012f381b9c445111a0f6d395ec920",
+      "engineSetup.claude.finish": "ab9b21071bf9a3adddadd2b3b8580cc37916d3854913fa87fb85a86d06e10c5b",
+      "engineSetup.claude.finishing": "e3384d33d9a29df0adfef9bc707cec43fad3267b48dd853af43d4a60039d1597",
+      "engineSetup.claude.security": "34ee9beac3350e3ba101e25b69d2c80996a2f263e1291a48decc19a302a2b207",
+      "engineSetup.claude.connected": "426ba959753edfbe38d7a030bd5d094ecbb418206304e58afcc91307a00b44ab",
+      "engineSetup.claude.connectedAccount": "7c74fb2ecc04b81046affe78b7d74dde6fe3e5dad50ba4ba02492620d8451e13",
+      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe"
     },
     "hi": {
       "noEngines.title": "af88855a5f80377de709995229ba3907df9e8fb3b940fbf7c0d9cbe6eea54afe",
@@ -5519,7 +5552,18 @@
       "remote.serverPairing.minutesAgo": "5a0d9752dcc98ad174b74fb774137062709188753404e9337d7271c0b0120765",
       "remote.serverPairing.hoursAgo": "15c7928eb8c8a23a031fa4285a389f713d67fa26262565c0574801cb3f3dc0c1",
       "remote.serverPairing.daysAgo": "de3a2d58e357b552aa9c313bfbda543e0e98eea4a23fe65dcc257ca6ea06514c",
-      "remote.serverPairing.error": "45037f1c0212f956e66bb6e3bc627c6be2880a1c09afb973ea238225a7ab38ac"
+      "remote.serverPairing.error": "45037f1c0212f956e66bb6e3bc627c6be2880a1c09afb973ea238225a7ab38ac",
+      "engineSetup.claude.description": "b36c19aa9140ffea9171b6b7525513c4e9653d00726c242d673e998c1fd7dea5",
+      "engineSetup.claude.start": "168e2c1b9cf37745b05a14f30c971f8f1a047e83f300b4205db74c9fdca7c29e",
+      "engineSetup.claude.starting": "cdca9524ec00f4e3f6a911f36d30c6a460a5bd6ec96e5803ee25fd08ba805c7e",
+      "engineSetup.claude.open": "2026f9f179ebe3aa4afdb35e276e93503c7a80ef8f44becf7ab02df0c2b2f49c",
+      "engineSetup.claude.codeLabel": "a96080b9680863fc258b3eff690a46bebfb012f381b9c445111a0f6d395ec920",
+      "engineSetup.claude.finish": "ab9b21071bf9a3adddadd2b3b8580cc37916d3854913fa87fb85a86d06e10c5b",
+      "engineSetup.claude.finishing": "e3384d33d9a29df0adfef9bc707cec43fad3267b48dd853af43d4a60039d1597",
+      "engineSetup.claude.security": "34ee9beac3350e3ba101e25b69d2c80996a2f263e1291a48decc19a302a2b207",
+      "engineSetup.claude.connected": "426ba959753edfbe38d7a030bd5d094ecbb418206304e58afcc91307a00b44ab",
+      "engineSetup.claude.connectedAccount": "7c74fb2ecc04b81046affe78b7d74dde6fe3e5dad50ba4ba02492620d8451e13",
+      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe"
     },
     "ja": {
       "noEngines.title": "af88855a5f80377de709995229ba3907df9e8fb3b940fbf7c0d9cbe6eea54afe",
@@ -6899,7 +6943,18 @@
       "remote.serverPairing.minutesAgo": "5a0d9752dcc98ad174b74fb774137062709188753404e9337d7271c0b0120765",
       "remote.serverPairing.hoursAgo": "15c7928eb8c8a23a031fa4285a389f713d67fa26262565c0574801cb3f3dc0c1",
       "remote.serverPairing.daysAgo": "de3a2d58e357b552aa9c313bfbda543e0e98eea4a23fe65dcc257ca6ea06514c",
-      "remote.serverPairing.error": "45037f1c0212f956e66bb6e3bc627c6be2880a1c09afb973ea238225a7ab38ac"
+      "remote.serverPairing.error": "45037f1c0212f956e66bb6e3bc627c6be2880a1c09afb973ea238225a7ab38ac",
+      "engineSetup.claude.description": "b36c19aa9140ffea9171b6b7525513c4e9653d00726c242d673e998c1fd7dea5",
+      "engineSetup.claude.start": "168e2c1b9cf37745b05a14f30c971f8f1a047e83f300b4205db74c9fdca7c29e",
+      "engineSetup.claude.starting": "cdca9524ec00f4e3f6a911f36d30c6a460a5bd6ec96e5803ee25fd08ba805c7e",
+      "engineSetup.claude.open": "2026f9f179ebe3aa4afdb35e276e93503c7a80ef8f44becf7ab02df0c2b2f49c",
+      "engineSetup.claude.codeLabel": "a96080b9680863fc258b3eff690a46bebfb012f381b9c445111a0f6d395ec920",
+      "engineSetup.claude.finish": "ab9b21071bf9a3adddadd2b3b8580cc37916d3854913fa87fb85a86d06e10c5b",
+      "engineSetup.claude.finishing": "e3384d33d9a29df0adfef9bc707cec43fad3267b48dd853af43d4a60039d1597",
+      "engineSetup.claude.security": "34ee9beac3350e3ba101e25b69d2c80996a2f263e1291a48decc19a302a2b207",
+      "engineSetup.claude.connected": "426ba959753edfbe38d7a030bd5d094ecbb418206304e58afcc91307a00b44ab",
+      "engineSetup.claude.connectedAccount": "7c74fb2ecc04b81046affe78b7d74dde6fe3e5dad50ba4ba02492620d8451e13",
+      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe"
     },
     "pt-br": {
       "noEngines.title": "af88855a5f80377de709995229ba3907df9e8fb3b940fbf7c0d9cbe6eea54afe",
@@ -8279,7 +8334,18 @@
       "remote.serverPairing.minutesAgo": "5a0d9752dcc98ad174b74fb774137062709188753404e9337d7271c0b0120765",
       "remote.serverPairing.hoursAgo": "15c7928eb8c8a23a031fa4285a389f713d67fa26262565c0574801cb3f3dc0c1",
       "remote.serverPairing.daysAgo": "de3a2d58e357b552aa9c313bfbda543e0e98eea4a23fe65dcc257ca6ea06514c",
-      "remote.serverPairing.error": "45037f1c0212f956e66bb6e3bc627c6be2880a1c09afb973ea238225a7ab38ac"
+      "remote.serverPairing.error": "45037f1c0212f956e66bb6e3bc627c6be2880a1c09afb973ea238225a7ab38ac",
+      "engineSetup.claude.description": "b36c19aa9140ffea9171b6b7525513c4e9653d00726c242d673e998c1fd7dea5",
+      "engineSetup.claude.start": "168e2c1b9cf37745b05a14f30c971f8f1a047e83f300b4205db74c9fdca7c29e",
+      "engineSetup.claude.starting": "cdca9524ec00f4e3f6a911f36d30c6a460a5bd6ec96e5803ee25fd08ba805c7e",
+      "engineSetup.claude.open": "2026f9f179ebe3aa4afdb35e276e93503c7a80ef8f44becf7ab02df0c2b2f49c",
+      "engineSetup.claude.codeLabel": "a96080b9680863fc258b3eff690a46bebfb012f381b9c445111a0f6d395ec920",
+      "engineSetup.claude.finish": "ab9b21071bf9a3adddadd2b3b8580cc37916d3854913fa87fb85a86d06e10c5b",
+      "engineSetup.claude.finishing": "e3384d33d9a29df0adfef9bc707cec43fad3267b48dd853af43d4a60039d1597",
+      "engineSetup.claude.security": "34ee9beac3350e3ba101e25b69d2c80996a2f263e1291a48decc19a302a2b207",
+      "engineSetup.claude.connected": "426ba959753edfbe38d7a030bd5d094ecbb418206304e58afcc91307a00b44ab",
+      "engineSetup.claude.connectedAccount": "7c74fb2ecc04b81046affe78b7d74dde6fe3e5dad50ba4ba02492620d8451e13",
+      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe"
     },
     "zh": {
       "noEngines.title": "af88855a5f80377de709995229ba3907df9e8fb3b940fbf7c0d9cbe6eea54afe",
@@ -9659,7 +9725,18 @@
       "remote.serverPairing.minutesAgo": "5a0d9752dcc98ad174b74fb774137062709188753404e9337d7271c0b0120765",
       "remote.serverPairing.hoursAgo": "15c7928eb8c8a23a031fa4285a389f713d67fa26262565c0574801cb3f3dc0c1",
       "remote.serverPairing.daysAgo": "de3a2d58e357b552aa9c313bfbda543e0e98eea4a23fe65dcc257ca6ea06514c",
-      "remote.serverPairing.error": "45037f1c0212f956e66bb6e3bc627c6be2880a1c09afb973ea238225a7ab38ac"
+      "remote.serverPairing.error": "45037f1c0212f956e66bb6e3bc627c6be2880a1c09afb973ea238225a7ab38ac",
+      "engineSetup.claude.description": "b36c19aa9140ffea9171b6b7525513c4e9653d00726c242d673e998c1fd7dea5",
+      "engineSetup.claude.start": "168e2c1b9cf37745b05a14f30c971f8f1a047e83f300b4205db74c9fdca7c29e",
+      "engineSetup.claude.starting": "cdca9524ec00f4e3f6a911f36d30c6a460a5bd6ec96e5803ee25fd08ba805c7e",
+      "engineSetup.claude.open": "2026f9f179ebe3aa4afdb35e276e93503c7a80ef8f44becf7ab02df0c2b2f49c",
+      "engineSetup.claude.codeLabel": "a96080b9680863fc258b3eff690a46bebfb012f381b9c445111a0f6d395ec920",
+      "engineSetup.claude.finish": "ab9b21071bf9a3adddadd2b3b8580cc37916d3854913fa87fb85a86d06e10c5b",
+      "engineSetup.claude.finishing": "e3384d33d9a29df0adfef9bc707cec43fad3267b48dd853af43d4a60039d1597",
+      "engineSetup.claude.security": "34ee9beac3350e3ba101e25b69d2c80996a2f263e1291a48decc19a302a2b207",
+      "engineSetup.claude.connected": "426ba959753edfbe38d7a030bd5d094ecbb418206304e58afcc91307a00b44ab",
+      "engineSetup.claude.connectedAccount": "7c74fb2ecc04b81046affe78b7d74dde6fe3e5dad50ba4ba02492620d8451e13",
+      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe"
     }
   }
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1376,5 +1376,16 @@
   "remote.serverPairing.minutesAgo": "{minutes} 分钟前",
   "remote.serverPairing.hoursAgo": "{hours} 小时前",
   "remote.serverPairing.daysAgo": "{days} 天前",
-  "remote.serverPairing.error": "无法连接服务器：{error}"
+  "remote.serverPairing.error": "无法连接服务器：{error}",
+  "engineSetup.claude.description": "用你自己的 Claude 订阅在此服务器上登录 Claude Code。在浏览器中打开 Anthropic 的登录页面并登录，然后把页面显示的代码粘贴到这里。无需终端，也不用共享密码。",
+  "engineSetup.claude.start": "登录 Claude",
+  "engineSetup.claude.starting": "正在准备登录…",
+  "engineSetup.claude.open": "打开 Claude 登录页面",
+  "engineSetup.claude.codeLabel": "粘贴该页面显示的代码",
+  "engineSetup.claude.finish": "完成登录",
+  "engineSetup.claude.finishing": "正在与 Claude Code 核对…",
+  "engineSetup.claude.security": "只粘贴你在此处发起的登录所得到的代码。代码只会交给此服务器上的 Claude Code 一次，绝不保存；你的密码只留在 Anthropic。此服务器上的机器人共享你订阅的用量限制。",
+  "engineSetup.claude.connected": "Claude 已连接，正在刷新你的模型。",
+  "engineSetup.claude.connectedAccount": "此服务器已连接 Claude",
+  "engineSetup.claude.invalidChallenge": "Claude Code 没有返回有效的 Anthropic 登录链接。请取消后重试。"
 }

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -463,7 +463,7 @@ export interface InstanceInfo {
   };
   /** `custom` agents sit below the rail divider — no subscription catalog. */
   access?: "subscription" | "custom";
-  authentication?: { method: "device-code" | "browser" };
+  authentication?: { method: "device-code" | "paste-code" | "browser" };
   install?: EngineInstall;
   /** Configured CLI path override — set ONLY when the user overrode it;
    * absent means the driver default is in effect. */


### PR DESCRIPTION
For a hosted server used by someone without SSH: **Settings → Engines → Claude → Sign in to Claude.**

How it works: the server spawns the unmodified `claude auth login` over pipes with no browser available, so the CLI prints Anthropic's own sign-in link and then waits on stdin for the code that page shows once the user has signed in. Settings shows that link (only Anthropic's hosts, over https, validated on both sides), the user opens it in their own browser, signs in, pastes the code back, and the server hands it to the CLI's stdin once and confirms the result with `claude auth status --json`. The login lands where Claude Code keeps it for the account that runs the bots. Nothing is stored by OpenMausBot and there is no OAuth client code in the repo.

Why this route: it is the sign-in Anthropic's legal page permits for a hosted, unmodified Claude Code with the user's own subscription. The route other tools took, their own OAuth flow against Claude Code's client id, is prohibited, server-blocked since January, and was not built. `claude setup-token` (a long-lived token) is an Ink TUI that prints nothing without a terminal, so it is not driven here; it remains available by hand as `CLAUDE_CODE_OAUTH_TOKEN`.

Plumbing: the Claude driver exposes start/get/complete/cancel exactly like the Codex device flow; the registry reports a new `paste-code` authentication method when a provider has both a status and a completion step (Codex stays `device-code`, managed engines stay `browser`); `POST /api/instances/:id/auth/complete` accepts `code` beside `callbackUrl`; one login per credential home at a time, turns never blocked.

Tests (stand-in CLI, no network): link shown and validated, a second click returns the same flow without a second process, pasted code accepted and the login confirmed through the status command, rejected code reported with the process gone, malformed code refused before anything is sent, a non-Anthropic link never shown, cancel kills the process, missing binary fails safely. UI test for the link allow-list. 29 tests in the touched suites; typecheck (server and UI), lint, and the locale check pass. Strings in all eight locales; docs gain "Signing the engines in without a terminal".

Not verified: a real sign-in against Anthropic from a hosted box (needs a real subscription in a browser; the fake CLI reproduces the CLI's printed prompt as observed on 2.1.261).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added hosted Claude Code sign-in through Anthropic’s browser flow.
  - Users can open the sign-in page, paste a one-time code, and track connection status.
  - Added cancellation, expiration, validation, and success/error states.
  - Added localized Claude sign-in guidance in supported languages.

- **Documentation**
  - Documented signing engine CLIs in from Settings → Engines without using a terminal.

- **Bug Fixes**
  - Improved authentication flow handling, secure sign-in link validation, and hosted server connection feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->