### PR TITLE
feat(cli): serve --domain — HTTPS on your own domain with a managed Caddy

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -97,6 +97,18 @@ is present. Three ways to make the server reachable from elsewhere:
   fleet issued and skip `login`: the address and connector token are fetched
   at every start and nothing is written to disk. A rejected credential stops
   the start with a clear message rather than serving locally.
+- **Your own domain, still one command:**
+
+  ```sh
+  npx openmausbot serve --domain maus.example.com
+  ```
+
+  Point the domain's A record at this machine and open ports 80 and 443.
+  The server downloads a pinned Caddy once into its data dir, writes the
+  same Caddyfile the Docker stack uses, runs it as a child, and Caddy gets
+  and renews the certificate from Let's Encrypt. On Linux, binding ports 80
+  and 443 as a normal user needs one privilege grant; when Caddy reports the
+  refusal, `serve` prints the exact `setcap` command to run once.
 - **Behind your own proxy or domain:** `npx openmausbot serve --public-url
   https://maus.example.com`, with the proxy rules from "Putting a proxy in
   front".

--- a/server/caddy.test.ts
+++ b/server/caddy.test.ts
@@ -1,0 +1,105 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { CADDY_ASSETS, CADDY_VERSION, caddyfileFor, ensureCaddy, normalizeDomainOption, pinnedCaddyPath, portPermissionRefused, resolveCaddyBinary, startCaddy } from "./caddy.ts";
+import { removeTempDir } from "./testing/cleanup.ts";
+
+const posix = process.platform !== "win32";
+
+describe("the managed Caddy", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "omb-caddy-"));
+  });
+  afterEach(() => removeTempDir(dir));
+
+  it("pins one release per platform with a sha512 from the release's checksums", () => {
+    for (const [target, asset] of Object.entries(CADDY_ASSETS)) {
+      expect(asset.name).toContain(CADDY_VERSION);
+      expect(asset.sha512, target).toMatch(/^[0-9a-f]{128}$/);
+    }
+    expect(pinnedCaddyPath(dir, "linux", "x64")).toBe(join(dir, "caddy", `${CADDY_VERSION}-linux-x64`, "caddy"));
+  });
+
+  it("writes the Docker stack's Caddyfile with this server's ports and no admin API", () => {
+    const file = caddyfileFor({ domain: "maus.example.com", appPort: 18799, webhookPort: 18800 });
+    expect(file).toContain("maus.example.com {");
+    expect(file).toContain("reverse_proxy 127.0.0.1:18799");
+    expect(file).toContain("handle /hooks/*");
+    expect(file).toContain("reverse_proxy 127.0.0.1:18800");
+    expect(file).toContain("flush_interval -1");
+    expect(file).toContain("admin off");
+  });
+
+  it("resolves OMB_CADDY_PATH, then the pinned download, then PATH", () => {
+    const pinned = pinnedCaddyPath(dir, "linux", "x64");
+    const onPath = join(dir, "bin", "caddy");
+    const exists = (p: string) => p === pinned || p === onPath || p === join(dir, "custom");
+    expect(resolveCaddyBinary({ dataDir: dir, env: { OMB_CADDY_PATH: join(dir, "custom") }, platform: "linux", arch: "x64", exists })).toBe(join(dir, "custom"));
+    expect(resolveCaddyBinary({ dataDir: dir, env: { OMB_CADDY_PATH: "relative/caddy" }, platform: "linux", arch: "x64", exists })).toBeNull();
+    expect(resolveCaddyBinary({ dataDir: dir, env: { PATH: join(dir, "bin") }, platform: "linux", arch: "x64", exists })).toBe(pinned);
+    expect(resolveCaddyBinary({ dataDir: join(dir, "elsewhere"), env: { PATH: join(dir, "bin") }, platform: "linux", arch: "x64", exists })).toBe(onPath);
+    expect(resolveCaddyBinary({ dataDir: join(dir, "elsewhere"), env: { PATH: "" }, platform: "linux", arch: "x64", exists })).toBeNull();
+  });
+
+  it("takes a bare public hostname for --domain", () => {
+    expect(normalizeDomainOption(" HTTPS://Maus.Example.com/ ")).toBe("maus.example.com");
+    expect(normalizeDomainOption("maus.example.com:443")).toEqual({ error: expect.stringContaining("bare hostname") });
+    expect(normalizeDomainOption("localhost")).toEqual({ error: expect.stringContaining("bare hostname") });
+    expect(normalizeDomainOption("box.internal")).toEqual({ error: expect.stringContaining("public domain") });
+    expect(normalizeDomainOption("nodots")).toEqual({ error: expect.stringContaining("bare hostname") });
+  });
+
+  it.skipIf(!posix)("downloads a pinned archive once, verifies its digest, and extracts the binary", async () => {
+    const src = join(dir, "src");
+    mkdirSync(src);
+    writeFileSync(join(src, "caddy"), "#!/bin/sh\necho fake caddy\n", { mode: 0o755 });
+    const archive = join(dir, "caddy_test_linux_amd64.tar.gz");
+    expect(spawnSync("tar", ["-czf", archive, "-C", src, "caddy"]).status).toBe(0);
+    const bytes = readFileSync(archive);
+    const sha512 = createHash("sha512").update(bytes).digest("hex");
+    let fetched = 0;
+    const fetchImpl = (async () => {
+      fetched += 1;
+      return new Response(bytes, { status: 200 });
+    }) as unknown as typeof fetch;
+    const dataDir = join(dir, "data");
+    const binary = await ensureCaddy({ dataDir, env: { PATH: "" }, platform: "linux", arch: "x64", asset: { name: "caddy_test_linux_amd64.tar.gz", sha512, url: "https://stub.invalid/caddy.tgz" }, fetchImpl });
+    expect(binary).toBe(pinnedCaddyPath(dataDir, "linux", "x64"));
+    expect(existsSync(binary)).toBe(true);
+    expect(statSync(binary).mode & 0o111).not.toBe(0);
+    expect(fetched).toBe(1);
+    expect(await ensureCaddy({ dataDir, env: { PATH: "" }, platform: "linux", arch: "x64", fetchImpl })).toBe(binary);
+    expect(fetched).toBe(1);
+    const other = join(dir, "data2");
+    await expect(ensureCaddy({ dataDir: other, env: { PATH: "" }, platform: "linux", arch: "x64", asset: { name: "caddy_test_linux_amd64.tar.gz", sha512: "0".repeat(128), url: "https://stub.invalid/x" }, fetchImpl })).rejects.toThrow(/SHA-512/);
+    expect(existsSync(pinnedCaddyPath(other, "linux", "x64"))).toBe(false);
+  });
+
+  it.skipIf(!posix)("runs Caddy with the written Caddyfile and stops it; a port refusal becomes the privilege hint", async () => {
+    const fake = join(dir, "fake-caddy");
+    writeFileSync(fake, `#!/bin/sh\necho "$@" > "${join(dir, "args.txt")}"\nexec sleep 300\n`, { mode: 0o755 });
+    chmodSync(fake, 0o755);
+    const running = await startCaddy({ binary: fake, dataDir: dir, domain: "maus.example.com", appPort: 18799, webhookPort: 18800, settleMs: 300 });
+    try {
+      // the stand-in writes its arguments from a shell that may start slowly under load
+      await expect.poll(() => existsSync(join(dir, "args.txt")), { timeout: 5_000 }).toBe(true);
+      expect(readFileSync(join(dir, "args.txt"), "utf8").trim()).toBe(`run --config ${running.configFile} --adapter caddyfile`);
+      expect(readFileSync(running.configFile, "utf8")).toContain("reverse_proxy 127.0.0.1:18799");
+      expect(statSync(running.configFile).mode & 0o077).toBe(0);
+    } finally {
+      await running.stop();
+    }
+    expect(await running.exited).not.toBeUndefined();
+
+    const refusing = join(dir, "refusing-caddy");
+    writeFileSync(refusing, "#!/bin/sh\necho 'Error: loading initial config: listen tcp :443: bind: permission denied' >&2\nexit 1\n", { mode: 0o755 });
+    await expect(startCaddy({ binary: refusing, dataDir: join(dir, "d2"), domain: "maus.example.com", appPort: 1, webhookPort: 2, settleMs: 2000 })).rejects.toThrow(/ports 80 and 443/);
+    expect(portPermissionRefused("listen tcp :443: bind: permission denied")).toBe(true);
+    expect(portPermissionRefused("some other error")).toBe(false);
+  });
+});

--- a/server/caddy.ts
+++ b/server/caddy.ts
@@ -1,0 +1,221 @@
+// `openmausbot serve --domain maus.example.com`: HTTPS on your own domain
+// with nothing to configure. The server downloads a pinned Caddy once into
+// the data dir (the same way it fetches cloudflared and the browser engine),
+// writes the Caddyfile the Docker stack ships, and runs Caddy as its child:
+// Caddy gets and renews the certificate from Let's Encrypt and forwards to
+// the loopback server with the real Host and the forwarded headers the
+// server's remote-session rules expect. The loopback bind never changes.
+//
+// What the operator still owns: a DNS record for the domain pointing at this
+// machine, and ports 80 and 443 reachable. Binding those ports needs a
+// privilege on Linux; `serve` says exactly which command grants it to the
+// downloaded binary when Caddy reports the refusal.
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join, resolve } from "node:path";
+
+export const CADDY_VERSION = "2.11.4";
+
+/** Release assets by platform-arch, with the sha512 from the release's checksums file. */
+export const CADDY_ASSETS: Readonly<Record<string, { name: string; sha512: string }>> = Object.freeze({
+  "linux-x64": { name: `caddy_${CADDY_VERSION}_linux_amd64.tar.gz`, sha512: "8220d1f013b6f27510247b2360c9e0ca9f018feebd82515f07635318b34ff9777ccc8fd0b6e6f2486ce3a33fe389fbb7db12d05baa474f4587509fb4f5ebf1c9" },
+  "linux-arm64": { name: `caddy_${CADDY_VERSION}_linux_arm64.tar.gz`, sha512: "d5a7c423853c24a799765e0e8210d5c7c22a8f56ed37a3cae2fb9f58be138853c02b4efd6b59d576e6d8c7c0d30b9c1592deeaa6a536ff69bcca23b8c1ea709c" },
+  "darwin-x64": { name: `caddy_${CADDY_VERSION}_mac_amd64.tar.gz`, sha512: "e04eb10f9ce7e2e079bc9bff1bd5d3a3164888d1edbb1a49e5d15be4eab691b57e89ed36bb29c65ba43f1ba8d9279e0967b1003991c13fe4cb78384c3caf25de" },
+  "darwin-arm64": { name: `caddy_${CADDY_VERSION}_mac_arm64.tar.gz`, sha512: "3190ae0df98b59ab4b6021556fa35adc3c526a4f3e138776b0eaec8a037cc26121cbbb1ad53453f565551b47d37d5ba4755e2c2c3652256737fe2ce9e53c8ec0" },
+});
+
+const DOWNLOAD_TIMEOUT_MS = 180_000;
+
+export function caddyTarget(platform: NodeJS.Platform = process.platform, arch: string = process.arch): string {
+  return `${platform}-${arch}`;
+}
+
+export function pinnedCaddyPath(dataDir: string, platform: NodeJS.Platform = process.platform, arch: string = process.arch): string {
+  return join(dataDir, "caddy", `${CADDY_VERSION}-${caddyTarget(platform, arch)}`, platform === "win32" ? "caddy.exe" : "caddy");
+}
+
+/** OMB_CADDY_PATH, then the pinned download, then a `caddy` on PATH. */
+export function resolveCaddyBinary(options: { dataDir: string; env?: NodeJS.ProcessEnv; platform?: NodeJS.Platform; arch?: string; exists?: (p: string) => boolean } ): string | null {
+  const env = options.env ?? process.env;
+  const exists = options.exists ?? existsSync;
+  const platform = options.platform ?? process.platform;
+  const override = env.OMB_CADDY_PATH?.trim();
+  if (override) return resolve(override) === override && exists(override) ? override : null;
+  const pinned = pinnedCaddyPath(options.dataDir, platform, options.arch);
+  if (exists(pinned)) return pinned;
+  const executable = platform === "win32" ? "caddy.exe" : "caddy";
+  for (const part of (env.PATH ?? "").split(delimiter)) {
+    const dir = part.trim();
+    if (!dir) continue;
+    const candidate = join(dir, executable);
+    if (exists(candidate)) return candidate;
+  }
+  return null;
+}
+
+/** Download the pinned release once, verify its digest, extract the binary. */
+export async function ensureCaddy(options: {
+  dataDir: string;
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  arch?: string;
+  fetchImpl?: typeof fetch;
+  /** Tests pin their own asset and URL; production resolves the release table. */
+  asset?: { name: string; sha512: string; url?: string };
+  log?: (line: string) => void;
+}): Promise<string> {
+  const platform = options.platform ?? process.platform;
+  const found = resolveCaddyBinary({ dataDir: options.dataDir, env: options.env, platform, arch: options.arch });
+  if (found) return found;
+  if (platform === "win32") throw new Error("--domain is not available on Windows yet; put your own HTTPS proxy in front (docs/self-hosting.md)");
+  const target = caddyTarget(platform, options.arch);
+  const asset: { name: string; sha512: string; url?: string } | undefined = options.asset ?? CADDY_ASSETS[target];
+  if (!asset) throw new Error(`Caddy publishes no build for ${target}`);
+  const destination = pinnedCaddyPath(options.dataDir, platform, options.arch);
+  const directory = join(destination, "..");
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const url = asset.url ?? `https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/${asset.name}`;
+  options.log?.(`downloading Caddy ${CADDY_VERSION} once (about 15 MB, digest pinned) into ${directory}`);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
+  timer.unref?.();
+  let body: Buffer;
+  try {
+    const response = await (options.fetchImpl ?? fetch)(url, { redirect: "follow", signal: controller.signal });
+    if (!response.ok) throw new Error(`the Caddy download failed (HTTP ${response.status})`);
+    body = Buffer.from(await response.arrayBuffer());
+  } finally {
+    clearTimeout(timer);
+  }
+  const digest = createHash("sha512").update(body).digest("hex");
+  if (digest !== asset.sha512) throw new Error("the Caddy download failed its SHA-512 check; nothing was installed");
+  const scratch = mkdtempSync(join(tmpdir(), "openmaus-caddy-"));
+  try {
+    const archive = join(scratch, asset.name);
+    writeFileSync(archive, body, { mode: 0o600 });
+    const extracted = spawnSync("tar", ["-xzf", archive, "-C", scratch, "caddy"], { stdio: "ignore" });
+    if (extracted.status !== 0) throw new Error("the Caddy archive could not be extracted (is `tar` installed?)");
+    const staging = `${destination}.${randomBytes(6).toString("hex")}.part`;
+    renameSync(join(scratch, "caddy"), staging);
+    chmodSync(staging, 0o755);
+    renameSync(staging, destination);
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+  return destination;
+}
+
+/** The Docker stack's Caddyfile with this server's ports; certificates and
+ * state live under the data dir so they survive restarts and upgrades. */
+export function caddyfileFor(input: { domain: string; appPort: number; webhookPort: number }): string {
+  return [
+    "# Written by openmausbot serve --domain. Edit the command, not this file.",
+    "{",
+    "\tadmin off",
+    "\tlog {",
+    "\t\tlevel WARN",
+    "\t}",
+    "}",
+    "",
+    `${input.domain} {`,
+    "\tencode zstd gzip",
+    "",
+    "\t# Webhook ingress has its own per-hook secrets and is meant for third parties.",
+    "\thandle /hooks/* {",
+    `\t\treverse_proxy 127.0.0.1:${input.webhookPort}`,
+    "\t}",
+    "",
+    "\thandle {",
+    `\t\treverse_proxy 127.0.0.1:${input.appPort} {`,
+    "\t\t\t# SSE: stream events as they arrive",
+    "\t\t\tflush_interval -1",
+    "\t\t}",
+    "\t}",
+    "}",
+    "",
+  ].join("\n");
+}
+
+export interface RunningCaddy {
+  configFile: string;
+  exited: Promise<number | null>;
+  stop(): Promise<void>;
+}
+
+/** Whether a Caddy exit was the ports refusing to bind (a privilege problem, not a config one). */
+export function portPermissionRefused(output: string): boolean {
+  return /permission denied|bind: operation not permitted|EACCES/i.test(output) && /:80|:443|listen/i.test(output);
+}
+
+export function portPermissionHint(binary: string): string {
+  return process.platform === "linux"
+    ? `Caddy may not bind ports 80 and 443 as this user. Grant it once with:\n  sudo setcap 'cap_net_bind_service=+ep' ${binary}\nthen run the same command again. (A service unit can grant the same capability.)`
+    : "Caddy may not bind ports 80 and 443 as this user. Run the server as an administrator, or put your own HTTPS proxy in front.";
+}
+
+/** Run Caddy as a child with the Caddyfile for this domain. Resolves once
+ * Caddy has stayed up for a moment; rejects with its output if it exits first. */
+export async function startCaddy(options: {
+  binary: string;
+  dataDir: string;
+  domain: string;
+  appPort: number;
+  webhookPort: number;
+  env?: NodeJS.ProcessEnv;
+  log?: (line: string) => void;
+  settleMs?: number;
+}): Promise<RunningCaddy> {
+  const home = join(options.dataDir, "caddy");
+  mkdirSync(join(home, "data"), { recursive: true, mode: 0o700 });
+  mkdirSync(join(home, "config"), { recursive: true, mode: 0o700 });
+  const configFile = join(home, "Caddyfile");
+  writeFileSync(configFile, caddyfileFor(options), { mode: 0o600 });
+  const child: ChildProcess = spawn(options.binary, ["run", "--config", configFile, "--adapter", "caddyfile"], {
+    env: { ...(options.env ?? process.env), XDG_DATA_HOME: join(home, "data"), XDG_CONFIG_HOME: join(home, "config") },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  const receive = (chunk: Buffer) => {
+    const text = chunk.toString("utf8");
+    if (output.length < 16_384) output += text;
+    for (const line of text.split(/\r?\n/)) {
+      if (!line.trim()) continue;
+      // Caddy logs JSON; surface warnings and errors, keep the rest quiet.
+      if (/"level":"(warn|error)"/.test(line) || /^\S+\s+(WARN|ERROR)/.test(line) || !line.startsWith("{")) options.log?.(`caddy: ${line.slice(0, 400)}`);
+    }
+  };
+  child.stdout?.on("data", receive);
+  child.stderr?.on("data", receive);
+  const exited = new Promise<number | null>((done) => {
+    child.once("error", () => done(1));
+    child.once("exit", (code) => done(code));
+  });
+  const settled = await Promise.race([exited.then((code) => ({ code })), new Promise<{ code: undefined }>((r) => setTimeout(() => r({ code: undefined }), options.settleMs ?? 1500))]);
+  if (settled.code !== undefined) {
+    const reason = portPermissionRefused(output) ? portPermissionHint(options.binary) : output.trim().split("\n").slice(-3).join("\n");
+    throw new Error(`Caddy stopped right after starting (exit ${settled.code}).\n${reason}`);
+  }
+  return {
+    configFile,
+    exited,
+    stop: async () => {
+      if (child.exitCode !== null || child.signalCode !== null) return;
+      child.kill("SIGTERM");
+      await Promise.race([exited, new Promise((r) => setTimeout(r, 5_000))]);
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+    },
+  };
+}
+
+/** `--domain` takes a bare hostname; the same shape Settings → Custom domain accepts. */
+export function normalizeDomainOption(raw: string): string | { error: string } {
+  const value = raw.trim().toLowerCase().replace(/^https?:\/\//, "").replace(/\/+$/, "");
+  const label = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+  if (!value || value.length > 253 || !value.includes(".") || /[\s/:@?#]/.test(value) || !value.split(".").every((part) => label.test(part))) {
+    return { error: "--domain takes a bare hostname such as maus.example.com" };
+  }
+  if (/(?:^|\.)(?:localhost|local|internal|invalid)$/.test(value)) return { error: "--domain needs a public domain name that resolves to this machine" };
+  return value;
+}

--- a/server/cli.test.ts
+++ b/server/cli.test.ts
@@ -44,6 +44,9 @@ describe("openmausbot command line", () => {
     expect(parseArgs(["access", "list"], {})).toMatchObject({ command: "access", accessAction: "list" });
     expect(parseArgs(["access"], {})).toEqual({ error: "access needs one of: list, add EMAIL [--chat-only], remove EMAIL" });
     expect(parseArgs(["access", "add"], {})).toEqual({ error: "add needs a value" });
+    expect(parseArgs(["serve", "--domain", "Maus.Example.com"], {})).toMatchObject({ command: "serve", domain: "maus.example.com" });
+    expect(parseArgs(["serve", "--domain", "localhost"], {})).toEqual({ error: expect.stringContaining("bare hostname") });
+    expect(parseArgs(["serve", "--domain", "maus.example.com", "--tunnel"], {})).toEqual({ error: expect.stringContaining("--domain already gives") });
   });
 
   it("prints a scannable block with the link, or says where to type the code", () => {
@@ -523,4 +526,43 @@ describe("openmausbot access", () => {
       await removeTempDir(home);
     }
   });
+});
+
+describe.skipIf(process.platform === "win32")("serve --domain", () => {
+  it("runs a managed Caddy for the domain and serves the pairing link there", async () => {
+    const home = mkdtempSync(join(tmpdir(), "omb-cli-domain-"));
+    const dataDir = join(home, "data");
+    mkdirSync(dataDir, { recursive: true });
+    const fake = join(home, "fake-caddy");
+    writeFileSync(fake, `#!/bin/sh\necho "$@" > "${join(home, "caddy-args.txt")}"\necho $$ > "${join(home, "caddy.pid")}"\nexec sleep 300\n`, { mode: 0o755 });
+    const port = 21000 + Math.floor(Math.random() * 9000);
+    const child = spawn(process.execPath, ["--experimental-strip-types", join(SERVER_DIR, "openmausbot.ts"), "serve", "--domain", "omb.example.test", "--port", String(port), "--data-dir", dataDir], {
+      cwd: join(SERVER_DIR, ".."),
+      env: { PATH: process.env.PATH ?? "", HOME: home, USERPROFILE: home, OMB_WEBHOOK_PORT: String(port + 1), OMB_BROWSER_CONNECTION: join(home, "browser-connection.json"), OMB_CADDY_PATH: fake },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let out = "";
+    child.stdout?.on("data", (chunk) => (out += String(chunk)));
+    child.stderr?.on("data", (chunk) => (out += String(chunk)));
+    try {
+      const deadline = Date.now() + 60_000;
+      while (!out.includes("open or scan:") && Date.now() < deadline && child.exitCode === null) await new Promise((r) => setTimeout(r, 200));
+      expect(out).toContain(`OpenMausBot is running on http://127.0.0.1:${port}, reachable at https://omb.example.test`);
+      expect(out).toContain("https: Caddy serves https://omb.example.test");
+      expect(out).toContain("open or scan:  https://omb.example.test/pair#code=");
+      const args = readFileSync(join(home, "caddy-args.txt"), "utf8").trim();
+      expect(args).toMatch(/^run --config .*Caddyfile --adapter caddyfile$/);
+      const caddyfile = readFileSync(join(dataDir, "caddy", "Caddyfile"), "utf8");
+      expect(caddyfile).toContain("omb.example.test {");
+      expect(caddyfile).toContain(`reverse_proxy 127.0.0.1:${port}`);
+      expect(caddyfile).toContain(`reverse_proxy 127.0.0.1:${port + 1}`);
+    } finally {
+      const caddyPid = Number(readFileSync(join(home, "caddy.pid"), "utf8").trim() || "0");
+      child.kill("SIGTERM");
+      await exited(child);
+      await new Promise((r) => setTimeout(r, 300));
+      if (caddyPid) expect(() => process.kill(caddyPid, 0)).toThrow();
+      await removeTempDir(home);
+    }
+  }, 120_000);
 });

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -7,7 +7,7 @@
 //   openmausbot setup [--data-dir ~/.openmausbot]
 //   openmausbot start [serve options]
 //   openmausbot serve [--port 8799] [--data-dir ~/.openmausbot] [--label "cab mini"]
-//                     [--public-url https://host] [--tailscale | --tunnel] [--no-pair]
+//                     [--public-url https://host] [--tailscale | --tunnel | --domain HOST] [--no-pair]
 //   openmausbot pair  [--label "My MacBook"] [--client] [--public-url https://host]
 //   openmausbot sessions [revoke <id>]
 //   openmausbot status
@@ -32,6 +32,7 @@ import qrcode from "qrcode-terminal";
 
 import { parseAllowList } from "./account-signin.ts";
 import { writeFileAtomic } from "./atomic.ts";
+import { ensureCaddy, normalizeDomainOption, startCaddy, type RunningCaddy } from "./caddy.ts";
 import { explainTailscaleFailure, tailscaleServe, tailscaleServeOff, tailscaleStatus, type TailscaleStatus } from "./tailscale.ts";
 import { defaultSetupIo, SetupCancelled, type SetupIo } from "./cli-prompts.ts";
 import { normalizePhoneOrigin, phonePairingInstructions, runPhoneSetup } from "./cli-phone-setup.ts";
@@ -62,6 +63,8 @@ export interface CliOptions {
   dataDir: string;
   label?: string;
   publicUrl?: string;
+  /** `serve --domain host`: HTTPS on your own domain through a managed Caddy. */
+  domain?: string;
   tailscale: boolean;
   tunnel: boolean;
   client: boolean;
@@ -117,6 +120,11 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
       else if (arg === "--label") options.label = value();
       else if (arg === "--public-url") options.publicUrl = value().replace(/\/+$/, "");
       else if (arg === "--tailscale") options.tailscale = true;
+      else if (arg === "--domain") {
+        const domain = normalizeDomainOption(value());
+        if (typeof domain !== "string") return domain;
+        options.domain = domain;
+      }
       else if (arg === "--tunnel") options.tunnel = true;
       else if (arg === "--client") options.client = true;
       else if (arg === "--no-pair") options.pair = false;
@@ -140,6 +148,7 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
   if (options.publicUrl && !/^https?:\/\//.test(options.publicUrl)) return { error: "--public-url must start with http:// or https://" };
   if (options.tailscale && options.tunnel) return { error: "choose one of --tailscale (your tailnet) and --tunnel (a public address)" };
   if (options.command === "access" && !options.accessAction) return { error: "access needs one of: list, add EMAIL [--chat-only], remove EMAIL" };
+  if (options.domain && (options.tailscale || options.tunnel || options.publicUrl)) return { error: "--domain already gives the server its address; drop --tailscale, --tunnel and --public-url" };
   if (options.local && (options.tailscale || options.tunnel || options.publicUrl)) return { error: "--local cannot be combined with a remote-access option" };
   if (options.command === "browser" && !options.browserAction) return { error: "browser needs an action: install or status" };
   return options;
@@ -151,7 +160,7 @@ export const USAGE = `openmausbot — your team of AI bots, ready in a few steps
   openmausbot setup [--data-dir DIR]
   openmausbot start [the same options as serve]
   openmausbot serve [--port 8799] [--data-dir DIR] [--label NAME]
-                    [--public-url https://host] [--tailscale | --tunnel] [--no-pair]
+                    [--public-url https://host] [--tailscale | --tunnel | --domain HOST] [--no-pair]
   openmausbot pair  [--label NAME] [--client] [--public-url https://host]
   openmausbot sessions [revoke ID]
   openmausbot status
@@ -185,6 +194,10 @@ browser install: the bots' browser engine (agent-browser, pinned) into the
 --tunnel     serve at a public https://….openmausbot.com address through a
              Cloudflare tunnel: no domain, no proxy, no open port. Run
              \`openmausbot login\` once on this machine first.
+--domain     serve at https://HOST on your own domain: a pinned Caddy is
+             downloaded once and run alongside the server, and gets the
+             certificate itself. Point the domain's DNS at this machine and
+             open ports 80 and 443.
 
 --no-open   do not open a browser window
 --no-pair   skip phone setup and do not print a pairing code
@@ -708,6 +721,16 @@ export async function runServe(options: CliOptions, log: (line: string) => void 
     if (publicUrl && publicUrl !== plan.access.endpoint) log(`note: --public-url is ignored with --tunnel; the address is ${plan.access.endpoint}`);
     publicUrl = plan.access.endpoint;
   }
+  let caddyBinary: string | null = null;
+  if (options.domain) {
+    try {
+      caddyBinary = await ensureCaddy({ dataDir: options.dataDir, log });
+    } catch (error) {
+      console.error(`--domain: ${message(error)}`);
+      return 1;
+    }
+    publicUrl = `https://${options.domain}`;
+  }
   const entry = serverEntry();
   if (!entry.staticDir) log("note: no built UI found next to the server; the API runs but browsers get no page (build with `pnpm exec vite build`)");
   const env: NodeJS.ProcessEnv = {
@@ -771,11 +794,13 @@ export async function runServe(options: CliOptions, log: (line: string) => void 
     child.once("exit", (code, signal) => { exited = code ?? (signal === "SIGTERM" || signal === "SIGINT" ? 0 : 1); done(exited); });
   });
   let tunnel: RunningTunnel | null = null;
+  let caddy: RunningCaddy | null = null;
   let stopping: Promise<void> | null = null;
   const stop = () => {
     stopping ??= (async () => {
-      // The gateway stops accepting before the server it forwards to goes away.
+      // The gateway and the edge stop accepting before the server they forward to goes away.
       if (tunnel) await tunnel.stop().catch(() => undefined);
+      if (caddy) await caddy.stop().catch(() => undefined);
       if (tailscaleServing && tailscale) await tailscaleServeOff(tailscale).catch(() => undefined);
       if (exited === null) {
         child.kill("SIGTERM");
@@ -809,6 +834,19 @@ export async function runServe(options: CliOptions, log: (line: string) => void 
       return 1;
     }
     if (stopping || exited !== null) return await childExit;
+    if (options.domain && caddyBinary) {
+      try {
+        caddy = await startCaddy({ binary: caddyBinary, dataDir: options.dataDir, domain: options.domain, appPort: options.port, webhookPort: Number(env.OMB_WEBHOOK_PORT), log });
+        log(`https: Caddy serves ${publicUrl} → http://127.0.0.1:${options.port}; it gets the certificate from Let's Encrypt once DNS for ${options.domain} points at this machine`);
+        void caddy.exited.then((code) => {
+          if (!stopping) log(`caddy: stopped (exit ${code ?? "signal"}); ${publicUrl} is no longer served. Stop and start the server again.`);
+        });
+      } catch (error) {
+        console.error(`--domain: ${message(error)}`);
+        await stop();
+        return 1;
+      }
+    }
     if (plan && child.pid) {
       tunnel = startTunnel({
         dataDir: options.dataDir,


### PR DESCRIPTION
The seamless self-hosted domain: one command, one DNS record, no proxy to learn.

```sh
npx openmausbot serve --domain maus.example.com
```

- Downloads a pinned Caddy 2.11.4 once into the data dir (release asset and sha512 pinned, like cloudflared and the browser engine), writes the same Caddyfile the Docker stack ships with this server's ports, and runs Caddy as a child. Caddy gets and renews the Let's Encrypt certificate and forwards with the real Host and forwarded headers the remote-session rules expect. The loopback bind never changes; Caddy's admin API is off; certificates live under the data dir so they survive restarts and upgrades.
- Ports 80 and 443 need a privilege on Linux as a normal user: when Caddy reports the refusal, `serve` prints the exact `setcap` command to run once on the downloaded binary. A service unit can grant the same capability (next PR).
- `--domain` excludes `--tailscale`, `--tunnel` and `--public-url`; the pairing link and QR use `https://<domain>`. Windows is refused with a pointer to the proxy docs.

Tests: pinned table shape; Caddyfile content; resolution order (override, pinned, PATH); a real tar.gz through a stub fetch with digest verification, a second call that downloads nothing, and a tampered download that installs nothing; running and stopping a stand-in Caddy with the written config (0600); the privilege hint on a port refusal; argument parsing and exclusivity; the CLI end to end with a stand-in Caddy (pairing link at the domain, Caddy started with the config, both ports proxied, both processes gone after SIGTERM). Typecheck and lint clean.

Not verified: a real certificate issuance (needs a public box with DNS); the Caddyfile is byte-for-byte the one the Docker stack already runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--domain HOST` support for serving OpenMausBot over HTTPS on a custom domain.
  * Automatically manages HTTPS proxying and certificate acquisition.
  * Added validation for domain format and incompatible serving options.
  * Added command-line controls for managing sign-in access, including chat-only access.

* **Bug Fixes**
  * Added clearer guidance when required network port permissions are unavailable.

* **Documentation**
  * Updated self-hosting and CLI help with domain and access-management instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->