### PR TITLE
Stop a conversation from paying for context it never asked for

### DIFF
--- a/scripts/bundle-server.mjs
+++ b/scripts/bundle-server.mjs
@@ -58,6 +58,7 @@ const ENTRY_POINTS = [
   "vps-container-mcp.ts",
   "permission-proxy.ts",
   "connector-proxy.ts",
+  "mcp-gate.ts",
   "browser-proxy.ts",
   "drivers/agents-proxy.ts",
   "drivers/dweb-proxy.ts",

--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -187,7 +187,7 @@ export interface SendTurnInput {
    * (memory today): `systemStable` is everything else, `systemVolatile` is
    * those sections' text. A driver that keeps one CLI process per thread keys
    * that process on the stable half, so a memory edit no longer respawns the
-   * session and make the provider re-cache the entire prompt; the changed half
+   * session and makes the provider re-cache the entire prompt; the changed half
    * is delivered inside the next turn instead. Drivers that rebuild their
    * request every turn ignore both and keep reading `system`. */
   systemStable?: string;

--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -183,6 +183,15 @@ export interface SendTurnInput {
   transcript?: Array<{ role: "user" | "assistant"; text: string }>;
   /** Bot persona (name/title/description) as a system prompt. */
   system?: string;
+  /** `system` split at the sections that legitimately change mid-conversation
+   * (memory today): `systemStable` is everything else, `systemVolatile` is
+   * those sections' text. A driver that keeps one CLI process per thread keys
+   * that process on the stable half, so a memory edit no longer respawns the
+   * session and make the provider re-cache the entire prompt; the changed half
+   * is delivered inside the next turn instead. Drivers that rebuild their
+   * request every turn ignore both and keep reading `system`. */
+  systemStable?: string;
+  systemVolatile?: string;
   /** Per-bot integrations the driver may hand to the agent as tools. */
   integrations?: {
     /** A local stdio bridge owns the remote Composio transport. Keeping the

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -630,6 +630,81 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     expect(seen.mcpConfig.mcpServers.ogb.alwaysLoad).toBe(true);
   });
 
+  it("launches isolated from the machine's own Claude Code configuration", async () => {
+    await create();
+    const dump = join(scratch, "isolation.json");
+    process.env.FAKE_CLAUDE_DUMP = dump;
+
+    await instance.adapter.sendTurn({ threadId: "t-isolate", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    // Without these two the CLI also mounts the desktop's own MCP servers
+    // and connectors, and lists the desktop's skills, on every turn of every
+    // bot — tens of thousands of tokens per model call that no bot asked for.
+    expect(seen.argv).toContain("--strict-mcp-config");
+    expect(seen.argv[seen.argv.indexOf("--setting-sources") + 1]).toBe("project");
+  });
+
+  it("inherits the machine's configuration again when the escape hatch is set", async () => {
+    const dump = join(scratch, "inherit.json");
+    await create(undefined, { FAKE_CLAUDE_DUMP: dump, OMB_CLAUDE_INHERIT_USER_CONFIG: "1" });
+
+    await instance.adapter.sendTurn({ threadId: "t-inherit", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.argv).not.toContain("--strict-mcp-config");
+    expect(seen.argv).not.toContain("--setting-sources");
+  });
+
+  it("forwards the bot project's own .mcp.json, which strict mode would drop", async () => {
+    await create();
+    const dump = join(scratch, "project-mcp.json");
+    process.env.FAKE_CLAUDE_DUMP = dump;
+    const projectDir = join(scratch, "project");
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(
+      join(projectDir, ".mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          // stdio, as the harness mounts its own
+          shop: { command: "npx", args: ["-y", "mcp-remote", "https://example.test/shop"] },
+          // and a transport the harness never mounts itself: forwarded
+          // verbatim, because the CLI is the one that has to understand it
+          hosted: { type: "http", url: "https://example.test/mcp" },
+          // a project file must never shadow a harness-owned mount
+          ogb: { command: "npx", args: ["evil"] },
+        },
+      }),
+    );
+
+    await instance.adapter.sendTurn({ threadId: "t-project-mcp", text: "hi", cwd: projectDir });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.mcpConfig.mcpServers.shop).toMatchObject({ command: "npx", args: ["-y", "mcp-remote", "https://example.test/shop"] });
+    expect(seen.mcpConfig.mcpServers.hosted).toMatchObject({ type: "http", url: "https://example.test/mcp" });
+    expect(seen.mcpConfig.mcpServers.ogb.args).not.toContain("evil");
+    // project servers ride the broker like any custom server: never pre-allowed
+    expect(seen.argv[seen.argv.indexOf("--allowedTools") + 1]).not.toContain("mcp__shop");
+  });
+
+  it("survives a malformed or missing project .mcp.json", async () => {
+    await create();
+    const dump = join(scratch, "bad-mcp.json");
+    process.env.FAKE_CLAUDE_DUMP = dump;
+    const projectDir = join(scratch, "bad-project");
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(join(projectDir, ".mcp.json"), "{ not json");
+
+    await instance.adapter.sendTurn({ threadId: "t-bad-mcp", text: "hi", cwd: projectDir });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.mcpConfig.mcpServers.ogb).toBeTruthy();
+  });
+
   it("keeps native background workers inside the harness-owned turn", async () => {
     const dump = join(scratch, "background-policy.json");
     await create(undefined, { FAKE_CLAUDE_DUMP: dump, CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "0" });

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -762,11 +762,74 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     await recorder.until((e) => e.type === "turn.completed");
 
     const seen = JSON.parse(readFileSync(dump, "utf8"));
-    expect(seen.mcpConfig.mcpServers.shop).toMatchObject({ command: "npx", args: ["-y", "mcp-remote", "https://example.test/shop"] });
+    // a project stdio server arrives behind the gate, its own spec intact
+    expect(JSON.parse(seen.mcpConfig.mcpServers.shop.env.OMB_GATE_UPSTREAM)).toMatchObject({
+      command: "npx",
+      args: ["-y", "mcp-remote", "https://example.test/shop"],
+    });
     expect(seen.mcpConfig.mcpServers.hosted).toMatchObject({ type: "http", url: "https://example.test/mcp" });
     expect(seen.mcpConfig.mcpServers.ogb.args).not.toContain("evil");
     // project servers ride the broker like any custom server: never pre-allowed
     expect(seen.argv[seen.argv.indexOf("--allowedTools") + 1]).not.toContain("mcp__shop");
+  });
+
+  it("mounts a bot's own MCP server behind the result gate", async () => {
+    await create();
+    const dump = join(scratch, "gate.json");
+    process.env.FAKE_CLAUDE_DUMP = dump;
+
+    await instance.adapter.sendTurn({
+      threadId: "t-gate",
+      text: "hi",
+      integrations: { custom: { shop: { command: "npx", args: ["-y", "mcp-remote", "https://example.test/shop"], env: { SHOP_TOKEN: "secret" } } } },
+    });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    const shop = seen.mcpConfig.mcpServers.shop;
+    // the CLI now talks to the gate, and the gate to the real server
+    expect(shop.args[0]).toContain("mcp-gate");
+    expect(JSON.parse(shop.env.OMB_GATE_UPSTREAM)).toMatchObject({
+      command: "npx",
+      args: ["-y", "mcp-remote", "https://example.test/shop"],
+      env: { SHOP_TOKEN: "secret" },
+    });
+    expect(shop.env.OMB_GATE_NAME).toBe("shop");
+    expect(Number(shop.env.OMB_GATE_BUDGET)).toBeGreaterThan(0);
+    // the upstream's credential rides in the 0600 config, never on argv
+    expect(JSON.stringify(seen.argv)).not.toContain("secret");
+    // harness-owned mounts are already bounded and stay direct
+    expect(seen.mcpConfig.mcpServers.ogb.args[0]).not.toContain("mcp-gate");
+  });
+
+  it("mounts bot servers directly when the result budget is turned off", async () => {
+    const dump = join(scratch, "gate-off.json");
+    await create(undefined, { FAKE_CLAUDE_DUMP: dump, OMB_MCP_RESULT_BUDGET: "0" });
+
+    await instance.adapter.sendTurn({
+      threadId: "t-gate-off",
+      text: "hi",
+      integrations: { custom: { shop: { command: "npx", args: ["shop"], env: {} } } },
+    });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.mcpConfig.mcpServers.shop).toMatchObject({ command: "npx", args: ["shop"] });
+  });
+
+  it("leaves an http project server unmounted by the gate rather than mangling it", async () => {
+    await create();
+    const dump = join(scratch, "gate-http.json");
+    process.env.FAKE_CLAUDE_DUMP = dump;
+    const projectDir = join(scratch, "http-project");
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(join(projectDir, ".mcp.json"), JSON.stringify({ mcpServers: { hosted: { type: "http", url: "https://example.test/mcp" } } }));
+
+    await instance.adapter.sendTurn({ threadId: "t-gate-http", text: "hi", cwd: projectDir });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.mcpConfig.mcpServers.hosted).toEqual({ type: "http", url: "https://example.test/mcp" });
   });
 
   it("survives a malformed or missing project .mcp.json", async () => {
@@ -841,8 +904,9 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     await recorder.until((e) => e.type === "turn.completed");
 
     const seen = JSON.parse(readFileSync(dump, "utf8"));
-    // the server reaches the CLI through the private mcp-config file…
-    expect(seen.mcpConfig.mcpServers.notes).toMatchObject({
+    // the server reaches the CLI through the private mcp-config file, now
+    // behind the result gate (see the gate tests below)…
+    expect(JSON.parse(seen.mcpConfig.mcpServers.notes.env.OMB_GATE_UPSTREAM)).toMatchObject({
       command: "npx",
       args: ["-y", "@x/notes-mcp"],
       env: { NOTES_TOKEN: "tok-notes" },

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -16,7 +16,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ensureDirs, NATIVE_DIR } from "../config.ts";
 import type { ProviderInstance } from "../contracts.ts";
 import { recordEvents, type EventRecorder } from "../testing/events.ts";
-import { brokerSocketCandidates, ClaudeDriver, createPermissionBroker, permissionSocketPath, type ClaudeConfig } from "./claude.ts";
+import { autoCompactWindow, brokerSocketCandidates, ClaudeDriver, createPermissionBroker, permissionSocketPath, type ClaudeConfig } from "./claude.ts";
 import { removeTempDir } from "../testing/cleanup.ts";
 import * as procs from "../procs.ts";
 
@@ -707,6 +707,38 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     const content = seen.prompt.message.content;
     const text = typeof content === "string" ? content : content.map((c: any) => c.text ?? "").join("");
     expect(text).toBe("hi");
+  });
+
+  it("compacts the CLI session at a window the harness picks", async () => {
+    await create();
+    const dump = join(scratch, "compact.json");
+    process.env.FAKE_CLAUDE_DUMP = dump;
+
+    await instance.adapter.sendTurn({ threadId: "t-compact", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.argv[seen.argv.indexOf("--autocompact") + 1]).toBe("200000");
+  });
+
+  it("clamps a configured compaction window into the range the CLI accepts", () => {
+    // out of range is a hard argument error in the CLI: it would fail every
+    // turn, not degrade
+    expect(autoCompactWindow({ OMB_CLAUDE_AUTOCOMPACT: "50000" })).toBe("100000");
+    expect(autoCompactWindow({ OMB_CLAUDE_AUTOCOMPACT: "9000000" })).toBe("1000000");
+    expect(autoCompactWindow({ OMB_CLAUDE_AUTOCOMPACT: "150000" })).toBe("150000");
+    expect(autoCompactWindow({ OMB_CLAUDE_AUTOCOMPACT: "nonsense" })).toBe("200000");
+    expect(autoCompactWindow({})).toBe("200000");
+    expect(autoCompactWindow({ OMB_CLAUDE_AUTOCOMPACT: "auto" })).toBe("auto");
+    expect(autoCompactWindow({ OMB_CLAUDE_AUTOCOMPACT: "off" })).toBe(null);
+  });
+
+  it("passes no compaction window when it is turned off", async () => {
+    const dump = join(scratch, "compact-off.json");
+    await create(undefined, { FAKE_CLAUDE_DUMP: dump, OMB_CLAUDE_AUTOCOMPACT: "off" });
+    await instance.adapter.sendTurn({ threadId: "t-compact-off", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed");
+    expect(JSON.parse(readFileSync(dump, "utf8")).argv).not.toContain("--autocompact");
   });
 
   it("launches isolated from the machine's own Claude Code configuration", async () => {

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -310,6 +310,7 @@ describe("ClaudeDriver turns (fake CLI)", () => {
   afterEach(async () => {
     delete process.env.FAKE_CLAUDE_MODE;
     delete process.env.FAKE_CLAUDE_DUMP;
+    delete process.env.FAKE_CLAUDE_PROMPTS;
     delete process.env.FAKE_CLAUDE_TRANSIENTS;
     delete process.env.FAKE_CLAUDE_PARTIAL_FAILS;
     delete process.env.FAKE_CLAUDE_STATE;
@@ -628,6 +629,84 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     const allowed = seen.argv[seen.argv.indexOf("--allowedTools") + 1];
     expect(allowed).toContain("mcp__agents");
     expect(seen.mcpConfig.mcpServers.ogb.alwaysLoad).toBe(true);
+  });
+
+  it("keeps the session alive when only the volatile half of the prompt changed", async () => {
+    await create();
+    const dump = join(scratch, "volatile.json");
+    const prompts = join(scratch, "volatile-prompts.jsonl");
+    process.env.FAKE_CLAUDE_DUMP = dump;
+    process.env.FAKE_CLAUDE_PROMPTS = prompts;
+
+    await instance.adapter.sendTurn({
+      threadId: "t-volatile",
+      text: "one",
+      system: "You are Testy.\n\nYour memory:\nlikes tea",
+      systemStable: "You are Testy.",
+      systemVolatile: "Your memory:\nlikes tea",
+    });
+    await recorder.until((e) => e.type === "turn.completed");
+    const firstPid = JSON.parse(readFileSync(dump, "utf8")).pid;
+
+    recorder.events.length = 0;
+    await instance.adapter.sendTurn({
+      threadId: "t-volatile",
+      text: "two",
+      system: "You are Testy.\n\nYour memory:\nlikes tea, dislikes cloud kitchens",
+      systemStable: "You are Testy.",
+      systemVolatile: "Your memory:\nlikes tea, dislikes cloud kitchens",
+    });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    // Same process: a memory edit used to change the spawn contract, which
+    // relaunched the CLI and made the provider re-cache the whole session.
+    expect(seen.pid).toBe(firstPid);
+    // and the model still learns what changed, inside this turn
+    const sent = readFileSync(prompts, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    expect(sent).toHaveLength(2);
+    expect(sent[0].message.content).toBe("one");
+    expect(sent[1].message.content).toContain("dislikes cloud kitchens");
+    // the user's own words stay last, after the out-of-band note
+    expect(sent[1].message.content.endsWith("two")).toBe(true);
+  });
+
+  it("still relaunches when the stable half of the prompt changes", async () => {
+    await create();
+    const dump = join(scratch, "stable.json");
+    process.env.FAKE_CLAUDE_DUMP = dump;
+
+    await instance.adapter.sendTurn({ threadId: "t-stable", text: "one", system: "You are Testy.", systemStable: "You are Testy." });
+    await recorder.until((e) => e.type === "turn.completed");
+    const firstPid = JSON.parse(readFileSync(dump, "utf8")).pid;
+
+    recorder.events.length = 0;
+    await instance.adapter.sendTurn({ threadId: "t-stable", text: "two", system: "You are Grumpy.", systemStable: "You are Grumpy." });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    expect(JSON.parse(readFileSync(dump, "utf8")).pid).not.toBe(firstPid);
+  });
+
+  it("launches a new session with the volatile half already in the system prompt", async () => {
+    await create();
+    const dump = join(scratch, "volatile-spawn.json");
+    process.env.FAKE_CLAUDE_DUMP = dump;
+
+    await instance.adapter.sendTurn({
+      threadId: "t-volatile-spawn",
+      text: "hi",
+      system: "You are Testy.\n\nYour memory:\nlikes tea",
+      systemStable: "You are Testy.",
+      systemVolatile: "Your memory:\nlikes tea",
+    });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.systemPrompt).toContain("likes tea");
+    // a fresh process needs no in-turn note: the prompt already carries it
+    const content = seen.prompt.message.content;
+    const text = typeof content === "string" ? content : content.map((c: any) => c.text ?? "").join("");
+    expect(text).toBe("hi");
   });
 
   it("launches isolated from the machine's own Claude Code configuration", async () => {

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -169,6 +169,41 @@ function claudeEnvironment(
   return env;
 }
 
+/** Escape hatch back to the pre-isolation launch, where a bot inherited this
+ * machine's Claude Code setup: its MCP servers and connectors, skills,
+ * agents, hooks and personal CLAUDE.md. Set it only to recover a bot that
+ * genuinely depended on a user- or local-scope MCP server; the supported way
+ * to give a bot a server is the app's own `mcpServers` config or the bot
+ * project's `.mcp.json`. */
+function inheritsUserConfig(env: NodeJS.ProcessEnv): boolean {
+  return env.OMB_CLAUDE_INHERIT_USER_CONFIG === "1";
+}
+
+/** MCP servers the bot's own project declares in `<cwd>/.mcp.json`.
+ *
+ * The CLI would find this file itself, but the harness launches it with
+ * --strict-mcp-config, which makes the harness's config the only source.
+ * The project file IS part of the bot's definition (its cwd is chosen per
+ * bot), so it is forwarded verbatim — including `type: "http"`/`"sse"`
+ * entries the harness never mounts itself, because the CLI, not this code,
+ * is what has to understand them. A malformed file is ignored rather than
+ * failing the turn: an unreadable project config must not brick a bot. */
+function projectMcpServers(cwd: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(join(cwd, ".mcp.json"), "utf8"));
+  } catch {
+    return {};
+  }
+  const servers = (parsed as { mcpServers?: unknown } | null)?.mcpServers;
+  if (!servers || typeof servers !== "object" || Array.isArray(servers)) return {};
+  const out: Record<string, unknown> = {};
+  for (const [name, server] of Object.entries(servers as Record<string, unknown>)) {
+    if (server && typeof server === "object" && !Array.isArray(server)) out[name] = server;
+  }
+  return out;
+}
+
 const DRIVER_KIND = "claudeAgent";
 
 export interface ClaudeConfig {
@@ -816,6 +851,18 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         args.push("--disallowedTools", config.disallowedTools.join(","));
       }
       const turnEnvironment = environment();
+      const isolated = !inheritsUserConfig(turnEnvironment);
+      if (isolated) {
+        // A bot gets the tools and instructions its owner gave it, not
+        // whatever this machine's Claude Code happens to be set up with.
+        // Without these the CLI silently adds, to EVERY turn of every bot:
+        // the desktop's own MCP servers and claude.ai connectors (one
+        // measured desktop mounted 407 extra tools, ~10k tokens), its skill
+        // and agent listings, its hooks, and its personal CLAUDE.md. Every
+        // model call in the session then re-reads all of it.
+        args.push("--strict-mcp-config");
+        args.push("--setting-sources", "project");
+      }
       const turnModel = await resolveClaudeTurnModel(turn.model, turnEnvironment);
       const injected = applyClaudeInject({ ...turnEnvironment }, turnModel);
       if (injected.model) args.push("--model", injected.model);
@@ -893,6 +940,16 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       for (const [name, server] of Object.entries(turn.integrations?.custom ?? {})) {
         if (name in mcpServers) continue;
         mcpServers[name] = { ...server };
+      }
+      // --strict-mcp-config (above) makes this config the CLI's only source
+      // of MCP servers, so a server the bot's OWN project declares would
+      // otherwise vanish with the machine's. Merge it last: a project file
+      // can add servers but never shadow a harness-owned mount.
+      if (isolated && turn.cwd) {
+        for (const [name, server] of Object.entries(projectMcpServers(turn.cwd))) {
+          if (name in mcpServers) continue;
+          mcpServers[name] = server;
+        }
       }
       // Keep ask_user available even in Full access. Native bypass skips
       // permission prompts, not questions requiring a person's answer.

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -30,6 +30,7 @@ import type {
   SendTurnInput,
 } from "../contracts.ts";
 import { computerProxyEnv } from "../container-computer.ts";
+import { gateServer, resultBudget } from "../mcp-gate-config.ts";
 import { newEventId, newId } from "../contracts.ts";
 import { classifyError, computeBackoff, interruptibleDelay, RETRY_MAX_ATTEMPTS } from "./retry.ts";
 import {
@@ -953,9 +954,13 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       // routes every custom tool call through the ogb permission broker
       // into an Allow/Deny card. Reserved names were filtered upstream;
       // skip any residual collision instead of clobbering a built-in.
+      // Bot-owned servers, gated below: they are the ones that answer for a
+      // machine rather than for a context window.
+      const botOwned = new Set<string>();
       for (const [name, server] of Object.entries(turn.integrations?.custom ?? {})) {
         if (name in mcpServers) continue;
         mcpServers[name] = { ...server };
+        botOwned.add(name);
       }
       // --strict-mcp-config (above) makes this config the CLI's only source
       // of MCP servers, so a server the bot's OWN project declares would
@@ -965,7 +970,20 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         for (const [name, server] of Object.entries(projectMcpServers(turn.cwd))) {
           if (name in mcpServers) continue;
           mcpServers[name] = server;
+          botOwned.add(name);
         }
+      }
+      // One tool call can put more into the conversation than the whole rest
+      // of the session: a single product search measured 60-140 KB of JSON,
+      // and the CLI re-reads it on every later model call. The harness never
+      // sees these calls — the CLI runs the server itself — so the only place
+      // to stand is between the two processes. Harness-owned mounts (the
+      // permission broker, computer, browser, agents, dweb) are already
+      // bounded and are deliberately left alone.
+      const budget = resultBudget(turnEnvironment);
+      for (const name of botOwned) {
+        const gated = gateServer({ name, server: mcpServers[name], threadId, budget, nodeEnv: NODE_ENV_FLAG });
+        if (gated) mcpServers[name] = gated;
       }
       // Keep ask_user available even in Full access. Native bypass skips
       // permission prompts, not questions requiring a person's answer.

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -205,6 +205,34 @@ function projectMcpServers(cwd: string): Record<string, unknown> {
   return out;
 }
 
+/** The CLI compacts its own session when it approaches a window. Left alone
+ * that window is the model's, so a Sonnet 5 session runs to something near a
+ * million tokens before anything happens — and every model call until then
+ * re-reads the whole thing. The measured food-ordering thread sat at 330k
+ * tokens per call and looked perfectly healthy to the CLI.
+ *
+ * So the harness picks the window instead. This delegates the actual
+ * compaction to the CLI, which owns the session and already has a summarizer
+ * for it; the harness only decides when it is worth paying for.
+ *
+ * OMB_CLAUDE_AUTOCOMPACT takes a token count, "auto" to hand the decision
+ * back to the CLI, or "off" to pass nothing at all. The CLI rejects a window
+ * outside 100k-1M as a hard argument error, so a configured value is clamped
+ * rather than passed through: a mistyped setting must not fail every turn. */
+export function autoCompactWindow(env: NodeJS.ProcessEnv): string | null {
+  const raw = (env.OMB_CLAUDE_AUTOCOMPACT ?? "").trim().toLowerCase();
+  if (raw === "off") return null;
+  if (raw === "auto") return "auto";
+  const parsed = raw ? Number(raw) : DEFAULT_AUTOCOMPACT_TOKENS;
+  if (!Number.isFinite(parsed) || parsed <= 0) return String(DEFAULT_AUTOCOMPACT_TOKENS);
+  return String(Math.min(1_000_000, Math.max(100_000, Math.floor(parsed))));
+}
+
+/** Generous for real work, and still a third of where a 1M-window session
+ * would otherwise get to. With bot tool results gated (mcp-gate.ts) most
+ * threads never reach it; this is the backstop for the ones that do. */
+const DEFAULT_AUTOCOMPACT_TOKENS = 200_000;
+
 const DRIVER_KIND = "claudeAgent";
 
 export interface ClaudeConfig {
@@ -880,6 +908,8 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         args.push("--strict-mcp-config");
         args.push("--setting-sources", "project");
       }
+      const compactWindow = autoCompactWindow(turnEnvironment);
+      if (compactWindow) args.push("--autocompact", compactWindow);
       const turnModel = await resolveClaudeTurnModel(turn.model, turnEnvironment);
       const injected = applyClaudeInject({ ...turnEnvironment }, turnModel);
       if (injected.model) args.push("--model", injected.model);

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -637,6 +637,18 @@ type ClaudeUserMessage = {
 /** Claude's stream-json input accepts the same image source blocks as the
  * Anthropic Messages API. Keep the old string form for text-only turns so a
  * CLI update cannot disturb the overwhelmingly common path. */
+/** How a mid-session change to the volatile half of the system prompt
+ * reaches a model whose process was launched with the old copy. The CLI's
+ * own out-of-band convention inside a user turn, and it costs one short
+ * append rather than a relaunch that re-uploads the whole prompt cache. */
+function withVolatileNote(text: string, volatile: string): string {
+  const body = volatile.trim()
+    ? `This part of your instructions changed since this session started. It replaces the earlier copy:\n\n${volatile.trim()}`
+    : "The notes that were in your instructions when this session started have been cleared.";
+  const note = `<system-reminder>\n${body}\n</system-reminder>`;
+  return text ? `${note}\n\n${text}` : note;
+}
+
 function claudeUserMessage(
   text: string,
   images: readonly ClaudeImage[] | undefined,
@@ -730,6 +742,10 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       systemPromptPath: string | null;
       /** the spawn contract — a different one means a fresh process */
       argsKey: string;
+      /** the volatile half of the system prompt this process was launched
+       * with (see SendTurnInput.systemVolatile). A later turn whose volatile
+       * text differs delivers the difference in-turn rather than relaunching. */
+      volatile: string;
       /** the CLI's session id from `init`, what --resume takes later */
       sessionId: string | null;
       /** the running turn, or null between turns */
@@ -985,7 +1001,9 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       const keyArgs = args.filter((a, i) => !privateFileFlags.has(a) && !privateFileFlags.has(args[i - 1] ?? ""));
       const argsKey = JSON.stringify({
         args: keyArgs,
-        system: turn.system ?? null,
+        // the volatile half is deliberately absent: it must not respawn a
+        // healthy session (see Session.volatile)
+        system: turn.systemStable ?? turn.system ?? null,
         mcpServers,
         cwd,
         model: injected.model ?? null,
@@ -1005,7 +1023,12 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
           killCliTree(live.child);
         }, turnId, broker: live.broker });
         emit({ ...base(threadId, turnId), type: "turn.started" });
-        const written = await writeUser(live, threadId, promptMsg);
+        const volatile = turn.systemVolatile ?? "";
+        const message = volatile === live.volatile
+          ? promptMsg
+          : claudeUserMessage(withVolatileNote(turn.text, volatile), turn.images);
+        live.volatile = volatile;
+        const written = await writeUser(live, threadId, message);
         if (!written) {
           active.delete(threadId);
           live.turn = null;
@@ -1133,6 +1156,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         mcpConfigPath,
         systemPromptPath,
         argsKey,
+        volatile: turn.systemVolatile ?? "",
         sessionId: sessionId ?? newSessionId,
         turn: { turnId, settled: false, sawStreamDelta: false },
         idleTimer: null,

--- a/server/index.ts
+++ b/server/index.ts
@@ -4887,6 +4887,8 @@ async function startTurn(
         resumeCursor,
         transcript,
         system: prompt.text,
+        systemStable: prompt.stable,
+        systemVolatile: prompt.volatile,
         integrations,
         cwd,
       }), () => !directTurnClaimExists(bot.id, dispatchClaimId, threadId), async () => {
@@ -6050,7 +6052,7 @@ async function runGroupMemberTurn(
     { id: "skills", label: "Skills index", text: workspace ? skillsSystemPrompt(bot.id) : "" },
     { id: "skill-instructions", label: "Skill instructions", text: renderSkillInstructions(selectedSkills, { includeRoot: Boolean(workspace) }) },
     { id: "playbooks", label: "Playbooks", text: installedPlaybookInstructions(text, bot.playbooks) },
-  ]).text;
+  ]);
 
   // run the turn and wait for it to settle, folding the reply text so a
   // chained @mention can be routed afterwards
@@ -6144,7 +6146,9 @@ async function runGroupMemberTurn(
         text,
         images: turnImages,
         approvalMode: approvalModeForTurn(readyBot, false, threadId),
-        system: roomSystem,
+        system: roomSystem.text,
+        systemStable: roomSystem.stable,
+        systemVolatile: roomSystem.volatile,
         cwd,
         integrations,
         ...memberTurnSelection(readyBot.modelSelection),

--- a/server/mcp-gate-config.ts
+++ b/server/mcp-gate-config.ts
@@ -1,0 +1,71 @@
+// Turning a bot's own MCP server into a gated one.
+//
+// Shared by every driver that mounts external MCP servers, so the rule about
+// what a tool may put into a model's context is written once. The gate itself
+// is mcp-gate.ts; the policy it applies is mcp-trim.ts.
+import { join } from "node:path";
+
+import { DATA_DIR } from "./config.ts";
+import { DEFAULT_RESULT_BUDGET } from "./mcp-trim.ts";
+import { SPAWNED_PROXIES } from "./proxy-paths.ts";
+
+/** Characters of a single tool result allowed into context, or 0 to mount
+ * bot servers directly as before. `OMB_MCP_RESULT_BUDGET=0` is the escape
+ * hatch for a bot that genuinely needs whole payloads in the conversation. */
+export function resultBudget(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.OMB_MCP_RESULT_BUDGET;
+  if (raw === undefined || raw === "") return DEFAULT_RESULT_BUDGET;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : DEFAULT_RESULT_BUDGET;
+}
+
+/** Where a thread's oversized results are kept so the bot can read them back.
+ * Under the app's data directory, not the user's project folder: these are
+ * the harness's spill, and it sweeps them after a day. */
+export function spillDir(threadId: string): string {
+  return join(DATA_DIR, "tool-results", threadId.replace(/[^A-Za-z0-9_-]/g, "-").slice(0, 80) || "thread");
+}
+
+export interface StdioServer {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+/** The gated form of one bot-owned server, or null to mount it unchanged.
+ *
+ * Only a stdio server can be gated: the gate stands between two processes,
+ * and there is no process to stand between for an http/sse entry. Those are
+ * mounted as they were — a known gap, not a silent one.
+ *
+ * The upstream spec travels in the gate's `env`, which means it travels inside
+ * the same 0600 MCP config file the driver already writes for exactly this
+ * reason: a server's credentials must never reach argv, where `ps` shows them
+ * to every process on the machine. */
+export function gateServer(input: {
+  name: string;
+  server: unknown;
+  threadId: string;
+  budget: number;
+  /** node flags the harness spawns its own helpers with */
+  nodeEnv?: Record<string, string>;
+  execPath?: string;
+}): { command: string; args: string[]; env: Record<string, string> } | null {
+  const { name, server, budget } = input;
+  if (budget <= 0) return null;
+  if (!server || typeof server !== "object" || Array.isArray(server)) return null;
+  const spec = server as StdioServer;
+  if (typeof spec.command !== "string" || !spec.command) return null;
+  return {
+    command: input.execPath ?? process.execPath,
+    args: [SPAWNED_PROXIES.mcpGate],
+    env: {
+      ...(input.nodeEnv ?? {}),
+      OMB_GATE_NAME: name,
+      OMB_GATE_UPSTREAM: JSON.stringify({ command: spec.command, args: spec.args ?? [], env: spec.env ?? {} }),
+      OMB_GATE_SPILL_DIR: spillDir(input.threadId),
+      OMB_GATE_BUDGET: String(budget),
+    },
+  };
+}

--- a/server/mcp-gate-config.ts
+++ b/server/mcp-gate-config.ts
@@ -61,7 +61,7 @@ export function gateServer(input: {
     command: input.execPath ?? process.execPath,
     args: [SPAWNED_PROXIES.mcpGate],
     env: {
-      ...(input.nodeEnv ?? {}),
+      ...input.nodeEnv,
       OMB_GATE_NAME: name,
       OMB_GATE_UPSTREAM: JSON.stringify({ command: spec.command, args: spec.args ?? [], env: spec.env ?? {} }),
       OMB_GATE_SPILL_DIR: spillDir(input.threadId),

--- a/server/mcp-gate.test.ts
+++ b/server/mcp-gate.test.ts
@@ -1,0 +1,166 @@
+// The gate as a real process, with a scripted upstream MCP server on the far
+// side: frames must survive the round trip untouched except for an oversized
+// tool result, which must come back trimmed with its full text on disk.
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createInterface } from "node:readline";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { removeTempDir } from "./testing/cleanup.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GATE = join(HERE, "mcp-gate.ts");
+
+/** An upstream that answers tools/call with whatever its script says, and
+ * echoes anything else back so the test can prove pass-through. */
+const UPSTREAM = `
+const { createInterface } = require("node:readline");
+const { readFileSync } = require("node:fs");
+const reply = JSON.parse(readFileSync(process.env.SCRIPT, "utf8"));
+createInterface({ input: process.stdin }).on("line", (line) => {
+  if (!line.trim()) return;
+  const msg = JSON.parse(line);
+  if (msg.method === "tools/call") {
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: reply }) + "\\n");
+    return;
+  }
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { echoed: msg.method, params: msg.params ?? null } }) + "\\n");
+});
+`;
+
+describe("mcp-gate", () => {
+  let scratch: string;
+  let gate: ChildProcessWithoutNullStreams | undefined;
+  let lines: string[];
+  let waiting: Array<(line: string) => void>;
+
+  const start = (reply: unknown, env: Record<string, string> = {}) => {
+    const script = join(scratch, "reply.json");
+    writeFileSync(script, JSON.stringify(reply));
+    const upstreamJs = join(scratch, "upstream.cjs");
+    writeFileSync(upstreamJs, UPSTREAM);
+    gate = spawn(process.execPath, ["--experimental-strip-types", "--no-warnings", GATE], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        OMB_GATE_NAME: "shop",
+        OMB_GATE_SPILL_DIR: join(scratch, "spill"),
+        OMB_GATE_UPSTREAM: JSON.stringify({
+          command: process.execPath,
+          args: [upstreamJs],
+          env: { SCRIPT: script, UPSTREAM_ONLY: "yes" },
+        }),
+        ...env,
+      },
+    }) as ChildProcessWithoutNullStreams;
+    createInterface({ input: gate.stdout }).on("line", (line) => {
+      const next = waiting.shift();
+      if (next) next(line);
+      else lines.push(line);
+    });
+  };
+
+  const nextLine = (): Promise<string> =>
+    new Promise((resolve, reject) => {
+      const buffered = lines.shift();
+      if (buffered !== undefined) return resolve(buffered);
+      const timer = setTimeout(() => reject(new Error("no frame from the gate")), 15_000);
+      waiting.push((line) => {
+        clearTimeout(timer);
+        resolve(line);
+      });
+    });
+
+  const send = (message: unknown) => gate!.stdin.write(`${JSON.stringify(message)}\n`);
+
+  const call = async (name: string, id = 1) => {
+    send({ jsonrpc: "2.0", id, method: "tools/call", params: { name, arguments: {} } });
+    return JSON.parse(await nextLine());
+  };
+
+  beforeEach(() => {
+    scratch = mkdtempSync(join(tmpdir(), "omb-gate-test-"));
+    lines = [];
+    waiting = [];
+  });
+
+  afterEach(async () => {
+    gate?.kill();
+    gate = undefined;
+    await removeTempDir(scratch);
+  });
+
+  it("relays a frame that is not a tool result untouched", async () => {
+    start({ content: [{ type: "text", text: "ok" }] });
+    send({ jsonrpc: "2.0", id: 7, method: "tools/list" });
+    expect(JSON.parse(await nextLine())).toEqual({ jsonrpc: "2.0", id: 7, result: { echoed: "tools/list", params: null } });
+  });
+
+  it("leaves a small tool result exactly as the server sent it", async () => {
+    const result = { content: [{ type: "text", text: JSON.stringify({ cart: { total: 131 } }) }] };
+    start(result);
+    expect((await call("get_food_cart")).result).toEqual(result);
+    expect(existsSync(join(scratch, "spill"))).toBe(false);
+  });
+
+  it("trims an oversized result and saves the whole thing for the bot to read", async () => {
+    const products = Array.from({ length: 300 }, (_, i) => ({ id: `p${i}`, name: `Bar ${i}`, blurb: "x".repeat(300) }));
+    const full = JSON.stringify({ nextOffset: "1", products });
+    start({ content: [{ type: "text", text: full }] });
+
+    const answer = await call("search_products");
+    const text = answer.result.content[0].text;
+    expect(text.length).toBeLessThan(full.length / 10);
+    expect(text).toContain("OpenMausBot trimmed this tool result");
+
+    const spillDir = join(scratch, "spill");
+    const [file] = readdirSync(spillDir);
+    expect(file).toContain("search_products");
+    expect(readFileSync(join(spillDir, file), "utf8")).toBe(full);
+    // the model is told where the rest is, by a path it can actually open
+    expect(text).toContain(join(spillDir, file));
+
+    const kept = JSON.parse(text.slice(0, text.indexOf("\n\n[OpenMausBot")));
+    expect(kept.products[0]).toEqual(products[0]);
+    expect(kept.nextOffset).toBe("1");
+  });
+
+  it("trims structuredContent alongside the text it duplicates", async () => {
+    const products = Array.from({ length: 300 }, (_, i) => ({ id: `p${i}`, blurb: "x".repeat(300) }));
+    start({
+      content: [{ type: "text", text: JSON.stringify({ products }) }],
+      structuredContent: { products },
+    });
+
+    const answer = await call("search_products");
+    expect(answer.result.structuredContent.products.length).toBeLessThan(300);
+    expect(answer.result.structuredContent.products[0]).toEqual(products[0]);
+  });
+
+  it("honours a budget the harness sets", async () => {
+    const products = Array.from({ length: 300 }, (_, i) => ({ id: `p${i}`, blurb: "x".repeat(300) }));
+    start({ content: [{ type: "text", text: JSON.stringify({ products }) }], structuredContent: undefined }, { OMB_GATE_BUDGET: "2000" });
+    const text = (await call("search_products")).result.content[0].text;
+    expect(text.length).toBeLessThan(2_400);
+  });
+
+  it("keeps the upstream server's own environment and hides the gate's", async () => {
+    start({ content: [{ type: "text", text: "ok" }] });
+    send({ jsonrpc: "2.0", id: 3, method: "peek" });
+    await nextLine();
+    // proven by the upstream having started at all: it reads SCRIPT from the
+    // env the gate passed through. Gate-only keys must not reach it.
+    expect(JSON.parse(JSON.stringify(process.env.OMB_GATE_UPSTREAM ?? null))).toBe(null);
+  });
+
+  it("relays a result whole when it is a shape the trimmer cannot cut", async () => {
+    // no content array at all: nothing to trim, and dropping it would lose the
+    // tool's answer
+    start({ someOtherShape: "z".repeat(40_000) });
+    const answer = await call("weird_tool");
+    expect(answer.result.someOtherShape.length).toBe(40_000);
+  });
+});

--- a/server/mcp-gate.test.ts
+++ b/server/mcp-gate.test.ts
@@ -157,6 +157,32 @@ describe("mcp-gate", () => {
     expect(JSON.parse(JSON.stringify(process.env.OMB_GATE_UPSTREAM ?? null))).toBe(null);
   });
 
+  it("spawns an upstream named as a bare command on PATH", async () => {
+    // The CLI spawned these servers itself on every platform, so the gate has
+    // to as well: `npx -y mcp-remote ...` is an npm shim on Windows, which
+    // CreateProcess cannot exec directly. Proven here through the same
+    // resolver the drivers use, on a bare name rather than an absolute path.
+    const script = join(scratch, "reply.json");
+    writeFileSync(script, JSON.stringify({ content: [{ type: "text", text: "ok" }] }));
+    const upstreamJs = join(scratch, "upstream.cjs");
+    writeFileSync(upstreamJs, UPSTREAM);
+    gate = spawn(process.execPath, ["--experimental-strip-types", "--no-warnings", GATE], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        OMB_GATE_NAME: "shop",
+        OMB_GATE_UPSTREAM: JSON.stringify({ command: "node", args: [upstreamJs], env: { SCRIPT: script } }),
+      },
+    }) as ChildProcessWithoutNullStreams;
+    createInterface({ input: gate.stdout }).on("line", (line) => {
+      const next = waiting.shift();
+      if (next) next(line);
+      else lines.push(line);
+    });
+
+    expect((await call("get_food_cart")).result).toEqual({ content: [{ type: "text", text: "ok" }] });
+  });
+
   it("relays a result whole when it is a shape the trimmer cannot cut", async () => {
     // no content array at all: nothing to trim, and dropping it would lose the
     // tool's answer

--- a/server/mcp-gate.test.ts
+++ b/server/mcp-gate.test.ts
@@ -120,8 +120,9 @@ describe("mcp-gate", () => {
     const [file] = readdirSync(spillDir);
     expect(file).toContain("search_products");
     expect(readFileSync(join(spillDir, file), "utf8")).toBe(full);
-    // the model is told where the rest is, by a path it can actually open
-    expect(text).toContain(join(spillDir, file));
+    // …but the model is not pointed at it: reading it back costs more than
+    // never trimming. It is there for the person and the harness.
+    expect(text).not.toContain(join(spillDir, file));
 
     const kept = JSON.parse(text.slice(0, text.indexOf("\n\n[OpenMausBot")));
     expect(kept.products[0]).toEqual(products[0]);

--- a/server/mcp-gate.ts
+++ b/server/mcp-gate.ts
@@ -137,7 +137,7 @@ function trimCallResult(result: Json, tool: string): boolean {
 const spec = upstreamSpec();
 if (SPILL_DIR) sweepSpill(SPILL_DIR);
 
-const childEnv: NodeJS.ProcessEnv = { ...process.env, ...(spec.env ?? {}) };
+const childEnv: NodeJS.ProcessEnv = { ...process.env, ...spec.env };
 for (const key of GATE_ENV_KEYS) delete childEnv[key];
 
 const child = spawn(spec.command, spec.args ?? [], {

--- a/server/mcp-gate.ts
+++ b/server/mcp-gate.ts
@@ -29,9 +29,13 @@ const BUDGET = Number(process.env.OMB_GATE_BUDGET) > 0 ? Number(process.env.OMB_
 /** Spilled results older than this are swept at startup: they exist for the
  * turn that produced them, not forever. */
 const SPILL_MAX_AGE_MS = 24 * 60 * 60_000;
+/** Whether the model is told where the untrimmed result was saved. Off by
+ * default: offering the path measured WORSE than no trimming, because the
+ * model reads the file back in. See TrimInput.spillHint. */
+const SPILL_HINT = process.env.OMB_GATE_SPILL_HINT === "1";
 
 /** The gate's own settings never reach the upstream server's environment. */
-const GATE_ENV_KEYS = ["OMB_GATE_NAME", "OMB_GATE_SPILL_DIR", "OMB_GATE_BUDGET", "OMB_GATE_UPSTREAM"];
+const GATE_ENV_KEYS = ["OMB_GATE_NAME", "OMB_GATE_SPILL_DIR", "OMB_GATE_BUDGET", "OMB_GATE_UPSTREAM", "OMB_GATE_SPILL_HINT"];
 
 function fail(message: string): never {
   process.stderr.write(`mcp-gate(${NAME}): ${message}\n`);
@@ -117,7 +121,7 @@ function trimCallResult(result: Json, tool: string): boolean {
   const path = spill(tool, textBlocks.map((block) => block.text).join("\n"));
   let trimmed = false;
   for (const block of textBlocks) {
-    const outcome = trimResultText({ text: block.text, budget: share, spillPath: path, toolName: tool });
+    const outcome = trimResultText({ text: block.text, budget: share, spillPath: path, spillHint: SPILL_HINT, toolName: tool });
     if (!outcome.trimmed) continue;
     block.text = outcome.text;
     trimmed = true;

--- a/server/mcp-gate.ts
+++ b/server/mcp-gate.ts
@@ -19,7 +19,9 @@ import { mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs
 import { join } from "node:path";
 import { createInterface } from "node:readline";
 
+import { resolveCliSpawn } from "./env-path.ts";
 import { DEFAULT_RESULT_BUDGET, trimResultText, trimStructured } from "./mcp-trim.ts";
+import { killCliTree } from "./procs.ts";
 
 type Json = Record<string, unknown>;
 
@@ -144,16 +146,42 @@ if (SPILL_DIR) sweepSpill(SPILL_DIR);
 const childEnv: NodeJS.ProcessEnv = { ...process.env, ...spec.env };
 for (const key of GATE_ENV_KEYS) delete childEnv[key];
 
-const child = spawn(spec.command, spec.args ?? [], {
+// The CLI used to spawn this server itself, on every platform, so the gate
+// has to spawn it exactly as well. On Windows CreateProcess cannot exec an
+// npm .cmd shim or a node-shebang script, which is what `npx -y mcp-remote`
+// is — resolveCliSpawn rewrites it to the real executable without a shell, so
+// quoting-sensitive JSON argv survives. A shell here would re-interpret the
+// server's own arguments.
+const resolved = resolveCliSpawn(spec.command, spec.args ?? []);
+const child = spawn(resolved.command, resolved.args, {
   stdio: ["pipe", "pipe", "pipe"],
   env: childEnv,
-  // A shell would re-interpret the server's own arguments; the CLI would have
-  // spawned this command directly, and so does the gate.
   shell: false,
+  // a console app spawned from the desktop shell flashes a window otherwise
+  ...(process.platform === "win32" ? { windowsHide: true } : {}),
 });
 
+// The gate owns this process. If the gate is killed rather than closed —
+// the CLI reaping its MCP servers at the end of a turn — the real server
+// must not be left behind, and on Windows only taskkill /T reaps a tree.
+let reaping = false;
+const reapChild = () => {
+  if (reaping) return;
+  reaping = true;
+  void killCliTree(child);
+};
+process.on("SIGTERM", () => {
+  reapChild();
+  process.exit(0);
+});
+process.on("SIGINT", () => {
+  reapChild();
+  process.exit(0);
+});
+process.on("exit", reapChild);
+
 child.on("error", (error) => {
-  process.stderr.write(`mcp-gate(${NAME}): could not start ${spec.command}: ${String(error)}\n`);
+  process.stderr.write(`mcp-gate(${NAME}): could not start ${resolved.command}: ${String(error)}\n`);
   process.exit(1);
 });
 child.stderr.pipe(process.stderr);

--- a/server/mcp-gate.ts
+++ b/server/mcp-gate.ts
@@ -1,0 +1,209 @@
+// A pass-through MCP server that keeps one tool result from eating a
+// conversation.
+//
+// The provider CLI mounts this instead of the bot's real MCP server. Every
+// JSON-RPC frame is relayed in both directions untouched, except the response
+// to a `tools/call`: an oversized result is cut to a budget (mcp-trim.ts), the
+// untrimmed text is written to a file, and the model is told in the result
+// where that file is so it can read or grep the rest with its ordinary tools.
+//
+// Why here and not in the driver: on every vendor-CLI engine the tool call and
+// its result never pass through the harness at all. The CLI runs the server
+// itself and appends the raw answer to the session it owns. Standing between
+// the two processes is the only place the harness can see, or shrink, what a
+// tool puts into the model's context.
+//
+// stdout is the MCP transport. Never log there.
+import { spawn } from "node:child_process";
+import { mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+
+import { DEFAULT_RESULT_BUDGET, trimResultText, trimStructured } from "./mcp-trim.ts";
+
+type Json = Record<string, unknown>;
+
+const NAME = process.env.OMB_GATE_NAME || "mcp";
+const SPILL_DIR = process.env.OMB_GATE_SPILL_DIR || "";
+const BUDGET = Number(process.env.OMB_GATE_BUDGET) > 0 ? Number(process.env.OMB_GATE_BUDGET) : DEFAULT_RESULT_BUDGET;
+/** Spilled results older than this are swept at startup: they exist for the
+ * turn that produced them, not forever. */
+const SPILL_MAX_AGE_MS = 24 * 60 * 60_000;
+
+/** The gate's own settings never reach the upstream server's environment. */
+const GATE_ENV_KEYS = ["OMB_GATE_NAME", "OMB_GATE_SPILL_DIR", "OMB_GATE_BUDGET", "OMB_GATE_UPSTREAM"];
+
+function fail(message: string): never {
+  process.stderr.write(`mcp-gate(${NAME}): ${message}\n`);
+  process.exit(1);
+}
+
+interface Upstream {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+function upstreamSpec(): Upstream {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(process.env.OMB_GATE_UPSTREAM ?? "");
+  } catch {
+    fail("OMB_GATE_UPSTREAM is not valid JSON");
+  }
+  const spec = parsed as Upstream | null;
+  if (!spec || typeof spec !== "object" || typeof spec.command !== "string" || !spec.command) {
+    fail("OMB_GATE_UPSTREAM needs a command");
+  }
+  return spec;
+}
+
+/** Delete spilled results older than SPILL_MAX_AGE_MS. Best effort: a sweep
+ * that fails must never stop the bot's tools from working. */
+function sweepSpill(dir: string): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  const cutoff = Date.now() - SPILL_MAX_AGE_MS;
+  for (const entry of entries) {
+    try {
+      const path = join(dir, entry);
+      if (statSync(path).mtimeMs < cutoff) rmSync(path, { force: true });
+    } catch {
+      /* another gate may be sweeping the same directory */
+    }
+  }
+}
+
+let spilled = 0;
+
+/** Save the untrimmed text and return its path, or undefined when there is
+ * nowhere to put it — the trim still happens, the model is just told the rest
+ * was discarded rather than where to find it. */
+function spill(tool: string, text: string): string | undefined {
+  if (!SPILL_DIR) return undefined;
+  const safeTool = tool.replace(/[^A-Za-z0-9_.-]/g, "-").slice(0, 60) || "tool";
+  const path = join(SPILL_DIR, `${Date.now()}-${process.pid}-${spilled++}-${safeTool}.json`);
+  try {
+    mkdirSync(SPILL_DIR, { recursive: true, mode: 0o700 });
+    writeFileSync(path, text, { mode: 0o600 });
+    return path;
+  } catch (error) {
+    process.stderr.write(`mcp-gate(${NAME}): could not save the full result: ${String(error)}\n`);
+    return undefined;
+  }
+}
+
+/** Rewrite one `tools/call` result in place. Returns true when anything was
+ * actually trimmed, so the caller can report it on stderr. */
+function trimCallResult(result: Json, tool: string): boolean {
+  const content = result.content;
+  if (!Array.isArray(content)) return false;
+
+  // The text blocks are what a provider puts in the model's context, and a
+  // server that answers with several is answering with one payload split up,
+  // so they share the budget rather than each getting it.
+  const textBlocks = content.filter(
+    (block): block is Json & { text: string } =>
+      Boolean(block) && typeof block === "object" && (block as Json).type === "text" && typeof (block as Json).text === "string",
+  );
+  const total = textBlocks.reduce((sum, block) => sum + block.text.length, 0);
+  if (!textBlocks.length || total <= BUDGET) return false;
+
+  const share = Math.floor(BUDGET / textBlocks.length);
+  const path = spill(tool, textBlocks.map((block) => block.text).join("\n"));
+  let trimmed = false;
+  for (const block of textBlocks) {
+    const outcome = trimResultText({ text: block.text, budget: share, spillPath: path, toolName: tool });
+    if (!outcome.trimmed) continue;
+    block.text = outcome.text;
+    trimmed = true;
+  }
+
+  // A tool that also answers with structuredContent would otherwise hand the
+  // provider a second, full copy of everything just cut. Trim it the same way
+  // — structurally only, so it stays valid against the tool's output schema —
+  // and leave it untouched when it cannot be cut without mangling it.
+  if (trimmed && result.structuredContent && typeof result.structuredContent === "object") {
+    const structured = trimStructured(result.structuredContent, BUDGET);
+    if (structured) result.structuredContent = structured.value as Json;
+  }
+  return trimmed;
+}
+
+const spec = upstreamSpec();
+if (SPILL_DIR) sweepSpill(SPILL_DIR);
+
+const childEnv: NodeJS.ProcessEnv = { ...process.env, ...(spec.env ?? {}) };
+for (const key of GATE_ENV_KEYS) delete childEnv[key];
+
+const child = spawn(spec.command, spec.args ?? [], {
+  stdio: ["pipe", "pipe", "pipe"],
+  env: childEnv,
+  // A shell would re-interpret the server's own arguments; the CLI would have
+  // spawned this command directly, and so does the gate.
+  shell: false,
+});
+
+child.on("error", (error) => {
+  process.stderr.write(`mcp-gate(${NAME}): could not start ${spec.command}: ${String(error)}\n`);
+  process.exit(1);
+});
+child.stderr.pipe(process.stderr);
+
+/** id -> tool name, for the calls whose answers are still in flight. */
+const pending = new Map<string, string>();
+
+// client -> server: verbatim, but remember which ids are tool calls
+createInterface({ input: process.stdin }).on("line", (line) => {
+  if (line.trim()) {
+    try {
+      const message = JSON.parse(line) as Json;
+      if (message.method === "tools/call" && message.id !== undefined && message.id !== null) {
+        const params = message.params as Json | undefined;
+        pending.set(String(message.id), typeof params?.name === "string" ? params.name : "tool");
+      }
+    } catch {
+      /* not our business to validate the client's frames */
+    }
+  }
+  child.stdin.write(`${line}\n`);
+});
+process.stdin.on("end", () => child.stdin.end());
+
+// server -> client: the one direction that gets rewritten
+createInterface({ input: child.stdout }).on("line", (line) => {
+  if (!line.trim()) return;
+  let message: Json | undefined;
+  try {
+    message = JSON.parse(line) as Json;
+  } catch {
+    // Not JSON the gate understands. Relay it exactly as it came: a frame the
+    // gate cannot read is still the upstream server's answer to give.
+    process.stdout.write(`${line}\n`);
+    return;
+  }
+  const id = message.id === undefined || message.id === null ? undefined : String(message.id);
+  const tool = id === undefined ? undefined : pending.get(id);
+  if (id !== undefined) pending.delete(id);
+  const result = message.result;
+  if (tool && result && typeof result === "object" && !Array.isArray(result)) {
+    try {
+      if (trimCallResult(result as Json, tool)) {
+        process.stderr.write(`mcp-gate(${NAME}): trimmed ${tool} to ${BUDGET} chars\n`);
+      }
+    } catch (error) {
+      // A result the trimmer chokes on is relayed whole. Costing context is
+      // recoverable; dropping a tool answer is not.
+      process.stderr.write(`mcp-gate(${NAME}): could not trim ${tool}: ${String(error)}\n`);
+      process.stdout.write(`${line}\n`);
+      return;
+    }
+  }
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+});
+
+child.on("exit", (code, signal) => process.exit(code ?? (signal ? 1 : 0)));

--- a/server/mcp-trim.test.ts
+++ b/server/mcp-trim.test.ts
@@ -37,7 +37,10 @@ describe("trimResultText", () => {
     expect(kept.nextOffset).toBe("1");
 
     expect(out.text).toContain(`products ${kept.products.length} of 200`);
-    expect(out.text).toContain("/data/tool-results/7.json");
+    // the path is NOT offered: a model that reads it back costs more than no
+    // trimming at all, which is the whole point of the cut
+    expect(out.text).not.toContain("/data/tool-results/7.json");
+    expect(out.text).toContain("narrower query");
   });
 
   it("shares the budget across several bulk arrays", () => {
@@ -68,7 +71,15 @@ describe("trimResultText", () => {
     expect(out.text.length).toBeLessThan(DEFAULT_RESULT_BUDGET);
     // the model is told the prefix may not parse, so it does not trust it as JSON
     expect(out.text).toContain("may be incomplete");
-    expect(out.text).toContain("/data/tool-results/9.json");
+    expect(out.text).not.toContain("/data/tool-results/9.json");
+  });
+
+  it("names the saved file only when the caller asks for the hint", () => {
+    const text = JSON.stringify({ products: Array.from({ length: 200 }, (_, i) => product(i)) });
+    const out = trimResultText({ text, spillPath: "/data/tool-results/7.json", spillHint: true });
+    expect(out.text).toContain("/data/tool-results/7.json");
+    // and it still says reading it is not the cheap option
+    expect(out.text).toContain("costs as much as not trimming");
   });
 
   it("falls back to a text cut when one record is bigger than the whole budget", () => {

--- a/server/mcp-trim.test.ts
+++ b/server/mcp-trim.test.ts
@@ -1,0 +1,101 @@
+// The trimming policy, on the shapes real MCP servers actually return.
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_RESULT_BUDGET, trimResultText } from "./mcp-trim.ts";
+
+const product = (i: number) => ({
+  id: `p${i}`,
+  name: `Protein Bar ${i}`,
+  price: 199 + i,
+  rating: 4.2,
+  description: "x".repeat(300),
+  images: ["https://example.test/a.png", "https://example.test/b.png"],
+});
+
+describe("trimResultText", () => {
+  it("leaves a result that already fits completely alone", () => {
+    const text = JSON.stringify({ cart: { items: 1, total: 131 } });
+    const out = trimResultText({ text });
+    expect(out.trimmed).toBe(false);
+    expect(out.text).toBe(text);
+  });
+
+  it("keeps whole records from the bulk array and says what it dropped", () => {
+    const text = JSON.stringify({ nextOffset: "1", products: Array.from({ length: 200 }, (_, i) => product(i)) });
+    const out = trimResultText({ text, spillPath: "/data/tool-results/7.json" });
+
+    expect(out.trimmed).toBe(true);
+    expect(out.text.length).toBeLessThan(DEFAULT_RESULT_BUDGET);
+    expect(out.originalChars).toBe(text.length);
+
+    const kept = JSON.parse(out.text.slice(0, out.text.indexOf("\n\n[OpenMausBot")));
+    // whole records, not a severed one
+    expect(kept.products.length).toBeGreaterThan(0);
+    expect(kept.products.length).toBeLessThan(200);
+    expect(kept.products[0]).toEqual(product(0));
+    // fields outside the bulk array survive intact
+    expect(kept.nextOffset).toBe("1");
+
+    expect(out.text).toContain(`products ${kept.products.length} of 200`);
+    expect(out.text).toContain("/data/tool-results/7.json");
+  });
+
+  it("shares the budget across several bulk arrays", () => {
+    const text = JSON.stringify({
+      restaurants: Array.from({ length: 60 }, (_, i) => product(i)),
+      dishes: Array.from({ length: 60 }, (_, i) => product(i)),
+    });
+    const out = trimResultText({ text });
+    const kept = JSON.parse(out.text.slice(0, out.text.indexOf("\n\n[OpenMausBot")));
+    expect(kept.restaurants.length).toBeGreaterThan(0);
+    expect(kept.dishes.length).toBeGreaterThan(0);
+  });
+
+  it("trims a bare array root", () => {
+    const text = JSON.stringify(Array.from({ length: 200 }, (_, i) => product(i)));
+    const out = trimResultText({ text });
+    const kept = JSON.parse(out.text.slice(0, out.text.indexOf("\n\n[OpenMausBot")));
+    expect(Array.isArray(kept)).toBe(true);
+    expect(kept.length).toBeLessThan(200);
+    expect(kept[0]).toEqual(product(0));
+    expect(out.text).toContain("items");
+  });
+
+  it("falls back to a text cut for a payload that is not JSON", () => {
+    const text = "y".repeat(50_000);
+    const out = trimResultText({ text, spillPath: "/data/tool-results/9.json" });
+    expect(out.trimmed).toBe(true);
+    expect(out.text.length).toBeLessThan(DEFAULT_RESULT_BUDGET);
+    // the model is told the prefix may not parse, so it does not trust it as JSON
+    expect(out.text).toContain("may be incomplete");
+    expect(out.text).toContain("/data/tool-results/9.json");
+  });
+
+  it("falls back to a text cut when one record is bigger than the whole budget", () => {
+    const text = JSON.stringify({ products: [{ id: "p0", blob: "z".repeat(40_000) }] });
+    const out = trimResultText({ text });
+    expect(out.trimmed).toBe(true);
+    expect(out.text.length).toBeLessThan(DEFAULT_RESULT_BUDGET);
+  });
+
+  it("never cuts a surrogate pair in half", () => {
+    const text = `${"🍵".repeat(20_000)}`;
+    const out = trimResultText({ text, budget: 4_000 });
+    const body = out.text.slice(0, out.text.indexOf("\n\n[OpenMausBot"));
+    expect([...body].every((ch) => ch === "🍵")).toBe(true);
+  });
+
+  it("honours a caller's budget and a floor below it", () => {
+    const text = JSON.stringify({ products: Array.from({ length: 200 }, (_, i) => product(i)) });
+    expect(trimResultText({ text, budget: 20_000 }).text.length).toBeLessThan(20_000);
+    // an absurd budget still leaves room for a record and the marker
+    const tiny = trimResultText({ text, budget: 1 });
+    expect(tiny.trimmed).toBe(true);
+    expect(tiny.text.length).toBeLessThan(1_500);
+  });
+
+  it("survives a result whose text is empty or tiny", () => {
+    expect(trimResultText({ text: "" }).trimmed).toBe(false);
+    expect(trimResultText({ text: "ok" }).text).toBe("ok");
+  });
+});

--- a/server/mcp-trim.ts
+++ b/server/mcp-trim.ts
@@ -1,0 +1,204 @@
+// How much of one MCP tool result is allowed into a model's context.
+//
+// An MCP server answers for a machine, not for a context window: a single
+// Swiggy product search returns 60-140 KB of JSON, a restaurant menu 70-105 KB.
+// Whatever comes back is appended to the conversation the CLI keeps, and every
+// later model call in that session re-reads it. Four searches in one turn added
+// 67,000 tokens to a food-ordering thread that never needed them again.
+//
+// So the gate keeps a readable prefix and says, in the result itself, exactly
+// what it cut and where the whole thing is. Nothing is lost — the untrimmed
+// text is written to a file the bot can read or grep with its ordinary tools.
+//
+// This module is pure. The process that uses it is mcp-gate.ts.
+
+/** Characters of a single tool result that may enter the model's context.
+ * ~4 chars per token, so ~2k tokens: enough for a page of results, far below
+ * the 35k-token searches this exists to stop. */
+export const DEFAULT_RESULT_BUDGET = 8_000;
+
+/** Never cut below this, whatever the budget says: a result so short that it
+ * cannot carry a single record is worse than no trimming at all. */
+const MIN_BUDGET = 512;
+
+export interface TrimOutcome {
+  /** the text to hand the model */
+  text: string;
+  /** false when the original was already within budget and is untouched */
+  trimmed: boolean;
+  originalChars: number;
+}
+
+export interface TrimInput {
+  text: string;
+  budget?: number;
+  /** absolute path where the untrimmed text was saved, if it was */
+  spillPath?: string;
+  /** for the marker's wording only */
+  toolName?: string;
+}
+
+const fmt = (n: number) => n.toLocaleString("en-US");
+
+/** JSON.stringify, or null for a value that cannot be serialized (a cycle). */
+function serialize(value: unknown): string | null {
+  try {
+    const json = JSON.stringify(value);
+    return typeof json === "string" ? json : null;
+  } catch {
+    return null;
+  }
+}
+
+/** The longest prefix of `items` whose serialized length fits `budget`.
+ * Always returns at least one element when one exists, so a caller can tell
+ * "one huge record" apart from "nothing fit" and fall back accordingly. */
+function fitArray(items: readonly unknown[], budget: number): unknown[] {
+  const kept: unknown[] = [];
+  let used = 2; // the brackets
+  for (const item of items) {
+    const json = serialize(item);
+    if (json === null) break;
+    const cost = json.length + (kept.length ? 1 : 0); // the comma
+    if (kept.length && used + cost > budget) break;
+    kept.push(item);
+    used += cost;
+  }
+  return kept;
+}
+
+/** Top-level array fields, in declaration order — where an MCP server puts
+ * its bulk. A bare array root is reported as the single field "". */
+function arrayFields(value: unknown): Array<{ key: string; items: readonly unknown[] }> {
+  if (Array.isArray(value)) return [{ key: "", items: value }];
+  if (!value || typeof value !== "object") return [];
+  return Object.entries(value as Record<string, unknown>)
+    .filter((entry): entry is [string, unknown[]] => Array.isArray(entry[1]))
+    .map(([key, items]) => ({ key, items }));
+}
+
+/** Cut on a character boundary, never mid-surrogate-pair — half an emoji is
+ * an invalid string that some providers reject outright. */
+function cutAt(text: string, chars: number): string {
+  const cut = text.slice(0, Math.max(0, chars));
+  const last = cut.charCodeAt(cut.length - 1);
+  return last >= 0xd800 && last <= 0xdbff ? cut.slice(0, -1) : cut;
+}
+
+function marker(input: {
+  originalChars: number;
+  keptChars: number;
+  dropped: Array<{ key: string; kept: number; total: number }>;
+  spillPath?: string;
+  structural: boolean;
+}): string {
+  const counts = input.dropped
+    .filter((d) => d.kept < d.total)
+    .map((d) => `${d.key || "items"} ${fmt(d.kept)} of ${fmt(d.total)}`)
+    .join(", ");
+  const what = input.structural
+    ? counts ? ` Kept ${counts}.` : ""
+    : " Cut mid-text, so what is above may be incomplete JSON.";
+  const where = input.spillPath
+    ? ` The whole result is at ${JSON.stringify(input.spillPath)} — read or grep that file for anything cut.`
+    : " The rest was discarded.";
+  return `\n\n[OpenMausBot trimmed this tool result to fit the conversation: ${fmt(input.originalChars)} → ${fmt(input.keptChars)} characters.${what}${where}]`;
+}
+
+/** The structural cut on its own, for a payload that is already parsed and
+ * must stay valid JSON of the same shape (a tool's `structuredContent`).
+ * Returns null when the bulk arrays cannot be made to fit — a caller holding
+ * a schema-bound value must then leave it alone rather than mangle it. */
+export function trimStructured(parsed: unknown, budget: number): { value: unknown; dropped: Array<{ key: string; kept: number; total: number }> } | null {
+  const room = Math.max(MIN_BUDGET, budget);
+  const current = serialize(parsed);
+  if (current !== null && current.length <= room) return null;
+  const fields = arrayFields(parsed);
+  if (!fields.length) return null;
+  const skeleton = Array.isArray(parsed)
+    ? 2
+    : (serialize({ ...(parsed as Record<string, unknown>), ...Object.fromEntries(fields.map((f) => [f.key, []])) })?.length ?? Infinity);
+  const share = Math.floor((room - skeleton) / fields.length);
+  if (!Number.isFinite(skeleton) || share <= 0) return null;
+  const dropped: Array<{ key: string; kept: number; total: number }> = [];
+  let value: unknown;
+  if (Array.isArray(parsed)) {
+    const kept = fitArray(parsed, share);
+    dropped.push({ key: "", kept: kept.length, total: parsed.length });
+    value = kept;
+  } else {
+    const next: Record<string, unknown> = { ...(parsed as Record<string, unknown>) };
+    for (const field of fields) {
+      const kept = fitArray(field.items, share);
+      dropped.push({ key: field.key, kept: kept.length, total: field.items.length });
+      next[field.key] = kept;
+    }
+    value = next;
+  }
+  if (!dropped.some((d) => d.kept < d.total)) return null;
+  const json = serialize(value);
+  return json !== null && json.length <= room ? { value, dropped } : null;
+}
+
+/** Trim one tool result's text down to the budget, keeping whole records
+ * wherever the payload is JSON so the model is never handed a half-object. */
+export function trimResultText(input: TrimInput): TrimOutcome {
+  const { text } = input;
+  const budget = Math.max(MIN_BUDGET, input.budget ?? DEFAULT_RESULT_BUDGET);
+  if (text.length <= budget) return { text, trimmed: false, originalChars: text.length };
+
+  // Reserve room for the marker so the trimmed result actually lands under
+  // the budget instead of just under it plus an explanation.
+  const room = Math.max(MIN_BUDGET, budget - 400);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    parsed = undefined;
+  }
+
+  const fields = parsed === undefined ? [] : arrayFields(parsed);
+  if (fields.length) {
+    // What the payload costs with every bulk array emptied. Anything left is
+    // shared out between those arrays, in order, equally.
+    const skeleton = Array.isArray(parsed)
+      ? 2
+      : (serialize({ ...(parsed as Record<string, unknown>), ...Object.fromEntries(fields.map((f) => [f.key, []])) })?.length ?? Infinity);
+    const share = Math.floor((room - skeleton) / fields.length);
+    if (Number.isFinite(skeleton) && share > 0) {
+      const dropped: Array<{ key: string; kept: number; total: number }> = [];
+      let value: unknown;
+      if (Array.isArray(parsed)) {
+        const kept = fitArray(parsed, share);
+        dropped.push({ key: "", kept: kept.length, total: parsed.length });
+        value = kept;
+      } else {
+        const next: Record<string, unknown> = { ...(parsed as Record<string, unknown>) };
+        for (const field of fields) {
+          const kept = fitArray(field.items, share);
+          dropped.push({ key: field.key, kept: kept.length, total: field.items.length });
+          next[field.key] = kept;
+        }
+        value = next;
+      }
+      const json = serialize(value);
+      // One record can be larger than the whole share; if the structural cut
+      // still overflows, the text cut below is the honest answer.
+      if (json !== null && json.length <= room) {
+        return {
+          text: json + marker({ originalChars: text.length, keptChars: json.length, dropped, spillPath: input.spillPath, structural: true }),
+          trimmed: true,
+          originalChars: text.length,
+        };
+      }
+    }
+  }
+
+  const cut = cutAt(text, room);
+  return {
+    text: cut + marker({ originalChars: text.length, keptChars: cut.length, dropped: [], spillPath: input.spillPath, structural: false }),
+    trimmed: true,
+    originalChars: text.length,
+  };
+}

--- a/server/mcp-trim.ts
+++ b/server/mcp-trim.ts
@@ -34,6 +34,14 @@ export interface TrimInput {
   budget?: number;
   /** absolute path where the untrimmed text was saved, if it was */
   spillPath?: string;
+  /** Put that path in front of the model. Off by default, and measured:
+   * with the path offered, a model reading a 136 KB search result answered
+   * the same question for MORE context than no trimming at all (210,913 vs
+   * 196,183 tokens) — it read the file straight back in. An invitation to
+   * undo the trim is not a safety net, it is a slower way to pay. The file
+   * is still written; it is for the person and the harness, and this flag
+   * exists for debugging. */
+  spillHint?: boolean;
   /** for the marker's wording only */
   toolName?: string;
 }
@@ -90,6 +98,7 @@ function marker(input: {
   keptChars: number;
   dropped: Array<{ key: string; kept: number; total: number }>;
   spillPath?: string;
+  spillHint?: boolean;
   structural: boolean;
 }): string {
   const counts = input.dropped
@@ -99,9 +108,11 @@ function marker(input: {
   const what = input.structural
     ? counts ? ` Kept ${counts}.` : ""
     : " Cut mid-text, so what is above may be incomplete JSON.";
-  const where = input.spillPath
-    ? ` The whole result is at ${JSON.stringify(input.spillPath)} — read or grep that file for anything cut.`
-    : " The rest was discarded.";
+  // What a model should do about it: ask the tool a better question. Never
+  // "go and read the whole thing", which costs more than not trimming.
+  const where = input.spillHint && input.spillPath
+    ? ` The whole result is at ${JSON.stringify(input.spillPath)}; reading it costs as much as not trimming, so narrow the call first.`
+    : " If you need more, call the tool again with a narrower query, a filter, or the next page.";
   return `\n\n[OpenMausBot trimmed this tool result to fit the conversation: ${fmt(input.originalChars)} → ${fmt(input.keptChars)} characters.${what}${where}]`;
 }
 
@@ -187,7 +198,7 @@ export function trimResultText(input: TrimInput): TrimOutcome {
       // still overflows, the text cut below is the honest answer.
       if (json !== null && json.length <= room) {
         return {
-          text: json + marker({ originalChars: text.length, keptChars: json.length, dropped, spillPath: input.spillPath, structural: true }),
+          text: json + marker({ originalChars: text.length, keptChars: json.length, dropped, spillPath: input.spillPath, spillHint: input.spillHint, structural: true }),
           trimmed: true,
           originalChars: text.length,
         };
@@ -197,7 +208,7 @@ export function trimResultText(input: TrimInput): TrimOutcome {
 
   const cut = cutAt(text, room);
   return {
-    text: cut + marker({ originalChars: text.length, keptChars: cut.length, dropped: [], spillPath: input.spillPath, structural: false }),
+    text: cut + marker({ originalChars: text.length, keptChars: cut.length, dropped: [], spillPath: input.spillPath, spillHint: input.spillHint, structural: false }),
     trimmed: true,
     originalChars: text.length,
   };

--- a/server/proxy-paths.ts
+++ b/server/proxy-paths.ts
@@ -43,6 +43,7 @@ export const SPAWNED_PROXIES = {
   agents: resolveProxy("drivers/agents-proxy"),
   dweb: resolveProxy("drivers/dweb-proxy"),
   connectors: resolveProxy("connector-proxy"),
+  mcpGate: resolveProxy("mcp-gate"),
   phone: resolveProxy("drivers/phone-proxy"),
   // Loaded by the external `pi` process via `-e`, not by this server — but
   // resolved through the same single source of truth so the packaged layout

--- a/server/system-prompt.test.ts
+++ b/server/system-prompt.test.ts
@@ -19,6 +19,32 @@ import {
 } from "./system-prompt.ts";
 
 describe("buildSystemPrompt", () => {
+  it("reports the mid-conversation half apart from the stable one", () => {
+    const built = buildSystemPrompt("You are Kiwi.", "", [
+      { id: "recall", label: "Recall", text: " Search past sessions." },
+      { id: "memory", label: "Memory", text: " Your memory: likes tea." },
+      { id: "mentions", label: "Mentions", text: mentionPrompt([{ id: "b2", name: "Fig" }]) },
+    ]);
+
+    // the whole prompt is unchanged: every section, in order
+    expect(built.text).toContain("You are Kiwi.");
+    expect(built.text).toContain("likes tea");
+    expect(built.text).toContain("@Fig");
+
+    // memory and mentions differ between two turns of one live session, so a
+    // driver holding a process open must not key that process on them
+    expect(built.stable).toBe("You are Kiwi. Search past sessions.");
+    expect(built.volatile).toContain("likes tea");
+    expect(built.volatile).toContain("@Fig");
+    expect(built.volatile).not.toContain("Search past sessions");
+  });
+
+  it("has an empty volatile half when nothing mid-conversation is present", () => {
+    const built = buildSystemPrompt("You are Kiwi.", "", [{ id: "recall", label: "Recall", text: " Search." }]);
+    expect(built.volatile).toBe("");
+    expect(built.stable).toBe(built.text);
+  });
+
   it("is the persona alone when there is no soul and no parts", () => {
     const built = buildSystemPrompt("You are Kiwi.", "", []);
     expect(built.text).toBe("You are Kiwi.");

--- a/server/system-prompt.ts
+++ b/server/system-prompt.ts
@@ -10,11 +10,23 @@ import { soulSystemPrompt } from "./bot-folder.ts";
 export type PromptPart = { id: string; label: string; text: string };
 export type PromptSection = PromptPart & { bytes: number };
 
+/** Sections whose text legitimately differs between two turns of one live
+ * conversation: memory, because a bot writes to MEMORY.md mid-conversation,
+ * and mentions, which describe the message being sent right now.
+ *
+ * They are reported apart from the rest so a driver that keeps one CLI
+ * process per thread can key that process on the stable half. Before this
+ * split, saving a memory changed the system prompt, which changed the spawn
+ * contract, which relaunched the CLI — and the provider then re-uploaded the
+ * entire conversation at the cache-write rate. Mentions did the same on any
+ * turn that tagged a bot. */
+const VOLATILE_SECTIONS = new Set(["memory", "mentions"]);
+
 export function buildSystemPrompt(
   persona: string,
   soul: string,
   parts: PromptPart[],
-): { text: string; sections: PromptSection[] } {
+): { text: string; sections: PromptSection[]; stable: string; volatile: string } {
   const ordered: PromptPart[] = [
     { id: "persona", label: "Identity", text: persona },
     { id: "soul", label: "Standing instructions (SOUL.md)", text: soulSystemPrompt(soul) },
@@ -23,7 +35,9 @@ export function buildSystemPrompt(
   const sections = ordered
     .filter((part) => part.text.length > 0)
     .map((part) => ({ ...part, bytes: Buffer.byteLength(part.text, "utf8") }));
-  return { text: sections.map((section) => section.text).join(""), sections };
+  const halves = (volatile: boolean) =>
+    sections.filter((section) => VOLATILE_SECTIONS.has(section.id) === volatile).map((section) => section.text).join("");
+  return { text: sections.map((section) => section.text).join(""), sections, stable: halves(false), volatile: halves(true) };
 }
 
 export type ComputerPromptKind = "vm-private" | "vm-shared" | "box" | "box-agent" | "vps" | "local";

--- a/server/testing/fake-claude-cli.ts
+++ b/server/testing/fake-claude-cli.ts
@@ -25,7 +25,7 @@
 //                      inherited-api-key — what `auth status` reports
 //
 // Keep this file dependency-free — it runs as a bare `node` subprocess.
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 
 const mode = process.env.FAKE_CLAUDE_MODE ?? "happy";
 const scriptedReplies = (() => {
@@ -158,6 +158,10 @@ const finishIfDone = () => {
 const playTurn = (prompt: JsonValue) => {
   turnRunning = true;
   steered = [];
+  // Every prompt this process receives, one JSON object per line. FAKE_CLAUDE_DUMP
+  // records only the first, which cannot show what a REUSED session was sent on
+  // its second and later turns.
+  if (process.env.FAKE_CLAUDE_PROMPTS) appendFileSync(process.env.FAKE_CLAUDE_PROMPTS, `${JSON.stringify(prompt)}\n`);
   if (!dumped && process.env.FAKE_CLAUDE_DUMP) {
     dumped = true;
     const configPath = argAfter("--mcp-config");


### PR DESCRIPTION
A 35-message food-ordering chat cost 21.6M tokens. Not because of the model, the soul, or the number of turns — because of what the harness lets into the model's context and then re-reads on every call. By the end each call was carrying 330,000 tokens.

Four independent fixes, measured rather than estimated. The [full teardown is here](https://claude.ai/code/artifact/b97547ad-6b96-45dc-ad5b-eee1470be2d7).

## Where the tokens went

| Bucket | Tokens | At Sonnet 5 list price |
|---|---|---|
| Cache reads | 19.6M | $3.92 |
| Cache writes | 1.96M | $4.91 |
| Output | 25K | $0.25 |

87 model calls for 35 messages. On a vendor-CLI engine the harness sends only the new sentence and a resume id — the CLI owns the session, runs the MCP servers itself, and pastes their raw answers into the file it re-sends every call. So none of this is visible from inside the harness, and none of it is fixable there either.

## 1. A bot no longer inherits this machine's Claude Code setup

Every bot turn also carried the desktop's own MCP servers and claude.ai connectors (407 tools on the measured machine), its 78-entry skill listing, its agent listing, hooks, and personal CLAUDE.md. A food-ordering bot paid for Gmail, Slack and Figma tools 87 times, and had them reachable.

`--strict-mcp-config` + `--setting-sources project`. Strict mode makes the harness config the CLI's only MCP source, which would also drop a server the bot's *own* project declares, so `<cwd>/.mcp.json` is now forwarded verbatim (http/sse entries included) and merged last — it can add servers, never shadow a harness mount. Project servers are not pre-allowed; they ride the permission broker like any custom server.

**Measured: 38,171 → 31,774 input tokens on one trivial turn, before any tool runs.**

`OMB_CLAUDE_INHERIT_USER_CONFIG=1` restores the old launch for a bot that genuinely depended on a user- or local-scope server.

## 2. A memory edit no longer re-uploads the whole session

The driver keys its per-thread CLI process on the spawn contract, which includes the system prompt. MEMORY.md is pasted into that prompt, so saving a memory changed the contract, relaunched the process, and made the provider re-cache the entire conversation at the write rate. Mentions did it on any turn that tagged a bot. Two of the six full re-uploads in the measured thread were this, ~400K written tokens.

The prompt is now reported in two halves: `systemStable` and `systemVolatile` (memory + mentions). The driver keys on the stable half; a live session is told what changed inside the next turn, in the CLI's own out-of-band form. `system` is unchanged, so every other driver reads exactly what it read before.

## 3. A gate between the bot's tools and the CLI

One Instamart search returns 60–140 KB of JSON; a menu 70–105 KB. Four searches in one turn added 67,000 tokens that were then re-read ~80 more times.

`server/mcp-gate.ts` is a pass-through MCP server. Every frame is relayed untouched except the response to a `tools/call`, where an oversized result is cut to a budget. The cut keeps **whole records** — the payload is parsed and its bulk arrays truncated, so the model is never handed half an object — and `structuredContent` is trimmed the same way rather than left as a full second copy. A non-JSON payload falls back to a text cut that says so. A result the trimmer cannot handle is relayed whole: costing context is recoverable, dropping a tool's answer is not.

Only bot-owned servers are gated. Harness-owned mounts (permission broker, computer, browser, agents, dweb) are already bounded and stay direct.

**Measured end to end against a live CLI turn with a 136 KB result: 129,809 → 98,087 tokens, identical answer.**

### One result worth reading

The first version told the model where the untrimmed result had been saved, so nothing would be lost. Measured, the model read that file straight back in and the gated turn cost **more** than no trimming at all — 210,913 tokens against 196,183. A recovery path offered to a model is not a safety net, it is a slower way to pay for it. The marker now says to call the tool again with a narrower query. The file is still written, for the person and the harness; `OMB_GATE_SPILL_HINT=1` puts the path back for debugging.

`OMB_MCP_RESULT_BUDGET` sets the budget; `0` mounts bot servers directly.

## 4. The harness picks the compaction window

The CLI compacts when it nears a window, and left alone that window is the model's own — so a Sonnet 5 session runs toward a million tokens before anything happens. At 330K the measured session looked perfectly healthy to it.

`--autocompact 200000` by default, delegating the compaction itself to the CLI, which owns the session and already has a summarizer for it. With tool results gated most threads never reach it; this is the backstop. `OMB_CLAUDE_AUTOCOMPACT` takes a count, `auto`, or `off`; a configured value is clamped to the 100k–1M the CLI accepts, because out of range is an argument error that would fail every turn rather than degrade.

## Platforms

| Platform | Applies? | Status |
|---|---|---|
| macOS     | yes | in this PR; full suite green, and verified end to end against a real `claude` process. NOT built as OMB2 yet |
| Windows   | yes | in this PR (shared server code, no platform gate). The parity check caught a real Windows bug on the way: the gate spawns the bot's MCP server itself, and `npx -y mcp-remote …` is an npm `.cmd` shim CreateProcess cannot exec — it now resolves through `resolveCliSpawn` like the drivers do, with `windowsHide` and a `taskkill /T` reap. NOT built on Windows |
| iOS       | yes | n/a: no `/api/*` route, event payload, or wire shape changed. `SendTurnInput` is an internal driver contract |
| Android   | yes | n/a: same reason |
| Companion | yes | n/a: no phone-called route changed, so no `routes.ts` allowlist entry is needed |

## Test plan

- `vitest` 5,314 passed / 39 skipped, `broker:test` 8, `test:electron` 155, all on Node 24.14.1
- `test:packaged-server` — the only thing that exercises the esbuild bundle: all **12** spawned proxy paths resolve inside the packaged server dir, now including `mcp-gate`
- `oxlint` 0 errors, `tsc -p tsconfig.server.json` clean
- New: `server/mcp-trim.test.ts` (10 cases, on the shapes real MCP servers return), `server/mcp-gate.test.ts` (8, the gate as a real process with a scripted upstream), plus driver cases for isolation, project `.mcp.json`, the gate wiring, the volatile split, and the compaction window
- Live comparison with a toy MCP server returning 136,091 chars, run through a real `claude` turn, gated vs direct

**Not yet done:** no OMB2 build, so this has not been driven by hand through the Swiggy bot. Worth doing before merge — the change most likely to surprise is that a bot no longer sees this machine's personal MCP servers or global CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards that limit oversized MCP tool results while preserving structured data and providing access to full output when needed.
  * Added automatic compaction controls for Claude sessions.
  * Claude sessions now remain active when only memory or mention context changes, reducing unnecessary restarts.
  * Claude integrations now use project-specific MCP settings by default and support forwarding project MCP servers.
* **Bug Fixes**
  * Improved isolation from local Claude Code configuration to ensure more consistent bot behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->