### PR TITLE
fix(chat): resolve message direction per block so RTL content renders correctly

### DIFF
--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -58,6 +58,9 @@ instructions, history restore, skill/memory refresh, and stale-response isolatio
 The [independent threads fixture](threads.md) checks nested sidebar navigation,
 per-thread models, simultaneous direct conversations and thread-scoped Stop.
 
+The [right-to-left fixture](bidi.md) checks per-block direction in bot replies
+and per-line direction in sent turns, with code pinned left-to-right.
+
 The [routines fixture](routines.md) checks confirmed proposals, manual and
 scheduled runs, central run logs, List/Calendar views, and bot-scoped routines
 using the real renderer and an isolated fake-engine server.

--- a/docs/verification/bidi.md
+++ b/docs/verification/bidi.md
@@ -18,8 +18,10 @@ these checks. What is being verified is content direction, per block.
 
 ## Check the real UI
 
-1. The sent bubble must resolve **per line**: the Arabic lines sit right, the
-   English line between them sits left. One line must not decide for the rest.
+1. The sent bubble must resolve **per line**: the Arabic and Hebrew lines sit
+   right, the English line between them sits left. One line must not decide
+   for the rest. The inner element holding the text must have `chat-text`:
+   `unicode-bidi` does not inherit from the outer bubble.
 2. In the Arabic reply, the heading, paragraphs, list and quote all read
    right-to-left — bullets on the right, the quote's rule on the right.
 3. Its table's columns run right-to-left, and every header sits over its own
@@ -42,7 +44,7 @@ catch that regression.
 ## Permanent regression checks
 
 ```sh
-pnpm exec vitest run src/components/ChatMarkdown.test.ts
+pnpm exec vitest run src/components/ChatMarkdown.test.ts src/components/ChatView.controls.test.ts
 ```
 
 These cover first-strong-character resolution, per-block direction, the

--- a/docs/verification/bidi.md
+++ b/docs/verification/bidi.md
@@ -1,0 +1,53 @@
+# Right-to-left message content
+
+Launch the real renderer and server with only an offline provider and a
+disposable data directory:
+
+```sh
+node --experimental-strip-types scripts/verify-bidi.ts
+```
+
+Open the printed `previewUrl`. The fixture seeds Probe with one thread holding
+a multi-line user turn that mixes Arabic and English lines, an Arabic reply
+covering every block a bot answer can contain, and an English reply that ends
+on an Arabic paragraph.
+
+Message text is written in the user's or the model's language, which is
+independent of the UI language: the app chrome stays left-to-right throughout
+these checks. What is being verified is content direction, per block.
+
+## Check the real UI
+
+1. The sent bubble must resolve **per line**: the Arabic lines sit right, the
+   English line between them sits left. One line must not decide for the rest.
+2. In the Arabic reply, the heading, paragraphs, list and quote all read
+   right-to-left — bullets on the right, the quote's rule on the right.
+3. Its table's columns run right-to-left, and every header sits over its own
+   data. A header drifting to the opposite edge from its column means cells
+   are resolving individually instead of inheriting the table.
+4. Its fenced block and inline spans stay left-to-right inside the RTL
+   paragraphs, and `buildIndex()` does not reorder the sentence holding it.
+5. The English paragraph closing that same Arabic reply reads left-to-right on
+   its own. In the second reply the relationship inverts: an English answer
+   ends on an Arabic paragraph that must align right.
+6. Type both scripts in the composer. The field follows what is being written,
+   so a message reads the same while typed as after it is sent.
+
+Direction is resolved from each block's own text rather than delegated to
+HTML's `dir="auto"`, which ignores any descendant carrying its own `dir` — a
+quote or a table whose children each resolved their own direction would find
+no text left to judge and fall back to the app's LTR. Checks 2 and 3 are what
+catch that regression.
+
+## Permanent regression checks
+
+```sh
+pnpm exec vitest run src/components/ChatMarkdown.test.ts
+```
+
+These cover first-strong-character resolution, per-block direction, the
+table's single direction, logical box properties, and code pinned
+left-to-right and isolated.
+
+Stop the foreground launcher with Ctrl-C. It closes only its own UI/server and
+deletes its disposable home; the printed server log remains available.

--- a/scripts/verify-bidi.ts
+++ b/scripts/verify-bidi.ts
@@ -93,6 +93,7 @@ try {
     "شغّل الاختبارات وقل لي أين المشكلة",
     "Then run pnpm typecheck and paste the output",
     "وبعدها ارفع الفرع",
+    "שלום עולם",
   ].join("\n")]);
   await control(["wait", "--bot", probe.id, "--timeout", "30"]);
   await control(["send", "--bot", probe.id, "--text", "Now summarise that in English"]);

--- a/scripts/verify-bidi.ts
+++ b/scripts/verify-bidi.ts
@@ -1,0 +1,121 @@
+// Right-to-left message rendering in the real app, one disposable home.
+//
+// A unit test can only prove the markup; whether an Arabic answer actually
+// reads correctly is a question about the rendered bubble. This seeds a
+// scripted reply that exercises every block a bot reply can contain — prose
+// around inline code, a list, a table, a quote, a fenced block, and a trailing
+// English paragraph — and mounts the real renderer against it.
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { createServer } from "vite";
+import { launchVerificationServer, runControlOmb } from "./control-omb.ts";
+
+const ARABIC_REPLY = [
+  "## تقرير الأداء الأسبوعي",
+  "",
+  "راجعت الملفات الثلاثة، والنتيجة أن `buildIndex()` هي المسؤولة عن التأخير الأكبر — تستهلك 340ms من أصل 512ms.",
+  "",
+  "الأسباب الرئيسية:",
+  "",
+  "- استدعاء `fs.readFileSync` داخل الحلقة بدل قراءة واحدة مسبقة",
+  "- عدم وجود cache للنتائج بين الاستدعاءات المتتالية",
+  "- تمرير المصفوفة كاملة إلى `sort()` في كل مرة (المشكلة الأهم)",
+  "",
+  "| الدالة | الزمن | النسبة |",
+  "| --- | --- | --- |",
+  "| buildIndex | 340ms | 66% |",
+  "| parseHeaders | 118ms | 23% |",
+  "| flush | 54ms | 11% |",
+  "",
+  "> ملاحظة: القياسات أُخذت على macOS مع Node 24، وقد تختلف على Linux.",
+  "",
+  "الإصلاح المقترح في `src/lib/index.ts`:",
+  "",
+  "```ts",
+  "// hoist the read out of the loop and memoize per content hash",
+  "const cache = new Map<string, Index>();",
+  "",
+  "export function buildIndex(paths: string[]): Index {",
+  "  const hit = cache.get(paths.join(\"|\"));",
+  "  if (hit) return hit;",
+  "  return merge(paths.map((p) => readFileSync(p, \"utf8\")).map(parse));",
+  "}",
+  "```",
+  "",
+  "And here is an English paragraph closing the same reply — it must stay left-to-right on its own, independently of every block above it.",
+].join("\n");
+
+const ENGLISH_REPLY = [
+  "## Weekly performance report",
+  "",
+  "`buildIndex()` owns the delay: 340ms of 512ms. Fix it in `src/lib/index.ts`.",
+  "",
+  "- hoist the read out of the loop",
+  "- memoize per content hash",
+  "",
+  "وهذه فقرة عربية تُغلق ردًّا إنجليزيًّا — يجب أن تُقرأ من اليمين وحدها.",
+].join("\n");
+
+const fixture = await launchVerificationServer();
+let ui: Awaited<ReturnType<typeof createServer>> | undefined;
+try {
+  const api = async (method: string, path: string, body?: unknown) => {
+    const response = await fetch(`${fixture.info.url}${path}`, {
+      method, headers: { "content-type": "application/json" },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    const result = await response.json();
+    if (!response.ok) throw new Error(`${method} ${path}: ${JSON.stringify(result)}`);
+    return result;
+  };
+  const control = (args: string[]) => runControlOmb([...args, "--url", fixture.info.url]);
+
+  await control(["new-bot", "--name", "Probe"]);
+  const { bots } = await api("GET", "/api/bots?messages=0");
+  const probe = bots.find((bot: { name: string }) => bot.name === "Probe");
+
+  // Each turn spawns a fresh CLI, so the reply cursor lives in a file inside
+  // this fixture's own home rather than in the process.
+  const replyState = join(fixture.info.dataDir, "bidi-reply-cursor");
+  const wrapper = join(fixture.info.dataDir, "bidi-claude.mjs");
+  writeFileSync(wrapper, [
+    "#!/usr/bin/env node",
+    `process.env.FAKE_CLAUDE_REPLIES = ${JSON.stringify(JSON.stringify([ARABIC_REPLY, ENGLISH_REPLY]))};`,
+    `process.env.FAKE_CLAUDE_REPLY_STATE = ${JSON.stringify(replyState)};`,
+    `await import(${JSON.stringify(pathToFileURL(fileURLToPath(new URL("../server/testing/fake-claude-cli.ts", import.meta.url))).href)});`,
+  ].join("\n"), { mode: 0o700 });
+  await api("PATCH", "/api/instances/claude", { cli: wrapper });
+
+  // A multi-line user turn that mixes scripts: the sent bubble must resolve
+  // each line on its own, not let the first line decide for all of them.
+  await control(["send", "--bot", probe.id, "--text", [
+    "شغّل الاختبارات وقل لي أين المشكلة",
+    "Then run pnpm typecheck and paste the output",
+    "وبعدها ارفع الفرع",
+  ].join("\n")]);
+  await control(["wait", "--bot", probe.id, "--timeout", "30"]);
+  await control(["send", "--bot", probe.id, "--text", "Now summarise that in English"]);
+  await control(["wait", "--bot", probe.id, "--timeout", "30"]);
+
+  ui = await createServer({
+    root: fileURLToPath(new URL("..", import.meta.url)),
+    server: { host: "127.0.0.1", port: 0, proxy: { "/api": { target: fixture.info.url } } },
+    plugins: [{ name: "isolated-bidi", configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (req.url !== "/__bidi.html") return next();
+        void server.transformIndexHtml(req.url, '<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>Isolated OpenMaus Bidi</title></head><body><div id="root"></div><script type="module" src="/scripts/testing/threads-preview.tsx"></script></body></html>')
+          .then((html) => { res.setHeader("content-type", "text/html"); res.end(html); }).catch(next);
+      });
+    } }],
+  });
+  await ui.listen();
+  console.log(JSON.stringify({ ...fixture.info, previewUrl: `${ui.resolvedUrls!.local[0]}__bidi.html` }));
+  await new Promise<void>((resolve) => {
+    process.once("SIGINT", resolve);
+    process.once("SIGTERM", resolve);
+  });
+} finally {
+  await ui?.close();
+  await fixture.close();
+}

--- a/src/components/ChatMarkdown.test.ts
+++ b/src/components/ChatMarkdown.test.ts
@@ -10,6 +10,7 @@ import {
   markdownImageName,
   markdownImageOpenUrl,
   localFilePath,
+  textDirection,
 } from "./ChatMarkdown";
 
 vi.mock("react", async (importOriginal) => {
@@ -228,5 +229,93 @@ describe("ChatMarkdown code blocks", () => {
     expect(html).toContain('aria-label="Copy code to clipboard"');
     expect(html).toContain('aria-label="Wrap long lines"');
     expect(html).toContain("line1\nline2\nline3");
+  });
+});
+
+describe("bidi: message content carries its own direction", () => {
+  const ARABIC = "مرحبا بالعالم";
+
+  it("reads direction from the first strong letter, ignoring weak characters", () => {
+    expect(textDirection("مرحبا")).toBe("rtl");
+    expect(textDirection("hello")).toBe("ltr");
+    expect(textDirection("")).toBe("ltr");
+    // digits, punctuation and emoji are directionally weak — keep scanning
+    expect(textDirection("  «2024» — مرحبا hello")).toBe("rtl");
+    expect(textDirection("🎉 42. hello مرحبا")).toBe("ltr");
+    expect(textDirection("שלום")).toBe("rtl");
+  });
+
+  it("gives every block its own direction instead of the UI's", () => {
+    const html = renderToStaticMarkup(createElement(ChatMarkdown, {
+      text: [
+        `# ${ARABIC}`,
+        "",
+        `${ARABIC} paragraph`,
+        "",
+        "An English paragraph stays left-to-right.",
+        "",
+        `> ${ARABIC}`,
+        "",
+        `- ${ARABIC}`,
+        "",
+        `| ${ARABIC} | b |`,
+        "| --- | --- |",
+        `| ${ARABIC} | 2 |`,
+      ].join("\n"),
+    }));
+
+    expect(html).toContain('<div dir="rtl" class="mt-2 text-[16px] font-semibold">');
+    expect(html).toContain('<p dir="rtl">');
+    expect(html).toContain('<p dir="ltr">An English paragraph');
+    expect(html).toContain('<blockquote dir="rtl"');
+    expect(html).toContain('<ul dir="rtl"');
+    expect(html).toContain('<table dir="rtl"');
+  });
+
+  it("keeps a table on one direction so columns and cells stay aligned", () => {
+    // cells must NOT resolve individually: an Arabic header over a Latin
+    // column would hang off the opposite edge from its own data
+    const html = renderToStaticMarkup(createElement(ChatMarkdown, {
+      text: `| ${ARABIC} | ms |\n| --- | --- |\n| buildIndex | 340 |`,
+    }));
+    expect(html).toContain('<table dir="rtl"');
+    expect(html).not.toContain("<th dir=");
+    expect(html).not.toContain("<td dir=");
+  });
+
+  it("judges a block by its prose, not by the code inside it", () => {
+    const html = renderToStaticMarkup(createElement(ChatMarkdown, {
+      text: `\`fs.readFileSync\` ${ARABIC} داخل الحلقة`,
+    }));
+    expect(html).toContain('<p dir="rtl">');
+  });
+
+  it("uses logical box properties so indents and rules follow the text", () => {
+    const html = renderToStaticMarkup(createElement(ChatMarkdown, {
+      text: `- ${ARABIC}\n\n1. ${ARABIC}\n\n> ${ARABIC}\n\n| a |\n| --- |\n| b |`,
+    }));
+
+    expect(html).toContain("list-disc space-y-1 ps-5");
+    expect(html).toContain("list-decimal space-y-1 ps-5");
+    expect(html).toContain("border-s-2 border-hairline ps-3");
+    expect(html).toContain("px-2 py-1.5 text-start font-semibold");
+    expect(html).not.toMatch(/class="[^"]*\bpl-5\b/);
+    expect(html).not.toMatch(/class="[^"]*\bborder-l-2\b/);
+    expect(html).not.toMatch(/class="[^"]*\btext-left\b/);
+  });
+
+  it("pins code left-to-right and isolates it from the surrounding RTL text", () => {
+    const inline = renderToStaticMarkup(createElement(ChatMarkdown, {
+      text: `${ARABIC} \`items[0].name\` ${ARABIC}`,
+    }));
+    expect(inline).toContain('<code dir="ltr"');
+    expect(inline).toContain("[unicode-bidi:isolate]");
+
+    const fenced = renderToStaticMarkup(createElement(CodeBlock, {
+      code: "const total = items[0].count + 1;",
+      lang: "ts",
+      streaming: false,
+    }));
+    expect(fenced).toContain('<div dir="ltr"');
   });
 });

--- a/src/components/ChatMarkdown.test.ts
+++ b/src/components/ChatMarkdown.test.ts
@@ -243,10 +243,20 @@ describe("bidi: message content carries its own direction", () => {
     expect(textDirection("  «2024» — مرحبا hello")).toBe("rtl");
     expect(textDirection("🎉 42. hello مرحبا")).toBe("ltr");
     expect(textDirection("שלום")).toBe("rtl");
-    // scripts in living use beyond the obvious two
-    expect(textDirection("\u{10D00}\u{10D01}")).toBe("rtl"); // Hanifi Rohingya
+    // the ranges have to hold for every RTL script, not a maintained list:
+    // these span all four blocks Unicode reserves for right-to-left letters
+    expect(textDirection("\u0780")).toBe("rtl"); // Thaana
+    expect(textDirection("\u07CA")).toBe("rtl"); // N'Ko
+    expect(textDirection("\uFB2E")).toBe("rtl"); // Hebrew presentation form
+    expect(textDirection("\u{10D00}")).toBe("rtl"); // Hanifi Rohingya
+    expect(textDirection("\u{10E80}")).toBe("rtl"); // Yezidi
+    expect(textDirection("\u{10D50}")).toBe("rtl"); // Garay (10D40 is a digit)
+    expect(textDirection("\u{10F70}")).toBe("rtl"); // Old Uyghur
     expect(textDirection("\u{1E900}")).toBe("rtl"); // Adlam
-    expect(textDirection("\u{0780}")).toBe("rtl"); // Thaana
+    // and must not swallow the LTR scripts that sit near those blocks
+    expect(textDirection("\u{11000}\u{11005}")).toBe("ltr"); // Brahmi
+    expect(textDirection("\u0915")).toBe("ltr"); // Devanagari
+    expect(textDirection("\u4E2D")).toBe("ltr"); // Han
   });
 
   it("gives every block its own direction instead of the UI's", () => {

--- a/src/components/ChatMarkdown.test.ts
+++ b/src/components/ChatMarkdown.test.ts
@@ -243,6 +243,10 @@ describe("bidi: message content carries its own direction", () => {
     expect(textDirection("  «2024» — مرحبا hello")).toBe("rtl");
     expect(textDirection("🎉 42. hello مرحبا")).toBe("ltr");
     expect(textDirection("שלום")).toBe("rtl");
+    // scripts in living use beyond the obvious two
+    expect(textDirection("\u{10D00}\u{10D01}")).toBe("rtl"); // Hanifi Rohingya
+    expect(textDirection("\u{1E900}")).toBe("rtl"); // Adlam
+    expect(textDirection("\u{0780}")).toBe("rtl"); // Thaana
   });
 
   it("gives every block its own direction instead of the UI's", () => {
@@ -317,5 +321,30 @@ describe("bidi: message content carries its own direction", () => {
       streaming: false,
     }));
     expect(fenced).toContain('<div dir="ltr"');
+  });
+
+  it("gives links a base direction, not isolation alone", () => {
+    // isolate keeps a link from disturbing the sentence around it, but the
+    // link's own contents still lay out along its inherited direction — a URL
+    // in an RTL paragraph needs an LTR base of its own.
+    const url = renderToStaticMarkup(createElement(ChatMarkdown, {
+      text: `${ARABIC} <https://example.test/a/b?x=1> ${ARABIC}`,
+    }));
+    expect(url).toContain('dir="auto"');
+
+    // an Arabic label must not be pinned LTR, which is why the anchor
+    // resolves rather than hard-coding a direction
+    const labelled = renderToStaticMarkup(createElement(ChatMarkdown, {
+      text: `[${ARABIC}](https://example.test/a)`,
+    }));
+    expect(labelled).toContain('dir="auto"');
+
+    // a local path is always left-to-right, so that root is pinned. It needs
+    // a message context: without one the link degrades to a plain label.
+    const path = renderToStaticMarkup(createElement(ChatMarkdown, {
+      text: `${ARABIC} [report](/Users/maus/out/report.md) ${ARABIC}`,
+      message: { threadId: "thread-1", messageId: "message-1" },
+    }));
+    expect(path).toContain('<span dir="ltr"');
   });
 });

--- a/src/components/ChatMarkdown.tsx
+++ b/src/components/ChatMarkdown.tsx
@@ -116,17 +116,19 @@ function unwrapLinkedImages() {
 //
 // Code is skipped when judging: an answer that opens with `fs.readFileSync`
 // and continues in Arabic is an Arabic paragraph, not an English one.
-// Right-to-left scripts in living use. JS regexes cannot match on
-// Bidi_Class, so the scripts are named; historic ones (Phoenician, Old
-// Turkic, the Pahlavis) are left out deliberately — nobody writes messages
-// in them, and every name here costs a branch on the hot path.
-const RTL_SCRIPT = /[\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Adlam}\p{Script=Hanifi_Rohingya}\p{Script=Samaritan}\p{Script=Mandaic}]/u;
+// JS regexes cannot match on Bidi_Class, and naming scripts one at a time has
+// no end to it: Hanifi Rohingya, Yezidi, Garay and Old Uyghur are all
+// right-to-left, and Unicode keeps adding more. These are instead the blocks
+// Unicode reserves for right-to-left letters, so the set stays correct
+// without being maintained — and a plane-1 range is one comparison rather
+// than a property lookup.
+const RTL_LETTER = /[\u0590-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF\u{10800}-\u{10FFF}\u{1E800}-\u{1EFFF}]/u;
 
 /** Direction of `value`, from its first strong character (letters only —
  * digits and punctuation are directionally weak). Defaults to "ltr". */
 export function textDirection(value: string): "rtl" | "ltr" {
   const strong = /\p{Letter}/u.exec(value);
-  return strong && RTL_SCRIPT.test(strong[0]) ? "rtl" : "ltr";
+  return strong && RTL_LETTER.test(strong[0]) ? "rtl" : "ltr";
 }
 
 interface HastNode {

--- a/src/components/ChatMarkdown.tsx
+++ b/src/components/ChatMarkdown.tsx
@@ -116,7 +116,11 @@ function unwrapLinkedImages() {
 //
 // Code is skipped when judging: an answer that opens with `fs.readFileSync`
 // and continues in Arabic is an Arabic paragraph, not an English one.
-const RTL_SCRIPT = /[\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Adlam}\p{Script=Samaritan}\p{Script=Mandaic}]/u;
+// Right-to-left scripts in living use. JS regexes cannot match on
+// Bidi_Class, so the scripts are named; historic ones (Phoenician, Old
+// Turkic, the Pahlavis) are left out deliberately — nobody writes messages
+// in them, and every name here costs a branch on the hot path.
+const RTL_SCRIPT = /[\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Adlam}\p{Script=Hanifi_Rohingya}\p{Script=Samaritan}\p{Script=Mandaic}]/u;
 
 /** Direction of `value`, from its first strong character (letters only —
  * digits and punctuation are directionally weak). Defaults to "ltr". */
@@ -345,7 +349,7 @@ function LocalFileLink({ filePath, children, message }: { filePath: string; chil
         : null;
 
   return (
-    <span className="inline-flex flex-wrap items-center gap-x-1.5 [unicode-bidi:isolate]">
+    <span dir="ltr" className="inline-flex flex-wrap items-center gap-x-1.5 [unicode-bidi:isolate]">
       <button
         type="button"
         onClick={() => void save.save()}
@@ -492,6 +496,7 @@ function ChatMarkdownComponent({ text, streaming = false, message }: { text: str
                 href={href}
                 target="_blank"
                 rel="noreferrer"
+                dir="auto"
                 className="break-words text-accent underline decoration-accent/40 hover:decoration-accent [unicode-bidi:isolate]"
               >
                 {children}

--- a/src/components/ChatMarkdown.tsx
+++ b/src/components/ChatMarkdown.tsx
@@ -7,6 +7,14 @@
 // fence is very likely complete), then highlights and caches — so the settled
 // bubble, a fresh component instance, mounts straight from cache instead of
 // popping from plain to highlighted.
+//
+// Bidi: message text is written in the user's or the model's language, which
+// is independent of the UI language, so every block resolves its own
+// direction from its own first strong character — one Arabic paragraph reads
+// right-to-left while the English one under it does not. Code is the
+// exception: fenced blocks and inline spans pin dir="ltr" and isolate
+// themselves, so a snippet never reorders and never scrambles the RTL
+// sentence holding it.
 import { memo, useEffect, useRef, useState, type ReactNode } from "react";
 import Markdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -97,6 +105,49 @@ function unwrapLinkedImages() {
     };
     visit(tree);
   };
+}
+
+// Direction is resolved here rather than delegated to HTML's dir="auto",
+// because that algorithm skips any descendant carrying its own dir: a
+// <blockquote dir="auto"> whose paragraphs each resolve their own direction
+// finds no text left to judge and silently falls back to the app's LTR,
+// putting its rule on the left of right-to-left prose. Same trap for a table
+// whose cells resolve individually — the columns never reverse.
+//
+// Code is skipped when judging: an answer that opens with `fs.readFileSync`
+// and continues in Arabic is an Arabic paragraph, not an English one.
+const RTL_SCRIPT = /[\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Adlam}\p{Script=Samaritan}\p{Script=Mandaic}]/u;
+
+/** Direction of `value`, from its first strong character (letters only —
+ * digits and punctuation are directionally weak). Defaults to "ltr". */
+export function textDirection(value: string): "rtl" | "ltr" {
+  const strong = /\p{Letter}/u.exec(value);
+  return strong && RTL_SCRIPT.test(strong[0]) ? "rtl" : "ltr";
+}
+
+interface HastNode {
+  type?: string;
+  tagName?: string;
+  value?: string;
+  children?: HastNode[];
+}
+
+function blockText(node: HastNode | undefined): string {
+  if (!node) return "";
+  if (node.type === "text") return node.value ?? "";
+  if (node.tagName === "code" || node.tagName === "pre") return "";
+  return (node.children ?? []).map(blockText).join("");
+}
+
+/** Direction a rendered block adopts, read from its own text. */
+export function blockDirection(node: unknown): "rtl" | "ltr" {
+  return textDirection(blockText(node as HastNode));
+}
+
+/** Props react-markdown hands a block component we only re-tag. */
+interface BlockProps {
+  node?: unknown;
+  children?: ReactNode;
 }
 
 /** Props for the {@link CodeBlock} component. */
@@ -197,8 +248,10 @@ export function CodeBlock({ code, lang, streaming }: CodeBlockProps) {
   const displayLanguage = getLanguageDisplayName(lang);
   const lineCount = countLines(code);
 
+  // Code reads left-to-right whatever language surrounds it, so the block pins
+  // its own direction rather than inheriting the message's.
   return (
-    <div className="my-2 overflow-hidden rounded-lg border border-hairline/40 bg-inset">
+    <div dir="ltr" className="my-2 overflow-hidden rounded-lg border border-hairline/40 bg-inset">
       <div className="flex items-center justify-between gap-2 border-b border-hairline/30 bg-raised/30 px-3 py-1.5 text-xs">
         <div className="flex min-w-0 flex-1 items-center gap-2">
           <span title={displayLanguage} className="min-w-0 truncate rounded border border-hairline/40 bg-raised px-1.5 py-0.5 text-[11px] font-medium tracking-wide text-ink select-none">
@@ -292,13 +345,13 @@ function LocalFileLink({ filePath, children, message }: { filePath: string; chil
         : null;
 
   return (
-    <span className="inline-flex flex-wrap items-center gap-x-1.5">
+    <span className="inline-flex flex-wrap items-center gap-x-1.5 [unicode-bidi:isolate]">
       <button
         type="button"
         onClick={() => void save.save()}
         disabled={save.state === "saving"}
         title="Save a copy"
-        className="inline-flex items-center gap-1 break-words text-left text-accent underline decoration-accent/40 hover:decoration-accent disabled:cursor-wait"
+        className="inline-flex items-center gap-1 break-words text-start text-accent underline decoration-accent/40 hover:decoration-accent disabled:cursor-wait"
       >
         {children}
         {save.state === "saving" ? (
@@ -380,7 +433,7 @@ function Spoiler({ children }: { children?: ReactNode }) {
         aria-label="Hide spoiler"
         title="Hide spoiler"
         onClick={() => setRevealed(false)}
-        className="ml-1 rounded px-0.5 text-[11px] text-ink-secondary hover:text-ink"
+        className="ms-1 rounded px-0.5 text-[11px] text-ink-secondary hover:text-ink"
       >
         Hide
       </button>
@@ -428,7 +481,7 @@ function ChatMarkdownComponent({ text, streaming = false, message }: { text: str
           },
           code({ children }: { children?: ReactNode }) {
             return (
-              <code className="rounded bg-inset px-1 py-px text-[13px]">{children}</code>
+              <code dir="ltr" className="rounded bg-inset px-1 py-px text-[13px] [unicode-bidi:isolate]">{children}</code>
             );
           },
           a({ href, children }: { href?: string; children?: ReactNode }) {
@@ -439,54 +492,57 @@ function ChatMarkdownComponent({ text, streaming = false, message }: { text: str
                 href={href}
                 target="_blank"
                 rel="noreferrer"
-                className="break-words text-accent underline decoration-accent/40 hover:decoration-accent"
+                className="break-words text-accent underline decoration-accent/40 hover:decoration-accent [unicode-bidi:isolate]"
               >
                 {children}
               </a>
             );
           },
-          table({ children }: { children?: ReactNode }) {
+          table({ node, children }: BlockProps) {
             return (
               <div className="overflow-x-auto">
-                <table className="w-full border-collapse text-[13.5px]">{children}</table>
+                <table dir={blockDirection(node)} className="w-full border-collapse text-[13.5px]">{children}</table>
               </div>
             );
           },
           th({ children }: { children?: ReactNode }) {
             return (
-              <th className="border-b border-hairline/40 px-2 py-1.5 text-left font-semibold">{children}</th>
+              <th className="border-b border-hairline/40 px-2 py-1.5 text-start font-semibold">{children}</th>
             );
           },
           td({ children }: { children?: ReactNode }) {
             return <td className="border-b border-hairline/20 px-2 py-1.5 align-top">{children}</td>;
           },
-          ul({ children }: { children?: ReactNode }) {
-            return <ul className="list-disc space-y-1 pl-5">{children}</ul>;
+          p({ node, children }: BlockProps) {
+            return <p dir={blockDirection(node)}>{children}</p>;
           },
-          ol({ children }: { children?: ReactNode }) {
-            return <ol className="list-decimal space-y-1 pl-5">{children}</ol>;
+          ul({ node, children }: BlockProps) {
+            return <ul dir={blockDirection(node)} className="list-disc space-y-1 ps-5">{children}</ul>;
           },
-          h1({ children }: { children?: ReactNode }) {
-            return <div className="mt-2 text-[16px] font-semibold">{children}</div>;
+          ol({ node, children }: BlockProps) {
+            return <ol dir={blockDirection(node)} className="list-decimal space-y-1 ps-5">{children}</ol>;
           },
-          h2({ children }: { children?: ReactNode }) {
-            return <div className="mt-2 text-[15.5px] font-semibold">{children}</div>;
+          h1({ node, children }: BlockProps) {
+            return <div dir={blockDirection(node)} className="mt-2 text-[16px] font-semibold">{children}</div>;
           },
-          h3({ children }: { children?: ReactNode }) {
-            return <div className="mt-1.5 font-semibold">{children}</div>;
+          h2({ node, children }: BlockProps) {
+            return <div dir={blockDirection(node)} className="mt-2 text-[15.5px] font-semibold">{children}</div>;
           },
-          h4({ children }: { children?: ReactNode }) {
-            return <div className="mt-1.5 font-semibold">{children}</div>;
+          h3({ node, children }: BlockProps) {
+            return <div dir={blockDirection(node)} className="mt-1.5 font-semibold">{children}</div>;
           },
-          h5({ children }: { children?: ReactNode }) {
-            return <div className="mt-1.5 text-[14px] font-semibold">{children}</div>;
+          h4({ node, children }: BlockProps) {
+            return <div dir={blockDirection(node)} className="mt-1.5 font-semibold">{children}</div>;
           },
-          h6({ children }: { children?: ReactNode }) {
-            return <div className="mt-1.5 text-[13.5px] font-semibold text-ink-secondary">{children}</div>;
+          h5({ node, children }: BlockProps) {
+            return <div dir={blockDirection(node)} className="mt-1.5 text-[14px] font-semibold">{children}</div>;
           },
-          blockquote({ children }: { children?: ReactNode }) {
+          h6({ node, children }: BlockProps) {
+            return <div dir={blockDirection(node)} className="mt-1.5 text-[13.5px] font-semibold text-ink-secondary">{children}</div>;
+          },
+          blockquote({ node, children }: BlockProps) {
             return (
-              <blockquote className="border-l-2 border-hairline pl-3 text-ink-secondary">{children}</blockquote>
+              <blockquote dir={blockDirection(node)} className="border-s-2 border-hairline ps-3 text-ink-secondary">{children}</blockquote>
             );
           },
           del({ children }: { children?: ReactNode }) {

--- a/src/components/ChatView.controls.test.ts
+++ b/src/components/ChatView.controls.test.ts
@@ -43,6 +43,21 @@ const bot: Bot = {
 };
 
 describe("thread control placement", () => {
+  it.each([
+    "شغّل الاختبارات\nThen run typecheck\nوبعدها ارفع الفرع",
+    "שלום עולם\nThen run typecheck\nתודה רבה",
+    `${"مرحبا\n".repeat(10)}Then run typecheck`,
+  ])("applies per-line direction to the actual user text, including collapsed messages", (text) => {
+    const markup = renderToStaticMarkup(createElement(ChatView, { bot: {
+      ...bot,
+      messages: [{ id: "mixed-script", role: "user", kind: "text", at: 1, text }],
+    } }));
+    // unicode-bidi does not inherit: setting it on the bubble leaves this
+    // inner text block LTR. Keep the class directly on the node with prose.
+    expect(markup).toMatch(/<div class="chat-text[^"]*">(?:شغّل|שלום|مرحبا)/);
+    expect(markup).not.toMatch(/class="[^"]*chat-text[^"\n]*bg-bubble-user/);
+  });
+
   it("keeps the selected thread's model in the header and permissions inside the composer pill", () => {
     const markup = renderToStaticMarkup(createElement(ChatView, { bot }));
     expect(markup.match(/data-test-model-control/g)).toHaveLength(1);

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -224,7 +224,7 @@ class MessageBoundary extends Component<{ children: ReactNode; fallbackText: str
   render() {
     if (this.state.failed) {
       return (
-        <div className="w-fit max-w-[min(42rem,78%)] rounded-2xl bg-card px-4 py-2.5 text-[15px] leading-relaxed whitespace-pre-wrap text-ink">
+        <div className="chat-text w-fit max-w-[min(42rem,78%)] rounded-2xl bg-card px-4 py-2.5 text-[15px] leading-relaxed whitespace-pre-wrap text-ink">
           {this.props.fallbackText}
         </div>
       );
@@ -399,7 +399,7 @@ function Bubble({
             user && webhookView
               ? "overflow-hidden border border-accent/25 bg-card text-ink shadow-[0_10px_30px_rgba(0,0,0,0.18)]"
               : user
-                ? "bg-bubble-user px-4 py-2.5 whitespace-pre-wrap text-ink"
+                ? "chat-text bg-bubble-user px-4 py-2.5 whitespace-pre-wrap text-ink"
                 : "bg-card px-4 py-2.5 text-ink",
           )}
           title={new Date(message.at).toLocaleString()}
@@ -422,7 +422,7 @@ function Bubble({
                 <Webhook size={13} />
                 <span>{t("chat.webhookTask")}</span>
               </div>
-              <div className="px-4 py-3 whitespace-pre-wrap">{webhookView.task}</div>
+              <div className="chat-text px-4 py-3 whitespace-pre-wrap">{webhookView.task}</div>
               {webhookView.payload && (
                 <details className="border-t border-hairline/30 bg-inset/25 px-4 py-2.5 text-[11.5px] text-ink-secondary">
                   <summary className="cursor-pointer select-none hover:text-ink">{t("chat.viewPayload")}</summary>

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -399,7 +399,7 @@ function Bubble({
             user && webhookView
               ? "overflow-hidden border border-accent/25 bg-card text-ink shadow-[0_10px_30px_rgba(0,0,0,0.18)]"
               : user
-                ? "chat-text bg-bubble-user px-4 py-2.5 whitespace-pre-wrap text-ink"
+                ? "bg-bubble-user px-4 py-2.5 whitespace-pre-wrap text-ink"
                 : "bg-card px-4 py-2.5 text-ink",
           )}
           title={new Date(message.at).toLocaleString()}
@@ -440,7 +440,7 @@ function Bubble({
               )}
               {visibleText && (
                 <div
-                  className={cn(collapsible && "max-h-40 overflow-hidden [mask-image:linear-gradient(to_bottom,black_60%,transparent)]")}
+                  className={cn("chat-text", collapsible && "max-h-40 overflow-hidden [mask-image:linear-gradient(to_bottom,black_60%,transparent)]")}
                 >
                   {visibleText}
                 </div>

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -866,6 +866,8 @@ export function Composer({
           )}
           <textarea
           ref={inputRef}
+          // the message is composed in the writer's language, not the UI's
+          dir="auto"
           rows={1}
           value={text}
           onChange={(e) => {

--- a/src/components/ComposerQueuedMessages.tsx
+++ b/src/components/ComposerQueuedMessages.tsx
@@ -66,7 +66,7 @@ export function QueuedComposerMessages({
               className="shrink-0 text-ink-secondary"
               aria-hidden="true"
             />
-            <span className="min-w-0 flex-1 truncate text-[14px] text-ink" title={item.text}>
+            <span dir="auto" className="min-w-0 flex-1 truncate text-[14px] text-ink" title={item.text}>
               {item.text}
             </span>
             {index === 0 && onSteer && (

--- a/src/components/GroupView.tsx
+++ b/src/components/GroupView.tsx
@@ -270,7 +270,7 @@ const Transcript = memo(function Transcript({
                   className={cn(
                     "w-fit max-w-[min(42rem,78%)] rounded-2xl px-4 py-2.5 text-[15px] leading-relaxed",
                     !user && m.id === emergingId && "turn-answer",
-                    user ? "whitespace-pre-wrap bg-bubble-user text-ink" : "bg-card text-ink",
+                    user ? "chat-text whitespace-pre-wrap bg-bubble-user text-ink" : "bg-card text-ink",
                   )}
                   title={new Date(m.at).toLocaleString()}
                 >

--- a/src/components/ReplyQuote.tsx
+++ b/src/components/ReplyQuote.tsx
@@ -22,14 +22,14 @@ export function ReplyQuote({
       <MessageSquareReply size={compact ? 12 : 14} className="shrink-0 text-accent" />
       <span className="min-w-0 flex-1">
         <span className="block text-[10.5px] font-medium text-accent">{t("chat.reply.replyingTo", { name: replyAuthor(message, fallbackName) })}</span>
-        <span className="block truncate text-[11.5px] text-ink-secondary">{replySnippet(message.text ?? "")}</span>
+        <span dir="auto" className="block truncate text-[11.5px] text-ink-secondary">{replySnippet(message.text ?? "")}</span>
       </span>
     </>
   );
   return (
-    <div className="flex min-w-0 items-center gap-2 rounded-lg border-l-2 border-accent/60 bg-inset/70 px-2.5 py-1.5">
+    <div className="flex min-w-0 items-center gap-2 rounded-lg border-s-2 border-accent/60 bg-inset/70 px-2.5 py-1.5">
       {onJump ? (
-        <button type="button" onClick={onJump} className="flex min-w-0 flex-1 items-center gap-2 text-left" title={t("chat.reply.jump")}>
+        <button type="button" onClick={onJump} className="flex min-w-0 flex-1 items-center gap-2 text-start" title={t("chat.reply.jump")}>
           {body}
         </button>
       ) : (

--- a/src/styles.css
+++ b/src/styles.css
@@ -400,6 +400,18 @@
   color-scheme: var(--code-color-scheme);
 }
 
+/* Plain-text message bodies (user turns, webhook tasks, error fallbacks) are
+   written in whatever language the person used, which is independent of the
+   UI language. `plaintext` resolves direction per line from its own first
+   strong character, so a pasted block that mixes an Arabic sentence with an
+   English stack trace lays each line out correctly instead of letting the
+   first line decide for all of them — which is what a single dir="auto"
+   would do. `start` then follows that per-line direction. */
+.chat-text {
+  unicode-bidi: plaintext;
+  text-align: start;
+}
+
 html,
 body,
 #root {


### PR DESCRIPTION
## What

Message text is written in the user's or the model's language, which is
independent of the UI language. Today every block in a bubble inherits the
app's LTR, so an Arabic or Hebrew answer arrives broken: prose left-aligned
with its punctuation displaced, list markers and the blockquote rule on the
wrong side, and table columns in the wrong order.

This makes message **content** resolve its own direction, per block. The app's
own chrome is untouched — this is not UI localisation, and no RTL locale is
added here.

## How

- Every block in a rendered reply (`p`, headings, `ul`/`ol`, `blockquote`,
  `table`) resolves its direction from its own first strong character.
- Physical box properties around message content become logical ones:
  `pl-5` → `ps-5`, `border-l-2` → `border-s-2`, `text-left` → `text-start`.
- Code pins `dir="ltr"` and isolates itself — fenced blocks, inline spans,
  links and local file paths — so a snippet never reorders and never scrambles
  the RTL sentence holding it. Code is also skipped when judging a block, so a
  reply opening with `` `fs.readFileSync` `` and continuing in Arabic is still
  an Arabic paragraph.
- Plain-text bodies (user turns, webhook tasks, error fallbacks) use
  `unicode-bidi: plaintext`, which resolves **per line**: a pasted block mixing
  an Arabic sentence with an English stack trace lays each line out on its own
  rather than letting the first decide for all of them.
- The composer carries `dir="auto"`, so a message reads the same while it is
  typed as after it is sent.

### Why direction is computed rather than delegated to `dir="auto"`

This was the first implementation, and it does not work. HTML's `dir="auto"`
algorithm ignores any descendant carrying its own `dir`. A `<blockquote
dir="auto">` whose paragraphs each resolve their own direction has no text
left to judge, so it silently falls back to the app's LTR and puts its rule on
the left of right-to-left prose. A `<table dir="auto">` whose cells resolve
individually never reverses its columns, leaving every Arabic header hanging
off the opposite edge from its own data.

So `blockDirection()` reads each node's own text instead. Tables and lists
resolve once at the container and their cells and items inherit, which is what
keeps a header over its column and a marker on the same side as the indent
that makes room for it.

## Verification

`docs/verification/bidi.md` — the fixture scripts the offline provider with one
Arabic reply covering every block a bot answer can contain and one English
reply that ends on an Arabic paragraph, sends a user turn whose lines alternate
script, and mounts the real renderer against its own disposable home.

```sh
node --experimental-strip-types scripts/verify-bidi.ts
```

Confirmed in the real renderer: the sent bubble resolves per line; the Arabic
reply's bullets, quote rule and table columns all run right-to-left with each
header over its own data; its fenced and inline code stay left-to-right; the
English paragraph closing that reply reads left-to-right, and the Arabic
paragraph closing the English reply reads right-to-left.

Also `pnpm typecheck` (clean), `oxlint` (clean on touched files), and the full
`vitest run`: 404 files, 4908 passed / 39 skipped / 1 todo. Six new cases in
`src/components/ChatMarkdown.test.ts` cover first-strong-character resolution,
per-block direction, the table's single direction, logical box properties, and
code pinned left-to-right.

## Not in scope

- The iOS and Android companions render replies natively
  (`ios/App/MarkdownText.swift`, `android/.../ui/MarkdownText.kt`) and need the
  same treatment separately.
- No Arabic/Hebrew locale and no RTL app chrome; that is a much larger change
  and is deliberately kept out of this one.
- A **bare** filesystem path inside RTL prose still has its leading slash
  render at the far end of the path. That is the correct Unicode bidi result
  for an unisolated neutral character, not a regression; a path in backticks is
  fully isolated by this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved right-to-left and mixed-language text rendering across messages, Markdown, quotes, tables, lists, and composer input.
  * Automatically determines text direction per block or line while keeping code and inline snippets left-to-right.
  * Preserves whitespace and improves alignment for mixed-direction content.

* **Documentation**
  * Added verification guidance and a browser-based check for bidirectional text rendering.

* **Tests**
  * Added coverage for mixed-script direction handling across rendered content and multiline messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->