### PR TITLE
feat(brand): white-label works on a hosted server — public brand, favicon, layer in the package

### DIFF
--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -62,6 +62,8 @@ jobs:
           grep -q "no OpenMausBot server" pair.out
           # --tunnel ships its own processes and fails closed without an account
           test -f dist-server/tunnel-guardian.js && test -f dist-server/prepare-cloudflared.js
+          # the enterprise layer ships bundled (inert without a key) so a white-label key works on an npm install
+          test -f enterprise/server/index.js && test -f enterprise/LICENSE
           if HOME=/tmp/omb-pack/home node cli.js serve --tunnel --port 18798 --data-dir /tmp/omb-pack/data2 > tunnel.log 2>&1; then echo "serve --tunnel should refuse without login"; exit 1; fi
           grep -q "run \`openmausbot login\` first" tunnel.log
           kill %1; wait %1 || true

--- a/enterprise/README.md
+++ b/enterprise/README.md
@@ -30,7 +30,7 @@ open-source edition and the notice says what to fix.
 
 | id | grants |
 |---|---|
-| `whitelabel` | product name, tagline, accent colour, logo and support link from `brand.json` (below) |
+| `whitelabel` | product name, tagline, accent colour, logo, favicon and support link from `brand.json` (below) |
 | `sso` | identity-header trust behind an OIDC proxy |
 | `admin` | the admin panel routes |
 | `budgets` | per-bot and per-section spend limits |
@@ -70,6 +70,7 @@ volume in Docker) or point `OMB_BRAND_FILE` at one:
   "tagline": "Back office, on autopilot",
   "accent": "#1D4ED8",
   "logo": "data:image/svg+xml;base64,…",
+  "favicon": "data:image/png;base64,…",
   "supportUrl": "https://help.example.com"
 }
 ```

--- a/scripts/build-npm-package.mjs
+++ b/scripts/build-npm-package.mjs
@@ -24,6 +24,17 @@ mkdirSync(out, { recursive: true });
 cpSync(join(root, "dist-server"), join(out, "dist-server"), { recursive: true });
 cpSync(join(root, "dist"), join(out, "dist"), { recursive: true });
 if (existsSync(join(root, "skills"))) cpSync(join(root, "skills"), join(out, "skills"), { recursive: true });
+// The enterprise layer, bundled by scripts/bundle-server.mjs, under the path
+// server/enterprise.ts loads from: <package>/enterprise/server/index.js.
+// Source-available under its own license; inert without OMB_LICENSE_KEY.
+const enterpriseBundle = join(root, "dist-server", "enterprise", "server", "index.js");
+if (existsSync(enterpriseBundle)) {
+  mkdirSync(join(out, "enterprise", "server"), { recursive: true });
+  copyFileSync(enterpriseBundle, join(out, "enterprise", "server", "index.js"));
+  for (const file of ["LICENSE", "README.md"]) {
+    if (existsSync(join(root, "enterprise", file))) copyFileSync(join(root, "enterprise", file), join(out, "enterprise", file));
+  }
+}
 cpSync(join(root, "LICENSE"), join(out, "LICENSE"));
 
 // The bin lives next to the bundle so serverEntry() finds index.js by path.
@@ -39,7 +50,7 @@ writeFileSync(
       license: "Apache-2.0",
       type: "module",
       bin: { openmausbot: "cli.js" },
-      files: ["cli.js", "dist-server", "dist", "skills", "LICENSE", "README.md"],
+      files: ["cli.js", "dist-server", "dist", "skills", "enterprise", "LICENSE", "README.md"],
       engines: { node: ">=24" },
       repository: { type: "git", url: "https://github.com/milind-soni/OpenMausBot.git" },
       homepage: "https://github.com/milind-soni/OpenMausBot#readme",

--- a/scripts/build-npm-package.mjs
+++ b/scripts/build-npm-package.mjs
@@ -4,7 +4,7 @@
 //
 //   pnpm build:server && pnpm exec vite build && node scripts/build-npm-package.mjs
 //   cd release/npm && npm pack        # or npm publish --access public
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { copyFileSync, cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 

--- a/scripts/bundle-server.mjs
+++ b/scripts/bundle-server.mjs
@@ -18,7 +18,7 @@
 // drivers/ nested; import.meta.url still resolves to the same location, so
 // that lookup is unaffected.
 import { build } from "esbuild";
-import { copyFileSync, mkdirSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
@@ -123,6 +123,23 @@ await build({
   allowOverwrite: true,
   logLevel: "info",
 });
+
+// The enterprise layer (enterprise/LICENSE; delete the folder for pure OSS)
+// is loaded by path from <root>/enterprise/server/index.{ts,js}. A package
+// or image has no TypeScript runtime, so ship it bundled; the npm package
+// copies this file to enterprise/server/index.js beside the server.
+if (existsSync(join(root, "enterprise", "server", "index.ts"))) {
+  await build({
+    entryPoints: [join(root, "enterprise", "server", "index.ts")],
+    bundle: true,
+    platform: "node",
+    target: "node20",
+    format: "esm",
+    outfile: join(root, "dist-server", "enterprise", "server", "index.js"),
+    allowOverwrite: true,
+    logLevel: "info",
+  });
+}
 
 // pi-mcp-extension.ts is NOT an OpenMausBot entry point: it is loaded by the
 // external `pi` process (pi's own jiti), which resolves its

--- a/server/brand.test.ts
+++ b/server/brand.test.ts
@@ -75,3 +75,14 @@ describe("brand.json", () => {
     expect(status.notice).toMatch(/accent/);
   });
 });
+
+describe("the brand's favicon", () => {
+  it("accepts a small data URI or an https URL and refuses anything else", async () => {
+    const { brandSchema } = await import("./brand.ts");
+    expect(brandSchema.safeParse({ name: "Agent Ada", favicon: "data:image/png;base64,iVBORw0KGgo=" }).success).toBe(true);
+    expect(brandSchema.safeParse({ name: "Agent Ada", favicon: "https://agentada.cc/icon.png" }).success).toBe(true);
+    expect(brandSchema.safeParse({ name: "Agent Ada", favicon: "http://agentada.cc/icon.png" }).success).toBe(false);
+    expect(brandSchema.safeParse({ name: "Agent Ada", favicon: "/icon.png" }).success).toBe(false);
+    expect(brandSchema.safeParse({ name: "Agent Ada", favicon: `data:image/png;base64,${"A".repeat(130_000)}` }).success).toBe(false);
+  });
+});

--- a/server/brand.ts
+++ b/server/brand.ts
@@ -12,6 +12,7 @@ import { entitled } from "./enterprise.ts";
 
 const HEX_COLOUR = /^#[0-9a-fA-F]{6}$/;
 const MAX_LOGO_CHARS = 300_000;
+const MAX_FAVICON_CHARS = 120_000;
 
 export const brandSchema = z
   .object({
@@ -29,6 +30,12 @@ export const brandSchema = z
       .optional(),
     /** Where "get help" points for this deployment. */
     supportUrl: z.string().url().startsWith("https://", "supportUrl must be an https:// URL").optional(),
+    /** Tab and home-screen icon: an inline data:image/... URI (PNG or SVG, small) or an https:// URL. */
+    favicon: z
+      .string()
+      .max(MAX_FAVICON_CHARS, `favicon must be under ${MAX_FAVICON_CHARS} characters (a 64px PNG or a small SVG)`)
+      .refine((v) => v.startsWith("data:image/") || v.startsWith("https://"), "favicon must be a data:image/... URI or an https:// URL")
+      .optional(),
   })
   .strict();
 

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -926,6 +926,18 @@ describe("harness HTTP API", () => {
     });
     expect(probe.status).toBe(200);
     expect(probe.body).toEqual({ app: "openmausbot" });
+    // the brand is public too: the sign-in page is branded before anyone has a session
+    const brand = await new Promise<{ status: number; body: unknown }>((resolve, reject) => {
+      const req = request({ hostname: "127.0.0.1", port: PORT, path: "/api/brand", headers: { host: "example.com" } }, (res) => {
+        let raw = "";
+        res.on("data", (chunk) => (raw += chunk));
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, body: JSON.parse(raw) }));
+      });
+      req.on("error", reject);
+      req.end();
+    });
+    expect(brand.status).toBe(200);
+    expect(Reflect.get(Object(Reflect.get(Object(brand.body), "brand")), "name")).toBe("OpenMausBot");
     expect(await statusWithHeaders({ origin: "https://example.com" })).toBe(403);
     expect(await statusWithHeaders({ host: `127.0.0.2:${PORT}` })).toBe(200);
     expect(await statusWithHeaders({ host: `[::1]:${PORT}` })).toBe(200);

--- a/server/index.ts
+++ b/server/index.ts
@@ -8074,6 +8074,11 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
     if (method === "GET" && path === "/api/health" && !gate.auth) {
       return json(res, 200, { app: "openmausbot" });
     }
+    // The brand is public too: the sign-in page must carry the deployment's
+    // name and icon before anyone has a session, and it holds nothing secret.
+    if (method === "GET" && path === "/api/brand" && !gate.auth) {
+      return json(res, 200, loadBrand());
+    }
     if (!gate.auth) return json(res, gate.status, { error: gate.error });
     const auth = gate.auth;
 

--- a/src/lib/brand.test.ts
+++ b/src/lib/brand.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { accentInk, applyBrand, bootstrapBrand, brand, brandVars, DEFAULT_BRAND, luminance } from "./brand";
+import { accentInk, applyBrand, bootstrapBrand, brand, brandVars, DEFAULT_BRAND, iconType, luminance } from "./brand";
 
 describe("brand", () => {
   it("derives readable ink for light and dark accents", () => {
@@ -46,5 +46,13 @@ describe("brand", () => {
     expect(status.source).toBe("file");
     expect(brand().name).toBe("Reliable Platform");
     applyBrand({ brand: DEFAULT_BRAND, source: "default", file: "" });
+  });
+});
+
+describe("the tab icon", () => {
+  it("declares the type a data URI carries and nothing for a URL", () => {
+    expect(iconType("data:image/png;base64,AAAA")).toBe("image/png");
+    expect(iconType("data:image/svg+xml;base64,AAAA")).toBe("image/svg+xml");
+    expect(iconType("https://agentada.cc/icon.png")).toBe("");
   });
 });

--- a/src/lib/brand.ts
+++ b/src/lib/brand.ts
@@ -8,6 +8,7 @@ export interface Brand {
   tagline?: string;
   accent?: string;
   logo?: string;
+  favicon?: string;
   supportUrl?: string;
 }
 
@@ -65,11 +66,41 @@ export function brandVars(b: Brand): Record<string, string> {
   };
 }
 
-/** Stamp the brand on the document: title and accent variables. */
+/** The MIME type a data: URI declares, for the icon link's `type`. */
+export function iconType(href: string): string {
+  const match = /^data:(image\/[a-z0-9.+-]+)/i.exec(href);
+  return match ? match[1].toLowerCase() : "";
+}
+
+let defaultIcon: { href: string; type: string } | null = null;
+
+/** Point the tab icon at the brand's, or back at the app's when there is none. */
+function applyIcon(favicon: string | undefined): void {
+  const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+  if (!link) return;
+  defaultIcon ??= { href: link.getAttribute("href") ?? "", type: link.getAttribute("type") ?? "" };
+  const next = favicon ? { href: favicon, type: iconType(favicon) } : defaultIcon;
+  link.setAttribute("href", next.href);
+  if (next.type) link.setAttribute("type", next.type);
+  else link.removeAttribute("type");
+  let touch = document.querySelector<HTMLLinkElement>('link[rel="apple-touch-icon"][data-brand]');
+  if (favicon) {
+    if (!touch) {
+      touch = document.createElement("link");
+      touch.rel = "apple-touch-icon";
+      touch.dataset.brand = "1";
+      document.head.appendChild(touch);
+    }
+    touch.href = favicon;
+  } else touch?.remove();
+}
+
+/** Stamp the brand on the document: title, icon and accent variables. */
 export function applyBrand(status: BrandStatus): void {
   current = status;
   if (typeof document === "undefined") return;
   document.title = status.brand.name;
+  applyIcon(status.brand.favicon);
   const root = document.documentElement;
   for (const name of ["--color-accent", "--color-accent-border", "--color-focus", "--color-accent-text", "--color-accent-ink"]) {
     root.style.removeProperty(name);


### PR DESCRIPTION
Three gaps found while deploying the first white-labelled hosted workspace (an npm install behind Caddy, `OMB_LICENSE_KEY` with `whitelabel`):

- **`GET /api/brand` needed a session**, so the sign-in page a stranger sees carried the default name and icon. The brand holds nothing secret (name, tagline, accent, logo, support link), so it is public now, like `/api/health` and the environment descriptor: `/pair` is branded before anyone has a session.
- **No favicon in `brand.json`.** `favicon` joins the schema (a small `data:image/...` URI or an `https://` URL, capped at 120k characters). The client points the tab icon and the home-screen icon at it, with the right `type` for a data URI, and back at the app's own icon when a brand is cleared.
- **The npm package did not carry `enterprise/`**, so a key on an npm install reported "no enterprise layer exists". `scripts/bundle-server.mjs` now bundles `enterprise/server/index.ts` (source-available under `enterprise/LICENSE`, inert without a key) and the package ships it as `enterprise/server/index.js` with its LICENSE and README, exactly where `server/enterprise.ts` already looks. The `files` list gains `enterprise`; the standalone proof in the npm workflow asserts it ships.

Tests: favicon accept/refuse rules; the icon MIME type helper; the public brand route reached with a non-loopback Host. Typecheck (server and UI) and lint clean. Nothing customer-specific is in this change: it adds the ability to set an icon, not any image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for custom favicons, including browser tab and Apple touch icons.
  - Brand settings now accept secure HTTPS URLs or image data URIs for favicons.
  - Added a public brand endpoint so sign-in pages can display the deployment name and icon before authentication.
  - Enterprise capabilities are now included in npm packages for licensed deployments.

- **Documentation**
  - Updated white-label branding guidance and examples to include favicon configuration.

- **Tests**
  - Added coverage for favicon validation, icon handling, and public brand access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->