### PR TITLE
fix(ios): keep thread approvals correct on lock screen and reconnect

### DIFF
--- a/ios/App/LiveActivities.swift
+++ b/ios/App/LiveActivities.swift
@@ -20,12 +20,22 @@ final class LiveActivityCoordinator {
 
     func attach(to session: Session) {
         // Answer from the island: the intent runs in this process.
-        AnswerApprovalIntent.handler = { [weak session] threadId, requestId, choice, isPermission in
-            await session?.answer(threadId: threadId, requestId: requestId, choice: choice, isPermission: isPermission)
+        AnswerApprovalIntent.handler = { [weak self, weak session] threadId, requestId, choice, isPermission in
+            await self?.answer(session: session, threadId: threadId, requestId: requestId, choice: choice, isPermission: isPermission)
         }
         cancellable = session.$state
             .debounce(for: .milliseconds(400), scheduler: DispatchQueue.main)
             .sink { [weak self] state in self?.sync(state) }
+    }
+
+    private func answer(session: Session?, threadId: String, requestId: String, choice: String, isPermission: Bool) async {
+        guard Activity<BotActivityAttributes>.activities.contains(where: {
+            $0.content.state.canAnswer(threadId: threadId, requestId: requestId, choice: choice, isPermission: isPermission)
+        }) else {
+            session?.actionError = "This request has changed. Open the chat to review it."
+            return
+        }
+        await session?.answer(threadId: threadId, requestId: requestId, choice: choice, isPermission: isPermission)
     }
 
     private func sync(_ state: CompanionState) {
@@ -44,13 +54,8 @@ final class LiveActivityCoordinator {
                 kind: update.kind == .needsYou ? "needsYou" : "working",
                 headline: update.kind == .needsYou ? "\(bot.name) needs you" : "\(bot.name) is working",
                 line: update.line.isEmpty ? (update.card?.title ?? "") : update.line,
-                requestId: update.card?.isPending == true ? update.card?.requestId : nil,
-                // A Live Activity cannot show the reviewed SKILL.md. Keep the
-                // alert, but withhold action buttons until the user opens chat.
-                options: update.card?.isPending == true && update.card?.skillRequest == nil
-                    ? (update.card?.options ?? [])
-                    : [],
-                isPermission: update.card?.isPermission ?? false,
+                threadId: update.chat.threadId,
+                card: update.card,
                 since: since[bot.id]?.at ?? Date()
             )
             if lastSent[bot.id] == content { continue }
@@ -66,7 +71,9 @@ final class LiveActivityCoordinator {
                 )
                 : nil
             if let activity = Activity<BotActivityAttributes>.activities.first(where: { $0.attributes.botId == bot.id }) {
-                let newAsk = update.kind == .needsYou && lastSent[bot.id]?.requestId != content.requestId
+                let newAsk = update.kind == .needsYou && (
+                    lastSent[bot.id]?.threadId != content.threadId || lastSent[bot.id]?.requestId != content.requestId
+                )
                 Task { await activity.update(.init(state: content, staleDate: nil), alertConfiguration: newAsk ? alert : nil) }
             } else {
                 let attributes = BotActivityAttributes(botId: bot.id, threadId: bot.threadId, name: bot.name, color: bot.color)

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -776,14 +776,22 @@ final class Session: ObservableObject {
 
     private func hydrate(using client: CompanionClient) async throws {
         let generation = streamGeneration
-        let snapshot = try await client.fleetForHydration(messages: 50)
-        try Task.checkCancellation()
-        guard streamGeneration == generation, self.client?.connection.id == client.connection.id else {
-            throw CancellationError()
+        // Notification navigation can refresh while run() continues folding
+        // live events. Retry once if that makes the fetched snapshot stale.
+        for _ in 0..<2 {
+            let expectedCursor = state.cursor
+            let snapshot = try await client.fleetForHydration(messages: 50)
+            try Task.checkCancellation()
+            guard streamGeneration == generation, self.client?.connection.id == client.connection.id else {
+                throw CancellationError()
+            }
+            guard state.hydrate(snapshot.fleet, waitingThreads: snapshot.waitingThreads,
+                                ifCursorMatches: expectedCursor) else { continue }
+            log.info("hydrated \(snapshot.fleet.bots.count, privacy: .public) bots, \(snapshot.fleet.groups.count, privacy: .public) rooms")
+            NotificationCoordinator.shared.setBadge(state.unreadCount)
+            return
         }
-        log.info("hydrated \(snapshot.fleet.bots.count, privacy: .public) bots, \(snapshot.fleet.groups.count, privacy: .public) rooms")
-        state.hydrate(snapshot.fleet, waitingThreads: snapshot.waitingThreads)
-        NotificationCoordinator.shared.setBadge(state.unreadCount)
+        throw APIError.status(code: 409, message: "Conversations changed while loading. Please try opening this notification again.")
     }
 
     // MARK: - Which address to dial
@@ -1842,6 +1850,9 @@ final class Session: ObservableObject {
                 }
             }
             notificationChat = .bot(selected)
+        } catch is CancellationError {
+            // A refresh from the previous computer must not alert on the
+            // newly selected connection after its generation guard rejects it.
         } catch { actionError = error.localizedDescription }
     }
 

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -730,7 +730,7 @@ final class Session: ObservableObject {
                         // the request dies halfway through replay/hydration,
                         // reconnecting must still ask for the missing gap.
                         if !resumed {
-                            try await hydrate()
+                            try await hydrate(using: client)
                             state.resetCursor(cursor)
                         }
                         status = .live
@@ -774,11 +774,15 @@ final class Session: ObservableObject {
         }
     }
 
-    private func hydrate() async throws {
-        guard let client else { return }
-        let fleet = try await client.fleet(messages: 50)
-        log.info("hydrated \(fleet.bots.count, privacy: .public) bots, \(fleet.groups.count, privacy: .public) rooms")
-        state.hydrate(fleet)
+    private func hydrate(using client: CompanionClient) async throws {
+        let generation = streamGeneration
+        let snapshot = try await client.fleetForHydration(messages: 50)
+        try Task.checkCancellation()
+        guard streamGeneration == generation, self.client?.connection.id == client.connection.id else {
+            throw CancellationError()
+        }
+        log.info("hydrated \(snapshot.fleet.bots.count, privacy: .public) bots, \(snapshot.fleet.groups.count, privacy: .public) rooms")
+        state.hydrate(snapshot.fleet, waitingThreads: snapshot.waitingThreads)
         NotificationCoordinator.shared.setBadge(state.unreadCount)
     }
 
@@ -1805,8 +1809,7 @@ final class Session: ObservableObject {
         do {
             var bot = state.bot(target.botId)
             if bot == nil {
-                let fleet = try await client.fleet(messages: 50)
-                state.hydrate(fleet)
+                try await hydrate(using: client)
                 bot = state.bot(target.botId)
             }
             // A room's approval/question notification carries the asker bot

--- a/ios/Shared/BotActivity.swift
+++ b/ios/Shared/BotActivity.swift
@@ -6,27 +6,13 @@
 import ActivityKit
 import AppIntents
 import Foundation
+import CompanionCore
 
 struct BotActivityAttributes: ActivityAttributes {
-    public struct ContentState: Codable, Hashable {
-        /// `MausState.rawValue` — the face to wear.
-        var face: String
-        /// "needsYou" | "working" | "toReview"
-        var kind: String
-        /// "Scout needs you", "Forge is working"
-        var headline: String
-        /// The question, or what it is doing.
-        var line: String
-        /// A pending card to answer, when kind == needsYou.
-        var requestId: String?
-        var options: [String]
-        /// A permission card answers allow/deny; a question answers with text.
-        var isPermission: Bool
-        /// When this kind began — the island's timer and ring count from it.
-        var since: Date
-    }
+    public typealias ContentState = BotActivityContent
 
     var botId: String
+    /// Retained to decode existing activities. Routing uses ContentState.
     var threadId: String
     var name: String
     /// MausPalette colour name.

--- a/ios/Sources/CompanionCore/BotActivityContent.swift
+++ b/ios/Sources/CompanionCore/BotActivityContent.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Mutable Live Activity state shared by the app and widget. An activity is
+/// per bot, but its current request may belong to any of that bot's threads.
+public struct BotActivityContent: Codable, Hashable, Sendable {
+    public var face: String
+    public var kind: String
+    public var headline: String
+    public var line: String
+    /// Optional to decode activities created before thread-aware routing.
+    /// Never fall back to the activity's immutable, original thread.
+    public var threadId: String?
+    public var requestId: String?
+    public var options: [String]
+    public var isPermission: Bool
+    public var since: Date
+
+    public init(
+        face: String,
+        kind: String,
+        headline: String,
+        line: String,
+        threadId: String,
+        card: OptionCard?,
+        since: Date
+    ) {
+        self.face = face
+        self.kind = kind
+        self.headline = headline
+        self.line = line
+        self.threadId = threadId
+        self.requestId = card?.isPending == true ? card?.requestId : nil
+        // Compact surfaces cannot show the reviewed SKILL.md. Keep the
+        // alert, but require opening chat before answering a skill request.
+        self.options = card?.isPending == true && card?.skillRequest == nil ? (card?.options ?? []) : []
+        self.isPermission = card?.isPermission ?? false
+        self.since = since
+    }
+
+    /// The widget and intent handler use the same exact request target.
+    /// Legacy content can remain visible, but cannot offer approval buttons.
+    public var approvalThreadId: String? {
+        guard kind == "needsYou", let threadId, !threadId.isEmpty,
+              let requestId, !requestId.isEmpty, !options.isEmpty else { return nil }
+        return threadId
+    }
+
+    /// A rendered button can outlive the ask it displayed. Refuse stale or
+    /// legacy intent payloads rather than approving another thread's request.
+    public func canAnswer(threadId: String, requestId: String, choice: String, isPermission: Bool) -> Bool {
+        approvalThreadId == threadId && self.requestId == requestId
+            && options.contains(choice) && self.isPermission == isPermission
+    }
+}

--- a/ios/Sources/CompanionCore/Client.swift
+++ b/ios/Sources/CompanionCore/Client.swift
@@ -850,6 +850,28 @@ public struct CompanionClient: Sendable {
         return try await send(try makeRequest("GET", "/api/bots", query: query), as: Fleet.self)
     }
 
+    /// The fleet includes only each bot's selected transcript. Recover the
+    /// other threads currently awaiting a person before committing a cold
+    /// snapshot, so their approval cards do not depend on opening the chat.
+    /// Fail the whole refresh on a failed page: advancing the replay cursor
+    /// with a partial snapshot could permanently miss that request.
+    public func fleetForHydration(messages limit: Int = 50) async throws -> (
+        fleet: Fleet, waitingThreads: [String: ThreadPage]
+    ) {
+        try Task.checkCancellation()
+        let fleet = try await fleet(messages: limit)
+        var waitingThreads: [String: ThreadPage] = [:]
+        for bot in fleet.bots {
+            for task in bot.tasks ?? [] where task.activity == "waiting-on-you"
+                && task.threadId != bot.threadId && waitingThreads[task.threadId] == nil {
+                try Task.checkCancellation()
+                waitingThreads[task.threadId] = try await messages(threadId: task.threadId, limit: limit)
+            }
+        }
+        try Task.checkCancellation()
+        return (fleet, waitingThreads)
+    }
+
     /// Scrollback: the page before a message already held.
     public func messages(threadId: String, before: String? = nil, limit: Int = 50) async throws -> ThreadPage {
         var query = [URLQueryItem(name: "limit", value: String(limit))]

--- a/ios/Sources/CompanionCore/Models.swift
+++ b/ios/Sources/CompanionCore/Models.swift
@@ -223,6 +223,9 @@ public struct BotTask: Codable, Hashable, Sendable {
     public var createdAt: Double
     public var modelSelection: ModelSelection?
     public var busy: Bool?
+    /// Runtime state from newer computers; used to recover approvals in
+    /// background threads without downloading every conversation.
+    public var activity: String?
     public var unread: Bool?
     public var approvalMode: String?
     public var autoApprove: Bool?

--- a/ios/Sources/CompanionCore/Store.swift
+++ b/ios/Sources/CompanionCore/Store.swift
@@ -182,6 +182,19 @@ public struct CompanionState: Sendable {
 
     // MARK: - Hydrating
 
+    /// An HTTP snapshot may arrive after the live stream has already folded
+    /// newer messages. Reject it atomically rather than erase those events
+    /// while keeping a cursor that says they were applied.
+    public mutating func hydrate(
+        _ fleet: Fleet,
+        waitingThreads: [String: ThreadPage] = [:],
+        ifCursorMatches expectedCursor: String?
+    ) -> Bool {
+        guard cursor == expectedCursor else { return false }
+        hydrate(fleet, waitingThreads: waitingThreads)
+        return true
+    }
+
     /// Replace everything from a `GET /api/bots` response.
     public mutating func hydrate(_ fleet: Fleet, waitingThreads: [String: ThreadPage] = [:]) {
         bots = fleet.bots

--- a/ios/Sources/CompanionCore/Store.swift
+++ b/ios/Sources/CompanionCore/Store.swift
@@ -183,7 +183,7 @@ public struct CompanionState: Sendable {
     // MARK: - Hydrating
 
     /// Replace everything from a `GET /api/bots` response.
-    public mutating func hydrate(_ fleet: Fleet) {
+    public mutating func hydrate(_ fleet: Fleet, waitingThreads: [String: ThreadPage] = [:]) {
         bots = fleet.bots
         rooms = fleet.groups
         messages.removeAll()
@@ -197,6 +197,9 @@ public struct CompanionState: Sendable {
         for room in fleet.groups {
             messages[room.threadId] = room.messages ?? []
             hasMore[room.threadId] = room.hasMore ?? false
+        }
+        for (threadId, page) in waitingThreads where bot(forThread: threadId) != nil {
+            merge(page, intoThread: threadId)
         }
     }
 

--- a/ios/Tests/CompanionCoreTests/BotActivityContentTests.swift
+++ b/ios/Tests/CompanionCoreTests/BotActivityContentTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import CompanionCore
+
+final class BotActivityContentTests: XCTestCase {
+    private func card(_ requestId: String = "request") -> OptionCard {
+        OptionCard(title: "Run shell?", subtitle: "echo hello", options: ["Allow", "Deny"], requestId: requestId, tool: "shell")
+    }
+
+    private func content(threadId: String = "thread-a", card: OptionCard? = nil, kind: String = "needsYou") -> BotActivityContent {
+        BotActivityContent(
+            face: "waiting", kind: kind, headline: "Pepper needs you", line: "echo hello",
+            threadId: threadId, card: card ?? self.card(), since: Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    func testReusedActivityTargetsCurrentSiblingThreadEvenWhenRequestIdIsTheSame() throws {
+        // The per-bot activity began on A. Updating its content to B must
+        // move the button too; immutable activity attributes cannot do this.
+        let original = content(threadId: "thread-a")
+        let sibling = content(threadId: "thread-b")
+        let rendered = try JSONDecoder().decode(BotActivityContent.self, from: JSONEncoder().encode(sibling))
+        XCTAssertNotEqual(original, sibling, "A thread change must send an activity update")
+        XCTAssertEqual(rendered.approvalThreadId, "thread-b")
+        XCTAssertTrue(rendered.canAnswer(threadId: "thread-b", requestId: "request", choice: "Allow", isPermission: true))
+        XCTAssertFalse(rendered.canAnswer(threadId: "thread-a", requestId: "request", choice: "Allow", isPermission: true))
+    }
+
+    func testLegacyActivityDecodesButCannotAnswerUsingOriginalAttributes() throws {
+        let legacy = """
+        {"face":"waiting","kind":"needsYou","headline":"Pepper needs you","line":"echo hello",
+        "requestId":"request","options":["Allow","Deny"],"isPermission":true,"since":0}
+        """
+        let rendered = try JSONDecoder().decode(BotActivityContent.self, from: Data(legacy.utf8))
+        XCTAssertEqual(rendered.headline, "Pepper needs you")
+        XCTAssertNil(rendered.threadId)
+        XCTAssertNil(rendered.approvalThreadId)
+        XCTAssertFalse(rendered.canAnswer(threadId: "original-thread", requestId: "request", choice: "Allow", isPermission: true))
+    }
+
+    func testStaleOrChangedIntentCannotAnswer() {
+        let current = content(card: card("new-request"))
+        XCTAssertFalse(current.canAnswer(threadId: "thread-a", requestId: "old-request", choice: "Allow", isPermission: true))
+        XCTAssertFalse(current.canAnswer(threadId: "thread-a", requestId: "new-request", choice: "Always allow", isPermission: true))
+        XCTAssertFalse(current.canAnswer(threadId: "thread-a", requestId: "new-request", choice: "Allow", isPermission: false))
+        XCTAssertTrue(current.canAnswer(threadId: "thread-a", requestId: "new-request", choice: "Deny", isPermission: true))
+    }
+
+    func testQuestionKeepsItsExactChoicesAndResponseKind() {
+        let question = OptionCard(title: "Which?", subtitle: "", options: ["First", "Second"], requestId: "question")
+        let current = content(card: question)
+        XCTAssertTrue(current.canAnswer(threadId: "thread-a", requestId: "question", choice: "Second", isPermission: false))
+        XCTAssertFalse(current.canAnswer(threadId: "thread-a", requestId: "question", choice: "Allow", isPermission: true))
+    }
+
+    func testAnsweredDismissedAndWorkingStatesOfferNoAction() {
+        var answered = card()
+        answered.answered = "Allow"
+        var dismissed = card()
+        dismissed.dismissed = true
+        for current in [content(card: answered), content(card: dismissed), content(kind: "working")] {
+            XCTAssertNil(current.approvalThreadId)
+            XCTAssertFalse(current.canAnswer(threadId: "thread-a", requestId: "request", choice: "Allow", isPermission: true))
+        }
+    }
+
+    func testSkillApprovalStillRequiresOpeningTheChat() throws {
+        let payload = """
+        {"title":"Enable skill?","subtitle":"Review this skill","options":["Enable","Deny"],
+        "requestId":"skill","tool":"stage_skill","skillRequest":{
+        "version":1,"requestId":"skill","botId":"pepper","threadId":"thread-b","stagedId":"staged",
+        "action":"create","name":"verify","gist":"Verify the app","warnings":[],"createdAt":0}}
+        """
+        let skill = try JSONDecoder().decode(OptionCard.self, from: Data(payload.utf8))
+        let current = content(threadId: "thread-b", card: skill)
+        XCTAssertEqual(current.threadId, "thread-b")
+        XCTAssertEqual(current.requestId, "skill", "Keep the alert visible")
+        XCTAssertTrue(current.options.isEmpty)
+        XCTAssertNil(current.approvalThreadId)
+    }
+
+    func testEmptyTargetOrRequestCannotOfferButtons() {
+        XCTAssertNil(content(threadId: "").approvalThreadId)
+        XCTAssertNil(content(card: card("")).approvalThreadId)
+    }
+}

--- a/ios/Tests/CompanionCoreTests/WaitingThreadHydrationTests.swift
+++ b/ios/Tests/CompanionCoreTests/WaitingThreadHydrationTests.swift
@@ -77,6 +77,51 @@ final class WaitingThreadHydrationTests: XCTestCase {
         XCTAssertTrue(state.pendingApprovals.isEmpty, "The fresh page, not the older activity label, decides whether a card is actionable.")
     }
 
+    func testLateSnapshotCannotOverwriteAnApprovalResolvedByTheLiveStream() async throws {
+        let snapshot = try await client.fleetForHydration()
+        var state = CompanionState()
+        state.hydrate(snapshot.fleet, waitingThreads: snapshot.waitingThreads)
+        state.resetCursor("stream:1")
+        let expectedCursor = state.cursor
+
+        // A notification refresh captured this page before the live stream
+        // answered the request. Its slower response must not revive the card.
+        var resolved = try XCTUnwrap(state.pendingApprovals.first?.message)
+        resolved.card?.answered = "Allow"
+        state.apply(.messagePatch(threadId: "thread-a", message: resolved))
+        state.advance(to: 2)
+        XCTAssertFalse(state.hydrate(snapshot.fleet, waitingThreads: snapshot.waitingThreads,
+                                     ifCursorMatches: expectedCursor))
+
+        XCTAssertEqual(state.cursor, "stream:2")
+        XCTAssertTrue(state.pendingApprovals.isEmpty)
+        XCTAssertEqual(state.transcript(forThread: "thread-a").last?.card?.answered, "Allow")
+
+        // A bounded retry against the new cursor may now commit the fresh,
+        // answered page without losing or replaying the stream's progress.
+        WaitingThreadStub.responses["/api/threads/thread-a/messages"] = (200, Data(
+            Self.pendingPage.replacingOccurrences(of: "\"tool\":\"Bash\"", with: "\"tool\":\"Bash\",\"answered\":\"Allow\"").utf8
+        ))
+        let retryCursor = state.cursor
+        let fresh = try await client.fleetForHydration()
+        XCTAssertTrue(state.hydrate(fresh.fleet, waitingThreads: fresh.waitingThreads,
+                                    ifCursorMatches: retryCursor))
+        XCTAssertEqual(state.cursor, "stream:2")
+        XCTAssertTrue(state.pendingApprovals.isEmpty)
+        XCTAssertEqual(state.transcript(forThread: "thread-a").last?.card?.answered, "Allow")
+    }
+
+    func testColdSnapshotAcceptsANilCursorButCannotOverwriteANewerHello() async throws {
+        let snapshot = try await client.fleetForHydration()
+        var state = CompanionState()
+        XCTAssertTrue(state.hydrate(snapshot.fleet, waitingThreads: snapshot.waitingThreads,
+                                   ifCursorMatches: nil))
+        state.resetCursor("stream:0")
+        XCTAssertFalse(state.hydrate(Fleet(bots: [], groups: []), ifCursorMatches: nil))
+        XCTAssertEqual(state.pendingApprovals.map(\.threadId), ["thread-a"])
+        XCTAssertEqual(state.cursor, "stream:0")
+    }
+
     func testReconnectDoesNotKeepAStaleBackgroundApproval() async throws {
         let first = try await client.fleetForHydration()
         var state = CompanionState()

--- a/ios/Tests/CompanionCoreTests/WaitingThreadHydrationTests.swift
+++ b/ios/Tests/CompanionCoreTests/WaitingThreadHydrationTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+import XCTest
+@testable import CompanionCore
+
+private final class WaitingThreadStub: URLProtocol {
+    static var responses: [String: (Int, Data)] = [:]
+    static var requests: [URLRequest] = []
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        Self.requests.append(request)
+        let (status, body) = Self.responses[request.url!.path] ?? (404, Data())
+        client?.urlProtocol(self, didReceive: HTTPURLResponse(
+            url: request.url!, statusCode: status, httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+
+final class WaitingThreadHydrationTests: XCTestCase {
+    private var session: URLSession!
+    private var client: CompanionClient!
+
+    override func setUp() {
+        super.setUp()
+        WaitingThreadStub.requests = []
+        WaitingThreadStub.responses = [
+            "/api/bots": (200, Data(Self.fleetJSON.utf8)),
+            "/api/threads/thread-a/messages": (200, Data(Self.pendingPage.utf8)),
+        ]
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [WaitingThreadStub.self]
+        session = URLSession(configuration: configuration)
+        client = CompanionClient(
+            connection: Connection(name: "Fixture", host: "127.0.0.1", port: 8810),
+            token: "fixture-token", session: session
+        )
+    }
+
+    override func tearDown() {
+        session.invalidateAndCancel()
+        session = nil
+        client = nil
+        super.tearDown()
+    }
+
+    func testColdHydrationFindsBackgroundApprovalWithoutOpeningItsThread() async throws {
+        let snapshot = try await client.fleetForHydration(messages: 50)
+        var state = CompanionState()
+        state.hydrate(snapshot.fleet, waitingThreads: snapshot.waitingThreads)
+        XCTAssertEqual(state.bot("bot-1")?.threadId, "thread-b")
+        XCTAssertEqual(state.pendingApprovals.map(\.threadId), ["thread-a"])
+        XCTAssertEqual(state.pendingApprovals.map(\.message.id), ["approval-a"])
+        XCTAssertEqual(WaitingThreadStub.requests.map { $0.url!.path }, [
+            "/api/bots", "/api/threads/thread-a/messages",
+        ], "Only the waiting background thread needs a bounded page, not every task.")
+        let pageRequest = try XCTUnwrap(WaitingThreadStub.requests.last)
+        XCTAssertEqual(pageRequest.httpMethod, "GET")
+        XCTAssertEqual(pageRequest.value(forHTTPHeaderField: "Authorization"), "Bearer fixture-token")
+        XCTAssertEqual(URLComponents(url: pageRequest.url!, resolvingAgainstBaseURL: false)?.queryItems,
+                       [URLQueryItem(name: "limit", value: "50")])
+        XCTAssertEqual(state.hasMore["thread-a"], true)
+        XCTAssertEqual(state.activeLeafIds["thread-a"], "approval-a")
+    }
+
+    func testAnotherDeviceAnswersWhileTheBackgroundPageIsLoading() async throws {
+        WaitingThreadStub.responses["/api/threads/thread-a/messages"] = (200, Data(
+            Self.pendingPage.replacingOccurrences(of: "\"tool\":\"Bash\"", with: "\"tool\":\"Bash\",\"answered\":\"Allow\"").utf8
+        ))
+        let snapshot = try await client.fleetForHydration()
+        var state = CompanionState()
+        state.hydrate(snapshot.fleet, waitingThreads: snapshot.waitingThreads)
+        XCTAssertTrue(state.pendingApprovals.isEmpty, "The fresh page, not the older activity label, decides whether a card is actionable.")
+    }
+
+    func testReconnectDoesNotKeepAStaleBackgroundApproval() async throws {
+        let first = try await client.fleetForHydration()
+        var state = CompanionState()
+        state.hydrate(first.fleet, waitingThreads: first.waitingThreads)
+        XCTAssertEqual(state.pendingApprovals.count, 1)
+
+        WaitingThreadStub.requests = []
+        WaitingThreadStub.responses["/api/bots"] = (200, Data(
+            Self.fleetJSON.replacingOccurrences(of: "waiting-on-you", with: "idle").utf8
+        ))
+        let refreshed = try await client.fleetForHydration()
+        state.hydrate(refreshed.fleet, waitingThreads: refreshed.waitingThreads)
+        XCTAssertTrue(state.pendingApprovals.isEmpty)
+        XCTAssertNil(state.messages["thread-a"])
+        XCTAssertEqual(WaitingThreadStub.requests.map { $0.url!.path }, ["/api/bots"])
+    }
+
+    func testPageFailureDoesNotCommitAPartialSnapshotOrAdvanceTheCursor() async throws {
+        let first = try await client.fleetForHydration()
+        var state = CompanionState()
+        state.hydrate(first.fleet, waitingThreads: first.waitingThreads)
+        state.resetCursor("before-refresh")
+        WaitingThreadStub.responses["/api/threads/thread-a/messages"] = (503, Data(#"{"error":"offline"}"#.utf8))
+        do {
+            let refreshed = try await client.fleetForHydration()
+            state.hydrate(refreshed.fleet, waitingThreads: refreshed.waitingThreads)
+            state.resetCursor("incomplete-refresh")
+            XCTFail("A missing pending page must not look like a successful empty inbox.")
+        } catch APIError.status(let code, _) {
+            XCTAssertEqual(code, 503)
+        }
+        XCTAssertEqual(state.cursor, "before-refresh")
+        XCTAssertEqual(state.pendingApprovals.map(\.message.id), ["approval-a"])
+    }
+
+    func testOlderComputersWithoutTaskActivityStillHydrate() async throws {
+        WaitingThreadStub.responses["/api/bots"] = (200, Data(
+            Self.fleetJSON.replacingOccurrences(of: ",\"activity\":\"waiting-on-you\"", with: "").utf8
+        ))
+        let snapshot = try await client.fleetForHydration()
+        XCTAssertEqual(snapshot.fleet.bots.count, 1)
+        XCTAssertTrue(snapshot.waitingThreads.isEmpty)
+        XCTAssertEqual(WaitingThreadStub.requests.map { $0.url!.path }, ["/api/bots"])
+    }
+
+    func testCancelledHydrationDoesNotStartRequests() async throws {
+        let client = try XCTUnwrap(client)
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await client.fleetForHydration()
+        }
+        do {
+            _ = try await task.value
+            XCTFail("Cancelled refresh must not publish another computer's state.")
+        } catch is CancellationError {}
+        XCTAssertTrue(WaitingThreadStub.requests.isEmpty)
+    }
+
+    private static let fleetJSON = #"""
+    {"bots":[{
+      "id":"bot-1","threadId":"thread-b","name":"Scout","title":"Researcher",
+      "description":"Finds evidence.","notifications":true,"color":"blue","unread":true,
+      "modelSelection":{"instanceId":"codex","model":"default"},"createdAt":1,"busy":true,
+      "tasks":[
+        {"threadId":"thread-a","title":"A","createdAt":1,"activity":"waiting-on-you","busy":true},
+        {"threadId":"thread-b","title":"B","createdAt":2,"activity":"working","busy":true},
+        {"threadId":"thread-idle","title":"Idle","createdAt":3,"activity":"idle","busy":false},
+        {"threadId":"thread-running","title":"Running","createdAt":4,"activity":"working","busy":true}
+      ],
+      "messages":[{"id":"selected","role":"user","kind":"text","at":1,"text":"Current thread"}]
+    }],"groups":[]}
+    """#
+
+    private static let pendingPage = #"""
+    {"messages":[
+      {"id":"root-a","role":"user","kind":"text","at":1,"text":"Run task A"},
+      {"id":"approval-a","role":"bot","kind":"options","parentId":"root-a","at":2,
+       "card":{"title":"Approval needed","subtitle":"Run task A","options":["Allow","Deny"],"requestId":"request-a","tool":"Bash"}}
+    ],"hasMore":true,"activeLeafId":"approval-a"}
+    """#
+}

--- a/ios/Widgets/OpenMausWidgets.swift
+++ b/ios/Widgets/OpenMausWidgets.swift
@@ -42,8 +42,8 @@ struct BotActivityWidget: Widget {
                     .padding(.top, 2)
                 }
                 DynamicIslandExpandedRegion(.bottom) {
-                    if context.state.kind == "needsYou", let requestId = context.state.requestId, !context.state.options.isEmpty {
-                        AnswerButtons(context: context, requestId: requestId)
+                    if let threadId = context.state.approvalThreadId, let requestId = context.state.requestId {
+                        AnswerButtons(context: context, threadId: threadId, requestId: requestId)
                             .padding(.top, 4)
                     }
                 }
@@ -96,8 +96,8 @@ private struct LockScreenView: View {
                     .font(.system(size: 13))
                     .foregroundStyle(.white.opacity(0.7))
                     .lineLimit(2)
-                if context.state.kind == "needsYou", let requestId = context.state.requestId, !context.state.options.isEmpty {
-                    AnswerButtons(context: context, requestId: requestId)
+                if let threadId = context.state.approvalThreadId, let requestId = context.state.requestId {
+                    AnswerButtons(context: context, threadId: threadId, requestId: requestId)
                         .padding(.top, 4)
                 }
             }
@@ -110,13 +110,14 @@ private struct LockScreenView: View {
 /// The card's options, as pills — exactly the options the card offered.
 private struct AnswerButtons: View {
     let context: ActivityViewContext<BotActivityAttributes>
+    let threadId: String
     let requestId: String
 
     var body: some View {
         HStack(spacing: 8) {
             ForEach(context.state.options, id: \.self) { option in
                 Button(intent: AnswerApprovalIntent(
-                    threadId: context.attributes.threadId,
+                    threadId: threadId,
                     requestId: requestId,
                     choice: option,
                     isPermission: context.state.isPermission

--- a/server/independent-threads-api.test.ts
+++ b/server/independent-threads-api.test.ts
@@ -21,7 +21,7 @@ describe("independent bot tasks through the isolated control surface", () => {
       method, headers: { "content-type": "application/json", ...(fromApp ? { origin: session.info.url } : {}) },
       ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
     });
-    if (method !== "GET") evidence.push({ method, path, body, status: response.status });
+    if (method !== "GET") evidence.push({ method, path, ...(path.startsWith("/api/auth/") ? {} : { body }), status: response.status });
     return { status: response.status, body: await response.json() as any };
   };
   const tool = async (name: string, args: Record<string, unknown>) => {
@@ -120,6 +120,58 @@ describe("independent bot tasks through the isolated control surface", () => {
     expect(readFileSync(project, "utf8")).toBe("Generated project files are retained.");
     evidence.push({ cappedTitleLength: 80, blankMemoryReplacementRejected: true, generatedFilesRetained: true });
   }, 30_000);
+
+  it("exposes background waiting threads and pins paired approval answers to the displayed request", async () => {
+    const created = await tool("create_bot", { name: "Phone approval fixture", instance_id: "claude", model: models[0] });
+    const botId = created.bot.id;
+    const threadA = created.bot.activeTaskId;
+    await api("PATCH", `/api/bots/${botId}/tasks/${threadA}`, { approvalMode: "ask" });
+    await control(["send", "--bot", botId, "--task", threadA, "--text", "Hold thread A for approval"]);
+    const answersA = await permission(models[0], "phone-approval-a");
+
+    const second = await tool("create_task", { target_type: "bot", target_id: botId, title: "Phone background B" });
+    const threadB = second.task.taskId;
+    await control(["set-model", "--bot", botId, "--task", threadB, "--instance", "claude", "--model", models[1]]);
+    await api("PATCH", `/api/bots/${botId}/tasks/${threadB}`, { approvalMode: "ask" });
+    await control(["send", "--bot", botId, "--task", threadB, "--text", "Hold thread B for approval"]);
+    const answersB = await permission(models[1], "phone-approval-b");
+    await expect.poll(async () => (await botState(botId)).tasks.filter((task: any) => task.activity === "waiting-on-you").length).toBe(2);
+    await tool("switch_task", { target_type: "bot", target_id: botId, task_id: threadA });
+
+    const invitation = await api("POST", "/api/auth/pairing", { label: "Isolated iOS approval fixture", scopes: ["client", "admin"] });
+    expect(invitation.status).toBe(200);
+    const accepted = await api("POST", "/api/auth/pair", { code: invitation.body.code, label: "Isolated iOS client" });
+    expect(accepted.status).toBe(200);
+    const paired = async (method: string, path: string, body?: unknown) => {
+      const response = await fetch(`${session.info.url}${path}`, {
+        method, headers: { "content-type": "application/json", authorization: `Bearer ${accepted.body.token}` },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      });
+      return { status: response.status, body: await response.json() as any };
+    };
+    const fleet = await paired("GET", "/api/bots?messages=50");
+    const bot = fleet.body.bots.find((candidate: any) => candidate.id === botId);
+    expect(bot.threadId).toBe(threadA);
+    expect(bot.tasks.find((task: any) => task.threadId === threadB)?.activity).toBe("waiting-on-you");
+    expect(bot.messages.some((message: any) => message.card?.requestId === "phone-approval-b")).toBe(false);
+    const background = await paired("GET", `/api/threads/${threadB}/messages?limit=50`);
+    expect(background.body.messages.some((message: any) => message.card?.requestId === "phone-approval-b" && !message.card.answered)).toBe(true);
+
+    // A stale island's immutable A target must never authorize B's request.
+    const stale = await paired("POST", `/api/threads/${threadA}/respond`, { requestId: "phone-approval-b", behavior: "allow" });
+    expect(stale.body.outcome).toBe("unavailable");
+    expect(answersA).toEqual([]);
+    expect(answersB).toEqual([]);
+    const answered = await paired("POST", `/api/threads/${threadB}/respond`, { requestId: "phone-approval-b", behavior: "allow" });
+    expect(answered.status).toBe(200);
+    expect(answered.body.outcome).toBe("allowed-once");
+    await expect.poll(() => answersB.some((answer) => answer.id === "phone-approval-b")).toBe(true);
+    expect(answersA).toEqual([]);
+    expect((await botState(botId)).tasks.find((task: any) => task.taskId === threadA)?.activity).toBe("waiting-on-you");
+    evidence.push({ phoneApproval: { botId, threadA, threadB, backgroundActivity: "waiting-on-you", staleOutcome: stale.body.outcome, displayedOutcome: answered.body.outcome } });
+    await control(["interrupt", "--bot", botId, "--task", threadA]);
+    await control(["interrupt", "--bot", botId, "--task", threadB]);
+  }, 45_000);
 
   it("keeps A and B independent across selection, models, approvals, and stopping A", async () => {
     const created = await tool("create_bot", { name: "Independent fixture", instance_id: "claude", model: models[0] });


### PR DESCRIPTION
## Summary
- Route lock-screen and Dynamic Island approval buttons to the current thread and request, even when one bot has multiple running threads. Refuse stale or legacy button payloads instead of falling back to the original thread.
- On cold reconnect, restore pending approvals from background threads using the existing waiting-on-you task state. Commit only after every required page loads, and reject cancelled or replaced connections.
- Reject a refresh snapshot when newer stream events arrived during the fetch, retry once, and preserve the newer state on repeated contention.
- Keep skill approvals in chat, where their contents can be reviewed. No server runtime changes or new dependencies.

## Verification
- 362 Swift CompanionCore tests pass, including 7 activity-targeting and 8 background-hydration regressions.
- iOS app and widget build successfully for the simulator.
- 10 isolated independent-thread and paired-approval HTTP tests pass, including wrong-thread rejection and independent approval resolution.
- TypeScript typecheck, scoped lint, and whitespace checks pass.
- No live phone or user data was modified; physical-device UI was not exercised.

## Distribution
The maintainer will publish the updated iOS app through TestFlight. This PR does not trigger a desktop release or a TestFlight upload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Approval requests can now appear and remain actionable when they originate from background conversation threads.
  * Approval actions are linked to the correct conversation, including when multiple requests are pending.
  * Live Activity approval buttons now support questions and permission requests with their exact choices.

* **Bug Fixes**
  * Prevented stale or mismatched approval actions from being applied to the wrong request.
  * Improved session refresh reliability when conversation data changes during loading.
  * Prevented outdated refresh results from overwriting newer app state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->