### PR TITLE
fix(chat): let an inline code span break so it cannot leave the bubble

### DIFF
--- a/src/components/ChatMarkdown.test.ts
+++ b/src/components/ChatMarkdown.test.ts
@@ -401,6 +401,17 @@ describe("bidi: message content carries its own direction", () => {
     expect(fenced).toContain('<div dir="ltr"');
   });
 
+  it("lets an inline span break, so a long path cannot leave the bubble", () => {
+    // an unbreakable token wider than the bubble has nowhere to go but
+    // outside it, and in an RTL paragraph that is off the left edge, where
+    // the line ends — the direction that reads as text escaping the message
+    const html = renderToStaticMarkup(createElement(ChatMarkdown, {
+      text: `${ARABIC} \`dist/{download,privacy,terms,license,support,presskit,changelogs,docs,about,feedback}\` ${ARABIC}`,
+    }));
+    const inline = /<code [^>]*class="([^"]*)"/.exec(html)?.[1] ?? "";
+    expect(inline).toContain("break-words");
+  });
+
   it("gives links a base direction, not isolation alone", () => {
     // isolate keeps a link from disturbing the sentence around it, but the
     // link's own contents still lay out along its inherited direction — a URL

--- a/src/components/ChatMarkdown.tsx
+++ b/src/components/ChatMarkdown.tsx
@@ -497,8 +497,12 @@ function ChatMarkdownComponent({ text, streaming = false, message, mentionPeers 
             );
           },
           code({ children }: { children?: ReactNode }) {
+            // break-words because a path or an identifier can be longer than
+            // the bubble is wide, and an unbreakable token has nowhere to go
+            // but outside it — off the left edge in a right-to-left paragraph,
+            // where the line ends.
             return (
-              <code dir="ltr" className="rounded bg-inset px-1 py-px text-[13px] [unicode-bidi:isolate]">{children}</code>
+              <code dir="ltr" className="rounded bg-inset px-1 py-px text-[13px] break-words [unicode-bidi:isolate]">{children}</code>
             );
           },
           // markdown never emits a span itself (no raw HTML); the only


### PR DESCRIPTION
## What

An inline code span can be longer than the bubble is wide, and an unbreakable
token has nowhere to go but outside it. Links in `ChatMarkdown.tsx` already
carry `break-words`; inline code did not.

Reported from real use, where a bot reply contained:

    `dist/{download,privacy,terms,license,support,presskit,changelogs,docs,about,feedback}`

— 85 characters, no break opportunity.

## Not a regression from #994

Worth stating plainly, since that is where it was noticed. I rendered the same
paragraph through the current component and through the one from `cb4e458b`
(immediately before the bidi work) at identical bubble geometry, and measured
the overflow:

| | overflow |
| --- | --- |
| current — Arabic paragraph (RTL) | **87px left** |
| `cb4e458b` — same Arabic paragraph | 87px right |
| current — English paragraph (LTR) | 87px right |
| `cb4e458b` — same English paragraph | 87px right |

Same magnitude in all four. The bug predates #994; what that PR changed is the
side it escapes on. A right-to-left line ends on the left, so the token now
spills off the left edge of the message column instead of the right — which
reads as text escaping the message rather than a long line running on, and is
why it surfaced now.

## How

`break-words` on the inline code span, matching what the anchor and
`LocalFileLink` in the same file already do. `overflow-wrap: anywhere` also
zeroes the overflow; `break-words` was chosen for consistency with the
existing utilities here.

Fenced blocks are unaffected — `CodeBlock` already has `overflow-x-auto` and
its own wrap toggle.

## Verification

Measured in the browser against a control: with the change, the current
component overflows 0px in both the RTL and LTR paragraphs, while the
extracted `cb4e458b` component rendered beside it still overflows 87px — so
the difference is attributable to this change and not to the harness.

The new test fails without the fix (`1 failed | 34 passed`) and passes with it.
Full `vitest run src/`: 144 files, 1171 tests, all passing. `tsc -b` clean,
`oxlint` clean on the touched files.
