### PR TITLE
fix(pair): do not repeat the gate's ordinary no-session wording under the email form

### DIFF
--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { reasonWorthShowing } from "./session";
+
+describe("what the pair page says about why it was shown", () => {
+  it("stays quiet for the ordinary no-session case and repeats anything else", () => {
+    expect(reasonWorthShowing("forbidden: this request came through a proxy (pair this device to use the server remotely)")).toBeNull();
+    expect(reasonWorthShowing("forbidden: loopback host required (pair this device to use the server remotely)")).toBeNull();
+    expect(reasonWorthShowing("403")).toBeNull();
+    expect(reasonWorthShowing(undefined)).toBeNull();
+    expect(reasonWorthShowing("unauthorized: this session has expired or was revoked; pair this device again")).toMatch(/expired or was revoked/);
+  });
+});

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -109,3 +109,13 @@ export function startEmailSignIn(email: string, fetchImpl: typeof fetch = fetch)
 export function verifyEmailSignIn(input: { email: string; code: string; label: string }, fetchImpl: typeof fetch = fetch): Promise<{ ok: true } | { ok: false; error: string }> {
   return postAuth("/api/auth/email/verify", { email: input.email, code: input.code, label: input.label }, fetchImpl);
 }
+
+/** The gate's ordinary "you have no session" wording is why the pair page is
+ * shown at all; repeating it under an email form reads like an error. Only a
+ * reason that says something else (a session that expired or was revoked)
+ * is worth showing. */
+export function reasonWorthShowing(reason: string | undefined): string | null {
+  if (!reason) return null;
+  if (/through a proxy|loopback host required|cross-origin request|^40[13]$/i.test(reason)) return null;
+  return reason;
+}

--- a/src/pair/PairPage.tsx
+++ b/src/pair/PairPage.tsx
@@ -5,6 +5,7 @@ import {
   newAttemptId,
   pairWithCode,
   readSessionState,
+  reasonWorthShowing,
   startEmailSignIn,
   verifyEmailSignIn,
   type EnvironmentDescriptor,
@@ -97,7 +98,7 @@ export function PairPage({ initialCode, reason }: { initialCode: string | null; 
               : "Enter your email and we will send you a one-time code."
             : "Enter the pairing code shown on the server. Codes work once and expire after five minutes."}
         </p>
-        {reason && !connected ? <p className="mt-3 text-[13px] text-ink-secondary">{reason}</p> : null}
+        {reasonWorthShowing(reason) && !connected ? <p className="mt-3 text-[13px] text-ink-secondary">{reasonWorthShowing(reason)}</p> : null}
         {connected ? (
           <p className="mt-4 text-[13.5px]">
             This browser is already connected.{" "}


### PR DESCRIPTION
Seen by the first hosted user: the pair page printed the gate's reason for being shown, "forbidden: this request came through a proxy (pair this device to use the server remotely)", under the new email form, where it reads as an error although nothing failed. The routine no-session reasons are now kept quiet on the pair page; a reason that says something else (a session that expired or was revoked) is still shown. Pure helper with a test; UI typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session messaging by hiding routine connection-related notices.
  * Continued displaying meaningful messages, such as expired or revoked session details, on the pairing screen.

* **Tests**
  * Added coverage to verify which session reasons are shown or suppressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->