### PR TITLE
Phones show who opened a thread and open it from the chip

### DIFF
--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/ChatScreen.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/ChatScreen.kt
@@ -109,6 +109,7 @@ import com.openmausbot.companion.core.Dictation
 import com.openmausbot.companion.core.DisplayedMessageAttachment
 import com.openmausbot.companion.core.DownloadedFile
 import com.openmausbot.companion.core.Message
+import com.openmausbot.companion.core.ThreadRef
 import com.openmausbot.companion.core.TranscriptRow
 import com.openmausbot.companion.core.target
 import com.openmausbot.companion.core.transcriptRows
@@ -145,6 +146,8 @@ fun ChatScreen(
      * push and drop it after a pop that removed the chat.
      */
     retainsDraft: (chatId: String) -> Boolean = { false },
+    /** An "Opened thread" chip pointing at another bot pushes that chat. */
+    onOpenChat: (Chat) -> Unit = {},
 ) {
     val session = LocalCompanion.current.session
     val state by session.state.collectAsState()
@@ -164,7 +167,7 @@ fun ChatScreen(
             // Resolve the owner without changing the task named by the destination.
             val resolved = (destination as? Destination.Thread)?.let { resolution.chat.target }
             LaunchedEffect(resolved) { if (resolved != null) onResolved(resolved) }
-            LoadedChat(resolution.chat, state, onBack, onOpenComputer, onOpenOverview, retainsDraft, onResolved)
+            LoadedChat(resolution.chat, state, onBack, onOpenComputer, onOpenOverview, retainsDraft, onResolved, onOpenChat)
         }
     }
 }
@@ -196,6 +199,7 @@ private fun LoadedChat(
     onOpenOverview: (String) -> Unit,
     retainsDraft: (chatId: String) -> Boolean,
     onSelectTask: (ChatTarget) -> Unit,
+    onOpenChat: (Chat) -> Unit,
 ) {
     // This screen's selected task, independent of the desktop's selection.
     val threadId = chat.threadId
@@ -392,6 +396,16 @@ private fun LoadedChat(
         preferredName = attachment.name,
         cacheResult = true,
     )
+
+    // A chip that opened a thread on this bot switches this screen in place,
+    // the way a thread row does; one that opened a thread on a teammate pushes
+    // that chat.
+    fun openThread(ref: ThreadRef) {
+        scope.launch {
+            val bot = session.openThread(ref) ?: return@launch
+            if (bot.id == chatId) onSelectTask(ChatTarget.Bot(bot.id, bot.threadId)) else onOpenChat(Chat.BotChat(bot))
+        }
+    }
     val focusedMessageId by session.focusedMessageId.collectAsState()
 
     val dictationListening by dictation.isListening.collectAsState()
@@ -823,8 +837,9 @@ private fun LoadedChat(
                                     endsRun = TranscriptLayout.endsRowRun(transcript, index),
                                     openLink = ::openLink,
                                     openAttachment = ::openAttachment,
+                                    openThread = ::openThread,
                                 )
-                                is TranscriptRow.ActivityRun -> ActivityRunChip(message.items)
+                                is TranscriptRow.ActivityRun -> ActivityRunChip(message.items, ::openThread)
                             }
                         }
                     }

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/Haptics.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/Haptics.kt
@@ -58,6 +58,9 @@ internal enum class TactileAction(val cue: HapticCue) {
     /** The disclosure on a folded activity run (`ActivityRunChip.swift:30`). */
     TOGGLE_ACTIVITY_RUN(HapticCue.SELECT),
 
+    /** An "Opened thread" chip going to its thread (`ChatView.swift` `ActivityChip`). */
+    OPEN_THREAD_CHIP(HapticCue.SELECT),
+
     /** Moving the phone to another paired computer (`SettingsView.swift:250`). */
     SWITCH_COMPUTER(HapticCue.SELECT),
 

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/MessageRow.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/MessageRow.kt
@@ -83,6 +83,7 @@ import com.openmausbot.companion.core.DisplayedMessageAttachment
 import com.openmausbot.companion.core.DownloadedFile
 import com.openmausbot.companion.core.Message
 import com.openmausbot.companion.core.OptionCard
+import com.openmausbot.companion.core.ThreadRef
 import com.openmausbot.companion.core.ToolActivity
 import com.openmausbot.companion.core.TranscriptCard
 import com.openmausbot.companion.core.TranscriptCards
@@ -111,6 +112,8 @@ fun MessageRow(
     openLink: ((String, Message) -> Unit)? = null,
     /** Open one exact user attachment through the authenticated computer route. */
     openAttachment: ((DisplayedMessageAttachment, Message, DownloadedFile?) -> Unit)? = null,
+    /** Where an "Opened thread" chip goes; null leaves the chip a receipt. */
+    openThread: ((ThreadRef) -> Unit)? = null,
 ) {
     val session = LocalCompanion.current.session
     val scope = rememberCoroutineScope()
@@ -151,6 +154,7 @@ fun MessageRow(
                 haptics = haptics,
                 openLink = openLink,
                 openAttachment = openAttachment,
+                openThread = openThread,
             )
 
             message.comm?.let {
@@ -390,11 +394,12 @@ private fun MessageContent(
     haptics: Haptics,
     openLink: ((String, Message) -> Unit)?,
     openAttachment: ((DisplayedMessageAttachment, Message, DownloadedFile?) -> Unit)?,
+    openThread: ((ThreadRef) -> Unit)?,
 ) {
     when (message.kind) {
         Message.Kind.TEXT -> TextBubble(chat.threadId, message, endsRun, openLink, openAttachment)
         Message.Kind.OPTIONS -> CardView(chat, message, haptics)
-        Message.Kind.ACTIVITY -> ActivityChip(message.tool)
+        Message.Kind.ACTIVITY -> ActivityChip(message.tool, message.threadRef, openThread)
         Message.Kind.SCREEN -> ScreenShot(chat.threadId, message)
         // A message kind from a newer computer. Almost everything the harness
         // sends carries `text`, so showing it is usually the whole message and
@@ -663,10 +668,15 @@ private fun AttachmentLoadFailure(label: String, onRetry: () -> Unit) {
  * None of iOS's detail is here, because none of it has data: `durationMs`,
  * `parameters` and `output` are dormant on that view and absent from
  * [ToolActivity]. Nothing to expand means nothing to tap, which is why this is
- * not a button.
+ * not a button — except a chip that names a thread it opened, which is the
+ * link to that thread.
  */
 @Composable
-private fun ActivityChip(tool: ToolActivity?) {
+private fun ActivityChip(
+    tool: ToolActivity?,
+    threadRef: ThreadRef? = null,
+    openThread: ((ThreadRef) -> Unit)? = null,
+) {
     if (tool == null) return
     val status = ActivityReceipt.status(tool.ok)
     val tint = when (status) {
@@ -674,9 +684,21 @@ private fun ActivityChip(tool: ToolActivity?) {
         ActivityStatus.SUCCESS -> secondaryTint
         ActivityStatus.ERROR -> MaterialTheme.colorScheme.error
     }
+    val haptics = rememberHaptics()
+    val linked = if (threadRef != null && openThread != null) {
+        Modifier
+            .heightIn(min = MIN_TOUCH_TARGET)
+            .clickable(role = Role.Button) {
+                haptics.play(TactileAction.OPEN_THREAD_CHIP)
+                openThread(threadRef)
+            }
+    } else {
+        Modifier
+    }
     Row(
         modifier = Modifier
             .padding(start = 4.dp)
+            .then(linked)
             .semantics(mergeDescendants = true) {
                 contentDescription = ActivityReceipt.announcement(tool.name, status)
             },
@@ -717,7 +739,7 @@ private fun ActivityChip(tool: ToolActivity?) {
 
 /** Several consecutive successful/running activity receipts, folded on demand. */
 @Composable
-fun ActivityRunChip(items: List<Message>) {
+fun ActivityRunChip(items: List<Message>, openThread: ((ThreadRef) -> Unit)? = null) {
     if (items.isEmpty()) return
     val haptics = rememberHaptics()
     // Keyed on the run's identity — the same one the LazyColumn keys the row by
@@ -769,7 +791,7 @@ fun ActivityRunChip(items: List<Message>) {
         }
         if (expanded) {
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                items.forEach { item -> ActivityChip(item.tool) }
+                items.forEach { item -> ActivityChip(item.tool, item.threadRef, openThread) }
             }
         }
     }

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/RootScreen.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/RootScreen.kt
@@ -387,6 +387,7 @@ private fun PairedScreen(
             onOpenOverview = { navigator.push(Destination.Overview(it)) },
             // Push Computer keeps the chat under the top; pop to roster does not.
             retainsDraft = navigator::retainsChatDraft,
+            onOpenChat = navigator::open,
         )
         is Destination.Computer -> ComputerScreen(
             botId = destination.botId,

--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/TaskSheet.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/TaskSheet.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.launch
 import com.openmausbot.companion.core.ChatTarget
 import com.openmausbot.companion.core.chat
 import com.openmausbot.companion.core.target
+import com.openmausbot.companion.core.openedByLabel
 
 /**
  * Separate contexts for an agent or channel — the port of
@@ -251,6 +252,13 @@ private fun TaskRow(
                 fontSize = 12.sp,
                 color = secondaryTint,
             )
+            task.openedByLabel?.let { openedBy ->
+                Text(
+                    text = openedBy,
+                    fontSize = 12.sp,
+                    color = secondaryTint,
+                )
+            }
         }
 
         if (current) {

--- a/android/app/src/test/kotlin/com/openmausbot/companion/ui/ExecutionFeedbackTest.kt
+++ b/android/app/src/test/kotlin/com/openmausbot/companion/ui/ExecutionFeedbackTest.kt
@@ -364,6 +364,7 @@ class TactileActionTest {
                 TactileAction.GRANT_APPROVAL to HapticCue.SELECT,
                 TactileAction.START_NEW_SECTION to HapticCue.SELECT,
                 TactileAction.TOGGLE_ACTIVITY_RUN to HapticCue.SELECT,
+                TactileAction.OPEN_THREAD_CHIP to HapticCue.SELECT,
                 TactileAction.SWITCH_COMPUTER to HapticCue.SELECT,
                 TactileAction.CONNECT_ANOTHER_COMPUTER to HapticCue.SELECT,
                 TactileAction.CHOOSE_QUICK_REPLY_ICON to HapticCue.SELECT,

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Models.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Models.kt
@@ -259,6 +259,10 @@ data class BotTask(
     val openedBy: ThreadOpener? = null,
 )
 
+/** The thread list's quiet second line, worded as the desktop words it. */
+val BotTask.openedByLabel: String?
+    get() = openedBy?.let { "opened by ${it.name}" }
+
 @Serializable
 data class Bot(
     val id: String,

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Models.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Models.kt
@@ -123,6 +123,18 @@ data class ToolActivity(
     val setup: Boolean? = null,
 )
 
+/**
+ * The thread an activity chip opened — "Opened thread #Title on Scout" — so
+ * the phone can go there. Newer computers only; a chip without one is just a
+ * receipt.
+ */
+@Serializable
+data class ThreadRef(
+    val botId: String,
+    val threadId: String,
+    val title: String,
+)
+
 @Serializable
 data class Sender(
     val botId: String,
@@ -150,6 +162,7 @@ data class Message(
     val text: String? = null,
     val card: OptionCard? = null,
     val tool: ToolActivity? = null,
+    val threadRef: ThreadRef? = null,
     val parentId: String? = null,
     val from: Sender? = null,
     val reactions: List<Reaction>? = null,
@@ -218,6 +231,18 @@ data class ModelSelection(
     val effort: String? = null,
 )
 
+/**
+ * The bot that opened a thread, on itself or on a teammate. Absent — which is
+ * every thread from an older computer — means the person opened it.
+ */
+@Serializable
+data class ThreadOpener(
+    val botId: String,
+    val name: String,
+    val delegationId: String? = null,
+    val at: Double,
+)
+
 @Serializable
 data class BotTask(
     val threadId: String,
@@ -231,6 +256,7 @@ data class BotTask(
     val autoApprove: Boolean? = null,
     val alwaysAllow: List<String>? = null,
     val projectId: String? = null,
+    val openedBy: ThreadOpener? = null,
 )
 
 @Serializable

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Session.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Session.kt
@@ -1646,6 +1646,53 @@ class Session(
         if (_focusedMessageId.value == messageId) _focusedMessageId.value = null
     }
 
+    /**
+     * A tapped "Opened thread #Title on Scout" chip. Lands on that thread by
+     * the route a thread row uses, which only changes what this phone is
+     * looking at — a bot mid-turn keeps working where it was. A thread the
+     * computer no longer has still lands on the bot, with a notice, rather
+     * than nowhere.
+     *
+     * @return the bot pinned to the thread, or to its current thread when the
+     *   switch failed; null when the bot itself is gone or the phone is not
+     *   paired (the notice is already posted).
+     */
+    suspend fun openThread(ref: ThreadRef): Bot? {
+        val activeClient = client
+        if (activeClient == null) {
+            _actionError.value = "Pair this phone with your computer to open that thread."
+            return null
+        }
+        return try {
+            var bot = _state.value.bot(ref.botId)
+            if (bot == null) {
+                val fleet = hydrateFn(activeClient, 50)
+                _state.update { it.hydrate(fleet) }
+                notificationSink.setBadge(_state.value.unreadCount)
+                bot = _state.value.bot(ref.botId)
+            }
+            var selected = bot
+                ?: throw APIError.Status(404, "That agent no longer exists.")
+            if (selected.threadId != ref.threadId) {
+                try {
+                    selected = activeClient.switchTask(selected.id, ref.threadId)
+                    _state.update { it.apply(Frame.Bot(selected)) }
+                } catch (error: Throwable) {
+                    if (error is kotlinx.coroutines.CancellationException) throw error
+                    // The thread may be gone (deleted since the chip was
+                    // written). The bot's current thread, and a word about it,
+                    // beats a dead tap.
+                    _actionError.value = THREAD_GONE_MESSAGE
+                }
+            }
+            selected.forTask(selected.threadId) ?: selected
+        } catch (error: Throwable) {
+            if (error is kotlinx.coroutines.CancellationException) throw error
+            _actionError.value = error.message
+            null
+        }
+    }
+
     suspend fun createTask(forBot: Bot, title: String?): Bot? {
         val activeClient = client ?: return null
         return try {
@@ -2040,6 +2087,7 @@ class Session(
             "This phone couldn't read its saved connection just now."
         const val SPENT_QR_MESSAGE =
             "That pairing code was already used. Start pairing again on your computer and rescan the new QR code."
+        const val THREAD_GONE_MESSAGE = "That thread is no longer on your computer."
 
         /** High-entropy QR token — distinct from a retryable six-digit code. */
         fun isQrCredential(credential: String): Boolean =

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/DecodingTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/DecodingTest.kt
@@ -443,4 +443,49 @@ class DecodingTest {
         assertTrue(overview.does.isNotEmpty())
         assertTrue(overview.wont.isNotEmpty())
     }
+
+    @Test
+    fun decodesAThreadOpenedByABotAndOneOpenedByThePerson() {
+        // Newer computers say which bot opened a thread on itself or a
+        // teammate. The captured fixtures predate that, so every thread in
+        // them was opened by the person — and must still decode as such.
+        val opened = CompanionJson.decodeFromString<BotTask>(
+            """{"threadId":"t2","title":"Ship it","createdAt":1,
+               "openedBy":{"botId":"scout","name":"Scout","delegationId":"d1","at":2}}""",
+        )
+        assertEquals(ThreadOpener("scout", "Scout", "d1", 2.0), opened.openedBy)
+
+        val minimal = CompanionJson.decodeFromString<BotTask>(
+            """{"threadId":"t1","title":"","createdAt":1,"openedBy":{"botId":"scout","name":"Scout","at":2}}""",
+        )
+        assertNull(minimal.openedBy?.delegationId)
+
+        val byThePerson = CompanionJson.decodeFromString<BotTask>(
+            """{"threadId":"t1","title":"","createdAt":1}""",
+        )
+        assertNull(byThePerson.openedBy)
+        decodeFixture<Fleet>("bots-paged").bots.flatMap { it.tasks.orEmpty() }.forEach { task ->
+            assertNull(task.openedBy, task.threadId)
+        }
+    }
+
+    @Test
+    fun decodesAThreadRefOnAnActivityChipAndItsAbsence() {
+        val chip = CompanionJson.decodeFromString<Message>(
+            """{"id":"m3","role":"bot","kind":"activity","at":1,
+               "tool":{"name":"Opened thread #Ship it on Scout","ok":true},
+               "threadRef":{"botId":"scout","threadId":"t2","title":"Ship it"}}""",
+        )
+        assertEquals(Message.Kind.ACTIVITY, chip.kind)
+        assertEquals("Opened thread #Ship it on Scout", chip.tool?.name)
+        assertEquals(ThreadRef("scout", "t2", "Ship it"), chip.threadRef)
+
+        val receipt = CompanionJson.decodeFromString<Message>(
+            """{"id":"m4","role":"bot","kind":"activity","at":1,"tool":{"name":"Read","ok":true}}""",
+        )
+        assertNull(receipt.threadRef)
+        decodeFixture<ThreadPage>("thread-page").messages.forEach { message ->
+            assertNull(message.threadRef, message.id)
+        }
+    }
 }

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/DecodingTest.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/DecodingTest.kt
@@ -470,6 +470,21 @@ class DecodingTest {
     }
 
     @Test
+    fun aThreadOpenedByABotSaysSoInTheList() {
+        // Same words as the desktop's thread list, so a person reading both
+        // screens reads one sentence.
+        val opened = CompanionJson.decodeFromString<BotTask>(
+            """{"threadId":"t2","title":"Ship it","createdAt":1,"openedBy":{"botId":"scout","name":"Scout","at":2}}""",
+        )
+        assertEquals("opened by Scout", opened.openedByLabel)
+
+        val byThePerson = CompanionJson.decodeFromString<BotTask>(
+            """{"threadId":"t1","title":"","createdAt":1}""",
+        )
+        assertNull(byThePerson.openedByLabel)
+    }
+
+    @Test
     fun decodesAThreadRefOnAnActivityChipAndItsAbsence() {
         val chip = CompanionJson.decodeFromString<Message>(
             """{"id":"m3","role":"bot","kind":"activity","at":1,

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/SessionP1Test.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/SessionP1Test.kt
@@ -231,6 +231,37 @@ class SessionP1Test {
     }
 
     @Test
+    fun threadChipSwitchesByTheTaskRouteAndLandsOnTheBotWhenTheThreadIsGone() = runTest {
+        val scout = bot("scout", "task-1", "task-1", "task-2")
+        val switched = scout.copy(threadId = "task-2")
+        val session = session { Fleet(listOf(scout), emptyList()) }
+        server.enqueue(json("""{"bot":${CompanionJson.encodeToString(switched)}}"""))
+
+        val opened = session.openThread(ThreadRef("scout", "task-2", "Task 2"))
+
+        assertEquals("task-2", opened?.threadId)
+        assertEquals("task-2", session.state.value.bot("scout")?.threadId)
+        assertEquals("POST /api/bots/scout/tasks/task-2", server.takeRequest().let { "${it.method} ${it.path}" })
+        assertNull(session.actionError)
+
+        // The chip's thread was deleted after the chip was written: land on
+        // the bot's current thread and say so, never nowhere.
+        server.enqueue(json("""{"error":"Task not found."}""", code = 404))
+        val fallback = session.openThread(ThreadRef("scout", "task-9", "Gone"))
+        assertEquals("task-2", fallback?.threadId)
+        assertEquals("POST /api/bots/scout/tasks/task-9", server.takeRequest().let { "${it.method} ${it.path}" })
+        assertEquals(Session.THREAD_GONE_MESSAGE, session.actionError)
+
+        // A thread the bot is already on needs no request at all.
+        session.actionError = null
+        assertEquals("task-2", session.openThread(ThreadRef("scout", "task-2", "Task 2"))?.threadId)
+        assertEquals(2, server.requestCount)
+
+        assertNull(session.openThread(ThreadRef("nobody", "task-1", "Nope")))
+        assertEquals("That agent no longer exists.", session.actionError)
+    }
+
+    @Test
     fun roomTaskNotificationSwitchesTheChannelAndFallsBackWhenTheTaskIsGone() = runTest {
         val room = room("room-1", "room-task-1", "room-task-1", "room-task-2")
         val switched = room.copy(

--- a/ios/App/ActivityRunChip.swift
+++ b/ios/App/ActivityRunChip.swift
@@ -12,6 +12,8 @@ import CompanionCore
 
 struct ActivityRunChip: View {
     let items: [Message]
+    /// Where an "Opened thread" chip inside the run goes once unfolded.
+    var openThread: ((ThreadRef) -> Void)? = nil
     @Environment(\.colorScheme) private var colorScheme
     @State private var expanded = false
 
@@ -59,7 +61,7 @@ struct ActivityRunChip: View {
             if expanded {
                 VStack(alignment: .leading, spacing: 4) {
                     ForEach(items, id: \.id) { item in
-                        ActivityChip(tool: item.tool)
+                        ActivityChip(tool: item.tool, threadRef: item.threadRef, openThread: openThread)
                     }
                 }
                 .transition(.opacity.combined(with: .move(edge: .top)))

--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -187,10 +187,11 @@ struct ChatView: View {
                                         chat: current,
                                         message: message,
                                         endsRun: endsRun(at: index, in: transcript),
-                                        openLink: openLink
+                                        openLink: openLink,
+                                        openThread: openThread
                                     )
                                 case let .activityRun(items):
-                                    ActivityRunChip(items: items)
+                                    ActivityRunChip(items: items, openThread: openThread)
                                 }
                             }
                             .id(row.id)
@@ -931,6 +932,17 @@ struct ChatView: View {
         )
     }
 
+    /// A chip that opened a thread on this bot switches this screen in
+    /// place; one that opened a thread on a teammate pushes that chat.
+    private func openThread(_ ref: ThreadRef) {
+        let shownBotId: String? = current.isBot ? current.id : nil
+        Task {
+            if let threadId = await session.openThread(ref, shownBotId: shownBotId) {
+                selectedThreadId = threadId
+            }
+        }
+    }
+
     private func openLink(_ url: URL, from message: Message) -> OpenURLAction.Result {
         guard let target = LocalMessageLink.resolve(url) else {
             fileOpenError = "This link can't be opened securely."
@@ -1233,6 +1245,8 @@ struct MessageRow: View {
     /// Last bubble of a run from the same side: the one that gets the tail.
     var endsRun = true
     let openLink: (URL, Message) -> OpenURLAction.Result
+    /// Where an "Opened thread" chip goes; nil leaves the chip a receipt.
+    var openThread: ((ThreadRef) -> Void)? = nil
     @EnvironmentObject private var session: Session
     @State private var editingText = ""
     @State private var showingEdit = false
@@ -1361,7 +1375,7 @@ struct MessageRow: View {
                 TextBubble(message: message, chat: chat, tailed: endsRun, openLink: openLink)
             }
         case .activity:
-            ActivityChip(tool: message.tool)
+            ActivityChip(tool: message.tool, threadRef: message.threadRef, openThread: openThread)
         case .screen:
             ScreenShot(threadId: chat.threadId, message: message)
         case .unknown:
@@ -1556,14 +1570,33 @@ struct TextBubble: View {
 /// transcript and they are context, not content.
 struct ActivityChip: View {
     let tool: ToolActivity?
+    /// The thread this chip opened, when it opened one.
+    var threadRef: ThreadRef? = nil
+    var openThread: ((ThreadRef) -> Void)? = nil
 
     var body: some View {
         if let tool {
-            SkillExecutionReceiptView(
+            let receipt = SkillExecutionReceiptView(
                 skillName: tool.name,
                 status: tool.ok.map { $0 ? "success" : "error" } ?? "running"
             )
             .padding(.leading, 2)
+
+            if let threadRef, let openThread {
+                // The receipt's own button has nothing to expand here, so the
+                // whole chip is the link to the thread it names.
+                Button {
+                    Haptics.selection()
+                    openThread(threadRef)
+                } label: {
+                    receipt.allowsHitTesting(false)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(tool.name)
+                .accessibilityHint("Opens the thread")
+            } else {
+                receipt
+            }
         }
     }
 }

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -1858,6 +1858,47 @@ final class Session: ObservableObject {
 
     func consumeNotificationChat() { notificationChat = nil }
 
+    // MARK: - Thread chips
+
+    /// A tapped "Opened thread #Title on Scout" chip. Lands on that thread by
+    /// the route a thread row uses, which only changes what this phone is
+    /// looking at — a bot mid-turn keeps working where it was. A thread the
+    /// computer no longer has still lands on the bot, with a notice, rather
+    /// than nowhere.
+    ///
+    /// Returns the thread to select in place when the chip's bot is the one
+    /// already on screen. Any other bot is pushed the way a notification is,
+    /// and nil comes back.
+    func openThread(_ ref: ThreadRef, shownBotId: String?) async -> String? {
+        guard let client else {
+            actionError = "Pair this device with your computer to open that thread."
+            return nil
+        }
+        do {
+            var bot = state.bot(ref.botId)
+            if bot == nil {
+                try await hydrate(using: client)
+                bot = state.bot(ref.botId)
+            }
+            guard var selected = bot else { throw APIError.status(code: 404, message: "That agent no longer exists.") }
+            if selected.threadId != ref.threadId {
+                do {
+                    selected = try await client.switchTask(botId: selected.id, threadId: ref.threadId)
+                    state.apply(.bot(selected))
+                } catch {
+                    // The thread may be gone (deleted since the chip was
+                    // written). The bot's current thread, and a word about
+                    // it, beats a dead tap.
+                    actionError = "That thread is no longer on your computer."
+                }
+            }
+            if selected.id == shownBotId { return selected.threadId }
+            notificationChat = .bot(selected)
+        } catch is CancellationError {
+        } catch { actionError = error.localizedDescription }
+        return nil
+    }
+
     func react(to message: Message, in threadId: String, emoji: String) async {
         guard let client else { return }
         do {

--- a/ios/App/TaskManagerView.swift
+++ b/ios/App/TaskManagerView.swift
@@ -58,6 +58,11 @@ struct TaskManagerView: View {
                                     Text(RelativeStamp.list(task.createdAt))
                                         .font(.caption)
                                         .foregroundStyle(Color.secondary)
+                                    if let openedBy = task.openedByLabel {
+                                        Text(verbatim: openedBy)
+                                            .font(.caption)
+                                            .foregroundStyle(Color.secondary)
+                                    }
                                 }
                                 Spacer()
                                 if task.threadId == current.threadId {

--- a/ios/Sources/CompanionCore/Models.swift
+++ b/ios/Sources/CompanionCore/Models.swift
@@ -106,6 +106,15 @@ public struct ToolActivity: Codable, Hashable, Sendable {
     public var setup: Bool?
 }
 
+/// The thread an activity chip opened — "Opened thread #Title on Scout" —
+/// so the phone can go there. Newer computers only; a chip without one is
+/// just a receipt.
+public struct ThreadRef: Codable, Hashable, Sendable {
+    public var botId: String
+    public var threadId: String
+    public var title: String
+}
+
 /// A credential request created by the desktop for one paused task.
 ///
 /// The phone may fill this request only through the QR-pinned HPKE transport.
@@ -184,6 +193,7 @@ public struct Message: Codable, Hashable, Identifiable, Sendable {
     public var card: OptionCard?
     public var secret: SecretRequestCardData?
     public var tool: ToolActivity?
+    public var threadRef: ThreadRef?
     /// The message this one follows; nil at the thread root. Two messages
     /// sharing a parent are a fork.
     public var parentId: String?
@@ -217,6 +227,15 @@ public struct ModelSelection: Codable, Hashable, Sendable {
     }
 }
 
+/// The bot that opened a thread, on itself or on a teammate. Absent — which
+/// is every thread from an older computer — means the person opened it.
+public struct ThreadOpener: Codable, Hashable, Sendable {
+    public var botId: String
+    public var name: String
+    public var delegationId: String?
+    public var at: Double
+}
+
 public struct BotTask: Codable, Hashable, Sendable {
     public var threadId: String
     public var title: String
@@ -231,6 +250,7 @@ public struct BotTask: Codable, Hashable, Sendable {
     public var autoApprove: Bool?
     public var alwaysAllow: [String]?
     public var projectId: String?
+    public var openedBy: ThreadOpener?
 }
 
 public struct Bot: Codable, Hashable, Identifiable, Sendable {

--- a/ios/Sources/CompanionCore/Models.swift
+++ b/ios/Sources/CompanionCore/Models.swift
@@ -251,6 +251,11 @@ public struct BotTask: Codable, Hashable, Sendable {
     public var alwaysAllow: [String]?
     public var projectId: String?
     public var openedBy: ThreadOpener?
+
+    /// The thread list's quiet second line, worded as the desktop words it.
+    public var openedByLabel: String? {
+        openedBy.map { "opened by \($0.name)" }
+    }
 }
 
 public struct Bot: Codable, Hashable, Identifiable, Sendable {

--- a/ios/Tests/CompanionCoreTests/DecodingTests.swift
+++ b/ios/Tests/CompanionCoreTests/DecodingTests.swift
@@ -518,6 +518,21 @@ final class DecodingTests: XCTestCase {
         }
     }
 
+    func testAThreadOpenedByABotSaysSoInTheList() throws {
+        // Same words as the desktop's thread list, so a person reading both
+        // screens reads one sentence.
+        let opened = try JSONDecoder().decode(
+            BotTask.self,
+            from: Data(#"{"threadId":"t2","title":"Ship it","createdAt":1,"openedBy":{"botId":"scout","name":"Scout","at":2}}"#.utf8)
+        )
+        XCTAssertEqual(opened.openedByLabel, "opened by Scout")
+
+        let byThePerson = try JSONDecoder().decode(
+            BotTask.self, from: Data(#"{"threadId":"t1","title":"","createdAt":1}"#.utf8)
+        )
+        XCTAssertNil(byThePerson.openedByLabel)
+    }
+
     func testDecodesAThreadRefOnAnActivityChipAndItsAbsence() throws {
         let json = """
         {"id":"m3","role":"bot","kind":"activity","at":1,

--- a/ios/Tests/CompanionCoreTests/DecodingTests.swift
+++ b/ios/Tests/CompanionCoreTests/DecodingTests.swift
@@ -489,6 +489,56 @@ final class DecodingTests: XCTestCase {
         XCTAssertEqual(message.text, "hi")
     }
 
+    func testDecodesAThreadOpenedByABotAndOneOpenedByThePerson() throws {
+        // Newer computers say which bot opened a thread on itself or a
+        // teammate. The captured fixtures predate that, so every thread in
+        // them was opened by the person — and must still decode as such.
+        let json = """
+        {"threadId":"t2","title":"Ship it","createdAt":1,
+         "openedBy":{"botId":"scout","name":"Scout","delegationId":"d1","at":2}}
+        """
+        let opened = try JSONDecoder().decode(BotTask.self, from: Data(json.utf8))
+        XCTAssertEqual(opened.openedBy?.botId, "scout")
+        XCTAssertEqual(opened.openedBy?.name, "Scout")
+        XCTAssertEqual(opened.openedBy?.delegationId, "d1")
+        XCTAssertEqual(opened.openedBy?.at, 2)
+
+        let minimal = try JSONDecoder().decode(
+            BotTask.self,
+            from: Data(#"{"threadId":"t1","title":"","createdAt":1,"openedBy":{"botId":"scout","name":"Scout","at":2}}"#.utf8)
+        )
+        XCTAssertNil(minimal.openedBy?.delegationId)
+
+        let byThePerson = try JSONDecoder().decode(
+            BotTask.self, from: Data(#"{"threadId":"t1","title":"","createdAt":1}"#.utf8)
+        )
+        XCTAssertNil(byThePerson.openedBy)
+        for task in try decode(Fleet.self, "bots-paged").bots.flatMap({ $0.tasks ?? [] }) {
+            XCTAssertNil(task.openedBy, task.threadId)
+        }
+    }
+
+    func testDecodesAThreadRefOnAnActivityChipAndItsAbsence() throws {
+        let json = """
+        {"id":"m3","role":"bot","kind":"activity","at":1,
+         "tool":{"name":"Opened thread #Ship it on Scout","ok":true},
+         "threadRef":{"botId":"scout","threadId":"t2","title":"Ship it"}}
+        """
+        let chip = try JSONDecoder().decode(Message.self, from: Data(json.utf8))
+        XCTAssertEqual(chip.kind, .activity)
+        XCTAssertEqual(chip.tool?.name, "Opened thread #Ship it on Scout")
+        XCTAssertEqual(chip.threadRef, ThreadRef(botId: "scout", threadId: "t2", title: "Ship it"))
+
+        let receipt = try JSONDecoder().decode(
+            Message.self,
+            from: Data(#"{"id":"m4","role":"bot","kind":"activity","at":1,"tool":{"name":"Read","ok":true}}"#.utf8)
+        )
+        XCTAssertNil(receipt.threadRef)
+        for message in try decode(ThreadPage.self, "thread-page").messages {
+            XCTAssertNil(message.threadRef, message.id)
+        }
+    }
+
     // MARK: - Pairing and errors
 
     func testDecodesThePairResponse() throws {


### PR DESCRIPTION
## In plain terms

Phones learn about threads a bot opened. Part of thread-aware bots (`docs/plans/2026-09-09-thread-aware-bots.md`); the server tools and the desktop chat links land in sibling PRs. Both fields are optional on the wire, so this is safe against older servers and can merge first.

- Thread lists show a quiet "opened by Scout" label when a bot opened the thread.
- The "Opened thread #Title on Scout" chip is tappable and goes to that thread, using the same switch route a thread row uses. Viewing never redirects running work. A thread that is gone lands on the bot with a short notice; an unknown bot likewise.
- Decoding tolerates the fields being absent, with fixtures from real payloads asserting nothing regresses.

## Test plan

- [x] iOS: `swift test --package-path ios` 365 tests green; unsigned simulator-target build succeeds. Decoding tests cover with-field, without-delegation-id and without-field; mutation-checked (computed nil → 5 assertions red).
- [x] Android: core 496 and app 862 unit tests green, debug APK builds. Session test drives the chip through the real switch route with a mock server, including the 404 fallback and the no-request case when already on the thread; mutation-checked (`@Transient` → 2 red).
- [x] Companion sidecar already allows the switch route (`companion/src/routes.ts`), asserted by its existing test; no change needed.

No live device or simulator run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Activity messages can now open referenced threads by tapping their thread chips.
  - Navigation switches to the relevant conversation or opens another bot’s chat when needed.
  - Threads opened by another bot now display an “opened by” label in thread lists and task details.
  - Missing threads fall back gracefully with an explanatory error message.
  - Added selection haptic feedback when opening a thread chip.
- **Bug Fixes**
  - Improved handling of unavailable bots and deleted threads during thread navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->