### PR TITLE
fix(sidebar): restore larger avatars when threads are hidden

### DIFF
--- a/src/components/Sidebar.simple-mode.test.ts
+++ b/src/components/Sidebar.simple-mode.test.ts
@@ -54,6 +54,27 @@ beforeEach(() => {
 afterEach(() => { vi.unstubAllGlobals(); });
 
 describe("bot-first sidebar", () => {
+  it.each([
+    { enabled: true, density: "comfortable", size: 32, spacing: ["gap-2", "py-2", "pl-6"] },
+    { enabled: true, density: "compact", size: 26, spacing: ["gap-1.5", "py-1", "pl-6"] },
+    { enabled: true, density: "icons", size: 44, spacing: ["justify-center", "px-1", "py-1.5"] },
+    { enabled: false, density: "comfortable", size: 56, spacing: ["gap-3", "py-2.5", "pl-2"] },
+    { enabled: false, density: "compact", size: 40, spacing: ["gap-2", "py-1.5", "pl-2"] },
+    { enabled: false, density: "icons", size: 44, spacing: ["justify-center", "px-1", "py-1.5"] },
+  ] as const)("sizes bot portraits and row spacing in $density density with threads $enabled", ({ enabled, density, size, spacing }) => {
+    fixture.showThreads = enabled;
+    for (const avatar of [{}, { avatarUrl: "/api/attachments/portrait.png", avatarCrop: "circle" as const }]) {
+      let tree: ReactNode;
+      function Capture() { tree = BotListItem({ ...rowProps(density), bot: { ...bot, ...avatar } }); return tree; }
+      const markup = renderToStaticMarkup(createElement(Capture));
+      const row = findElement(tree, "data-sidebar-bot-row", bot.id)!;
+      expect(String(row.props.className).split(" ")).toEqual(expect.arrayContaining([...spacing]));
+      expect(markup).toContain(avatar.avatarUrl
+        ? `width="${size}" height="${size}"`
+        : `width="${size}px" height="${size}px"`);
+    }
+  });
+
   for (const enabled of [true, false]) {
     it.each(densities)(`opens the last selected conversation on mouse or keyboard, %s density, threads ${enabled ? "on" : "off"}`, (density) => {
       fixture.showThreads = enabled;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1018,7 +1018,7 @@ export function BotListItem({
   useEffect(() => {
     if (iconOnly) setRenaming(false);
   }, [iconOnly]);
-  const avatarSize = iconOnly ? 44 : density === "compact" ? 26 : 32;
+  const avatarSize = iconOnly ? 44 : density === "compact" ? (showThreads ? 26 : 40) : (showThreads ? 32 : 56);
   // the visible branch, so a version switch changes the row with the chat
   const visible = visibleMessages(bot);
   const last = visible.at(-1);
@@ -1031,8 +1031,8 @@ export function BotListItem({
     iconOnly
       ? "justify-center px-1 py-1.5"
       : density === "compact"
-        ? cn("gap-1.5 py-1", showThreads ? "pl-6 pr-9 group-hover:pr-16 group-focus-within:pr-16 max-md:pr-16" : "pl-2 pr-9")
-        : cn("gap-2 py-2", showThreads ? "pl-6 pr-9 group-hover:pr-16 group-focus-within:pr-16 max-md:pr-16" : "pl-2 pr-9"),
+        ? cn(showThreads ? "gap-1.5 py-1" : "gap-2 py-1.5", showThreads ? "pl-6 pr-9 group-hover:pr-16 group-focus-within:pr-16 max-md:pr-16" : "pl-2 pr-9")
+        : cn(showThreads ? "gap-2 py-2" : "gap-3 py-2.5", showThreads ? "pl-6 pr-9 group-hover:pr-16 group-focus-within:pr-16 max-md:pr-16" : "pl-2 pr-9"),
     // Chief of Staff is called out by the crown label below, not by tinting
     // the whole row — an accent border + fill read as "selected" even when
     // another bot was active.


### PR DESCRIPTION
## Summary

Restore the original larger bot portraits when **Settings → Appearance → Show threads** is off. The preference previously hid thread controls but left the compact thread-style portraits behind.

- Threads off: **56px Comfortable / 40px Compact**, with the original gap and vertical row spacing.
- Threads on remains **32px / 26px**; Avatars only remains **44px** in either mode.
- No new setting, no shared-avatar changes, no group/channel changes, and no conversation/runtime changes.

## Verification

- Six-case toggle × density regression matrix covers mascot and uploaded-photo dimensions and row spacing.
- Focused sidebar/preference/settings tests pass; app and server typechecks pass; production renderer build passes.
- Drove the actual isolated `verify-threads.ts` app through Appearance settings and the sidebar density controls. Confirmed rendered sizes in all six cases, instant toggle changes, keyboard activation, and persistence after reload.
- Existing bot selection and activity-navigation tests remain green. No real-provider or mobile-runtime claim: this is a renderer-only layout fix.

Engine redesign #1026 is already merged; this is a separate small follow-up. No version bump or release workflow changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated the sidebar’s collapsed thread view with larger bot portraits and more spacious rows.
  - Adjusted padding and spacing across comfortable, compact, and icon-focused density settings for improved readability.
  - Preserved the existing sizing and spacing when the thread list is expanded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->