### PR TITLE
feat(cli): openmausbot service install — keep the server running across reboots

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -251,28 +251,24 @@ OMB_DATA_DIR="$HOME/.openmausbot" OMB_PORT=8799 \
   node --experimental-strip-types server/index.ts
 ```
 
-For something durable, run it under systemd:
+For something durable, let the CLI write the service for you:
 
-```ini
-# /etc/systemd/system/openmausbot.service
-[Unit]
-Description=OpenMausBot harness
-After=network.target
-
-[Service]
-User=maus
-WorkingDirectory=/home/maus/OpenMausBot
-Environment=OMB_DATA_DIR=/home/maus/.openmausbot
-Environment=OMB_PORT=8799
-ExecStart=/usr/bin/node --experimental-strip-types server/index.ts
-Restart=on-failure
-
-[Install]
-WantedBy=multi-user.target
+```sh
+npx openmausbot service install --domain maus.example.com   # or --tunnel, --tailscale, or nothing
 ```
 
-Engine CLIs read their logins from the service user's home — sign in as
-that user (`sudo -u maus claude` etc.) before starting the service.
+It renders a systemd unit (Linux) or a launchd agent (macOS) that runs the
+same `openmausbot serve …` with your options, restarts it if it stops, and,
+for `--domain`, grants the unit the capability to bind ports 80 and 443
+without root. The file is written next to your data and the two commands
+that install and start it are printed (they need `sudo` on Linux).
+`openmausbot service uninstall` prints the reverse. Install the package
+permanently first (`npm install -g openmausbot`): a service must not point
+at an `npx` cache that npm may prune.
+
+Engine CLIs read their logins from the service user's home: sign them in
+from Settings → Engines (below), or as that user in a terminal, before you
+rely on routines running unattended.
 
 ## Signing the engines in without a terminal
 

--- a/server/cli.test.ts
+++ b/server/cli.test.ts
@@ -44,6 +44,9 @@ describe("openmausbot command line", () => {
     expect(parseArgs(["access", "list"], {})).toMatchObject({ command: "access", accessAction: "list" });
     expect(parseArgs(["access"], {})).toEqual({ error: "access needs one of: list, add EMAIL [--chat-only], remove EMAIL" });
     expect(parseArgs(["access", "add"], {})).toEqual({ error: "add needs a value" });
+    expect(parseArgs(["service", "install", "--domain", "maus.example.com", "--port", "8799"], {})).toMatchObject({ command: "service", serviceAction: "install", domain: "maus.example.com", port: 8799 });
+    expect(parseArgs(["service", "uninstall"], {})).toMatchObject({ command: "service", serviceAction: "uninstall" });
+    expect(parseArgs(["service"], {})).toEqual({ error: expect.stringContaining("service needs one of") });
     expect(parseArgs(["serve", "--domain", "Maus.Example.com"], {})).toMatchObject({ command: "serve", domain: "maus.example.com" });
     expect(parseArgs(["serve", "--domain", "localhost"], {})).toEqual({ error: expect.stringContaining("bare hostname") });
     expect(parseArgs(["serve", "--domain", "maus.example.com", "--tunnel"], {})).toEqual({ error: expect.stringContaining("--domain already gives") });

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -33,6 +33,7 @@ import qrcode from "qrcode-terminal";
 import { parseAllowList } from "./account-signin.ts";
 import { writeFileAtomic } from "./atomic.ts";
 import { ensureCaddy, normalizeDomainOption, startCaddy, type RunningCaddy } from "./caddy.ts";
+import { runServiceCommand } from "./service-cli.ts";
 import { explainTailscaleFailure, tailscaleServe, tailscaleServeOff, tailscaleStatus, type TailscaleStatus } from "./tailscale.ts";
 import { defaultSetupIo, SetupCancelled, type SetupIo } from "./cli-prompts.ts";
 import { normalizePhoneOrigin, phonePairingInstructions, runPhoneSetup } from "./cli-phone-setup.ts";
@@ -58,7 +59,7 @@ import {
 const HERE = dirname(fileURLToPath(import.meta.url));
 
 export interface CliOptions {
-  command: "setup" | "start" | "serve" | "pair" | "sessions" | "status" | "login" | "logout" | "access" | "browser" | "help";
+  command: "setup" | "start" | "serve" | "pair" | "sessions" | "status" | "login" | "logout" | "access" | "service" | "browser" | "help";
   port: number;
   dataDir: string;
   label?: string;
@@ -73,6 +74,8 @@ export interface CliOptions {
   /** `access list|add|remove` */
   accessAction?: "list" | "add" | "remove";
   chatOnly?: boolean;
+  /** `service install|uninstall` */
+  serviceAction?: "install" | "uninstall";
   email?: string;
   /** `browser install [--with-deps]` */
   browserAction?: "install" | "status";
@@ -86,7 +89,7 @@ export interface CliOptions {
   phone?: "ios" | "android";
 }
 
-const COMMANDS = ["setup", "start", "serve", "pair", "sessions", "status", "login", "logout", "access", "browser", "help", "--help", "-h"];
+const COMMANDS = ["setup", "start", "serve", "pair", "sessions", "status", "login", "logout", "access", "service", "browser", "help", "--help", "-h"];
 
 export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): CliOptions | { error: string } {
   const implicitStart = !argv.length || (argv[0]!.startsWith("--") && argv[0] !== "--help");
@@ -137,6 +140,7 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
         options.accessAction = arg;
         if (arg !== "list") options.email = value();
       } else if (options.command === "access" && arg === "--chat-only") options.chatOnly = true;
+      else if (options.command === "service" && !options.serviceAction && (arg === "install" || arg === "uninstall")) options.serviceAction = arg;
       else if (options.command === "browser" && (arg === "install" || arg === "status")) options.browserAction = arg;
       else if (options.command === "browser" && arg === "--with-deps") options.withDeps = true;
       else return { error: `unknown argument "${arg}"` };
@@ -148,6 +152,7 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
   if (options.publicUrl && !/^https?:\/\//.test(options.publicUrl)) return { error: "--public-url must start with http:// or https://" };
   if (options.tailscale && options.tunnel) return { error: "choose one of --tailscale (your tailnet) and --tunnel (a public address)" };
   if (options.command === "access" && !options.accessAction) return { error: "access needs one of: list, add EMAIL [--chat-only], remove EMAIL" };
+  if (options.command === "service" && !options.serviceAction) return { error: "service needs one of: install [the same options as serve], uninstall" };
   if (options.domain && (options.tailscale || options.tunnel || options.publicUrl)) return { error: "--domain already gives the server its address; drop --tailscale, --tunnel and --public-url" };
   if (options.local && (options.tailscale || options.tunnel || options.publicUrl)) return { error: "--local cannot be combined with a remote-access option" };
   if (options.command === "browser" && !options.browserAction) return { error: "browser needs an action: install or status" };
@@ -167,6 +172,7 @@ export const USAGE = `openmausbot — your team of AI bots, ready in a few steps
   openmausbot login [--email you@example.com]
   openmausbot logout
   openmausbot access list | add EMAIL [--chat-only] | remove EMAIL
+  openmausbot service install [--domain HOST | --tunnel | --tailscale] [--port N] [--data-dir DIR] | uninstall
   openmausbot browser install [--with-deps] | status
 
 setup   choose AI access and optional phone access; keep existing bots and chats
@@ -181,6 +187,10 @@ logout  releases that address and signs out
 access  who may sign in with an emailed code at /pair: an address or
         @domain; --chat-only gives chat and approvals without settings.
         Takes effect at once, no restart.
+service keep the server running across reboots: writes a systemd unit
+        (Linux) or a launchd agent (macOS) for the same serve options and
+        prints the commands that install it. Install the package
+        permanently first (npm install -g openmausbot).
 browser install: the bots' browser engine (agent-browser, pinned) into the
         data dir, and Chrome for Testing into the user's browser cache.
         --with-deps also installs
@@ -988,6 +998,18 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
       return runLogin(options);
     case "access":
       return runAccess(options);
+    case "service":
+      return runServiceCommand({
+        action: options.serviceAction ?? "install",
+        dataDir: options.dataDir,
+        port: options.port,
+        domain: options.domain,
+        tunnel: options.tunnel,
+        tailscale: options.tailscale,
+        label: options.label,
+        script: process.argv[1] ?? "",
+        node: process.execPath,
+      }, { log: (line) => console.log(line), error: (line) => console.error(line) });
     case "logout":
       return runLogout(options);
     case "browser":

--- a/server/service-cli.test.ts
+++ b/server/service-cli.test.ts
@@ -1,0 +1,51 @@
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { runServiceCommand, serviceServeArgs } from "./service-cli.ts";
+import { removeTempDir } from "./testing/cleanup.ts";
+
+describe("openmausbot service", () => {
+  let dir: string;
+  const out: string[] = [];
+  const err: string[] = [];
+  const io = { log: (l: string) => out.push(l), error: (l: string) => err.push(l) };
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "omb-service-"));
+    out.length = 0;
+    err.length = 0;
+  });
+  afterEach(() => removeTempDir(dir));
+
+  it("repeats the serve options, one access mode at a time", () => {
+    expect(serviceServeArgs({ port: 8799, dataDir: "/d", domain: "a.example.com", tunnel: true, label: "x" })).toEqual(["--port", "8799", "--data-dir", "/d", "--no-pair", "--domain", "a.example.com", "--label", "x"]);
+    expect(serviceServeArgs({ port: 1, dataDir: "/d", tailscale: true })).toEqual(["--port", "1", "--data-dir", "/d", "--no-pair", "--tailscale"]);
+  });
+
+  it("writes the unit next to the data and prints how to install it; refuses an npx cache", () => {
+    const code = runServiceCommand({ action: "install", dataDir: dir, port: 8799, domain: "maus.example.com", script: "/usr/lib/node_modules/openmausbot/cli.js", node: "/usr/bin/node", platform: "linux", home: "/home/maus", user: "maus" }, io);
+    expect(code).toBe(0);
+    const unit = readFileSync(join(dir, "openmausbot.service"), "utf8");
+    expect(unit).toContain("--domain maus.example.com");
+    expect(unit).toContain("AmbientCapabilities=CAP_NET_BIND_SERVICE");
+    expect(out.join("\n")).toContain("sudo systemctl enable --now openmausbot");
+    expect(out.join("\n")).toContain("no setcap is needed");
+
+    out.length = 0;
+    const refused = runServiceCommand({ action: "install", dataDir: join(dir, "x"), port: 8799, script: "/home/maus/.npm/_npx/deadbeef/node_modules/openmausbot/cli.js", node: "/usr/bin/node", platform: "linux" }, io);
+    expect(refused).toBe(1);
+    expect(err.join("\n")).toMatch(/npm install -g openmausbot/);
+    expect(existsSync(join(dir, "x", "openmausbot.service"))).toBe(false);
+  });
+
+  it("writes a launchd agent on macOS and explains uninstall on both", () => {
+    expect(runServiceCommand({ action: "install", dataDir: dir, port: 8799, tunnel: true, script: "/opt/homebrew/lib/node_modules/openmausbot/cli.js", node: "/opt/homebrew/bin/node", platform: "darwin", home: "/Users/maus" }, io)).toBe(0);
+    expect(readFileSync(join(dir, "com.openmausbot.serve.plist"), "utf8")).toContain("<string>--tunnel</string>");
+    expect(out.join("\n")).toContain("launchctl bootstrap");
+    out.length = 0;
+    expect(runServiceCommand({ action: "uninstall", dataDir: dir, port: 8799, script: "/x", node: "/n", platform: "linux" }, io)).toBe(0);
+    expect(out.join("\n")).toContain("sudo systemctl disable --now openmausbot");
+    expect(runServiceCommand({ action: "install", dataDir: dir, port: 8799, script: "/x", node: "/n", platform: "win32" }, io)).toBe(1);
+  });
+});

--- a/server/service-cli.ts
+++ b/server/service-cli.ts
@@ -1,0 +1,80 @@
+// The `openmausbot service` command, kept separate from cli.ts so it can be
+// tested with explicit inputs: it renders the unit for this platform, writes
+// it next to the data, and prints the commands that install it.
+import { mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+
+import { currentUser, launchdPlist, servicePlan, systemdUnit, unstableInstallWarning } from "./service-unit.ts";
+
+export interface ServiceInstallInput {
+  action: "install" | "uninstall";
+  dataDir: string;
+  port: number;
+  domain?: string;
+  tunnel?: boolean;
+  tailscale?: boolean;
+  label?: string;
+  /** This CLI's own entry, as node saw it (process.argv[1]) and node itself (process.execPath). */
+  script: string;
+  node: string;
+  platform?: NodeJS.Platform;
+  home?: string;
+  user?: string;
+}
+
+export interface ServiceIo {
+  log(line: string): void;
+  error(line: string): void;
+}
+
+/** The `serve` arguments the service repeats, from the options given to `service install`. */
+export function serviceServeArgs(input: Pick<ServiceInstallInput, "port" | "dataDir" | "domain" | "tunnel" | "tailscale" | "label">): string[] {
+  const args = ["--port", String(input.port), "--data-dir", input.dataDir, "--no-pair"];
+  if (input.domain) args.push("--domain", input.domain);
+  else if (input.tunnel) args.push("--tunnel");
+  else if (input.tailscale) args.push("--tailscale");
+  if (input.label) args.push("--label", input.label);
+  return args;
+}
+
+export function runServiceCommand(input: ServiceInstallInput, io: ServiceIo): number {
+  const platform = input.platform ?? process.platform;
+  const home = input.home ?? homedir();
+  const plan = servicePlan(platform, input.dataDir, home);
+  if (!plan) {
+    io.error("services are written for Linux (systemd) and macOS (launchd); on Windows, use Task Scheduler to run `openmausbot serve` at startup");
+    return 1;
+  }
+  if (input.action === "uninstall") {
+    io.log(`to stop and remove the service:`);
+    for (const line of plan.deactivate) io.log(`  ${line}`);
+    return 0;
+  }
+  const warning = unstableInstallWarning(input.script);
+  if (warning) {
+    io.error(warning);
+    return 1;
+  }
+  const spec = {
+    node: input.node,
+    script: input.script,
+    serveArgs: serviceServeArgs(input),
+    dataDir: input.dataDir,
+    user: input.user ?? currentUser(),
+    home,
+    bindsLowPorts: Boolean(input.domain),
+    ...(input.label ? { label: input.label } : {}),
+  };
+  const rendered = platform === "darwin" ? launchdPlist(spec) : systemdUnit(spec);
+  mkdirSync(input.dataDir, { recursive: true, mode: 0o700 });
+  writeFileSync(plan.file, rendered, { mode: 0o644 });
+  io.log(`wrote ${plan.file}`);
+  io.log("");
+  io.log(platform === "darwin" ? "to install and start it (runs at login):" : "to install and start it (runs at boot, restarts if it stops):");
+  for (const line of plan.activate) io.log(`  ${line}`);
+  io.log("");
+  if (input.domain && platform === "linux") io.log("the unit grants Caddy the capability for ports 80 and 443, so no setcap is needed under the service");
+  io.log(`logs: ${platform === "darwin" ? `${input.dataDir}/logs/service.log` : "journalctl -u openmausbot -f"}`);
+  io.log(`change options later by running \`openmausbot service install\` again with the new ones, then: ${platform === "darwin" ? plan.activate[1] : "sudo systemctl daemon-reload && sudo systemctl restart openmausbot"}`);
+  return 0;
+}

--- a/server/service-unit.test.ts
+++ b/server/service-unit.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { launchdPlist, serviceCommand, servicePlan, systemdUnit, unstableInstallWarning, type ServiceSpec } from "./service-unit.ts";
+
+const spec: ServiceSpec = {
+  node: "/usr/bin/node",
+  script: "/usr/lib/node_modules/openmausbot/cli.js",
+  serveArgs: ["--port", "8799", "--data-dir", "/home/maus/.openmausbot", "--domain", "maus.example.com", "--no-pair"],
+  dataDir: "/home/maus/.openmausbot",
+  user: "maus",
+  home: "/home/maus",
+  bindsLowPorts: true,
+  label: "agentada",
+};
+
+describe("service units", () => {
+  it("runs the same serve command, with strip-types only for a checkout", () => {
+    expect(serviceCommand(spec)).toEqual(["/usr/bin/node", "/usr/lib/node_modules/openmausbot/cli.js", "serve", ...spec.serveArgs]);
+    expect(serviceCommand({ ...spec, script: "/srv/OpenMausBot/server/openmausbot.ts" })[1]).toBe("--experimental-strip-types");
+  });
+
+  it("renders a systemd unit that restarts, runs as the user, and grants low ports only for --domain", () => {
+    const unit = systemdUnit(spec);
+    expect(unit).toContain("Description=OpenMausBot (agentada)");
+    expect(unit).toContain("User=maus");
+    expect(unit).toContain("Environment=OMB_DATA_DIR=/home/maus/.openmausbot");
+    expect(unit).toContain("ExecStart=/usr/bin/node /usr/lib/node_modules/openmausbot/cli.js serve --port 8799 --data-dir /home/maus/.openmausbot --domain maus.example.com --no-pair");
+    expect(unit).toContain("Restart=always");
+    expect(unit).toContain("AmbientCapabilities=CAP_NET_BIND_SERVICE");
+    expect(unit).toContain("WantedBy=multi-user.target");
+    const local = systemdUnit({ ...spec, bindsLowPorts: false, serveArgs: ["--port", "8799", "--data-dir", "/home/maus/.openmausbot"] });
+    expect(local).not.toContain("CAP_NET_BIND_SERVICE");
+    // a path with a space is quoted for systemd
+    expect(systemdUnit({ ...spec, dataDir: "/home/maus/My Data", serveArgs: ["--data-dir", "/home/maus/My Data"] })).toContain('ExecStart=/usr/bin/node /usr/lib/node_modules/openmausbot/cli.js serve --data-dir "/home/maus/My Data"');
+  });
+
+  it("renders a launchd agent that keeps the server alive and logs under the data dir", () => {
+    const plist = launchdPlist({ ...spec, home: "/Users/maus", dataDir: "/Users/maus/.openmausbot" });
+    expect(plist).toContain("<string>com.openmausbot.serve</string>");
+    expect(plist).toContain("<string>/usr/bin/node</string>");
+    expect(plist).toContain("<string>serve</string>");
+    expect(plist).toContain("<string>maus.example.com</string>");
+    expect(plist).toContain("<key>KeepAlive</key>");
+    expect(plist).toContain("/Users/maus/.openmausbot/logs/service.log");
+    expect(launchdPlist({ ...spec, serveArgs: ["--label", "a & b <c>"] })).toContain("<string>a &amp; b &lt;c&gt;</string>");
+  });
+
+  it("refuses to point a service at an npx cache, and knows where each platform's file goes", () => {
+    expect(unstableInstallWarning("/home/maus/.npm/_npx/abc123/node_modules/openmausbot/cli.js")).toMatch(/npm install -g openmausbot/);
+    expect(unstableInstallWarning("/usr/lib/node_modules/openmausbot/cli.js")).toBeNull();
+    const linux = servicePlan("linux", "/home/maus/.openmausbot");
+    expect(linux?.installed).toBe("/etc/systemd/system/openmausbot.service");
+    expect(linux?.activate.join("\n")).toContain("systemctl enable --now openmausbot");
+    const mac = servicePlan("darwin", "/Users/maus/.openmausbot", "/Users/maus");
+    expect(mac?.installed).toBe("/Users/maus/Library/LaunchAgents/com.openmausbot.serve.plist");
+    expect(mac?.activate.join("\n")).toContain("launchctl bootstrap gui/$(id -u)");
+    expect(servicePlan("win32", "C:\\x")).toBeNull();
+  });
+});

--- a/server/service-unit.ts
+++ b/server/service-unit.ts
@@ -1,0 +1,150 @@
+// `openmausbot service install`: keep the server running across reboots.
+// Renders a systemd unit (Linux) or a launchd agent (macOS) that runs the
+// same `openmausbot serve …` the operator just used, and either installs it
+// (when allowed to) or writes it next to the data and prints the two
+// commands that install it. Pure rendering lives here so it is testable;
+// the CLI decides where the file goes.
+import { homedir, userInfo } from "node:os";
+import { basename, dirname, join } from "node:path";
+
+export interface ServiceSpec {
+  /** How to start this same CLI: absolute node, then its script. */
+  node: string;
+  script: string;
+  /** `serve …` arguments, already validated by the CLI. */
+  serveArgs: string[];
+  dataDir: string;
+  /** Unix user the service runs as (systemd only). */
+  user: string;
+  home: string;
+  /** Needs ports 80 and 443 (serve --domain): grant the capability to the unit. */
+  bindsLowPorts: boolean;
+  label?: string;
+}
+
+export const SYSTEMD_UNIT_NAME = "openmausbot.service";
+export const LAUNCHD_LABEL = "com.openmausbot.serve";
+
+function quoteSystemd(value: string): string {
+  // systemd's ExecStart splits on whitespace and understands double quotes.
+  return /[\s"\\]/.test(value) ? `"${value.replace(/[\\"]/g, "\\$&")}"` : value;
+}
+
+function needsStripTypes(script: string): boolean {
+  return script.endsWith(".ts");
+}
+
+export function serviceCommand(spec: Pick<ServiceSpec, "node" | "script" | "serveArgs">): string[] {
+  return [spec.node, ...(needsStripTypes(spec.script) ? ["--experimental-strip-types"] : []), spec.script, "serve", ...spec.serveArgs];
+}
+
+export function systemdUnit(spec: ServiceSpec): string {
+  const lines = [
+    "# Written by `openmausbot service install`. Re-run it to change the options.",
+    "[Unit]",
+    `Description=OpenMausBot${spec.label ? ` (${spec.label})` : ""}`,
+    "After=network-online.target",
+    "Wants=network-online.target",
+    "",
+    "[Service]",
+    "Type=simple",
+    `User=${spec.user}`,
+    `WorkingDirectory=${spec.home}`,
+    `Environment=HOME=${spec.home}`,
+    `Environment=OMB_DATA_DIR=${spec.dataDir}`,
+    `ExecStart=${serviceCommand(spec).map(quoteSystemd).join(" ")}`,
+    "Restart=always",
+    "RestartSec=3",
+    "KillMode=mixed",
+    "TimeoutStopSec=30",
+  ];
+  if (spec.bindsLowPorts) {
+    lines.push("# serve --domain: Caddy binds ports 80 and 443 without running as root.");
+    lines.push("AmbientCapabilities=CAP_NET_BIND_SERVICE");
+    lines.push("CapabilityBoundingSet=CAP_NET_BIND_SERVICE");
+  }
+  lines.push("", "[Install]", "WantedBy=multi-user.target", "");
+  return lines.join("\n");
+}
+
+function xml(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export function launchdPlist(spec: ServiceSpec): string {
+  const args = serviceCommand(spec).map((arg) => `\t\t<string>${xml(arg)}</string>`).join("\n");
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+    '<plist version="1.0">',
+    "<dict>",
+    "\t<key>Label</key>",
+    `\t<string>${LAUNCHD_LABEL}</string>`,
+    "\t<key>ProgramArguments</key>",
+    "\t<array>",
+    args,
+    "\t</array>",
+    "\t<key>EnvironmentVariables</key>",
+    "\t<dict>",
+    "\t\t<key>HOME</key>",
+    `\t\t<string>${xml(spec.home)}</string>`,
+    "\t\t<key>OMB_DATA_DIR</key>",
+    `\t\t<string>${xml(spec.dataDir)}</string>`,
+    "\t\t<key>PATH</key>",
+    "\t\t<string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>",
+    "\t</dict>",
+    "\t<key>WorkingDirectory</key>",
+    `\t<string>${xml(spec.home)}</string>`,
+    "\t<key>RunAtLoad</key>",
+    "\t<true/>",
+    "\t<key>KeepAlive</key>",
+    "\t<true/>",
+    "\t<key>StandardOutPath</key>",
+    `\t<string>${xml(join(spec.dataDir, "logs", "service.log"))}</string>`,
+    "\t<key>StandardErrorPath</key>",
+    `\t<string>${xml(join(spec.dataDir, "logs", "service.log"))}</string>`,
+    "</dict>",
+    "</plist>",
+    "",
+  ].join("\n");
+}
+
+/** An `npx` cache path is pruned without notice; a service must not point at it. */
+export function unstableInstallWarning(script: string): string | null {
+  const normalized = script.replace(/\\/g, "/");
+  if (/\/_npx\//.test(normalized) || /\/\.npm\/_npx\//.test(normalized)) {
+    return `this command runs from an npx cache (${dirname(script)}), which npm may delete at any time. Install it permanently first (npm install -g openmausbot) and run \`openmausbot service install\` from that install.`;
+  }
+  return null;
+}
+
+/** Where the rendered file goes and how to activate it, per platform. */
+export function servicePlan(platform: NodeJS.Platform, dataDir: string, home = homedir()): { file: string; installed: string; activate: string[]; deactivate: string[] } | null {
+  if (platform === "linux") {
+    const installed = `/etc/systemd/system/${SYSTEMD_UNIT_NAME}`;
+    return {
+      file: join(dataDir, SYSTEMD_UNIT_NAME),
+      installed,
+      activate: [`sudo install -m 644 ${join(dataDir, SYSTEMD_UNIT_NAME)} ${installed}`, "sudo systemctl daemon-reload", `sudo systemctl enable --now ${basename(SYSTEMD_UNIT_NAME, ".service")}`],
+      deactivate: [`sudo systemctl disable --now ${basename(SYSTEMD_UNIT_NAME, ".service")}`, `sudo rm ${installed}`, "sudo systemctl daemon-reload"],
+    };
+  }
+  if (platform === "darwin") {
+    const installed = join(home, "Library", "LaunchAgents", `${LAUNCHD_LABEL}.plist`);
+    return {
+      file: join(dataDir, `${LAUNCHD_LABEL}.plist`),
+      installed,
+      activate: [`mkdir -p ${dirname(installed)} && cp ${join(dataDir, `${LAUNCHD_LABEL}.plist`)} ${installed}`, `launchctl bootstrap gui/$(id -u) ${installed}`],
+      deactivate: [`launchctl bootout gui/$(id -u)/${LAUNCHD_LABEL}`, `rm ${installed}`],
+    };
+  }
+  return null;
+}
+
+export function currentUser(): string {
+  try {
+    return userInfo().username;
+  } catch {
+    return process.env.USER || process.env.USERNAME || "openmausbot";
+  }
+}

--- a/server/service-unit.ts
+++ b/server/service-unit.ts
@@ -5,7 +5,11 @@
 // commands that install it. Pure rendering lives here so it is testable;
 // the CLI decides where the file goes.
 import { homedir, userInfo } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { posix } from "node:path";
+
+// Unit files describe a Linux or macOS machine, so their paths are POSIX
+// whatever host renders them (the Windows CI runner included).
+const { basename, dirname, join } = posix;
 
 export interface ServiceSpec {
   /** How to start this same CLI: absolute node, then its script. */


### PR DESCRIPTION
The last piece of the seamless self-hosted setup: survive reboots without writing a unit file by hand.

```sh
npx openmausbot service install --domain maus.example.com   # or --tunnel, --tailscale, or nothing
npx openmausbot service uninstall
```

- Renders a systemd unit (Linux) or a launchd agent (macOS) that runs the same `openmausbot serve …` with the given options, restarts it if it stops, runs as the current user with the data dir pinned, and, for `--domain`, grants the unit `CAP_NET_BIND_SERVICE` so Caddy binds ports 80 and 443 under the service with no `setcap` and no root.
- Writes the file next to the data and prints the commands that install and start it (`sudo install … && systemctl enable --now` on Linux, `launchctl bootstrap` on macOS); `uninstall` prints the reverse. Logs: `journalctl -u openmausbot -f`, or the data dir's `logs/service.log` on macOS.
- Refuses a CLI running from an npx cache (npm may prune it) and says to `npm install -g openmausbot` first.

Tests (11 in the new suites plus the parser cases): the repeated serve arguments; the systemd unit's user, data dir, quoted `ExecStart`, restart policy and capability lines; the launchd agent's `KeepAlive`, log paths and XML escaping; the npx refusal; per-platform file and commands; the command end to end against a temp data dir on Linux and macOS shapes. Typecheck and lint clean. Docs: the "From source" section now leads with the command and keeps the engine sign-in note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `service install` and `service uninstall` commands for managing the server as a background service.
  * Added Linux systemd and macOS launchd support, including automatic restarts and startup after reboot.
  * Services support domain, port, and Tailscale access options.
  * Services can bind to ports 80/443 without running the server as root.

* **Documentation**
  * Updated self-hosting guidance with installation, activation, removal, prerequisites, and engine sign-in instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->