### PR TITLE
feat(settings): edit who can sign in with an email, from the browser

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -363,8 +363,10 @@ OMB_SIGNIN_EMAILS="her@yourcompany.com, @yourcompany.com"   # full access
 OMB_SIGNIN_MEMBER_EMAILS="freelancer@example.com"          # chat and approvals only
 ```
 
-With the npm package, the same thing from the command line, with the server
-running or not, no restart needed:
+Signed in as an admin? Settings → Remote access → **Who can sign in with an
+email** edits the same list in the browser, no command line needed. With the
+npm package, the same thing from the command line, with the server running
+or not, no restart needed:
 
 ```sh
 npx openmausbot access add her@yourcompany.com

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -15,6 +15,7 @@ import { EnginesSettings } from "./EnginesSettings";
 import { LocalComputerSection } from "./LocalComputerSection";
 import { CompanionSection } from "./CompanionSection";
 import { ServerPairingCard } from "./ServerPairingCard";
+import { SignInAccessCard } from "./SignInAccessCard";
 import { CustomDomainSettings } from "./CustomDomainSettings";
 import { BrowserProfilesManager } from "./BrowserProfilesManager";
 import { RemoteComputerSection } from "./RemoteComputerSection";
@@ -593,6 +594,7 @@ export function SettingsModal() {
                 <RemoteComputerSection />
                 {!remoteActive && <CustomDomainSettings />}
                 {/* a hosted server reached from a browser: pair phones and see devices here; the desktop app has its own companion flow */}
+                {!window.ogb && <SignInAccessCard />}
                 {!window.ogb && <ServerPairingCard />}
                 {!remoteActive && <CompanionSection profileEmail={state.config?.profile?.email} />}
               </>

--- a/src/components/SignInAccessCard.test.ts
+++ b/src/components/SignInAccessCard.test.ts
@@ -1,0 +1,28 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { normalizeAccessEntry, SignInAccessCard, withEntry, withoutEntry } from "./SignInAccessCard";
+
+describe("who may sign in with an emailed code", () => {
+  it("accepts an address or an @domain and nothing else", () => {
+    expect(normalizeAccessEntry(" Her@Example.com ")).toBe("her@example.com");
+    expect(normalizeAccessEntry("@Agentada.cc")).toBe("@agentada.cc");
+    expect(normalizeAccessEntry("nope")).toBeNull();
+    expect(normalizeAccessEntry("@nodot")).toBeNull();
+    expect(normalizeAccessEntry("two words@x.com")).toBeNull();
+    expect(normalizeAccessEntry("")).toBeNull();
+  });
+
+  it("moves an entry between the lists instead of duplicating it, and removes from both", () => {
+    const start = { admins: ["a@x.com"], members: ["b@x.com"] };
+    expect(withEntry(start, "b@x.com", "admin")).toEqual({ admins: ["a@x.com", "b@x.com"], members: [] });
+    expect(withEntry(start, "a@x.com", "member")).toEqual({ admins: [], members: ["b@x.com", "a@x.com"] });
+    expect(withEntry(start, "@y.com", "member")).toEqual({ admins: ["a@x.com"], members: ["b@x.com", "@y.com"] });
+    expect(withoutEntry(start, "a@x.com")).toEqual({ admins: [], members: ["b@x.com"] });
+  });
+
+  it("renders nothing until it knows who is asking", () => {
+    expect(renderToStaticMarkup(createElement(SignInAccessCard))).toBe("");
+  });
+});

--- a/src/components/SignInAccessCard.tsx
+++ b/src/components/SignInAccessCard.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from "react";
+
+import { t } from "@/lib/i18n";
+import { api } from "@/state/store";
+import { readSessionState, type SessionState } from "../lib/session";
+import { canPairDevices } from "./ServerPairingCard";
+import { Card } from "./SettingsPrimitives";
+
+export interface SignInLists {
+  admins: string[];
+  members: string[];
+}
+
+/** An address or `@domain`, lower-cased; null when it is neither. */
+export function normalizeAccessEntry(raw: string): string | null {
+  const value = raw.trim().toLowerCase();
+  if (!value || /\s/.test(value)) return null;
+  if (value.startsWith("@")) return /^@[^@\s]+\.[^@\s]+$/.test(value) ? value : null;
+  return /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(value) ? value : null;
+}
+
+/** Adding moves an entry between the lists rather than duplicating it. */
+export function withEntry(lists: SignInLists, entry: string, role: "admin" | "member"): SignInLists {
+  const admins = lists.admins.filter((item) => item !== entry);
+  const members = lists.members.filter((item) => item !== entry);
+  return role === "admin" ? { admins: [...admins, entry], members } : { admins, members: [...members, entry] };
+}
+
+export function withoutEntry(lists: SignInLists, entry: string): SignInLists {
+  return { admins: lists.admins.filter((item) => item !== entry), members: lists.members.filter((item) => item !== entry) };
+}
+
+const input = "w-full rounded-md border border-line bg-surface px-3 py-2 text-[14px] text-ink outline-none focus:border-accent-border";
+const button = "rounded-md bg-accent px-3 py-1.5 text-[13px] font-medium text-accent-ink disabled:opacity-50";
+const quiet = "rounded-md border border-line px-2.5 py-1 text-[12px] text-ink hover:bg-surface";
+
+/** Settings → Remote access on a hosted server: who may sign in at /pair
+ * with an emailed code. Admins only; saved through the config API and
+ * applied on the next request, so no restart. */
+export function SignInAccessCard() {
+  const [session, setSession] = useState<SessionState | null>(null);
+  const [lists, setLists] = useState<SignInLists | null>(null);
+  const [draft, setDraft] = useState("");
+  const [role, setRole] = useState<"admin" | "member">("admin");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [publicUrl, setPublicUrl] = useState<string | null>(null);
+
+  async function load() {
+    try {
+      const config = await api("/api/config");
+      const current = config?.signIn;
+      setLists({ admins: Array.isArray(current?.admins) ? current.admins : [], members: Array.isArray(current?.members) ? current.members : [] });
+      const domain = await api("/api/settings/custom-domain").catch(() => null);
+      setPublicUrl(typeof domain?.publicUrl === "string" ? domain.publicUrl : null);
+    } catch (e) {
+      setError(t("remote.signInAccess.error", { error: e instanceof Error ? e.message : String(e) }));
+    }
+  }
+
+  useEffect(() => {
+    void readSessionState().then((state) => {
+      setSession(state);
+      if (canPairDevices(state)) void load();
+    });
+  }, []);
+
+  if (!canPairDevices(session) || !lists) return null;
+
+  async function save(next: SignInLists) {
+    setBusy(true);
+    setError(null);
+    try {
+      await api("/api/config", { method: "PUT", body: JSON.stringify({ signIn: next }) });
+      setLists(next);
+    } catch (e) {
+      setError(t("remote.signInAccess.error", { error: e instanceof Error ? e.message : String(e) }));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function add() {
+    const entry = normalizeAccessEntry(draft);
+    if (!entry || !lists) {
+      setError(t("remote.signInAccess.invalid"));
+      return;
+    }
+    await save(withEntry(lists, entry, role));
+    setDraft("");
+  }
+
+  const rows = [...lists.admins.map((entry) => ({ entry, role: "admin" as const })), ...lists.members.map((entry) => ({ entry, role: "member" as const }))];
+
+  return (
+    <Card title={t("remote.signInAccess.title")} subtitle={t("remote.signInAccess.subtitle")}>
+      {publicUrl ? (
+        <p className="mt-2 text-[12.5px] text-ink-secondary">
+          {t("remote.signInAccess.link")} <code className="select-all text-ink">{publicUrl}/pair</code>
+        </p>
+      ) : null}
+      <form
+        className="mt-3 flex flex-wrap items-center gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void add();
+        }}
+      >
+        <input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder={t("remote.signInAccess.placeholder")}
+          autoComplete="off"
+          spellCheck={false}
+          className={`${input} max-w-[320px] flex-1`}
+          aria-label={t("remote.signInAccess.placeholder")}
+        />
+        <label className="flex items-center gap-1.5 text-[13px] text-ink">
+          <input type="radio" name="signin-role" checked={role === "admin"} onChange={() => setRole("admin")} />
+          {t("remote.serverPairing.scope.admin")}
+        </label>
+        <label className="flex items-center gap-1.5 text-[13px] text-ink">
+          <input type="radio" name="signin-role" checked={role === "member"} onChange={() => setRole("member")} />
+          {t("remote.serverPairing.scope.client")}
+        </label>
+        <button type="submit" disabled={busy || !draft.trim()} className={button}>
+          {t("remote.signInAccess.add")}
+        </button>
+      </form>
+      {rows.length === 0 ? (
+        <p className="mt-3 text-[12.5px] text-ink-secondary">{t("remote.signInAccess.empty")}</p>
+      ) : (
+        <ul className="mt-3 divide-y divide-line">
+          {rows.map(({ entry, role: entryRole }) => (
+            <li key={entry} className="flex flex-wrap items-center justify-between gap-2 py-2 text-[13px]">
+              <span className="text-ink">
+                {entry}
+                <span className="text-ink-secondary"> · {entryRole === "admin" ? t("remote.serverPairing.scope.admin") : t("remote.serverPairing.scope.client")}</span>
+              </span>
+              <button type="button" disabled={busy} onClick={() => void save(withoutEntry(lists, entry))} className={quiet}>
+                {t("remote.signInAccess.remove")}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <p className="mt-3 text-[11.5px] leading-relaxed text-ink-secondary">{t("remote.signInAccess.note")}</p>
+      {error ? <p className="mt-2 text-[13px] text-danger">{error}</p> : null}
+    </Card>
+  );
+}

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1390,5 +1390,15 @@
   "engineSetup.claude.security": "Füge nur einen Code ein, den du über eine hier gestartete Anmeldung erhalten hast. Er wird einmal an Claude Code auf diesem Server übergeben und nie gespeichert; dein Passwort bleibt bei Anthropic. Bots auf diesem Server teilen sich das Nutzungslimit deines Abos.",
   "engineSetup.claude.connected": "Claude verbunden. Deine Modelle werden aktualisiert.",
   "engineSetup.claude.connectedAccount": "Claude auf diesem Server verbunden",
-  "engineSetup.claude.invalidChallenge": "Claude Code hat keinen gültigen Anmeldelink von Anthropic zurückgegeben. Abbrechen und erneut versuchen."
+  "engineSetup.claude.invalidChallenge": "Claude Code hat keinen gültigen Anmeldelink von Anthropic zurückgegeben. Abbrechen und erneut versuchen.",
+  "remote.signInAccess.title": "Wer sich per E-Mail anmelden darf",
+  "remote.signInAccess.subtitle": "Personen auf dieser Liste melden sich unter /pair mit einem einmaligen Code an, der an ihre E-Mail geht. Vollzugriff ist alles, was der Eigentümer kann; Chat und Freigaben ist für Personen, die nur mit den Bots sprechen.",
+  "remote.signInAccess.link": "Schicke ihnen diesen Link:",
+  "remote.signInAccess.placeholder": "name@firma.de oder @firma.de",
+  "remote.signInAccess.add": "Hinzufügen",
+  "remote.signInAccess.remove": "Entfernen",
+  "remote.signInAccess.empty": "Noch niemand. Füge eine Adresse hinzu, oder @deinefirma.de für alle in deiner Firma.",
+  "remote.signInAccess.invalid": "Gib eine E-Mail-Adresse ein oder @domain für alle dieser Domain.",
+  "remote.signInAccess.note": "Änderungen gelten sofort. Wer entfernt wird, kann sich nicht neu anmelden; bestehende Geräte bleiben angemeldet, bis du sie oben abmeldest.",
+  "remote.signInAccess.error": "Konnte nicht speichern: {error}"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1524,5 +1524,15 @@
   "engineSetup.claude.security": "Only paste a code from a sign-in you started here. It is handed to Claude Code on this server once and never stored; your password stays with Anthropic. Bots on this server share your subscription's usage limits.",
   "engineSetup.claude.connected": "Claude connected. Your models are being refreshed.",
   "engineSetup.claude.connectedAccount": "Claude connected on this server",
-  "engineSetup.claude.invalidChallenge": "Claude Code did not return a valid Anthropic sign-in link. Cancel and try again."
+  "engineSetup.claude.invalidChallenge": "Claude Code did not return a valid Anthropic sign-in link. Cancel and try again.",
+  "remote.signInAccess.title": "Who can sign in with an email",
+  "remote.signInAccess.subtitle": "People on this list sign in at /pair with a one-time code sent to their email. Full access is everything the owner can do; chat and approvals is for people who only talk to the bots.",
+  "remote.signInAccess.link": "Send them this link:",
+  "remote.signInAccess.placeholder": "name@company.com or @company.com",
+  "remote.signInAccess.add": "Add",
+  "remote.signInAccess.remove": "Remove",
+  "remote.signInAccess.empty": "Nobody yet. Add an address, or @yourcompany.com for everyone at your company.",
+  "remote.signInAccess.invalid": "Enter an email address, or @domain for everyone at that domain.",
+  "remote.signInAccess.note": "Changes apply immediately. Removing someone stops new sign-ins; their existing devices stay signed in until you sign them out above.",
+  "remote.signInAccess.error": "Could not save: {error}"
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1390,5 +1390,15 @@
   "engineSetup.claude.security": "Pega solo un código de un inicio de sesión que hayas empezado aquí. Se entrega una vez a Claude Code en este servidor y nunca se guarda; tu contraseña se queda en Anthropic. Los bots de este servidor comparten los límites de uso de tu suscripción.",
   "engineSetup.claude.connected": "Claude conectado. Tus modelos se están actualizando.",
   "engineSetup.claude.connectedAccount": "Claude conectado en este servidor",
-  "engineSetup.claude.invalidChallenge": "Claude Code no devolvió un enlace de inicio de sesión válido de Anthropic. Cancela e inténtalo de nuevo."
+  "engineSetup.claude.invalidChallenge": "Claude Code no devolvió un enlace de inicio de sesión válido de Anthropic. Cancela e inténtalo de nuevo.",
+  "remote.signInAccess.title": "Quién puede iniciar sesión con un email",
+  "remote.signInAccess.subtitle": "Las personas de esta lista inician sesión en /pair con un código de un solo uso enviado a su email. Acceso completo es todo lo que puede hacer el propietario; chat y aprobaciones es para quienes solo hablan con los bots.",
+  "remote.signInAccess.link": "Envíales este enlace:",
+  "remote.signInAccess.placeholder": "nombre@empresa.com o @empresa.com",
+  "remote.signInAccess.add": "Añadir",
+  "remote.signInAccess.remove": "Quitar",
+  "remote.signInAccess.empty": "Nadie todavía. Añade una dirección, o @tuempresa.com para todos en tu empresa.",
+  "remote.signInAccess.invalid": "Escribe un email, o @dominio para todos los de ese dominio.",
+  "remote.signInAccess.note": "Los cambios se aplican al instante. Quitar a alguien impide nuevos inicios de sesión; sus dispositivos siguen conectados hasta que los cierres arriba.",
+  "remote.signInAccess.error": "No se pudo guardar: {error}"
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1390,5 +1390,15 @@
   "engineSetup.claude.security": "Ne collez qu’un code issu d’une connexion lancée ici. Il est transmis une seule fois à Claude Code sur ce serveur et jamais stocké ; votre mot de passe reste chez Anthropic. Les bots de ce serveur partagent les limites d’usage de votre abonnement.",
   "engineSetup.claude.connected": "Claude connecté. Vos modèles sont en cours d’actualisation.",
   "engineSetup.claude.connectedAccount": "Claude connecté sur ce serveur",
-  "engineSetup.claude.invalidChallenge": "Claude Code n’a pas renvoyé de lien de connexion Anthropic valide. Annulez et réessayez."
+  "engineSetup.claude.invalidChallenge": "Claude Code n’a pas renvoyé de lien de connexion Anthropic valide. Annulez et réessayez.",
+  "remote.signInAccess.title": "Qui peut se connecter par e-mail",
+  "remote.signInAccess.subtitle": "Les personnes de cette liste se connectent sur /pair avec un code à usage unique envoyé à leur e-mail. Accès complet : tout ce que le propriétaire peut faire ; discussion et approbations : pour celles qui ne font que parler aux bots.",
+  "remote.signInAccess.link": "Envoyez-leur ce lien :",
+  "remote.signInAccess.placeholder": "nom@entreprise.com ou @entreprise.com",
+  "remote.signInAccess.add": "Ajouter",
+  "remote.signInAccess.remove": "Retirer",
+  "remote.signInAccess.empty": "Personne pour l’instant. Ajoutez une adresse, ou @votreentreprise.com pour toute l’entreprise.",
+  "remote.signInAccess.invalid": "Saisissez une adresse e-mail, ou @domaine pour tout le monde sur ce domaine.",
+  "remote.signInAccess.note": "Les changements s’appliquent immédiatement. Retirer quelqu’un bloque les nouvelles connexions ; ses appareils déjà connectés le restent jusqu’à ce que vous les déconnectiez ci-dessus.",
+  "remote.signInAccess.error": "Enregistrement impossible : {error}"
 }

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -1390,5 +1390,15 @@
   "engineSetup.claude.security": "केवल वही कोड पेस्ट करें जो यहाँ शुरू किए गए साइन-इन से मिला हो। यह इस सर्वर पर Claude Code को एक बार दिया जाता है और कभी सहेजा नहीं जाता; आपका पासवर्ड Anthropic के पास ही रहता है। इस सर्वर के बॉट आपकी सदस्यता की उपयोग सीमा साझा करते हैं।",
   "engineSetup.claude.connected": "Claude जुड़ गया। आपके मॉडल ताज़ा हो रहे हैं।",
   "engineSetup.claude.connectedAccount": "इस सर्वर पर Claude जुड़ा है",
-  "engineSetup.claude.invalidChallenge": "Claude Code ने Anthropic का मान्य साइन-इन लिंक नहीं दिया। रद्द करके फिर से प्रयास करें।"
+  "engineSetup.claude.invalidChallenge": "Claude Code ने Anthropic का मान्य साइन-इन लिंक नहीं दिया। रद्द करके फिर से प्रयास करें।",
+  "remote.signInAccess.title": "ईमेल से कौन साइन इन कर सकता है",
+  "remote.signInAccess.subtitle": "इस सूची के लोग /pair पर अपनी ईमेल पर भेजे गए एक बार के कोड से साइन इन करते हैं। पूरी पहुँच = वह सब जो मालिक कर सकता है; केवल चैट और अनुमोदन उन लोगों के लिए है जो सिर्फ़ बॉट से बात करते हैं।",
+  "remote.signInAccess.link": "उन्हें यह लिंक भेजें:",
+  "remote.signInAccess.placeholder": "naam@company.com या @company.com",
+  "remote.signInAccess.add": "जोड़ें",
+  "remote.signInAccess.remove": "हटाएँ",
+  "remote.signInAccess.empty": "अभी कोई नहीं। कोई पता जोड़ें, या पूरी कंपनी के लिए @yourcompany.com।",
+  "remote.signInAccess.invalid": "ईमेल पता लिखें, या उस डोमेन के सभी के लिए @domain।",
+  "remote.signInAccess.note": "बदलाव तुरंत लागू होते हैं। किसी को हटाने से नए साइन-इन रुक जाते हैं; उनके मौजूदा डिवाइस तब तक साइन इन रहते हैं जब तक आप उन्हें ऊपर साइन आउट न करें।",
+  "remote.signInAccess.error": "सहेज नहीं सका: {error}"
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1390,5 +1390,15 @@
   "engineSetup.claude.security": "ここで開始したサインインで得たコードだけを貼り付けてください。コードはこのサーバーの Claude Code に一度だけ渡され、保存されません。パスワードは Anthropic にのみ残ります。このサーバーのボットはあなたのサブスクリプションの利用上限を共有します。",
   "engineSetup.claude.connected": "Claude に接続しました。モデルを更新しています。",
   "engineSetup.claude.connectedAccount": "このサーバーで Claude に接続済み",
-  "engineSetup.claude.invalidChallenge": "Claude Code が有効な Anthropic のサインインリンクを返しませんでした。キャンセルしてやり直してください。"
+  "engineSetup.claude.invalidChallenge": "Claude Code が有効な Anthropic のサインインリンクを返しませんでした。キャンセルしてやり直してください。",
+  "remote.signInAccess.title": "メールでサインインできる人",
+  "remote.signInAccess.subtitle": "このリストの人は、メールに届く使い捨てコードで /pair からサインインします。フルアクセスはオーナーができるすべて、チャットと承認のみはボットと話すだけの人向けです。",
+  "remote.signInAccess.link": "このリンクを送ってください:",
+  "remote.signInAccess.placeholder": "name@company.com または @company.com",
+  "remote.signInAccess.add": "追加",
+  "remote.signInAccess.remove": "削除",
+  "remote.signInAccess.empty": "まだ誰もいません。アドレスを追加するか、会社全員なら @yourcompany.com を追加してください。",
+  "remote.signInAccess.invalid": "メールアドレス、またはそのドメイン全員を表す @domain を入力してください。",
+  "remote.signInAccess.note": "変更はすぐに反映されます。削除すると新しいサインインはできなくなります。既存のデバイスは上でサインアウトするまで残ります。",
+  "remote.signInAccess.error": "保存できませんでした: {error}"
 }

--- a/src/locales/pt-br.json
+++ b/src/locales/pt-br.json
@@ -1390,5 +1390,15 @@
   "engineSetup.claude.security": "Cole apenas um código de um login iniciado aqui. Ele é entregue uma vez ao Claude Code neste servidor e nunca é armazenado; sua senha fica com a Anthropic. Os bots deste servidor compartilham os limites de uso da sua assinatura.",
   "engineSetup.claude.connected": "Claude conectado. Seus modelos estão sendo atualizados.",
   "engineSetup.claude.connectedAccount": "Claude conectado neste servidor",
-  "engineSetup.claude.invalidChallenge": "O Claude Code não retornou um link de login válido da Anthropic. Cancele e tente novamente."
+  "engineSetup.claude.invalidChallenge": "O Claude Code não retornou um link de login válido da Anthropic. Cancele e tente novamente.",
+  "remote.signInAccess.title": "Quem pode entrar com e-mail",
+  "remote.signInAccess.subtitle": "As pessoas desta lista entram em /pair com um código de uso único enviado ao e-mail. Acesso completo é tudo o que o dono pode fazer; chat e aprovações é para quem só conversa com os bots.",
+  "remote.signInAccess.link": "Envie este link para elas:",
+  "remote.signInAccess.placeholder": "nome@empresa.com ou @empresa.com",
+  "remote.signInAccess.add": "Adicionar",
+  "remote.signInAccess.remove": "Remover",
+  "remote.signInAccess.empty": "Ninguém ainda. Adicione um endereço, ou @suaempresa.com para todos da empresa.",
+  "remote.signInAccess.invalid": "Digite um e-mail, ou @domínio para todos daquele domínio.",
+  "remote.signInAccess.note": "As mudanças valem na hora. Remover alguém impede novos logins; os dispositivos já conectados continuam até você desconectá-los acima.",
+  "remote.signInAccess.error": "Não foi possível salvar: {error}"
 }

--- a/src/locales/source-hashes.json
+++ b/src/locales/source-hashes.json
@@ -1393,7 +1393,17 @@
       "engineSetup.claude.security": "34ee9beac3350e3ba101e25b69d2c80996a2f263e1291a48decc19a302a2b207",
       "engineSetup.claude.connected": "426ba959753edfbe38d7a030bd5d094ecbb418206304e58afcc91307a00b44ab",
       "engineSetup.claude.connectedAccount": "7c74fb2ecc04b81046affe78b7d74dde6fe3e5dad50ba4ba02492620d8451e13",
-      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe"
+      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe",
+      "remote.signInAccess.title": "2970d968d4c9272d21b3dc58e70f6c8de199bc314d8fefbfe316645da8823ff8",
+      "remote.signInAccess.subtitle": "081f3dba81994a5286ff5f1f17c57677ac0f04d6cddfda7004b48de93463a4c3",
+      "remote.signInAccess.link": "5bf45afd080cb1da3f543b03a79c75908df3bc6917b13c280222c69439f02452",
+      "remote.signInAccess.placeholder": "8fa4d528a277c9975853692fb23c700216ab73d83f71b4aad936cc3eb42d02c3",
+      "remote.signInAccess.add": "9fd728c66c9a256b121472dabf32a34317aed01d8427d70ec830289cf23a7cc8",
+      "remote.signInAccess.remove": "c3812fc4acb861d5182fc2b8155f327f736fbe5e5eb86a7bd7afcb6dc5497282",
+      "remote.signInAccess.empty": "7166fa8f2d9ef4f4fbbbe7da946c67814553260b89fa71481e6e03a533284a86",
+      "remote.signInAccess.invalid": "f7571753e84241b531638ab312bb1b704d261eebae3a05d27f24c02a5ba5061e",
+      "remote.signInAccess.note": "ce9c15dc3fe23bbed92cb66d4cd54b8fdf0498f52f6bd2250067134b1ac65783",
+      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d"
     },
     "es": {
       "noEngines.title": "af88855a5f80377de709995229ba3907df9e8fb3b940fbf7c0d9cbe6eea54afe",
@@ -2787,7 +2797,17 @@
       "engineSetup.claude.security": "34ee9beac3350e3ba101e25b69d2c80996a2f263e1291a48decc19a302a2b207",
       "engineSetup.claude.connected": "426ba959753edfbe38d7a030bd5d094ecbb418206304e58afcc91307a00b44ab",
       "engineSetup.claude.connectedAccount": "7c74fb2ecc04b81046affe78b7d74dde6fe3e5dad50ba4ba02492620d8451e13",
-      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe"
+      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe",
+      "remote.signInAccess.title": "2970d968d4c9272d21b3dc58e70f6c8de199bc314d8fefbfe316645da8823ff8",
+      "remote.signInAccess.subtitle": "081f3dba81994a5286ff5f1f17c57677ac0f04d6cddfda7004b48de93463a4c3",
+      "remote.signInAccess.link": "5bf45afd080cb1da3f543b03a79c75908df3bc6917b13c280222c69439f02452",
+      "remote.signInAccess.placeholder": "8fa4d528a277c9975853692fb23c700216ab73d83f71b4aad936cc3eb42d02c3",
+      "remote.signInAccess.add": "9fd728c66c9a256b121472dabf32a34317aed01d8427d70ec830289cf23a7cc8",
+      "remote.signInAccess.remove": "c3812fc4acb861d5182fc2b8155f327f736fbe5e5eb86a7bd7afcb6dc5497282",
+      "remote.signInAccess.empty": "7166fa8f2d9ef4f4fbbbe7da946c67814553260b89fa71481e6e03a533284a86",
+      "remote.signInAccess.invalid": "f7571753e84241b531638ab312bb1b704d261eebae3a05d27f24c02a5ba5061e",
+      "remote.signInAccess.note": "ce9c15dc3fe23bbed92cb66d4cd54b8fdf0498f52f6bd2250067134b1ac65783",
+      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d"
     },
     "fr": {
       "noEngines.title": "af88855a5f80377de709995229ba3907df9e8fb3b940fbf7c0d9cbe6eea54afe",
@@ -4181,7 +4201,17 @@
       "engineSetup.claude.security": "34ee9beac3350e3ba101e25b69d2c80996a2f263e1291a48decc19a302a2b207",
       "engineSetup.claude.connected": "426ba959753edfbe38d7a030bd5d094ecbb418206304e58afcc91307a00b44ab",
       "engineSetup.claude.connectedAccount": "7c74fb2ecc04b81046affe78b7d74dde6fe3e5dad50ba4ba02492620d8451e13",
-      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe"
+      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe",
+      "remote.signInAccess.title": "2970d968d4c9272d21b3dc58e70f6c8de199bc314d8fefbfe316645da8823ff8",
+      "remote.signInAccess.subtitle": "081f3dba81994a5286ff5f1f17c57677ac0f04d6cddfda7004b48de93463a4c3",
+      "remote.signInAccess.link": "5bf45afd080cb1da3f543b03a79c75908df3bc6917b13c280222c69439f02452",
+      "remote.signInAccess.placeholder": "8fa4d528a277c9975853692fb23c700216ab73d83f71b4aad936cc3eb42d02c3",
+      "remote.signInAccess.add": "9fd728c66c9a256b121472dabf32a34317aed01d8427d70ec830289cf23a7cc8",
+      "remote.signInAccess.remove": "c3812fc4acb861d5182fc2b8155f327f736fbe5e5eb86a7bd7afcb6dc5497282",
+      "remote.signInAccess.empty": "7166fa8f2d9ef4f4fbbbe7da946c67814553260b89fa71481e6e03a533284a86",
+      "remote.signInAccess.invalid": "f7571753e84241b531638ab312bb1b704d261eebae3a05d27f24c02a5ba5061e",
+      "remote.signInAccess.note": "ce9c15dc3fe23bbed92cb66d4cd54b8fdf0498f52f6bd2250067134b1ac65783",
+      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d"
     },
     "hi": {
       "noEngines.title": "af88855a5f80377de709995229ba3907df9e8fb3b940fbf7c0d9cbe6eea54afe",
@@ -5575,7 +5605,17 @@
       "engineSetup.claude.security": "34ee9beac3350e3ba101e25b69d2c80996a2f263e1291a48decc19a302a2b207",
       "engineSetup.claude.connected": "426ba959753edfbe38d7a030bd5d094ecbb418206304e58afcc91307a00b44ab",
       "engineSetup.claude.connectedAccount": "7c74fb2ecc04b81046affe78b7d74dde6fe3e5dad50ba4ba02492620d8451e13",
-      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe"
+      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe",
+      "remote.signInAccess.title": "2970d968d4c9272d21b3dc58e70f6c8de199bc314d8fefbfe316645da8823ff8",
+      "remote.signInAccess.subtitle": "081f3dba81994a5286ff5f1f17c57677ac0f04d6cddfda7004b48de93463a4c3",
+      "remote.signInAccess.link": "5bf45afd080cb1da3f543b03a79c75908df3bc6917b13c280222c69439f02452",
+      "remote.signInAccess.placeholder": "8fa4d528a277c9975853692fb23c700216ab73d83f71b4aad936cc3eb42d02c3",
+      "remote.signInAccess.add": "9fd728c66c9a256b121472dabf32a34317aed01d8427d70ec830289cf23a7cc8",
+      "remote.signInAccess.remove": "c3812fc4acb861d5182fc2b8155f327f736fbe5e5eb86a7bd7afcb6dc5497282",
+      "remote.signInAccess.empty": "7166fa8f2d9ef4f4fbbbe7da946c67814553260b89fa71481e6e03a533284a86",
+      "remote.signInAccess.invalid": "f7571753e84241b531638ab312bb1b704d261eebae3a05d27f24c02a5ba5061e",
+      "remote.signInAccess.note": "ce9c15dc3fe23bbed92cb66d4cd54b8fdf0498f52f6bd2250067134b1ac65783",
+      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d"
     },
     "ja": {
       "noEngines.title": "af88855a5f80377de709995229ba3907df9e8fb3b940fbf7c0d9cbe6eea54afe",
@@ -6969,7 +7009,17 @@
       "engineSetup.claude.security": "34ee9beac3350e3ba101e25b69d2c80996a2f263e1291a48decc19a302a2b207",
       "engineSetup.claude.connected": "426ba959753edfbe38d7a030bd5d094ecbb418206304e58afcc91307a00b44ab",
       "engineSetup.claude.connectedAccount": "7c74fb2ecc04b81046affe78b7d74dde6fe3e5dad50ba4ba02492620d8451e13",
-      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe"
+      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe",
+      "remote.signInAccess.title": "2970d968d4c9272d21b3dc58e70f6c8de199bc314d8fefbfe316645da8823ff8",
+      "remote.signInAccess.subtitle": "081f3dba81994a5286ff5f1f17c57677ac0f04d6cddfda7004b48de93463a4c3",
+      "remote.signInAccess.link": "5bf45afd080cb1da3f543b03a79c75908df3bc6917b13c280222c69439f02452",
+      "remote.signInAccess.placeholder": "8fa4d528a277c9975853692fb23c700216ab73d83f71b4aad936cc3eb42d02c3",
+      "remote.signInAccess.add": "9fd728c66c9a256b121472dabf32a34317aed01d8427d70ec830289cf23a7cc8",
+      "remote.signInAccess.remove": "c3812fc4acb861d5182fc2b8155f327f736fbe5e5eb86a7bd7afcb6dc5497282",
+      "remote.signInAccess.empty": "7166fa8f2d9ef4f4fbbbe7da946c67814553260b89fa71481e6e03a533284a86",
+      "remote.signInAccess.invalid": "f7571753e84241b531638ab312bb1b704d261eebae3a05d27f24c02a5ba5061e",
+      "remote.signInAccess.note": "ce9c15dc3fe23bbed92cb66d4cd54b8fdf0498f52f6bd2250067134b1ac65783",
+      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d"
     },
     "pt-br": {
       "noEngines.title": "af88855a5f80377de709995229ba3907df9e8fb3b940fbf7c0d9cbe6eea54afe",
@@ -8363,7 +8413,17 @@
       "engineSetup.claude.security": "34ee9beac3350e3ba101e25b69d2c80996a2f263e1291a48decc19a302a2b207",
       "engineSetup.claude.connected": "426ba959753edfbe38d7a030bd5d094ecbb418206304e58afcc91307a00b44ab",
       "engineSetup.claude.connectedAccount": "7c74fb2ecc04b81046affe78b7d74dde6fe3e5dad50ba4ba02492620d8451e13",
-      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe"
+      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe",
+      "remote.signInAccess.title": "2970d968d4c9272d21b3dc58e70f6c8de199bc314d8fefbfe316645da8823ff8",
+      "remote.signInAccess.subtitle": "081f3dba81994a5286ff5f1f17c57677ac0f04d6cddfda7004b48de93463a4c3",
+      "remote.signInAccess.link": "5bf45afd080cb1da3f543b03a79c75908df3bc6917b13c280222c69439f02452",
+      "remote.signInAccess.placeholder": "8fa4d528a277c9975853692fb23c700216ab73d83f71b4aad936cc3eb42d02c3",
+      "remote.signInAccess.add": "9fd728c66c9a256b121472dabf32a34317aed01d8427d70ec830289cf23a7cc8",
+      "remote.signInAccess.remove": "c3812fc4acb861d5182fc2b8155f327f736fbe5e5eb86a7bd7afcb6dc5497282",
+      "remote.signInAccess.empty": "7166fa8f2d9ef4f4fbbbe7da946c67814553260b89fa71481e6e03a533284a86",
+      "remote.signInAccess.invalid": "f7571753e84241b531638ab312bb1b704d261eebae3a05d27f24c02a5ba5061e",
+      "remote.signInAccess.note": "ce9c15dc3fe23bbed92cb66d4cd54b8fdf0498f52f6bd2250067134b1ac65783",
+      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d"
     },
     "zh": {
       "noEngines.title": "af88855a5f80377de709995229ba3907df9e8fb3b940fbf7c0d9cbe6eea54afe",
@@ -9757,7 +9817,17 @@
       "engineSetup.claude.security": "34ee9beac3350e3ba101e25b69d2c80996a2f263e1291a48decc19a302a2b207",
       "engineSetup.claude.connected": "426ba959753edfbe38d7a030bd5d094ecbb418206304e58afcc91307a00b44ab",
       "engineSetup.claude.connectedAccount": "7c74fb2ecc04b81046affe78b7d74dde6fe3e5dad50ba4ba02492620d8451e13",
-      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe"
+      "engineSetup.claude.invalidChallenge": "a50de7d5c3c08440695083b57382773171cfdddaf7e6f5b299e873bc2164eefe",
+      "remote.signInAccess.title": "2970d968d4c9272d21b3dc58e70f6c8de199bc314d8fefbfe316645da8823ff8",
+      "remote.signInAccess.subtitle": "081f3dba81994a5286ff5f1f17c57677ac0f04d6cddfda7004b48de93463a4c3",
+      "remote.signInAccess.link": "5bf45afd080cb1da3f543b03a79c75908df3bc6917b13c280222c69439f02452",
+      "remote.signInAccess.placeholder": "8fa4d528a277c9975853692fb23c700216ab73d83f71b4aad936cc3eb42d02c3",
+      "remote.signInAccess.add": "9fd728c66c9a256b121472dabf32a34317aed01d8427d70ec830289cf23a7cc8",
+      "remote.signInAccess.remove": "c3812fc4acb861d5182fc2b8155f327f736fbe5e5eb86a7bd7afcb6dc5497282",
+      "remote.signInAccess.empty": "7166fa8f2d9ef4f4fbbbe7da946c67814553260b89fa71481e6e03a533284a86",
+      "remote.signInAccess.invalid": "f7571753e84241b531638ab312bb1b704d261eebae3a05d27f24c02a5ba5061e",
+      "remote.signInAccess.note": "ce9c15dc3fe23bbed92cb66d4cd54b8fdf0498f52f6bd2250067134b1ac65783",
+      "remote.signInAccess.error": "71a471a7b15e8647dda8cab60737a1b41901bdcbe3be10f477a9163b723f4e1d"
     }
   }
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1390,5 +1390,15 @@
   "engineSetup.claude.security": "只粘贴你在此处发起的登录所得到的代码。代码只会交给此服务器上的 Claude Code 一次，绝不保存；你的密码只留在 Anthropic。此服务器上的机器人共享你订阅的用量限制。",
   "engineSetup.claude.connected": "Claude 已连接，正在刷新你的模型。",
   "engineSetup.claude.connectedAccount": "此服务器已连接 Claude",
-  "engineSetup.claude.invalidChallenge": "Claude Code 没有返回有效的 Anthropic 登录链接。请取消后重试。"
+  "engineSetup.claude.invalidChallenge": "Claude Code 没有返回有效的 Anthropic 登录链接。请取消后重试。",
+  "remote.signInAccess.title": "谁可以用邮箱登录",
+  "remote.signInAccess.subtitle": "名单上的人在 /pair 用发到邮箱的一次性代码登录。完全访问等于所有者能做的一切；仅聊天和审批适合只和机器人对话的人。",
+  "remote.signInAccess.link": "把这个链接发给他们：",
+  "remote.signInAccess.placeholder": "name@company.com 或 @company.com",
+  "remote.signInAccess.add": "添加",
+  "remote.signInAccess.remove": "移除",
+  "remote.signInAccess.empty": "还没有人。添加一个地址，或用 @yourcompany.com 允许全公司。",
+  "remote.signInAccess.invalid": "请输入邮箱地址，或用 @domain 表示该域名下的所有人。",
+  "remote.signInAccess.note": "更改立即生效。移除某人会阻止其新的登录；已登录的设备会保留，直到你在上面将其退出。",
+  "remote.signInAccess.error": "无法保存：{error}"
 }


### PR DESCRIPTION
Follow-up to #970 and #974: the allow-list for email sign-in, editable in the browser so the workspace owner never needs the command line for it.

Settings → Remote access on a hosted server, admins only: **Who can sign in with an email** shows the list, adds an address or an `@domain` as full access or chat and approvals, removes entries, and shows the `/pair` link to send. It saves through the existing `PUT /api/config { signIn }` and the server reads the list per request, so changes apply at once; removing someone stops new sign-ins while their existing devices stay until signed out from the card above it. Adding an address already on the other list moves it rather than duplicating it. Chat-only sessions never see the card (the API refuses them anyway); the desktop app does not show it.

Tests: entry normalisation (address, `@domain`, rejects the rest), move-between-lists and remove, and that the card renders nothing before it knows who is asking. Strings in all eight locales with source hashes; `pnpm i18n:check`, the UI typecheck and lint pass. Docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser-based controls for managing who can sign in by email or domain.
  * Administrators can assign full-access or chat-and-approvals permissions, add or remove entries, and share the sign-in link.
  * Changes take effect immediately with validation and error feedback.

* **Documentation**
  * Updated self-hosting guidance to include the browser-based access-list workflow.

* **Localization**
  * Added translated sign-in access settings for supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->