### PR TITLE
fix(approvals): enable native Grok Auto and annotate scoped agent reads

### DIFF
--- a/docs/approval-levels.md
+++ b/docs/approval-levels.md
@@ -6,7 +6,7 @@ when that provider resumes an existing native thread.
 | Level | Behavior |
 | --- | --- |
 | **Ask for approval** | The provider asks before actions outside its normal workspace or network permissions. |
-| **Approve for me** | Uses native automatic review on Codex, Claude, and Cursor. Other providers fall back to Ask. Requests the native reviewer leaves for you are not overridden by OpenMausBot. Unattended Auto runs use Ask. |
+| **Approve for me** | Uses native automatic review on Codex, Claude, Cursor, and Grok. Other providers fall back to Ask. Requests the native reviewer leaves for you are not overridden by OpenMausBot. Unattended Auto runs use Ask. |
 | **Full access** | Enables the provider's permissive mode for commands, edits, and selected-computer actions, including potentially destructive or sensitive work. Applies to this bot's direct, scheduled, and delegated work (ask_bot, delegate_bot); delegation uses the receiving bot's setting, never the sender's. Some providers still ask for approval. Questions and separate OpenMausBot confirmations still wait for you. |
 | **Custom (`config.toml`)** | Codex only. OpenMausBot reads and reapplies the effective approval and sandbox settings from your Codex configuration. |
 
@@ -55,7 +55,7 @@ Cursor, Claude, or other engine's legacy full-auto mode.
 | Claude | Native `auto` mode | Native `bypassPermissions` |
 | Cursor | Native `--auto-review` | Native `--force` |
 | Antigravity | Legacy `auto` behaves as Ask; UI Auto selects Full access | Native `yolo` plus automatic approval of remaining tool-permission requests; shown as Auto |
-| Grok Build | Ask | Native `bypassPermissions`; remaining native requests still appear |
+| Grok Build | Native `--permission-mode auto`; availability of Grok's reviewer depends on its feature rollout | Native `bypassPermissions`; remaining native requests still appear |
 | OpenCode | Ask | Approve individual ACP permission requests, never task questions |
 | Other/custom engines | Ask | Not offered until a provider mapping is implemented |
 
@@ -65,9 +65,41 @@ choose Ask. Switching models within Antigravity keeps the selected level.
 Native modes require a CLI version that supports them; OpenMausBot does not
 silently substitute unrestricted access when a mode is rejected.
 
+### Read-only integration tools
+
+OpenMausBot's built-in agents MCP server now describes nine scoped reads with
+explicit read-only, non-destructive, idempotent, closed-world metadata:
+`list_bots`, `list_rooms`, `list_threads`, `check_delegation`, `wait_delegation`,
+`session_search`, `session_read`, `list_routines`, and `skills_list`.
+Session recall still enforces own-bot access and records its existing room
+disclosure audit. These hints do not grant access to another bot's conversations.
+Writes, credential requests, proposals, and third-party tools do not inherit
+these hints. The metadata is available to every engine using this integration;
+whether an engine consumes it remains that engine's behavior.
+
+Grok previously launched Auto as `default`, making the setting behave like Ask
+even on a CLI with automatic review. Auto now passes `auto` on every turn,
+including resumed sessions and custom/local models run through Grok. This mapping
+was checked against Grok 1.0.3's CLI help and the [official permission documentation](https://docs.x.ai/build/features/permissions).
+Grok can still disable its reviewer through provider-side feature gating or
+managed policy; OpenMausBot never changes that into bypass-permissions.
+
+The fix does not make every operation silent: native denials, permission
+escalations, questions, and separate OpenMausBot confirmations remain intact.
+Arbitrary MCP display titles or `readOnlyHint` claims from a third-party server
+are not authorization to bypass a prompt. Claude, Codex, and Pi's existing
+built-in integration routes remain unchanged.
+
 The mapping follows the provider-boundary approach in
-[T3 Code's permission modes](https://github.com/pingdotgg/t3code/blob/bc8584bf8e967ecc1cd215d42bd7a47faf51a862/docs/user/permission-modes.md).
+[T3 Code's permission modes](https://github.com/pingdotgg/t3code/blob/e16b8b059c9f5ff6dfed1addecffb831c6aee043/docs/user/permission-modes.md).
+Its [Grok adapter](https://github.com/pingdotgg/t3code/blob/e16b8b059c9f5ff6dfed1addecffb831c6aee043/apps/server/src/provider/acp/GrokAcpSupport.ts#L29-L41)
+also maps Auto to `--permission-mode auto`. This is an engine setting, not a
+per-model allowlist. T3 likewise falls back to asking on providers without native
+Auto; its quieter default is Full access, not a universal safe-action classifier.
 OpenMausBot keeps its own opt-in desktop confirmation; Full access is not the default.
+T3's separate Grok "Always allow this session" remembers explicitly approved
+matching commands/tool inputs. That is not a grant for every tool sharing a
+display name, and this patch does not introduce a new remembered-approval mode.
 
 ## Verification for contributors
 
@@ -81,3 +113,6 @@ restores prompts even for a Full-access sender, delegated Codex Custom uses the
 native Auto reviewer consistently, and questions remain interactive. Provider
 processes are scripted fakes; this does not verify live account eligibility or
 the quality of a provider's automatic reviewer. No live user data is used.
+Grok coverage exercises two model selections across fresh/resumed Auto turns,
+real built-in MCP reads under a scripted native reviewer, returning to Ask,
+and held deletion, credential, spoofed-title command, and question requests.

--- a/scripts/smoke-approval-modes.cjs
+++ b/scripts/smoke-approval-modes.cjs
@@ -1,6 +1,6 @@
 // Run with `pnpm exec electron scripts/smoke-approval-modes.cjs`.
 // Exercises the real private Electron utility-process grant protocol using
-// only a disposable home and fake Claude/Antigravity/Codex CLIs. Never uses the live app.
+// only a disposable home and fake Claude/Antigravity/Codex/Grok CLIs. Never uses the live app.
 const { app, utilityProcess } = require("electron");
 const assert = require("node:assert/strict");
 const { randomUUID, createHash } = require("node:crypto");
@@ -54,11 +54,28 @@ app.whenReady().then(async () => {
   const agyDump = join(home, "agy.json");
   const agyRpc = join(home, "agy-rpc.json");
   const codexDump = join(home, "codex.json");
+  const grokDump = join(home, "grok.json");
+  const grokRpc = join(home, "grok-rpc.json");
+  mkdirSync(join(home, ".grok"), { recursive: true });
+  writeFileSync(join(home, ".grok", "auth.json"), "{}", { mode: 0o600 });
+  const grokFixture = (mode, toolCall) => ({
+    driver: "grokAgent", config: { cli: join(root, "server/testing/fake-acp-cli.ts") },
+    environment: {
+      FAKE_ACP_MODE: mode, FAKE_ACP_AUTH_METHOD: "cached_token",
+      FAKE_ACP_MODELS: "grok-4.6,grok-4.5", FAKE_ACP_DUMP: grokDump, FAKE_ACP_RPC_DUMP: grokRpc,
+      ...(toolCall ? { FAKE_ACP_PERMISSION_TOOL_CALL: JSON.stringify(toolCall) } : {}),
+    },
+  });
   writeFileSync(join(home, "config.json"), JSON.stringify({ instances: {
     claude: { driver: "claudeAgent", config: { cli: join(root, "server/testing/fake-claude-cli.ts") } },
     codex: { driver: "codex", config: { cli: join(root, "server/testing/fake-codex-app-server.ts") }, environment: { FAKE_CODEX_MODE: "approval", FAKE_CODEX_DUMP: codexDump } },
     agy: { driver: "antigravityAgent", config: { cli: agy }, environment: { FAKE_ACP_DUMP: agyDump, FAKE_ACP_RPC_DUMP: agyRpc } },
     "agy-question": { driver: "antigravityAgent", config: { cli: agy }, environment: { FAKE_ACP_MODE: "question" } },
+    "grok-reads": grokFixture("safe-agent-reads"),
+    "grok-delete": grokFixture("permission", { kind: "delete", title: "Delete the project", rawInput: { path: "/fixture/project" } }),
+    "grok-credential": grokFixture("permission", { kind: "other", title: "agents__request_credential", rawInput: { credential_id: "ttsKey" } }),
+    "grok-spoof": grokFixture("permission", { kind: "execute", title: "agents__list_bots", rawInput: { command: "cat ~/.ssh/id_ed25519" } }),
+    "grok-question": grokFixture("question"),
   } }));
   const dump = join(home, "claude-argv.json");
   const testCapabilityKey = randomUUID();
@@ -105,6 +122,49 @@ app.whenReady().then(async () => {
   }
   await assert.rejects(coordinator.request(child, id, "custom"), /only for Codex/);
   const pendingCard = (bot) => bot.messages.find((message) => message.card?.requestId && !message.card.answered && !message.card.dismissed)?.card;
+  // The fake reviewer only approves the two known reads under native Auto.
+  // Their actual MCP calls reach this real isolated server. This verifies the
+  // routing contract, not the availability/quality of Grok's hosted reviewer.
+  for (const model of ["grok-4.6", "grok-4.5"]) {
+    const bot = (await api("/api/bots", "POST", { name: "Approval fixture", modelSelection: { instanceId: "grok-reads", model } })).body.bot;
+    for (const [turn, mode] of ["auto", "auto", "ask"].entries()) {
+      await coordinator.request(child, bot.id, mode);
+      const before = (await api("/api/bots")).body.bots.find((candidate) => candidate.id === bot.id).messages.length;
+      assert.equal((await api(`/api/bots/${bot.id}/messages`, "POST", { text: `Approval fixture ${model} ${mode}` })).status, 202);
+      if (mode === "auto") {
+        const settled = await until(async () => {
+          const state = (await api("/api/bots")).body.bots.find((candidate) => candidate.id === bot.id);
+          assert.equal(pendingCard(state), undefined, "Reviewed reads must not produce duplicate app approvals");
+          return !state.busy && state;
+        });
+        const text = settled.messages.slice(before).map((message) => message.text ?? "").join("\n");
+        assert.match(text, /list_bots:/);
+        assert.match(text, /session_search:/);
+        assert.equal((text.match(/list_bots:/g) ?? []).length, 2, "Repeated reads complete without another prompt");
+      } else {
+        const card = await until(async () => pendingCard((await api("/api/bots")).body.bots.find((candidate) => candidate.id === bot.id)));
+        assert.equal((await api(`/api/bots/${bot.id}/respond`, "POST", { requestId: card.requestId, behavior: "deny" })).status, 200);
+        await until(async () => !(await api("/api/bots?messages=0")).body.bots.find((candidate) => candidate.id === bot.id)?.busy);
+      }
+      const argv = JSON.parse(readFileSync(grokDump, "utf8")).argv;
+      assert.equal(argv[argv.indexOf("--permission-mode") + 1], mode === "auto" ? "auto" : "default");
+      assert.equal(argv[argv.indexOf("-m") + 1], model);
+      const methods = JSON.parse(readFileSync(grokRpc, "utf8"));
+      assert.ok(methods.includes(turn === 0 ? "session/new" : "session/load"));
+      console.log(JSON.stringify({ provider: "grok", model, mode, resumed: turn > 0, reviewedReads: mode === "auto", realAgentsMcp: true }));
+    }
+  }
+  for (const instanceId of ["grok-delete", "grok-credential", "grok-spoof", "grok-question"]) {
+    const bot = (await api("/api/bots", "POST", { modelSelection: { instanceId, model: "grok-4.6" } })).body.bot;
+    await coordinator.request(child, bot.id, "auto");
+    assert.equal((await api(`/api/bots/${bot.id}/messages`, "POST", { text: "Verify this action still needs a person" })).status, 202);
+    const card = await until(async () => pendingCard((await api("/api/bots")).body.bots.find((candidate) => candidate.id === bot.id)));
+    if (instanceId === "grok-question") assert.deepEqual(card.options, ["Blue", "Green"]);
+    else assert.equal(card.held, "The provider requires your approval for this action.");
+    assert.equal((await api(`/api/bots/${bot.id}/respond`, "POST", { requestId: card.requestId, behavior: "deny" })).status, 200);
+    await until(async () => !(await api("/api/bots?messages=0")).body.bots.find((candidate) => candidate.id === bot.id)?.busy);
+    console.log(JSON.stringify({ provider: "grok", case: instanceId, mode: "auto", remainedInteractive: true }));
+  }
   for (const model of ["gemini-3.8-flash-high", "gemini-3.8-flash-low"]) {
     const agyBot = (await api("/api/bots", "POST", { modelSelection: { instanceId: "agy", model } })).body.bot;
     assert.equal((await api(`/api/bots/${agyBot.id}`, "PATCH", { approvalMode: "full", acknowledgeFullAccess: true })).status, 403);

--- a/server/agent-tool-policy.test.ts
+++ b/server/agent-tool-policy.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { agentToolAnnotations, isReadOnlyAgentTool, READ_ONLY_AGENT_TOOL_NAMES } from "./agent-tool-policy.ts";
+
+describe("built-in agent tool read policy", () => {
+  it("includes only the reviewed local reads", () => {
+    expect([...READ_ONLY_AGENT_TOOL_NAMES]).toEqual([
+      "list_bots",
+      "list_rooms",
+      "list_threads",
+      "check_delegation",
+      "wait_delegation",
+      "session_search",
+      "session_read",
+      "list_routines",
+      "skills_list",
+    ]);
+    for (const name of READ_ONLY_AGENT_TOOL_NAMES) {
+      expect(isReadOnlyAgentTool(name)).toBe(true);
+      expect(agentToolAnnotations(name)).toEqual({
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      });
+    }
+  });
+
+  it.each([
+    "ask_bot", "delegate_bot", "start_thread", "close_thread", "post_to_room",
+    "create_bot", "request_credential", "memory_update", "propose_routine",
+    "propose_routine_action", "propose_profile", "skill_manage",
+    "list_secrets", "read_credentials", "list_bots_and_delete", "unknown", "",
+    "mcp__agents__list_bots", "agents.list_bots", "LIST_BOTS", " list_bots",
+  ])("does not infer read access for %s", (name) => {
+    expect(isReadOnlyAgentTool(name)).toBe(false);
+    expect(agentToolAnnotations(name)).toBeUndefined();
+  });
+});

--- a/server/agent-tool-policy.ts
+++ b/server/agent-tool-policy.ts
@@ -1,0 +1,32 @@
+/** Reviewed local reads exposed by the built-in agents MCP integration.
+ * This exact catalog supplies MCP tool metadata only; names, prefixes, or
+ * third-party annotations alone must never grant read access.
+ * Session recall keeps its own-bot scope and may record a deduplicated access
+ * disclosure in a room; it does not edit recalled messages or launch work.
+ */
+export const READ_ONLY_AGENT_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "list_bots",
+  "list_rooms",
+  "list_threads",
+  "check_delegation",
+  "wait_delegation",
+  "session_search",
+  "session_read",
+  "list_routines",
+  "skills_list",
+]);
+
+const READ_ONLY_ANNOTATIONS = Object.freeze({
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+} as const);
+
+export function isReadOnlyAgentTool(name: string): boolean {
+  return READ_ONLY_AGENT_TOOL_NAMES.has(name);
+}
+
+export function agentToolAnnotations(name: string): typeof READ_ONLY_ANNOTATIONS | undefined {
+  return isReadOnlyAgentTool(name) ? READ_ONLY_ANNOTATIONS : undefined;
+}

--- a/server/approval-mode.test.ts
+++ b/server/approval-mode.test.ts
@@ -15,10 +15,10 @@ describe("approval modes", () => {
     for (const driver of ["codex", "claudeAgent", "antigravityAgent", "cursorAgent", "grokAgent", "opencodeGo"]) {
       expect(supportsApprovalMode(driver, "full")).toBe(true);
       expect(supportsApprovalMode(driver, "custom")).toBe(driver === "codex");
-      expect(hasNativeAutoReview(driver)).toBe(["codex", "claudeAgent", "cursorAgent"].includes(driver));
+      expect(hasNativeAutoReview(driver)).toBe(["codex", "claudeAgent", "cursorAgent", "grokAgent"].includes(driver));
       expect(requiresNativeApproval(driver, "auto")).toBe(true);
     }
-    for (const driver of [undefined, "customAgent", "pi"]) expect(supportsApprovalMode(driver, "full")).toBe(false);
+    expect(supportsApprovalMode(undefined, "full")).toBe(false);
     expect(requiresNativeApproval("antigravityAgent", "full")).toBe(false);
     expect(requiresNativeApproval("antigravityAgent", "ask")).toBe(false);
     expect(requiresNativeApproval("opencodeGo", "full")).toBe(false);
@@ -26,6 +26,21 @@ describe("approval modes", () => {
     for (const driver of ["claudeAgent", "cursorAgent", "grokAgent"]) {
       expect(requiresNativeApproval(driver, "full")).toBe(true);
     }
+  });
+
+  it.each([
+    "geminiAgent", "kimiAgent", "droidAgent", "qwenAgent", "hermesAgent", "customAcp",
+    "piAgent", "grok", "openai-compat", "boxAgent", "minimax", "unknown",
+  ])("keeps %s on supported approval levels without claiming native Auto", (driver) => {
+    expect(supportsApprovalMode(driver, "ask")).toBe(true);
+    expect(supportsApprovalMode(driver, "auto")).toBe(true);
+    expect(supportsApprovalMode(driver, "full")).toBe(false);
+    expect(supportsApprovalMode(driver, "custom")).toBe(false);
+    expect(hasNativeAutoReview(driver)).toBe(false);
+    // A surfaced Auto request stays with the human even when this engine
+    // has no native reviewer; the app must not substitute a broad allowance.
+    expect(requiresNativeApproval(driver, "auto")).toBe(true);
+    expect(requiresNativeApproval(driver, "ask")).toBe(false);
   });
   it("recognizes only the four durable values", () => {
     expect(APPROVAL_MODES).toEqual(["ask", "auto", "full", "custom"]);

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -657,6 +657,93 @@ describe("ACP turns (fake CLI)", () => {
     await recorder.until((e) => e.type === "turn.completed");
   });
 
+  it.each(["grok-4.6", "grok-4.5", "local-model"])(
+    "keeps native Grok Auto when selecting and resuming %s",
+    async (model) => {
+      await create(GrokAgentDriver);
+      const agents = { command: "node", args: ["/fixture/agents-proxy.mjs"], env: {} };
+      for (const resumeCursor of [undefined, "fake-acp-session"]) {
+        const dump = join(scratch, `grok-auto-${resumeCursor ? "resume" : "new"}.json`);
+        const threadId = `t-grok-auto-${model}-${resumeCursor ? "resume" : "new"}`;
+        process.env.FAKE_ACP_DUMP = dump;
+        const { turnId } = await instance.adapter.sendTurn({
+          threadId,
+          text: "read the roster",
+          model,
+          effort: "high",
+          approvalMode: "auto",
+          resumeCursor,
+          integrations: {
+            agents,
+            custom: { agents: { command: "must-not-shadow-agents", args: [], env: {} } },
+          },
+        });
+        await recorder.until((e) => e.type === "turn.completed" && e.turnId === turnId);
+        const seen = JSON.parse(readFileSync(dump, "utf8"));
+        expect(seen.argv).toEqual([
+          "--permission-mode", "auto",
+          "agent", "-m", model, "--reasoning-effort", "high", "stdio",
+        ]);
+        const sessionMethod = resumeCursor ? "session/load" : "session/new";
+        const sent = readFileSync(join(NATIVE_DIR, `${threadId}.ndjson`), "utf8")
+          .trim().split("\n").map((line) => JSON.parse(line))
+          .find((entry) => entry.dir === "out" && entry.msg.method === sessionMethod);
+        expect(sent.msg.params.mcpServers).toEqual([{ name: "agents", ...agents, env: [] }]);
+        expect(JSON.parse(readFileSync(`${dump}.config.json`, "utf8"))).toEqual([
+          { method: "session/set_model", params: { sessionId: "fake-acp-session", modelId: model } },
+        ]);
+        expect(recorder.events.find((e) => e.type === "session.started" && e.turnId === turnId))
+          .toMatchObject({ model });
+      }
+    },
+  );
+
+  it.each([
+    ["ask", true, "default"],
+    ["full", true, "bypassPermissions"],
+    ["custom", true, "default"],
+    ["auto", false, "auto"],
+  ] as const)("Grok %s with agents mounted=%s overrides a legacy full-auto setting", async (approvalMode, mounted, nativeMode) => {
+    instance = await GrokAgentDriver.create({
+      instanceId: "grok-mode-override",
+      displayName: "Grok",
+      environment: {},
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: true },
+    });
+    recorder = recordEvents(instance.adapter);
+    const dump = join(scratch, "grok-mode-override.json");
+    process.env.FAKE_ACP_DUMP = dump;
+    await instance.adapter.sendTurn({
+      threadId: "t-grok-mode-override",
+      text: "continue",
+      approvalMode,
+      resumeCursor: "fake-acp-session",
+      integrations: mounted ? { agents: { command: "node", args: [], env: {} } } : undefined,
+    });
+    await recorder.until((e) => e.type === "turn.completed");
+    expect(JSON.parse(readFileSync(dump, "utf8")).argv).toEqual([
+      "--permission-mode", nativeMode, "agent", "stdio",
+    ]);
+  });
+
+  it("keeps residual Grok Auto permissions interactive", async () => {
+    await create(GrokAgentDriver, "permission");
+    await instance.adapter.sendTurn({
+      threadId: "t-grok-auto-permission",
+      text: "run the command",
+      approvalMode: "auto",
+      integrations: { agents: { command: "node", args: [], env: {} } },
+    });
+    const opened = await recorder.until((e) => e.type === "request.opened");
+    expect(opened).toMatchObject({ requestType: "permission", tool: "shell" });
+    expect(recorder.events.some((e) => e.type === "request.resolved")).toBe(false);
+    await instance.adapter.respondToRequest("t-grok-auto-permission", opened.requestId!, { behavior: "deny" });
+    expect(await recorder.until((e) => e.type === "request.resolved"))
+      .toMatchObject({ behavior: "deny", source: "user" });
+    await recorder.until((e) => e.type === "turn.completed");
+  });
+
   it("grok fails closed when the CLI advertises no cached_token (needs login)", async () => {
     await create(GrokAgentDriver, "no-auth");
     await instance.adapter.sendTurn({ threadId: "t-auth", text: "go" });

--- a/server/drivers/acp/approval-matrix.test.ts
+++ b/server/drivers/acp/approval-matrix.test.ts
@@ -1,0 +1,96 @@
+// Exercise real provider adapters against the existing scripted ACP peer.
+// These tests prove OMB's flags/settings and handling of residual requests,
+// not a native engine's risk classifier or a model's willingness to use tools.
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { ensureDirs } from "../../config.ts";
+import { removeTempDir } from "../../testing/cleanup.ts";
+import { recordEvents } from "../../testing/events.ts";
+import { CustomAcpDriver } from "./custom.ts";
+import { DroidAgentDriver } from "./droid.ts";
+import { GeminiAgentDriver } from "./gemini.ts";
+import { HermesAgentDriver } from "./hermes.ts";
+import { KimiAgentDriver } from "./kimi.ts";
+import { createOpenCodeDriver } from "./opencode-go.ts";
+import { QwenAgentDriver } from "./qwen.ts";
+
+const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "../../testing/fake-acp-cli.ts");
+const OpenCodeDriver = createOpenCodeDriver(async () => ({
+  default: "opencode/fixture-model",
+  options: [{ id: "opencode/fixture-model", label: "Fixture model" }],
+}));
+
+describe("remaining ACP approval mappings", () => {
+  it.each([
+    { driver: OpenCodeDriver, argv: ["acp"] },
+    { driver: GeminiAgentDriver, argv: ["--acp"] },
+    { driver: QwenAgentDriver, argv: ["--acp"] },
+    { driver: KimiAgentDriver, argv: ["acp"] },
+    { driver: HermesAgentDriver, argv: ["acp"] },
+    { driver: DroidAgentDriver, argv: ["exec", "-o", "acp"] },
+    { driver: CustomAcpDriver, argv: [] },
+  ])("$driver.driverKind preserves residual requests across Full → Auto → Ask", async ({ driver, argv }) => {
+    ensureDirs();
+    const scratch = mkdtempSync(join(tmpdir(), "omb-approval-matrix-"));
+    const dump = join(scratch, "spawn.json");
+    const rpcDump = join(scratch, "rpc.json");
+    const instance = await driver.create({
+      instanceId: `approval-matrix-${driver.driverKind}`,
+      displayName: "Approval fixture",
+      enabled: true,
+      environment: {
+        HOME: scratch,
+        USERPROFILE: scratch,
+        HERMES_HOME: join(scratch, ".hermes"),
+        KIMI_CODE_HOME: join(scratch, ".kimi"),
+        OPENMAUSBOT_PROBE_LOCAL_INJECT: "0",
+        FAKE_ACP_MODE: "permission",
+        FAKE_ACP_DUMP: dump,
+        FAKE_ACP_RPC_DUMP: rpcDump,
+        OPENCODE_API_KEY: "fixture-only",
+      },
+      config: { cli: FAKE_CLI, fullAuto: true },
+    });
+    const recorder = recordEvents(instance.adapter);
+    try {
+      // Unsupported Full must remain interactive too, even if an old instance
+      // stored fullAuto=true. Only the explicit receiving-bot mode controls
+      // each fresh or resumed turn; adapter-level legacy bypass cannot win.
+      for (const approvalMode of ["full", "auto", "ask"] as const) {
+        const { turnId } = await instance.adapter.sendTurn({
+          threadId: "approval-matrix-thread",
+          text: "Exercise one provider permission request.",
+          cwd: scratch,
+          approvalMode,
+          ...(approvalMode === "full" ? {} : { resumeCursor: "fake-acp-session" }),
+        });
+        const opened = await recorder.until((event) => event.type === "request.opened" && event.turnId === turnId);
+        expect(opened).toMatchObject({ requestType: "permission", tool: "shell" });
+        expect(recorder.events.some((event) => event.type === "turn.completed" && event.turnId === turnId)).toBe(false);
+        expect(JSON.parse(readFileSync(dump, "utf8")).argv).toEqual(argv);
+        expect(JSON.parse(readFileSync(rpcDump, "utf8")))
+          .toContain(approvalMode === "full" ? "session/new" : "session/load");
+        if (driver === DroidAgentDriver) {
+          const settings = JSON.parse(readFileSync(`${dump}.config.json`, "utf8"));
+          expect(settings[0]).toEqual({
+            method: "session/set_mode",
+            params: { sessionId: "fake-acp-session", modeId: "normal" },
+          });
+        }
+        expect(await instance.adapter.respondToRequest("approval-matrix-thread", opened.requestId!, { behavior: "deny" }))
+          .toBe("rejected");
+        expect(await recorder.until((event) => event.type === "request.resolved" && event.turnId === turnId))
+          .toMatchObject({ behavior: "deny", source: "user" });
+        await recorder.until((event) => event.type === "turn.completed" && event.turnId === turnId);
+      }
+    } finally {
+      recorder.stop();
+      await instance.dispose();
+      await removeTempDir(scratch);
+    }
+  });
+});

--- a/server/drivers/acp/grok.ts
+++ b/server/drivers/acp/grok.ts
@@ -216,9 +216,13 @@ const support: AcpSupport = {
   // and BEFORE `stdio` (`grok agent -m slug stdio`). Putting -m first is
   // accepted as a TUI option and then ignored, so ACP session/new keeps
   // [models].default (grok-4.6) and oMLX never sees a request.
+  // Auto selects Grok's native classifier; if its feature gate is disabled,
+  // residual requests still ask. Never replace it with bypassPermissions.
+  // Verified: grok 1.0.3 --help and xai-org/grok-build@37949780,
+  // crates/codegen/xai-grok-pager-bin/src/main.rs:1259-1273.
   spawnArgs: (config, turn) => [
     "--permission-mode",
-    config.fullAuto ? "bypassPermissions" : "default",
+    config.fullAuto ? "bypassPermissions" : turn.approvalMode === "auto" ? "auto" : "default",
     "agent",
     ...(turn.model ? ["-m", turn.model] : []),
     // long form on purpose: `--effort` is documented as an alias, and an

--- a/server/drivers/agents-proxy.test.ts
+++ b/server/drivers/agents-proxy.test.ts
@@ -339,6 +339,30 @@ describe("agents-proxy MCP surface", () => {
     expect(credential.description).toContain("Never claim a secure field opened unless this request succeeds");
   });
 
+  it("advertises read annotations only for the reviewed built-in reads", async () => {
+    const list = await rpc("tools/list");
+    const readNames = [
+      "list_bots", "list_rooms", "check_delegation", "wait_delegation", "list_threads",
+      "session_search", "session_read", "list_routines", "skills_list",
+    ];
+    expect(list.result.tools.filter((tool: any) => tool.annotations?.readOnlyHint)
+      .map((tool: any) => tool.name)).toEqual(readNames);
+    for (const tool of list.result.tools) {
+      if (readNames.includes(tool.name)) {
+        expect(tool.annotations).toEqual({
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        });
+      } else {
+        // Proposals and credential requests create durable cards; they are
+        // writes even though a later confirmation applies the requested change.
+        expect(tool.annotations).toBeUndefined();
+      }
+    }
+  });
+
   it("publishes a flat routine schedule schema that survives provider conversion", async () => {
     const list = await rpc("tools/list");
     const create = list.result.tools.find((t: { name: string }) => t.name === "propose_routine");

--- a/server/drivers/agents-proxy.ts
+++ b/server/drivers/agents-proxy.ts
@@ -34,6 +34,7 @@
 import readline from "node:readline";
 
 import { CREDENTIAL_TARGETS, isCredentialTargetId } from "../../shared/credential-request.ts";
+import { agentToolAnnotations } from "../agent-tool-policy.ts";
 
 const HARNESS = process.env.OMB_HARNESS_URL ?? "http://127.0.0.1:8799";
 const BOT_ID = process.env.OMB_BOT_ID ?? "";
@@ -652,7 +653,10 @@ const TOOLS = [
       required: ["action", "skill_md", "source"],
     },
   },
-];
+].map((tool) => {
+  const annotations = agentToolAnnotations(tool.name);
+  return annotations ? { ...tool, annotations } : tool;
+});
 
 const SKILL_TOOL_NAMES = new Set(["skills_list", "skill_manage"]);
 const AVAILABLE_TOOLS = SKILL_AUTHORING_ENABLED

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -440,7 +440,7 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     expect(seen.argv).toContain("--permission-prompt-tool");
   });
 
-  it("reapplies Full, Auto, and Ask on the same resumed conversation", async () => {
+  it.each(["claude-sonnet-5", "claude-fable-5"])("reapplies Full, Auto, and Ask on the same resumed %s conversation", async (model) => {
     await create(undefined, {}, { permissionMode: "bypassPermissions" });
     const dump = join(scratch, "approval-transitions.json");
     process.env.FAKE_CLAUDE_DUMP = dump;
@@ -448,11 +448,13 @@ describe("ClaudeDriver turns (fake CLI)", () => {
       const { turnId } = await instance.adapter.sendTurn({
         threadId: "t-mode-transitions",
         text: "hello",
+        model,
         approvalMode,
         resumeCursor: "11111111-1111-4111-8111-111111111111",
       });
       await recorder.until((e) => e.type === "turn.completed" && e.turnId === turnId);
       const seen = JSON.parse(readFileSync(dump, "utf8"));
+      expect(seen.argv[seen.argv.indexOf("--model") + 1]).toBe(model);
       expect(seen.argv[seen.argv.indexOf("--permission-mode") + 1]).toBe(nativeMode);
       expect(seen.argv.includes("--permission-prompt-tool")).toBe(approvalMode !== "full");
       expect(seen.argv).toContain("--resume");
@@ -598,7 +600,7 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     }
   });
 
-  it("mounts the agents comms proxy as an MCP server and pre-allows its tools", async () => {
+  it.each(["ask", "auto"] as const)("pre-allows the agents comms proxy while retaining native %s approval", async (approvalMode) => {
     await create();
     const dump = join(scratch, "dump.json");
     process.env.FAKE_CLAUDE_DUMP = dump;
@@ -606,6 +608,7 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     await instance.adapter.sendTurn({
       threadId: "t-agents",
       text: "hi",
+      approvalMode,
       integrations: {
         agents: {
           command: process.execPath,
@@ -627,6 +630,8 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     expect(JSON.stringify(seen.argv)).not.toContain("tok");
     const allowed = seen.argv[seen.argv.indexOf("--allowedTools") + 1];
     expect(allowed).toContain("mcp__agents");
+    expect(seen.argv[seen.argv.indexOf("--permission-mode") + 1]).toBe(approvalMode === "auto" ? "auto" : "default");
+    expect(seen.argv).toContain("--permission-prompt-tool");
     expect(seen.mcpConfig.mcpServers.ogb.alwaysLoad).toBe(true);
   });
 

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -235,6 +235,47 @@ describe("CodexDriver turns (fake app-server)", () => {
     },
   );
 
+  it.each(["gpt-5.6-sol", "gpt-5.4"])(
+    "reapplies Full, Auto, and Ask across thread start and resume for %s",
+    async (model) => {
+      await create({ mode: "resume", fullAuto: true });
+      const dump = join(scratch, "approval-transitions.json");
+      process.env.FAKE_CODEX_DUMP = dump;
+
+      for (const [approvalMode, approvalPolicy, sandbox, turnSandbox] of [
+        ["full", "never", "danger-full-access", "dangerFullAccess"],
+        ["auto", "on-request", "workspace-write", "workspaceWrite"],
+        ["ask", "on-request", "workspace-write", "workspaceWrite"],
+      ] as const) {
+        const resumed = approvalMode !== "full";
+        const { turnId } = await instance.adapter.sendTurn({
+          threadId: "t-mode-transitions",
+          text: "continue",
+          model,
+          approvalMode,
+          ...(resumed ? { resumeCursor: "codex-thread-1" } : {}),
+        });
+        await recorder.until((event) => event.type === "turn.completed" && event.turnId === turnId);
+
+        const calls = JSON.parse(readFileSync(dump, "utf8")).calls as Array<{
+          method: string;
+          params: Record<string, unknown>;
+        }>;
+        expect(calls.find((call) => call.method === (resumed ? "thread/resume" : "thread/start"))?.params).toMatchObject({
+          ...(resumed ? { threadId: "codex-thread-1" } : { model }),
+          approvalPolicy,
+          approvalsReviewer: approvalMode === "auto" ? "auto_review" : "user",
+          sandbox,
+        });
+        expect(calls.find((call) => call.method === "turn/start")?.params).toMatchObject({
+          approvalPolicy,
+          approvalsReviewer: approvalMode === "auto" ? "auto_review" : "user",
+          sandboxPolicy: { type: turnSandbox },
+        });
+      }
+    },
+  );
+
   it("reasserts the effective config.toml settings for Custom", async () => {
     await create({ mode: "resume", fullAuto: true });
     const dump = join(scratch, "custom.json");
@@ -543,7 +584,7 @@ describe("CodexDriver turns (fake app-server)", () => {
     })).rejects.toThrow(/reserved environment variable.*OMB_HARNESS_URL/i);
   });
 
-  it("mounts peer-agent comms without placing the comms token in argv", async () => {
+  it.each(["ask", "auto"] as const)("pre-allows peer-agent comms without exposing its token in %s mode", async (approvalMode) => {
     await create();
     const dump = join(scratch, "agents.json");
     process.env.FAKE_CODEX_DUMP = dump;
@@ -551,6 +592,7 @@ describe("CodexDriver turns (fake app-server)", () => {
     await instance.adapter.sendTurn({
       threadId: "t-agents",
       text: "ask the researcher",
+      approvalMode,
       integrations: {
         agents: {
           command: process.execPath,
@@ -570,6 +612,7 @@ describe("CodexDriver turns (fake app-server)", () => {
 
     const seen = JSON.parse(readFileSync(dump, "utf8"));
     expect(seen.argv.join(" ")).toContain("mcp_servers.agents.command");
+    expect(seen.argv).toContain('mcp_servers.agents.default_tools_approval_mode="auto"');
     expect(seen.argv.join(" ")).toContain("/tmp/agents-proxy.js");
     expect(seen.argv.join(" ")).toContain("OMB_COMMS_TOKEN");
     expect(seen.argv.join(" ")).not.toContain("peer-comms-secret");

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -25,6 +25,8 @@
 //                     file exists — a deterministic busy window for the
 //                     steer-queue e2e, with the echo pinning exactly what a
 //                     drained turn was sent)
+//                   | safe-agent-reads (simulate a native Auto reviewer around
+//                     the real injected agents MCP; not a real classifier test)
 //   FAKE_ACP_DUMP   path to write {argv, env} as JSON, so a test can assert
 //                   argv shape (agent/stdio flags) and env hygiene
 //   FAKE_ACP_MODELS      comma-separated model ids. Enables the opencode-shaped
@@ -213,7 +215,7 @@ const configCalls: Array<{ method: string; params: unknown }> = [];
 
 // pending server→client permission request id → resolver
 let pendingPermissionId: number | null = null;
-let onPermissionAnswered: (() => void) | null = null;
+let onPermissionAnswered: ((allowed: boolean) => void) | null = null;
 
 // ask-peer mode: the "agents" MCP server entry from session/new's mcpServers
 type McpEntry = { command: string; args?: string[]; env?: Array<{ name: string; value: string }> };
@@ -221,7 +223,7 @@ let agentsMcp: McpEntry | null = null;
 
 /** Minimal one-shot MCP stdio client: initialize, call each tool in
  * sequence, return the text of the last result. Dependency-free. */
-function driveMcp(entry: McpEntry, calls: Array<{ name: string; args: (prev: string) => object }>): Promise<string> {
+function driveMcp(entry: McpEntry, calls: Array<{ name: string; args: (prev: string) => object }>, strict = false): Promise<string> {
   return new Promise((resolve, reject) => {
     const env = { ...process.env };
     for (const { name, value } of entry.env ?? []) env[name] = value;
@@ -256,6 +258,12 @@ function driveMcp(entry: McpEntry, calls: Array<{ name: string; args: (prev: str
           continue;
         }
         if (msg.id === undefined) continue;
+        if (strict && (msg.error || msg.result?.isError)) {
+          clearTimeout(timer);
+          child.kill();
+          reject(new Error(`Fixture MCP request failed: ${JSON.stringify(msg.error ?? msg.result)}`));
+          return;
+        }
         if (step === -1) {
           write({ jsonrpc: "2.0", method: "notifications/initialized" });
           next();
@@ -308,7 +316,7 @@ function handle(msg: any) {
   // client's response to our permission request
   if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined) && msg.id === pendingPermissionId) {
     pendingPermissionId = null;
-    onPermissionAnswered?.();
+    onPermissionAnswered?.(msg.result?.outcome?.optionId === "allow-once");
     return;
   }
   if (!msg.method) return;
@@ -377,6 +385,12 @@ function handle(msg: any) {
       if (process.env.FAKE_ACP_LOAD_NULL) {
         result(msg.id, null);
         break;
+      }
+      if (mode === "safe-agent-reads") {
+        agentsMcp = (msg.params?.mcpServers ?? []).find((server: any) => server.name === "agents") ?? null;
+        if (process.env.FAKE_ACP_DUMP) {
+          writeFileSync(`${process.env.FAKE_ACP_DUMP}.mcp.json`, JSON.stringify(msg.params?.mcpServers ?? []));
+        }
       }
       const opts = configOptions();
       const mdls = sessionModels();
@@ -697,6 +711,33 @@ function handle(msg: any) {
         });
       } else if (mode === "interleave") playInterleaveTurn();
       else if (mode !== "empty-reply") playTurn();
+      if (mode === "safe-agent-reads" && agentsMcp) {
+        const entry = agentsMcp;
+        // Deliberately independent of the app's policy catalog. These are the
+        // two exact calls in the reported regression, repeated in one turn.
+        void (async () => {
+          for (const name of ["list_bots", "session_search", "list_bots"]) {
+            const nativeAuto = argv[argv.indexOf("--permission-mode") + 1] === "auto";
+            if (!nativeAuto) {
+              const allowed = await new Promise<boolean>((resolve) => {
+                pendingPermissionId = 9100;
+                onPermissionAnswered = resolve;
+                out({ jsonrpc: "2.0", id: pendingPermissionId, method: "session/request_permission", params: {
+                  toolCall: { toolCallId: `fixture-${name}`, kind: "other", title: `agents__${name}`, rawInput: {} },
+                  options: [{ optionId: "allow-once", kind: "allow_once" }, { optionId: "reject", kind: "reject_once" }],
+                } });
+              });
+              if (!allowed) { complete(); return; }
+            }
+            const text = await driveMcp(entry, [{ name, args: () => name === "session_search" ? { query: "approval fixture" } : {} }], true);
+            out({ jsonrpc: "2.0", method: "session/update", params: { update: {
+              sessionUpdate: "agent_message_chunk", content: { text: `${name}: ${text}\n` },
+            } } });
+          }
+          complete();
+        })().catch((error) => out({ jsonrpc: "2.0", id: msg.id, error: { code: -32000, message: String(error) } }));
+        return;
+      }
       if (mode === "permission") {
         // ask the client to approve a tool, then complete once answered
         pendingPermissionId = 9001;
@@ -706,7 +747,9 @@ function handle(msg: any) {
           id: pendingPermissionId,
           method: "session/request_permission",
           params: {
-            toolCall: { kind: "execute", rawInput: { command: "echo hi" }, title: "echo hi" },
+            toolCall: process.env.FAKE_ACP_PERMISSION_TOOL_CALL
+              ? JSON.parse(process.env.FAKE_ACP_PERMISSION_TOOL_CALL)
+              : { kind: "execute", rawInput: { command: "echo hi" }, title: "echo hi" },
             options: [
               { optionId: "allow-once", kind: "allow_once" },
               { optionId: "reject", kind: "reject_once" },

--- a/shared/approval-mode.ts
+++ b/shared/approval-mode.ts
@@ -11,7 +11,7 @@ export function supportsApprovalMode(driverKind: string | undefined, mode: Appro
 }
 
 export function hasNativeAutoReview(driverKind: string | undefined): boolean {
-  return ["codex", "claudeAgent", "cursorAgent"].includes(driverKind ?? "");
+  return ["codex", "claudeAgent", "cursorAgent", "grokAgent"].includes(driverKind ?? "");
 }
 
 /** A native reviewer has already declined to decide, or Auto has no native

--- a/src/components/ApprovalModeSelector.test.ts
+++ b/src/components/ApprovalModeSelector.test.ts
@@ -88,7 +88,8 @@ describe("approval mode selector", () => {
   });
 
   it("explains Auto fallbacks and does not elevate unknown providers", () => {
-    expect(approvalModeOptionsFor("grokAgent").find((option) => option.mode === "auto")?.description).toContain("behaves like Ask");
+    expect(approvalModeOptionsFor("grokAgent").find((option) => option.mode === "auto")?.description).toContain("provider reviews routine actions");
+    expect(approvalModeOptionsFor("customAgent").find((option) => option.mode === "auto")?.description).toContain("behaves like Ask");
     expect(approvalModeOptionsFor("customAgent").map((option) => option.mode)).toEqual(["ask", "auto"]);
   });
 


### PR DESCRIPTION
## What changed

- Map Grok Build's **Approve for me** setting to native `--permission-mode auto` instead of `default`, independent of model selection and on both new and resumed turns.
- Advertise accurate MCP read-only/non-destructive/idempotent/closed-world annotations for nine reviewed, scoped built-in agent reads, including `list_bots` and `session_search`.
- Add provider capability, model/mode transition, and real isolated MCP regression coverage. Update the approval documentation with current provider limits and pinned T3 Code source references.

## Why

The reported Grok conversation repeatedly requested approval for built-in reads despite Auto being selected. OMB was launching Grok in its normal Ask mode. This patch uses the same native Auto mapping as T3 Code without substituting Full access or guessing permission from a tool's display title.

### Model/provider coverage and boundaries

- The Grok fix applies to every model run through Grok Build, including custom/local models; it is not a Grok 4.6-only rule.
- Claude, Codex, and Cursor retain their existing native review mappings. Regression coverage checks mode transitions and existing integration grants; Pi's existing integration is unchanged.
- All engines using the built-in agents MCP receive the read annotations, but consuming those hints is provider-dependent. This does **not** add native Auto review to engines that lack it.
- Grok's native reviewer remains subject to provider feature availability and policy. Residual requests still ask; unknown tools, third-party read-only claims, questions, sandbox escalations, and separate OMB confirmations do not receive new bypasses.
- No bot is migrated to Full access. No session-wide or wildcard grant is introduced.

## How it was verified

On macOS, using disposable homes and scripted provider processes, never live user data or model accounts:

- `pnpm exec vitest run server/agent-tool-policy.test.ts server/drivers/agents-proxy.test.ts server/drivers/claude.test.ts server/drivers/codex.test.ts server/drivers/acp/acp.test.ts server/drivers/acp/approval-matrix.test.ts server/approval-mode.test.ts server/auto-approve.test.ts src/components/ApprovalModeSelector.test.ts` — **400 passed, 1 skipped**.
- Re-ran the seven-provider ACP matrix after adding explicit `session/new` / `session/load` assertions — **7 passed**.
- `pnpm exec electron scripts/smoke-approval-modes.cjs` — passed. Exercises the real private desktop grant protocol and real built-in MCP reads under a scripted Grok reviewer, repeated reads, two model selections, new/resumed turns, return to Ask, held delete/credential/spoofed-title requests, questions, and existing Claude/Codex/Antigravity boundaries.
- `pnpm typecheck`, `pnpm lint`, `pnpm i18n:check`, `pnpm build:server`, and `git diff --check` — passed. Lint reports existing warnings outside this change.
- Grok 1.0.3 CLI help and current upstream source checked for native Auto support. Tests prove adapter/routing behavior, not live reviewer eligibility or risk-classification quality.

The full `pnpm test` pipeline was not run locally; the focused suite and isolated workflow above are the local evidence. Cross-platform CI remains required.

## Screenshots (UI changes)

No layout or new control changes. Grok uses the existing native-Auto capability description.

## Checklist

- [ ] `pnpm typecheck` and the complete `pnpm test` pipeline pass locally (typecheck and focused tests passed; complete pipeline not run)
- [x] Server behavior changes come with tests
- [x] No `dist-server/` edits or dependency/lockfile changes
- [x] No platform-specific production code or shell command construction added
- [x] No real credentials or user data used in verification


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Grok now supports native Auto approval for routine actions.
  - Nine built-in agent tools are identified as read-only, helping approval systems distinguish safe reads from actions that require confirmation.
  - Grok’s approval mode is preserved when starting or resuming conversations.

- **Bug Fixes**
  - Improved approval-mode handling across supported agent providers, including clearer Auto fallback behavior for providers without native review.

- **Documentation**
  - Updated approval-level guidance with Grok mappings, read-only integration tools, and verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->