### PR TITLE
fix(chat): restore model and approval control positions

### DIFF
--- a/apps/docs/content/docs/features/bots-and-tasks.mdx
+++ b/apps/docs/content/docs/features/bots-and-tasks.mdx
@@ -23,7 +23,7 @@ Each thread remembers its own model and has its own progress, approvals, and Sto
 
 Folders are optional organization under a bot. For example, Pepper can have an **Email** folder containing **Triage Gmail** and **Triage iCloud**, alongside a **Website** folder.
 
-A thread chooses its model in the composer. Folders have no model or permission settings. Moving a thread does not change its model, account, or access, or interrupt it. Removing a folder leaves its conversations ungrouped; it does not delete their history.
+A thread chooses its model in the chat header and its Ask/Auto setting inside the composer. Folders have no model or permission settings. Moving a thread does not change its model, account, or access, or interrupt it. Removing a folder leaves its conversations ungrouped; it does not delete their history.
 
 All the bot's threads share its saved memory and skills; they do not automatically receive every sibling transcript. Folders are not separate accounts or privacy boundaries. Bot profiles can carry different access preferences, but app organization is not an operating-system sandbox.
 

--- a/docs/plans/2026-09-09-independent-threads.md
+++ b/docs/plans/2026-09-09-independent-threads.md
@@ -25,7 +25,8 @@ into cosmetic folders.
 
 The sidebar shows recent/active threads beneath a bot. **All threads** is the
 compact searchable picker, especially useful on smaller screens. The model
-picker stays in the composer and applies to the visible thread. There is no
+picker stays in the chat header, while Ask/Auto stays inside the composer;
+both apply to the visible thread. There is no
 second "Tasks" area for the same bot conversations.
 
 The sidebar borrows T3's compact searchable conversation hierarchy: quiet

--- a/docs/verification/threads.md
+++ b/docs/verification/threads.md
@@ -27,8 +27,10 @@ switching and Stop can be exercised without a real provider or account.
 6. Expand Launch team and select its separate histories. Group collaboration
    retains the existing serialized behavior; this does not enable concurrent
    group member turns.
-7. Check the upward model menu and that selecting a thread does not scroll the
-   whole document or hide the header. Test keyboard access to row menus too.
+7. Check the model selector in the header opens downward and Ask/Auto sits
+   inside the composer beside attachments. Both menus must stay visible.
+   Selecting a thread must not scroll the whole document or hide the header.
+   Test keyboard access to row menus too.
 
 The offline CLI may report an interrupted subprocess when stopped; the checks
 here concern ownership, state and navigation, not real-provider behavior.

--- a/src/components/ChatView.controls.test.ts
+++ b/src/components/ChatView.controls.test.ts
@@ -1,0 +1,66 @@
+import { createElement, type ComponentProps } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import type { Bot, InstanceInfo } from "@/state/store";
+import type { ApprovalModeSelector } from "./ApprovalModeSelector";
+import type { ModelPicker } from "./ModelPicker";
+
+const fixture = vi.hoisted(() => {
+  vi.stubGlobal("window", {});
+  vi.stubGlobal("localStorage", { getItem: () => null, setItem: () => {} });
+  return { dispatch: vi.fn(), model: null as ComponentProps<typeof ModelPicker> | null,
+    approval: null as ComponentProps<typeof ApprovalModeSelector> | null };
+});
+vi.mock("@/state/store", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/state/store")>();
+  return { ...original, useStore: () => ({
+    state: { ...original.initialState, instances: [{ instanceId: "test", driverKind: "codex", displayName: "Test" } as InstanceInfo] },
+    dispatch: fixture.dispatch,
+  }) };
+});
+vi.mock("./DesktopCapabilities", () => ({
+  useDesktopCapabilities: () => ({ capabilities: { dictation: { available: false } }, ready: true }),
+}));
+vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
+vi.mock("./ModelPicker", () => ({ ModelPicker: (props: ComponentProps<typeof ModelPicker>) => {
+  fixture.model = props;
+  return createElement("span", { "data-test-model-control": true });
+} }));
+vi.mock("./ApprovalModeSelector", () => ({ ApprovalModeSelector: (props: ComponentProps<typeof ApprovalModeSelector>) => {
+  fixture.approval = props;
+  return createElement("span", { "data-test-approval-control": true });
+} }));
+
+const { ChatView } = await import("./ChatView");
+afterAll(() => vi.unstubAllGlobals());
+
+const bot: Bot = {
+  id: "bot", threadId: "selected", name: "Pepper", title: "", description: "", color: "green",
+  notifications: true, unread: false, busy: true, messages: [],
+  modelSelection: { instanceId: "test", model: "profile-default" },
+  tasks: [{ threadId: "selected", title: "Selected", createdAt: 1, busy: false, activity: "idle",
+    modelSelection: { instanceId: "test", model: "thread-model" }, approvalMode: "ask" }],
+};
+
+describe("thread control placement", () => {
+  it("keeps the selected thread's model in the header and permissions inside the composer pill", () => {
+    const markup = renderToStaticMarkup(createElement(ChatView, { bot }));
+    expect(markup.match(/data-test-model-control/g)).toHaveLength(1);
+    expect(markup.indexOf("data-test-model-control")).toBeLessThan(markup.indexOf('role="log"'));
+    expect(markup.indexOf("data-test-approval-control")).toBeGreaterThan(markup.indexOf("rounded-3xl bg-raised"));
+    expect(markup.indexOf("data-test-approval-control")).toBeLessThan(markup.indexOf("<textarea"));
+    expect(markup).not.toContain('aria-label="Thread settings"');
+    expect(fixture.model).toMatchObject({ threadId: "selected", bot: { busy: false, modelSelection: { model: "thread-model" } } });
+    expect(fixture.approval).toMatchObject({ approvalMode: "ask", disabled: false, trustedModesAvailable: false });
+    fixture.approval!.onSelect("auto");
+    expect(fixture.dispatch).toHaveBeenLastCalledWith({ type: "updateTask", botId: "bot", threadId: "selected", patch: { approvalMode: "auto" } });
+  });
+
+  it("keeps both controls hidden for remote clients", () => {
+    window.ogb = { remoteClient: { active: true } } as NonNullable<Window["ogb"]>;
+    const markup = renderToStaticMarkup(createElement(ChatView, { bot }));
+    expect(markup).not.toContain("data-test-model-control");
+    expect(markup).not.toContain("data-test-approval-control");
+    delete window.ogb;
+  });
+});

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -56,6 +56,7 @@ import { hasRoutineExecutionTask, RoutineRunCard } from "./RoutineRunCard";
 import { AttachedFileChips, AttachedImageGallery } from "./AttachmentPreview";
 import { RenameTitle } from "./RenameTitle";
 import { TaskPicker } from "./TaskPicker";
+import { ModelPicker } from "./ModelPicker";
 import { ExportTranscriptMenu } from "./ExportTranscriptMenu";
 
 import { SpeakButton } from "./SpeakButton";
@@ -1195,6 +1196,7 @@ export function ChatView({ bot: profile }: { bot: Bot }) {
           <TaskPicker bot={bot} />
           <UsageChip bot={bot} />
           {!remoteClient && <WorkingFolderChip bot={bot} />}
+          {!remoteClient && <ModelPicker key={bot.threadId} bot={bot} threadId={bot.threadId} />}
           <CallButton bot={bot} />
           <button
             onClick={() => dispatch({ type: "toggleComputer" })}

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -25,7 +25,6 @@ import { BotAvatar } from "./Avatar";
 import { ComposerAttachments, pathForFile } from "./ComposerAttachments";
 import { LocalComputerAutoWarning } from "./LocalComputerAutoWarning";
 import { ApprovalModeSelector } from "./ApprovalModeSelector";
-import { ModelPicker } from "./ModelPicker";
 import { approvalModeFor, type ApprovalMode } from "../../shared/approval-mode";
 import {
   appendPastedText,
@@ -785,21 +784,6 @@ export function Composer({
             else if (bot) dispatch({ type: "cancelQueued", botId: bot.id, threadId, queueId });
           }}
         />
-        {modeBot && !remoteClient && !locked && (
-          <div className="relative z-[2] mb-1 flex flex-wrap items-center gap-2 px-2" aria-label="Thread settings">
-            <ModelPicker bot={modeBot} threadId={modeBot.threadId} />
-            {approvalEngine && <ApprovalModeSelector
-              approvalMode={modeBot.approvalMode}
-              autoApprove={modeBot.autoApprove}
-              providerName={approvalEngine.displayName}
-              driverKind={approvalEngine.driverKind}
-              onSelect={setApprovalMode}
-              disabled={Boolean(modeBot.busy)}
-              trustedModesAvailable={false}
-              trustedModesNotice="Full and Custom access are managed in bot settings in the desktop app."
-            />}
-          </div>
-        )}
         <div className="relative">
           {/* App-ground from the pill midline down, full-bleed. Bubbles may
               tuck into the top half of the radius; they must not show below
@@ -865,6 +849,18 @@ export function Composer({
                   <Target size={14} aria-hidden="true" />
                   {effectiveChannelMode === "goal" ? "/goal" : t("composer.goal.chip")}
                 </button>
+              )}
+              {modeBot && approvalEngine && !remoteClient && (
+                <ApprovalModeSelector
+                  approvalMode={modeBot.approvalMode}
+                  autoApprove={modeBot.autoApprove}
+                  providerName={approvalEngine.displayName}
+                  driverKind={approvalEngine.driverKind}
+                  onSelect={setApprovalMode}
+                  disabled={Boolean(modeBot.busy)}
+                  trustedModesAvailable={false}
+                  trustedModesNotice="Full and Custom access are managed in bot settings in the desktop app."
+                />
               )}
             </div>
           )}

--- a/src/components/ModelPicker.test.ts
+++ b/src/components/ModelPicker.test.ts
@@ -68,7 +68,7 @@ function renderEffort(instances: InstanceInfo[], effort?: EffortLevel): string {
 }
 
 describe("EffortRow", () => {
-  it("pins composer effort changes to its thread without changing profile defaults", () => {
+  it("pins thread effort changes without changing profile defaults", () => {
     fixture.instances = [engine(["high"])];
     const row = EffortRow({ bot: bot(), threadId: "independent-thread" })!;
     const levels = Children.toArray(row.props.children).at(-1) as ReactElement<{ children: ReactNode }>;
@@ -122,7 +122,7 @@ describe("ModelPicker trigger", () => {
   const effortChip = (markup: string) =>
     markup.match(/<span data-model-effort[^>]*>(.*?)<\/span>/s)?.[1].replace(/<!--.*?-->/g, "").trim();
 
-  it("names the thread in busy composer help and the bot in profile settings", () => {
+  it("names the thread in busy header help and the bot in profile settings", () => {
     fixture.instances = [engine()];
     for (const threadId of ["independent-thread", undefined]) {
       const markup = renderToStaticMarkup(createElement(ModelPicker, { bot: { ...bot(), busy: true }, threadId }));

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -483,7 +483,7 @@ export function ModelPicker({
             "flex overflow-hidden rounded-2xl border border-hairline/50 bg-card",
             contained
               ? "relative mt-3 w-full max-h-[min(420px,50dvh)]"
-              : cn("absolute z-30 w-[380px] max-w-[calc(100vw-2rem)] max-h-[min(480px,calc(100dvh-7rem))] shadow-2xl shadow-black/50", threadId ? "bottom-full left-0 mb-2" : "right-0 top-full mt-2"),
+              : "absolute right-0 top-full z-30 mt-2 w-[380px] max-w-[calc(100vw-2rem)] max-h-[min(480px,calc(100dvh-7rem))] shadow-2xl shadow-black/50",
           )}
         >
           <ModelEngineRail instances={state.instances} selectedInstance={railInstance} claudeInstance={claudeRailInstance} onSelect={selectRail} />

--- a/src/components/bot-settings/ModelSection.tsx
+++ b/src/components/bot-settings/ModelSection.tsx
@@ -18,14 +18,14 @@ export function ModelSection({ bot }: { bot: Bot }) {
             <div>
               <div className="text-[15px] font-medium text-ink">Default model</div>
               <div className="mt-0.5 text-[13px] text-ink-secondary">
-                For new threads. Each thread keeps its own model in the composer.
+                For new threads. Existing threads keep their own model choices.
               </div>
             </div>
           }
         />
       </div>
 
-      {/* Share the composer's effort choices, but edit the profile default. */}
+      {/* Share the model picker's effort choices, but edit the profile default. */}
       <EffortRow
         bot={bot}
         className="rounded-xl bg-card p-4"


### PR DESCRIPTION
## Summary
- Restore the model selector to the chat header and Ask/Auto beside attachments inside the composer.
- Keep model, account, effort, approval, and busy state pinned to the selected thread; reset the header picker when switching threads.
- Remove the extra above-composer controls row, restore downward model-menu anchoring, and update the docs.

## Verification
- 97 focused regression tests passed, including placement, thread-pinned permissions, and remote-client restrictions.
- Frontend and server typechecks, production build, focused lint, whitespace, and locale checks passed.
- Real browser checks against the isolated Threads fixture: header model menu opens downward; Ask/Auto opens above the composer; switching Gmail/iCloud retains their distinct models; no user data or real provider accounts touched.

Follow-up to #981, restoring the original requested control layout before release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The model selector now appears in the chat header and applies to the visible thread.
  - Ask/Auto remains available in the composer alongside attachments.
  - Both controls are hidden when using a remote client.

- **Documentation**
  - Updated user guidance and verification steps to reflect the new control locations and menu behavior.
  - Clarified that model settings apply to new threads, while existing threads retain their selected models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->