### PR TITLE
fix(mobile): keep thread-chip navigation on the right computer

### DIFF
--- a/android/app/src/main/kotlin/com/openmausbot/companion/ui/ChatScreen.kt
+++ b/android/app/src/main/kotlin/com/openmausbot/companion/ui/ChatScreen.kt
@@ -213,6 +213,10 @@ private fun LoadedChat(
     val chatDrafts = environment.chatDrafts
     val haptics = rememberHaptics()
     val scope = rememberCoroutineScope()
+    var threadOpenJob by remember { mutableStateOf<Job?>(null) }
+    DisposableEffect(threadId) {
+        onDispose { threadOpenJob?.cancel() }
+    }
     val lifecycleOwner = LocalLifecycleOwner.current
     // Words this computer is holding until the running turn settles.
     val queuedSends = state.pendingQueued[threadId].orEmpty()
@@ -401,7 +405,8 @@ private fun LoadedChat(
     // the way a thread row does; one that opened a thread on a teammate pushes
     // that chat.
     fun openThread(ref: ThreadRef) {
-        scope.launch {
+        threadOpenJob?.cancel()
+        threadOpenJob = scope.launch {
             val bot = session.openThread(ref) ?: return@launch
             if (bot.id == chatId) onSelectTask(ChatTarget.Bot(bot.id, bot.threadId)) else onOpenChat(Chat.BotChat(bot))
         }

--- a/android/core/src/main/kotlin/com/openmausbot/companion/core/Session.kt
+++ b/android/core/src/main/kotlin/com/openmausbot/companion/core/Session.kt
@@ -1654,19 +1654,22 @@ class Session(
      * than nowhere.
      *
      * @return the bot pinned to the thread, or to its current thread when the
-     *   switch failed; null when the bot itself is gone or the phone is not
-     *   paired (the notice is already posted).
+     *   thread is gone; null when opening fails or the connection changes.
      */
     suspend fun openThread(ref: ThreadRef): Bot? {
+        currentCoroutineContext().ensureActive()
         val activeClient = client
         if (activeClient == null) {
             _actionError.value = "Pair this phone with your computer to open that thread."
             return null
         }
+        _actionError.value = null
         return try {
             var bot = _state.value.bot(ref.botId)
             if (bot == null) {
                 val fleet = hydrateFn(activeClient, 50)
+                currentCoroutineContext().ensureActive()
+                if (client !== activeClient) return null
                 _state.update { it.hydrate(fleet) }
                 notificationSink.setBadge(_state.value.unreadCount)
                 bot = _state.value.bot(ref.botId)
@@ -1676,9 +1679,13 @@ class Session(
             if (selected.threadId != ref.threadId) {
                 try {
                     selected = activeClient.switchTask(selected.id, ref.threadId)
+                    currentCoroutineContext().ensureActive()
+                    if (client !== activeClient) return null
                     _state.update { it.apply(Frame.Bot(selected)) }
-                } catch (error: Throwable) {
-                    if (error is kotlinx.coroutines.CancellationException) throw error
+                } catch (error: APIError.Status) {
+                    currentCoroutineContext().ensureActive()
+                    if (client !== activeClient) return null
+                    if (error.code != 404) throw error
                     // The thread may be gone (deleted since the chip was
                     // written). The bot's current thread, and a word about it,
                     // beats a dead tap.
@@ -1688,6 +1695,8 @@ class Session(
             selected.forTask(selected.threadId) ?: selected
         } catch (error: Throwable) {
             if (error is kotlinx.coroutines.CancellationException) throw error
+            currentCoroutineContext().ensureActive()
+            if (client !== activeClient) return null
             _actionError.value = error.message
             null
         }

--- a/android/core/src/test/kotlin/com/openmausbot/companion/core/SessionP1Test.kt
+++ b/android/core/src/test/kotlin/com/openmausbot/companion/core/SessionP1Test.kt
@@ -4,17 +4,24 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 
@@ -262,6 +269,103 @@ class SessionP1Test {
     }
 
     @Test
+    fun threadChipDoesNotNavigateOnAuthenticationServerOrUnreadableResponseErrors() = runTest {
+        val scout = bot("scout", "task-1", "task-1", "task-2")
+        val session = session { Fleet(listOf(scout), emptyList()) }
+        for (code in listOf(401, 403, 409, 500)) {
+            server.enqueue(json("""{"error":"Switch failed: $code"}""", code = code))
+            assertNull(session.openThread(ThreadRef("scout", "task-2", "Task 2")))
+            assertEquals("Switch failed: $code", session.actionError)
+            assertEquals("task-1", session.state.value.bot("scout")?.threadId)
+        }
+        server.enqueue(json("not json"))
+        assertNull(session.openThread(ThreadRef("scout", "task-2", "Task 2")))
+        assertTrue(session.actionError != Session.THREAD_GONE_MESSAGE)
+
+        // A successful retry clears the error from the failed tap.
+        server.enqueue(json("""{"bot":${CompanionJson.encodeToString(scout.copy(threadId = "task-2"))}}"""))
+        assertEquals("task-2", session.openThread(ThreadRef("scout", "task-2", "Task 2"))?.threadId)
+        assertNull(session.actionError)
+    }
+
+    @Test
+    fun threadChipDiscardsAHydrationFromThePreviousComputer() = runTest {
+        val started = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        val session = session(otherComputer = true) {
+            started.complete(Unit)
+            release.await()
+            Fleet(listOf(bot("scout", "task-1", "task-1")), emptyList())
+        }
+        val opening = async { session.openThread(ThreadRef("scout", "task-1", "Task 1")) }
+        started.await()
+        session.switchComputer("other")
+        runCurrent()
+        assertEquals("other", session.connection.value?.id)
+        release.complete(Unit)
+
+        assertNull(opening.await())
+        assertTrue(session.state.value.bots.isEmpty())
+        assertNull(session.actionError)
+    }
+
+    @Test
+    fun threadChipDiscardsSwitchSuccessAndFailureFromThePreviousComputer() = runTest {
+        val scout = bot("scout", "task-1", "task-1", "task-2")
+        for (code in listOf(200, 404, 500)) {
+            val session = session(otherComputer = true) { Fleet(listOf(scout), emptyList()) }
+            session.openThread(ThreadRef("scout", "task-1", "Task 1"))
+            val started = CompletableDeferred<Unit>()
+            val release = CompletableDeferred<Unit>()
+            server.dispatcher = object : Dispatcher() {
+                override fun dispatch(request: RecordedRequest): MockResponse {
+                    started.complete(Unit)
+                    runBlocking { release.await() }
+                    return if (code == 200) json("""{"bot":${CompanionJson.encodeToString(scout.copy(threadId = "task-2"))}}""")
+                    else json("""{"error":"Old computer error"}""", code = code)
+                }
+            }
+            val opening = async { session.openThread(ThreadRef("scout", "task-2", "Task 2")) }
+            try {
+                started.await()
+                session.switchComputer("other")
+                runCurrent()
+                assertEquals("other", session.connection.value?.id)
+            } finally {
+                release.complete(Unit)
+            }
+            assertNull(opening.await())
+            assertTrue(session.state.value.bots.isEmpty())
+            assertNull(session.actionError)
+        }
+    }
+
+    @Test
+    fun threadChipCancellationDoesNotNavigateOrReportADeletedThread() = runTest {
+        val scout = bot("scout", "task-1", "task-1", "task-2")
+        val session = session { Fleet(listOf(scout), emptyList()) }
+        val started = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                started.complete(Unit)
+                runBlocking { release.await() }
+                return json("""{"error":"Task not found."}""", code = 404)
+            }
+        }
+        val opening = async { session.openThread(ThreadRef("scout", "task-2", "Task 2")) }
+        try {
+            started.await()
+            opening.cancel()
+        } finally {
+            release.complete(Unit)
+        }
+        assertFailsWith<CancellationException> { opening.await() }
+        assertEquals("task-1", session.state.value.bot("scout")?.threadId)
+        assertNull(session.actionError)
+    }
+
+    @Test
     fun roomTaskNotificationSwitchesTheChannelAndFallsBackWhenTheTaskIsGone() = runTest {
         val room = room("room-1", "room-task-1", "room-task-1", "room-task-2")
         val switched = room.copy(
@@ -405,6 +509,7 @@ class SessionP1Test {
     }
 
     private suspend fun TestScope.session(
+        otherComputer: Boolean = false,
         hydrate: suspend () -> Fleet = { Fleet(emptyList(), emptyList()) },
     ): Session {
         val connection = requireNotNull(Connection.parse(server.url("/").toString()))
@@ -414,6 +519,13 @@ class SessionP1Test {
                 override suspend fun load(): Connection = connection
                 override suspend fun save(connection: Connection) = Unit
                 override suspend fun clear() = Unit
+                override suspend fun loadRegistry() = ConnectionRegistryRestore(
+                    ConnectionRegistry(
+                        if (otherComputer) listOf(connection, connection.copy(id = "other")) else listOf(connection),
+                        connection.id,
+                    ),
+                    migratedLegacyConnection = false,
+                )
             },
             tokenStore = object : TokenStore {
                 override suspend fun save(connectionId: String, token: String) = Unit

--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -45,6 +45,7 @@ struct ChatView: View {
     @State private var filePreview: FilePreviewItem?
     @State private var fileDownloadTask: Task<Void, Never>?
     @State private var fileDownloadRequestID: UUID?
+    @State private var threadOpenTask: Task<Void, Never>?
     @State private var acceptsNextHardwareLineBreak = false
     @FocusState private var composerFocused: Bool
     @StateObject private var dictation = SpeechDictation()
@@ -369,10 +370,15 @@ struct ChatView: View {
             // started in the previous task must not open a sheet (or surface
             // its error) in the new one when the network reply arrives late.
             resetFilePreview()
+            cancelThreadOpen()
+        }
+        .onChange(of: session.connection?.id) { _, _ in
+            cancelThreadOpen()
         }
         .onDisappear {
             dictation.stop()
             resetFilePreview()
+            cancelThreadOpen()
         }
         .onChange(of: scenePhase) { _, phase in
             if phase != .active { dictation.stop() }
@@ -935,12 +941,19 @@ struct ChatView: View {
     /// A chip that opened a thread on this bot switches this screen in
     /// place; one that opened a thread on a teammate pushes that chat.
     private func openThread(_ ref: ThreadRef) {
+        cancelThreadOpen()
         let shownBotId: String? = current.isBot ? current.id : nil
-        Task {
-            if let threadId = await session.openThread(ref, shownBotId: shownBotId) {
-                selectedThreadId = threadId
-            }
+        threadOpenTask = Task {
+            let openedThreadId = await session.openThread(ref, shownBotId: shownBotId)
+            guard !Task.isCancelled else { return }
+            threadOpenTask = nil
+            if let openedThreadId { selectedThreadId = openedThreadId }
         }
+    }
+
+    private func cancelThreadOpen() {
+        threadOpenTask?.cancel()
+        threadOpenTask = nil
     }
 
     private func openLink(_ url: URL, from message: Message) -> OpenURLAction.Result {

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -1870,32 +1870,46 @@ final class Session: ObservableObject {
     /// already on screen. Any other bot is pushed the way a notification is,
     /// and nil comes back.
     func openThread(_ ref: ThreadRef, shownBotId: String?) async -> String? {
+        guard !Task.isCancelled else { return nil }
         guard let client else {
             actionError = "Pair this device with your computer to open that thread."
             return nil
         }
+        let generation = streamGeneration
+        let connectionID = client.connection.id
+        let requestIsCurrent = {
+            !Task.isCancelled && self.streamGeneration == generation && self.client?.connection.id == connectionID
+        }
+        actionError = nil
         do {
             var bot = state.bot(ref.botId)
             if bot == nil {
                 try await hydrate(using: client)
+                guard requestIsCurrent() else { return nil }
                 bot = state.bot(ref.botId)
             }
             guard var selected = bot else { throw APIError.status(code: 404, message: "That agent no longer exists.") }
             if selected.threadId != ref.threadId {
                 do {
                     selected = try await client.switchTask(botId: selected.id, threadId: ref.threadId)
+                    guard requestIsCurrent() else { return nil }
                     state.apply(.bot(selected))
-                } catch {
+                } catch APIError.status(code: 404, message: _) {
+                    guard requestIsCurrent() else { return nil }
                     // The thread may be gone (deleted since the chip was
                     // written). The bot's current thread, and a word about
                     // it, beats a dead tap.
                     actionError = "That thread is no longer on your computer."
                 }
             }
+            guard requestIsCurrent() else { return nil }
             if selected.id == shownBotId { return selected.threadId }
             notificationChat = .bot(selected)
         } catch is CancellationError {
-        } catch { actionError = error.localizedDescription }
+        } catch {
+            guard requestIsCurrent() else { return nil }
+            actionError = error.localizedDescription
+        }
         return nil
     }
 


### PR DESCRIPTION
## Why

Follow-up to #1018, which merged while its review was in progress. Tapping an opened-thread chip treated every server/authentication/network error as a deleted thread and navigated to a different conversation. A late response from the previously selected computer could also update the current computer's state.

## Fix

- Only an actual 404 uses the existing deleted-thread fallback.
- Other failures show their real error and leave navigation unchanged; a successful retry clears it.
- Cancel superseded/disposed requests, including iOS Back, thread changes and connection changes.
- Ignore hydration/switch responses belonging to a previous computer.

Five files; no wire-format, permission, server or visual-design changes.

## Verification

- Three regressions reproduced before the fix: non-404 navigation, stale hydration, and stale switch response.
- All 500 Android core tests and 43 focused navigation/haptics/receipt tests pass.
- Coverage includes 401/403/409/500, unreadable responses, retry, stale success/error after switching saved computers, and cancellation.
- Android debug Kotlin compilation passes.
- iOS CompanionCore: 365 tests pass. Unsigned simulator-target app build passes for arm64/x86_64.
- iOS behavior is source-reviewed and build-verified, not device/runtime tested. No live phone, provider account or user workspace was accessed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented outdated thread-opening requests from switching conversations after users navigate away, change connections, or select another thread.
  - Improved handling of cancelled or interrupted thread requests to avoid incorrect navigation and error messages.
  - Refined error handling so authentication, server, and unreadable responses no longer incorrectly report that a thread is unavailable.
  - Ensured results from previous connections cannot affect the currently active conversation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->