### PR TITLE
test(verify): one preview fixture, scriptable fake engine, and a docs drift test

### DIFF
--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -40,6 +40,8 @@ Use only mapped, tested commands:
 - [Chat turns](chat-turns.md)
 - [Channels](channels.md)
 - [Engines and Doctor](engines.md)
+- [Claude coordination and turn-scoped tools](claude-tool-lifecycle.md)
+- [Codex bot instructions](codex-instructions.md)
 - [Qwen model route selection](qwen-models.md)
 - [Team backups](team-backups.md)
 
@@ -47,6 +49,9 @@ Renderer-only behavior—Settings, sidebar drag-and-drop, the VM modal, the
 built-in browser panel, and updater UI—is not proven by this first harness.
 Use the relevant Electron/package smoke test and state that limitation. Add a
 map entry only after the shared control surface can really drive it.
+
+The [desktop server connection smoke](desktop-server-connection.md) mounts the
+real Settings connection component in disposable Electron windows.
 
 The [cloud preview fixture](cloud-preview.md) mounts the real Computer panel
 against an isolated server for image decoding, loading, and recovery UI checks.
@@ -57,6 +62,9 @@ watching, takeover, input, and profile switching.
 
 The [bot settings fixture](bot-settings.md) checks profile saves, standing
 instructions, history restore, skill/memory refresh, and stale-response isolation.
+
+The [sidebar fixture](sidebar.md) checks archive and delete confirmations, their
+default focus, keyboard wrapping and focus return against two disposable bots.
 
 The [avatar provider fixture](avatar-providers.md) checks image-provider settings,
 keyless local generation, saved-key handling, and safe errors with a local fake API.
@@ -71,11 +79,20 @@ The [routines fixture](routines.md) checks confirmed proposals, manual and
 scheduled runs, central run logs, List/Calendar views, and bot-scoped routines
 using the real renderer and an isolated fake-engine server.
 
+The [interval restrictions recipe](interval-restrictions.md) checks weekday and
+time-window limits on scheduled routines in that same disposable fixture.
+
 The [server settings recipe](server-settings.md) checks browser provider sign-in
 with an offline CLI and custom-domain validation without touching live accounts.
 
 The [engine library fixture](engines-ui.md) checks onboarding and Settings cards,
 responsive layouts, theme contrast, and status refreshes without losing drafts.
+
+The [Claude account recipe](claude-account.md) checks sign-out, cancellation and
+retry against an offline Claude CLI confined to a disposable home.
+
+The [Codex account recipe](codex-account.md) checks account switching against an
+offline Codex CLI whose identity is synthetic and whose credential directory is empty.
 
 The [mention fixture](mentions.md) checks candidate selection, composer highlighting,
 sent mentions, multiline scrolling and responsive wrapping in real chat views.
@@ -91,6 +108,12 @@ XFCE glyph rendering in disposable managed desktops, including fresh recreation.
 The optional [Podman full-stack acceptance recipe](podman-self-hosting.md)
 checks the Compose deployment with a fresh home, fake engine, and two desktops.
 It includes workspace ownership, persistence, and proxy authentication checks.
+
+The [Podman Firefox sandbox recipe](podman-firefox.md) checks the capability set a
+managed desktop keeps so Firefox can start, with before/after acceptance evidence.
+
+The [Hetzner launch record](hetzner-launch-2026-09-07.md) is a dated self-hosting
+run on a disposable VPS: what passed, what was corrected, and what it does not prove.
 
 Keep the JSON from `wait` and `messages`, the exact command sequence, and the
 fixture's printed log path. Evidence must show both the action and the resulting

--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -20,7 +20,9 @@ It gives the child a temporary data directory and home, chooses a free
 harness/webhook port pair, installs only the repository's fake engine, prints
 the URL, PID, data directory, and persistent log path, then stays attached to
 that exact child. The parent shell and the user's OpenMausBot data are
-untouched.
+untouched. Only `FAKE_CLAUDE_*` variables cross from the launcher's
+environment into that child, so a recipe can script the fake engine's mode,
+replies and tool calls without writing a wrapper CLI.
 
 Pass the printed URL explicitly from a second terminal:
 

--- a/docs/verification/claude-tool-lifecycle.md
+++ b/docs/verification/claude-tool-lifecycle.md
@@ -32,8 +32,14 @@ Sources:
 Regression checks:
 
 ```sh
-pnpm exec vitest run server/drivers/claude.test.ts server/drivers/agents-proxy.test.ts server/browser-connection.test.ts
+pnpm exec vitest run server/drivers/claude.test.ts server/drivers/agents-proxy.test.ts server/browser-proxy.test.ts
 ```
+
+The turn boundary itself — a capability whose owning turn has been replaced
+is refused with 401 even when its request body arrives late — is covered by
+`server/index.test.ts` ("binds profile proposals to the capability's bot and
+thread and rechecks late bodies"); every internal capability, the browser's
+included, passes through that same gate.
 
 For end-to-end verification, launch the isolated fixture described in
 [README.md](README.md), then follow [Chat turns](chat-turns.md). Never use the

--- a/docs/verification/mentions.md
+++ b/docs/verification/mentions.md
@@ -150,8 +150,8 @@ underscores following a recognized name. Tests include `@調査担当者`,
 `@everyone` is channel-only in the picker, composer, user bubbles and bot
 Markdown. The stylesheet also includes the requested declaration separator.
 
-Launch with `--bot-mentions` to configure the existing fake CLI through the
-fixture's instance endpoint. Its first reply mentions Juniper, 調査担当 and Atlas;
+Launch with `--bot-mentions` to script the existing fake CLI through the
+launcher's `FAKE_CLAUDE_*` environment. Its first reply mentions Juniper, 調査担当 and Atlas;
 subsequent replies use the default text to bound channel handoffs. Send
 `@Atlas Please ask the team to review.` through the channel composer. In the
 recorded run, Atlas's actual bot message highlighted Juniper red, 調査担当 orange

--- a/scripts/control-omb.ts
+++ b/scripts/control-omb.ts
@@ -34,7 +34,7 @@ export interface ControlOmbDependencies {
   env?: NodeJS.ProcessEnv;
 }
 
-const HELP = `control-omb — verify a running OpenMausBot instance through its shared MCP core
+export const HELP = `control-omb — verify a running OpenMausBot instance through its shared MCP core
 
 read-only:
   doctor [--url URL]

--- a/scripts/control-omb.ts
+++ b/scripts/control-omb.ts
@@ -373,7 +373,8 @@ export async function launchVerificationServer(
   // The fake engine's own knobs (mode, replies, tool calls) are the one thing
   // a caller may script into the child: FAKE_CLAUDE_* crosses, nothing else.
   for (const [key, value] of Object.entries(parentEnv)) {
-    if (key.startsWith("FAKE_CLAUDE_") && value) childEnv[key] = value;
+    // FAKE_CLAUDE_DUMP stays the launcher's: assertions read fixtureDumpPath.
+    if (key.startsWith("FAKE_CLAUDE_") && key !== "FAKE_CLAUDE_DUMP" && value) childEnv[key] = value;
   }
   // Opt-in live Local VM fixture: keep the temporary home and fake engine,
   // granting only the explicitly selected machine connection and static UI.

--- a/scripts/control-omb.ts
+++ b/scripts/control-omb.ts
@@ -370,6 +370,11 @@ export async function launchVerificationServer(
     // fixture through spawnCli without a shell.
     PATH: dirname(process.execPath),
   });
+  // The fake engine's own knobs (mode, replies, tool calls) are the one thing
+  // a caller may script into the child: FAKE_CLAUDE_* crosses, nothing else.
+  for (const [key, value] of Object.entries(parentEnv)) {
+    if (key.startsWith("FAKE_CLAUDE_") && value) childEnv[key] = value;
+  }
   // Opt-in live Local VM fixture: keep the temporary home and fake engine,
   // granting only the explicitly selected machine connection and static UI.
   if (localVm) Object.assign(childEnv, {

--- a/scripts/testing/preview-fixture.ts
+++ b/scripts/testing/preview-fixture.ts
@@ -1,0 +1,123 @@
+// The one Vite preview every verify-* fixture mounts: an isolated page for a
+// single entry module whose /api calls reach only the disposable fake-engine
+// server. vite.config.ts is inherited on purpose (react, tailwind, the @ alias)
+// so the page renders exactly what the app renders; only the host, the port
+// and the /api target are pinned here.
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { fileURLToPath } from "node:url";
+import { createServer } from "vite";
+
+export const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+
+export interface PreviewRoute {
+  /** Pathname to answer (the query string is ignored); a RegExp hands its match to the handler. */
+  path: string | RegExp;
+  /** Restrict to one HTTP method; any method when omitted. */
+  method?: string;
+  handler: (req: IncomingMessage, res: ServerResponse, match: RegExpExecArray | null) => void | Promise<void>;
+}
+
+export interface PreviewOptions {
+  /** Root-relative URL of the module the page loads, e.g. "/scripts/testing/x.tsx". */
+  entry: string;
+  /** Pathname the isolated page is served at, e.g. "/__x.html". */
+  route: string;
+  title: string;
+  /** Fixture-only endpoints beside the page: test pages, drift triggers, captured requests. */
+  extraRoutes?: PreviewRoute[];
+  /** Content of the viewport meta tag. */
+  viewport?: string;
+}
+
+export interface MountedPreview {
+  previewUrl: string;
+  close(): Promise<void>;
+}
+
+const escapeHtml = (text: string) =>
+  text.replace(/[&<>"]/g, (char) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[char] ?? char);
+
+const matchRoute = (route: PreviewRoute, pathname: string, method: string | undefined) => {
+  if (route.method !== undefined && route.method !== method) return undefined;
+  if (typeof route.path === "string") return route.path === pathname ? { match: null } : undefined;
+  const match = route.path.exec(pathname);
+  return match ? { match } : undefined;
+};
+
+/** Serve `entry` in an isolated page whose /api requests are proxied to `fixture`. */
+export async function mountPreview(
+  fixture: { info: { url: string } },
+  options: PreviewOptions,
+): Promise<MountedPreview> {
+  const { entry, route, title, extraRoutes = [], viewport = "width=device-width, initial-scale=1" } = options;
+  const page = `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="${escapeHtml(viewport)}"><title>${escapeHtml(title)}</title></head><body><div id="root"></div><script type="module" src="${escapeHtml(entry)}"></script></body></html>`;
+  const ui = await createServer({
+    root: REPO_ROOT,
+    server: { host: "127.0.0.1", port: 0, proxy: { "/api": { target: fixture.info.url } } },
+    plugins: [{
+      name: "isolated-preview",
+      configureServer(server) {
+        server.middlewares.use((req, res, next) => {
+          const pathname = (req.url ?? "").split("?")[0]!;
+          if (pathname === route) {
+            void server.transformIndexHtml(route, page)
+              .then((html) => { res.setHeader("content-type", "text/html"); res.end(html); })
+              .catch(next);
+            return;
+          }
+          for (const extra of extraRoutes) {
+            const hit = matchRoute(extra, pathname, req.method);
+            if (!hit) continue;
+            void Promise.resolve().then(() => extra.handler(req, res, hit.match)).catch(next);
+            return;
+          }
+          next();
+        });
+      },
+    }],
+  });
+  await ui.listen();
+  const base = ui.resolvedUrls?.local[0];
+  if (!base) {
+    await ui.close();
+    throw new Error("the preview server did not report a local URL");
+  }
+  return {
+    previewUrl: new URL(route, base).href,
+    close: () => ui.close(),
+  };
+}
+
+/** Resolve on the first SIGINT or SIGTERM: the "print the URL and wait" ending. */
+export function parkUntilSignal(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const settle = () => {
+      process.off("SIGINT", settle);
+      process.off("SIGTERM", settle);
+      resolve();
+    };
+    process.once("SIGINT", settle);
+    process.once("SIGTERM", settle);
+  });
+}
+
+export interface FixtureApiOptions {
+  /** Sent with every call; `origin: fixture.info.url` marks a request as the app's own. */
+  headers?: Record<string, string>;
+  /** Sees every call that succeeded, e.g. to record mutation evidence. */
+  observe?: (call: { method: string; path: string; status: number }) => void;
+}
+
+/** JSON fetch against the fixture server; a non-2xx status throws with the body. */
+export function fixtureApi(baseUrl: string, options: FixtureApiOptions = {}) {
+  return async (method: string, path: string, body?: unknown): Promise<any> => {
+    const response = await fetch(`${baseUrl}${path}`, {
+      method, headers: { "content-type": "application/json", ...options.headers },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    const result = await response.json();
+    if (!response.ok) throw new Error(`${method} ${path}: ${JSON.stringify(result)}`);
+    options.observe?.({ method, path, status: response.status });
+    return result;
+  };
+}

--- a/scripts/testing/verification-docs.test.ts
+++ b/scripts/testing/verification-docs.test.ts
@@ -1,0 +1,99 @@
+// Verification recipes are followed by hand, so nothing else notices when a
+// command, file, route or link they cite stops existing. This reads every
+// recipe under docs/verification and checks each citation against the tree.
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { HELP } from "../control-omb.ts";
+
+const ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const DOCS = join(ROOT, "docs", "verification");
+const recipes = readdirSync(DOCS).filter((name) => name.endsWith(".md")).sort();
+const text = (recipe: string) => readFileSync(join(DOCS, recipe), "utf8");
+// Paths inside external links belong to other repositories.
+const withoutUrls = (markdown: string) => markdown.replace(/https?:\/\/\S+/g, " ");
+const cited = (pattern: RegExp) => {
+  const hits: string[] = [];
+  for (const recipe of recipes) {
+    for (const match of withoutUrls(text(recipe)).matchAll(pattern)) hits.push(`${recipe}: ${match[1]!}`);
+  }
+  return hits;
+};
+const target = (hit: string) => hit.slice(hit.indexOf(": ") + 2);
+
+// The verbs `help` prints, minus the shell line under "isolated fixture".
+const helpVerbs = new Set([...HELP.matchAll(/^ {2}([a-z][\w-]*)(?= |$)/gm)].map((match) => match[1]!).filter((verb) => verb !== "node"));
+helpVerbs.add("help");
+
+const serverSource = readFileSync(join(ROOT, "server", "index.ts"), "utf8");
+const hooksSource = readFileSync(join(ROOT, "server", "webhook-ingress.ts"), "utf8");
+// server/index.ts matches routes two ways: `path === "/api/x"` and
+// `path.match(/^\/api\/x\/(a|b)$/)`. Collect the regex form too.
+const routePatterns = [...serverSource.matchAll(/\/(\^\\\/api\\\/(?:\[(?:[^\]\\]|\\.)*\]|[^/\\\n[]|\\.)*)\/[a-z]*/g)].map((match) => new RegExp(match[1]!));
+const PLACEHOLDER = /^(ID|:[\w-]+|<[^>]+>|\{[^}]+\})$/;
+
+const slug = (heading: string) => heading.trim().toLowerCase().replace(/[^\w\- ]/g, "").replace(/\s+/g, "-");
+
+describe("docs/verification recipes cite things that exist", () => {
+  it("use control:omb verbs that help lists", () => {
+    const used = cited(/pnpm control:omb ([a-z][\w-]*)/g);
+    expect(used.length).toBeGreaterThan(0);
+    expect(used.filter((hit) => !helpVerbs.has(target(hit)))).toEqual([]);
+    // the launcher form may also name `launch`, which pnpm cannot run
+    const direct = cited(/scripts\/control-omb\.ts ([a-z][\w-]*)/g);
+    expect(direct.filter((hit) => target(hit) !== "launch" && !helpVerbs.has(target(hit)))).toEqual([]);
+  });
+
+  it("cite source files that exist", () => {
+    const refs = cited(/(?<![\w/.-])((?:scripts|server|src|shared|electron|companion|enterprise)\/[\w./-]+\.(?:ts|tsx|mjs|cjs|py))(?![\w/])/g);
+    expect(refs.length).toBeGreaterThan(50);
+    expect([...new Set(refs.filter((hit) => !existsSync(join(ROOT, target(hit)))))]).toEqual([]);
+  });
+
+  it("cite test files that exist", () => {
+    const refs = cited(/(?<![\w/.-])([\w./-]+\.test\.(?:ts|mjs))(?![\w/])/g);
+    expect(refs.length).toBeGreaterThan(20);
+    expect([...new Set(refs.filter((hit) => !existsSync(join(ROOT, target(hit)))))]).toEqual([]);
+  });
+
+  it("cite API routes the server registers", () => {
+    const refs = cited(/(?<!\w)(\/(?:api|hooks)\/[\w./:{}<>-]+)/g);
+    expect(refs.length).toBeGreaterThan(5);
+    const registered = (route: string) => {
+      const path = route.replace(/[.,;:]+$/, "");
+      const source = path.startsWith("/hooks/") ? hooksSource : serverSource;
+      const segments = path.split("/").slice(1);
+      const literal = segments.findIndex((segment) => PLACEHOLDER.test(segment));
+      if (literal === -1) return source.includes(`"${path}"`) || routePatterns.some((pattern) => pattern.test(path));
+      // a placeholder path is known by its first two segments
+      const prefix = `/${segments.slice(0, Math.min(2, literal)).join("/")}`;
+      return source.includes(`"${prefix}`) || source.includes(`${prefix}/`)
+        || routePatterns.some((pattern) => pattern.test(segments.map((segment) => PLACEHOLDER.test(segment) ? "x-1" : segment).join("/").replace(/^/, "/")));
+    };
+    expect([...new Set(refs.filter((hit) => !registered(target(hit))))]).toEqual([]);
+  });
+
+  it("are all reachable from README.md", () => {
+    const linked = new Set([...text("README.md").matchAll(/\]\(([^)#\s]+\.md)/g)].map((match) => match[1]!));
+    expect(recipes.filter((recipe) => recipe !== "README.md" && !linked.has(recipe))).toEqual([]);
+  });
+
+  it("link to files and headings that exist", () => {
+    const broken: string[] = [];
+    for (const recipe of recipes) {
+      for (const [, link] of text(recipe).matchAll(/\]\(([^)\s]+)\)/g)) {
+        if (/^(https?:|mailto:|#)/.test(link!)) continue;
+        const [file, anchor] = link!.split("#");
+        const resolved = resolve(DOCS, file!);
+        if (!existsSync(resolved)) { broken.push(`${recipe}: ${link}`); continue; }
+        if (anchor && resolved.endsWith(".md")) {
+          const headings = [...readFileSync(resolved, "utf8").matchAll(/^#+\s+(.+)$/gm)].map((match) => slug(match[1]!));
+          if (!headings.includes(anchor)) broken.push(`${recipe}: ${link} (no such heading)`);
+        }
+      }
+    }
+    expect(broken).toEqual([]);
+  });
+});

--- a/scripts/verify-avatar-providers.ts
+++ b/scripts/verify-avatar-providers.ts
@@ -1,8 +1,7 @@
 // Real avatar UI and server, with a loopback-only fake Images API. No paid calls.
 import { createServer as createHttpServer } from "node:http";
-import { fileURLToPath } from "node:url";
-import { createServer } from "vite";
 import { launchVerificationServer, runControlOmb } from "./control-omb.ts";
+import { mountPreview, parkUntilSignal, type MountedPreview } from "./testing/preview-fixture.ts";
 
 const png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
 const requests: Array<{ path: string; model?: string; authorized: boolean }> = [];
@@ -30,32 +29,19 @@ await new Promise<void>((resolve) => imageApi.listen(0, "127.0.0.1", resolve));
 const imagePort = (imageApi.address() as { port: number }).port;
 const imageBase = `http://127.0.0.1:${imagePort}/v1`;
 let fixture: Awaited<ReturnType<typeof launchVerificationServer>> | undefined;
-let ui: Awaited<ReturnType<typeof createServer>> | undefined;
+let ui: MountedPreview | undefined;
 try {
   fixture = await launchVerificationServer();
   await runControlOmb(["new-bot", "--name", "Avatar Scout", "--url", fixture.info.url]);
-  ui = await createServer({
-    root: fileURLToPath(new URL("..", import.meta.url)),
-    server: { host: "127.0.0.1", port: 0, proxy: { "/api": { target: fixture.info.url } } },
-    plugins: [{ name: "avatar-provider-fixture", configureServer(server) {
-      server.middlewares.use((req, res, next) => {
-        if (req.url?.split("?")[0] === "/__avatar-providers.html") {
-          void server.transformIndexHtml(req.url, '<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Avatar providers — isolated fixture</title></head><body><div id="root"></div><script type="module" src="/src/testing/avatar-providers.tsx"></script></body></html>')
-            .then((html) => { res.setHeader("content-type", "text/html"); res.end(html); }).catch(next);
-          return;
-        }
-        if (req.url === "/__fixture/requests") {
-          res.setHeader("content-type", "application/json");
-          res.end(JSON.stringify(requests));
-          return;
-        }
-        next();
-      });
-    } }],
+  ui = await mountPreview(fixture, {
+    entry: "/src/testing/avatar-providers.tsx", route: "/__avatar-providers.html", title: "Avatar providers — isolated fixture",
+    extraRoutes: [{
+      path: "/__fixture/requests",
+      handler(_req, res) { res.setHeader("content-type", "application/json"); res.end(JSON.stringify(requests)); },
+    }],
   });
-  await ui.listen();
-  console.log(JSON.stringify({ ...fixture.info, imageBase, previewUrl: `${ui.resolvedUrls!.local[0]}__avatar-providers.html?base=${encodeURIComponent(imageBase)}` }));
-  await new Promise<void>((resolve) => { process.once("SIGINT", resolve); process.once("SIGTERM", resolve); });
+  console.log(JSON.stringify({ ...fixture.info, imageBase, previewUrl: `${ui.previewUrl}?base=${encodeURIComponent(imageBase)}` }));
+  await parkUntilSignal();
 } finally {
   await ui?.close();
   await fixture?.close();

--- a/scripts/verify-bidi.ts
+++ b/scripts/verify-bidi.ts
@@ -5,9 +5,10 @@
 // scripted reply that exercises every block a bot reply can contain — prose
 // around inline code, a list, a table, a quote, a fenced block, and a trailing
 // English paragraph — and mounts the real renderer against it.
-import { writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { removeTempDir } from "../server/testing/cleanup.ts";
 import { launchVerificationServer, runControlOmb } from "./control-omb.ts";
 import { fixtureApi, mountPreview, parkUntilSignal, type MountedPreview } from "./testing/preview-fixture.ts";
 
@@ -57,7 +58,18 @@ const ENGLISH_REPLY = [
   "وهذه فقرة عربية تُغلق ردًّا إنجليزيًّا — يجب أن تُقرأ من اليمين وحدها.",
 ].join("\n");
 
-const fixture = await launchVerificationServer();
+// Each turn spawns a fresh CLI, so the reply cursor lives in a file — in this
+// launcher's own scratch directory, since the fixture home does not exist
+// until the server is up. The launcher forwards FAKE_CLAUDE_* to its engine.
+const scratch = mkdtempSync(join(tmpdir(), "openmausbot-verify-bidi-"));
+const fixture = await launchVerificationServer({
+  ...process.env,
+  FAKE_CLAUDE_REPLIES: JSON.stringify([ARABIC_REPLY, ENGLISH_REPLY]),
+  FAKE_CLAUDE_REPLY_STATE: join(scratch, "bidi-reply-cursor"),
+}).catch(async (error) => {
+  await removeTempDir(scratch);
+  throw error;
+});
 let ui: MountedPreview | undefined;
 try {
   const api = fixtureApi(fixture.info.url);
@@ -66,18 +78,6 @@ try {
   await control(["new-bot", "--name", "Probe"]);
   const { bots } = await api("GET", "/api/bots?messages=0");
   const probe = bots.find((bot: { name: string }) => bot.name === "Probe");
-
-  // Each turn spawns a fresh CLI, so the reply cursor lives in a file inside
-  // this fixture's own home rather than in the process.
-  const replyState = join(fixture.info.dataDir, "bidi-reply-cursor");
-  const wrapper = join(fixture.info.dataDir, "bidi-claude.mjs");
-  writeFileSync(wrapper, [
-    "#!/usr/bin/env node",
-    `process.env.FAKE_CLAUDE_REPLIES = ${JSON.stringify(JSON.stringify([ARABIC_REPLY, ENGLISH_REPLY]))};`,
-    `process.env.FAKE_CLAUDE_REPLY_STATE = ${JSON.stringify(replyState)};`,
-    `await import(${JSON.stringify(pathToFileURL(fileURLToPath(new URL("../server/testing/fake-claude-cli.ts", import.meta.url))).href)});`,
-  ].join("\n"), { mode: 0o700 });
-  await api("PATCH", "/api/instances/claude", { cli: wrapper });
 
   // A multi-line user turn that mixes scripts: the sent bubble must resolve
   // each line on its own, not let the first line decide for all of them.
@@ -99,4 +99,5 @@ try {
 } finally {
   await ui?.close();
   await fixture.close();
+  await removeTempDir(scratch);
 }

--- a/scripts/verify-bidi.ts
+++ b/scripts/verify-bidi.ts
@@ -8,8 +8,8 @@
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { createServer } from "vite";
 import { launchVerificationServer, runControlOmb } from "./control-omb.ts";
+import { fixtureApi, mountPreview, parkUntilSignal, type MountedPreview } from "./testing/preview-fixture.ts";
 
 const ARABIC_REPLY = [
   "## تقرير الأداء الأسبوعي",
@@ -58,17 +58,9 @@ const ENGLISH_REPLY = [
 ].join("\n");
 
 const fixture = await launchVerificationServer();
-let ui: Awaited<ReturnType<typeof createServer>> | undefined;
+let ui: MountedPreview | undefined;
 try {
-  const api = async (method: string, path: string, body?: unknown) => {
-    const response = await fetch(`${fixture.info.url}${path}`, {
-      method, headers: { "content-type": "application/json" },
-      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
-    });
-    const result = await response.json();
-    if (!response.ok) throw new Error(`${method} ${path}: ${JSON.stringify(result)}`);
-    return result;
-  };
+  const api = fixtureApi(fixture.info.url);
   const control = (args: string[]) => runControlOmb([...args, "--url", fixture.info.url]);
 
   await control(["new-bot", "--name", "Probe"]);
@@ -99,23 +91,11 @@ try {
   await control(["send", "--bot", probe.id, "--text", "Now summarise that in English"]);
   await control(["wait", "--bot", probe.id, "--timeout", "30"]);
 
-  ui = await createServer({
-    root: fileURLToPath(new URL("..", import.meta.url)),
-    server: { host: "127.0.0.1", port: 0, proxy: { "/api": { target: fixture.info.url } } },
-    plugins: [{ name: "isolated-bidi", configureServer(server) {
-      server.middlewares.use((req, res, next) => {
-        if (req.url !== "/__bidi.html") return next();
-        void server.transformIndexHtml(req.url, '<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>Isolated OpenMaus Bidi</title></head><body><div id="root"></div><script type="module" src="/scripts/testing/threads-preview.tsx"></script></body></html>')
-          .then((html) => { res.setHeader("content-type", "text/html"); res.end(html); }).catch(next);
-      });
-    } }],
+  ui = await mountPreview(fixture, {
+    entry: "/scripts/testing/threads-preview.tsx", route: "/__bidi.html", title: "Isolated OpenMaus Bidi",
   });
-  await ui.listen();
-  console.log(JSON.stringify({ ...fixture.info, previewUrl: `${ui.resolvedUrls!.local[0]}__bidi.html` }));
-  await new Promise<void>((resolve) => {
-    process.once("SIGINT", resolve);
-    process.once("SIGTERM", resolve);
-  });
+  console.log(JSON.stringify({ ...fixture.info, previewUrl: ui.previewUrl }));
+  await parkUntilSignal();
 } finally {
   await ui?.close();
   await fixture.close();

--- a/scripts/verify-bot-settings.ts
+++ b/scripts/verify-bot-settings.ts
@@ -2,12 +2,11 @@
 import { execFileSync } from "node:child_process";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { createServer } from "vite";
 import { launchVerificationServer, runControlOmb } from "./control-omb.ts";
+import { mountPreview, parkUntilSignal, REPO_ROOT, type MountedPreview } from "./testing/preview-fixture.ts";
 
 const fixture = await launchVerificationServer();
-let ui: Awaited<ReturnType<typeof createServer>> | undefined;
+let ui: MountedPreview | undefined;
 try {
   for (const name of ["Settings Atlas", "Settings Juniper"]) {
     await runControlOmb(["new-bot", "--name", name, "--url", fixture.info.url]);
@@ -27,35 +26,24 @@ try {
     const result = installSkill(${JSON.stringify(atlas.id)}, 'fixture:settings', [{path:'SKILL.md',content:'---\\nname: fixture-check\\ndescription: Check fixture settings reliably\\n---\\nRead the fixture state and summarize it.\\n'}]);
     if ('error' in result) throw new Error(result.error);
     setSkillEnabled(${JSON.stringify(atlas.id)}, 'fixture-check', true);
-  `], { cwd: fileURLToPath(new URL("..", import.meta.url)), env: { ...process.env, OMB_DATA_DIR: fixture.info.dataDir } });
+  `], { cwd: REPO_ROOT, env: { ...process.env, OMB_DATA_DIR: fixture.info.dataDir } });
 
-  ui = await createServer({
-    root: fileURLToPath(new URL("..", import.meta.url)),
-    server: { host: "127.0.0.1", port: 0, proxy: { "/api": { target: fixture.info.url } } },
-    plugins: [{ name: "isolated-bot-settings", configureServer(server) {
-      server.middlewares.use((req, res, next) => {
-        if (req.url === "/__bot-settings.html") {
-          void server.transformIndexHtml(req.url, '<html><head><title>Isolated Bot Settings</title></head><body><div id="root"></div><script type="module" src="/src/testing/bot-settings.tsx"></script></body></html>')
-            .then((html) => { res.setHeader("content-type", "text/html"); res.end(html); }).catch(next);
-          return;
-        }
-        const match = req.url?.match(/^\/__fixture\/drift\/([\w-]+)$/);
-        if (match && req.method === "POST" && ids.has(match[1]!)) {
-          writeFileSync(join(fixture.info.dataDir, "bots", match[1]!, "SOUL.md"), "Outside edit from isolated settings fixture.", { mode: 0o600 });
-          res.setHeader("content-type", "application/json");
-          res.end('{"ok":true}');
-          return;
-        }
-        next();
-      });
-    } }],
+  ui = await mountPreview(fixture, {
+    entry: "/src/testing/bot-settings.tsx", route: "/__bot-settings.html", title: "Isolated Bot Settings",
+    extraRoutes: [{
+      // An outside edit of a bot's standing instructions, inside the fixture home only.
+      path: /^\/__fixture\/drift\/([\w-]+)$/, method: "POST",
+      handler(_req, res, match) {
+        const botId = match![1]!;
+        res.setHeader("content-type", "application/json");
+        if (!ids.has(botId)) { res.writeHead(404).end('{"error":"unknown fixture bot"}'); return; }
+        writeFileSync(join(fixture.info.dataDir, "bots", botId, "SOUL.md"), "Outside edit from isolated settings fixture.", { mode: 0o600 });
+        res.end('{"ok":true}');
+      },
+    }],
   });
-  await ui.listen();
-  console.log(JSON.stringify({ ...fixture.info, previewUrl: `${ui.resolvedUrls!.local[0]}__bot-settings.html` }));
-  await new Promise<void>((resolve) => {
-    process.once("SIGINT", resolve);
-    process.once("SIGTERM", resolve);
-  });
+  console.log(JSON.stringify({ ...fixture.info, previewUrl: ui.previewUrl }));
+  await parkUntilSignal();
 } finally {
   await ui?.close();
   await fixture.close();

--- a/scripts/verify-browser-live.ts
+++ b/scripts/verify-browser-live.ts
@@ -1,40 +1,33 @@
 // Actual browser + actual BrowserPanel, always in a disposable fixture HOME.
-import { fileURLToPath } from "node:url";
 import { readFileSync } from "node:fs";
-import { createServer } from "vite";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { launchVerificationServer, runControlOmb } from "./control-omb.ts";
+import { mountPreview, parkUntilSignal, type MountedPreview } from "./testing/preview-fixture.ts";
+
 
 const binaryPath = process.env.OMB_VERIFY_BROWSER_BINARY;
 const executablePath = process.env.OMB_VERIFY_BROWSER_CHROME;
 if (!binaryPath || !executablePath) throw new Error("Set OMB_VERIFY_BROWSER_BINARY and OMB_VERIFY_BROWSER_CHROME to explicit installed binaries.");
 const fixture = await launchVerificationServer(process.env, undefined, undefined, { binaryPath, executablePath });
-let ui: Awaited<ReturnType<typeof createServer>> | undefined;
+let ui: MountedPreview | undefined;
 try {
   await runControlOmb(["new-bot", "--name", "Pepper", "--url", fixture.info.url]);
   const { bots } = await (await fetch(`${fixture.info.url}/api/bots`)).json() as any;
   await fetch(`${fixture.info.url}/api/config`, { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ features: { browser: true } }) });
   await fetch(`${fixture.info.url}/api/bots/${bots[0].id}`, { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ browser: true }) });
-  ui = await createServer({
-    root: fileURLToPath(new URL("..", import.meta.url)),
-    server: { host: "127.0.0.1", port: 0, proxy: { "/api": { target: fixture.info.url } } },
-    plugins: [{ name: "isolated-browser-preview", configureServer(server) {
-      server.middlewares.use((req, res, next) => {
-        if (req.url === "/__browser-test-page") {
-          res.setHeader("content-type", "text/html");
-          res.end(readFileSync(new URL("./testing/browser-test-page.html", import.meta.url), "utf8"));
-          return;
-        }
-        if (req.url !== "/__browser-preview.html") return next();
-        void server.transformIndexHtml(req.url, '<html><head><title>Isolated Browser Preview</title></head><body><div id="root"></div><script type="module" src="/scripts/testing/browser-preview.tsx"></script></body></html>')
-          .then((html) => { res.setHeader("content-type", "text/html"); res.end(html); }).catch(next);
-      });
-    } }],
+  ui = await mountPreview(fixture, {
+    entry: "/scripts/testing/browser-preview.tsx", route: "/__browser-preview.html", title: "Isolated Browser Preview",
+    extraRoutes: [{
+      path: "/__browser-test-page",
+      handler(_req, res) {
+        res.setHeader("content-type", "text/html");
+        res.end(readFileSync(new URL("./testing/browser-test-page.html", import.meta.url), "utf8"));
+      },
+    }],
   });
-  await ui.listen();
-  console.log(JSON.stringify({ ...fixture.info, botId: bots[0].id, previewUrl: `${ui.resolvedUrls!.local[0]}__browser-preview.html`, testPage: `${ui.resolvedUrls!.local[0]}__browser-test-page` }, null, 2));
-  await new Promise<void>((resolve) => { process.once("SIGINT", resolve); process.once("SIGTERM", resolve); });
+  console.log(JSON.stringify({ ...fixture.info, botId: bots[0].id, previewUrl: ui.previewUrl, testPage: new URL("/__browser-test-page", ui.previewUrl).href }, null, 2));
+  await parkUntilSignal();
 } finally {
   await ui?.close();
   // close --all is scoped to this fixture's HOME, never the operator's.

--- a/scripts/verify-claude-account.ts
+++ b/scripts/verify-claude-account.ts
@@ -2,21 +2,13 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { createServer } from "vite";
 import { launchVerificationServer, runControlOmb } from "./control-omb.ts";
+import { fixtureApi, mountPreview, parkUntilSignal, type MountedPreview } from "./testing/preview-fixture.ts";
 
 const fixture = await launchVerificationServer();
-let ui: Awaited<ReturnType<typeof createServer>> | undefined;
+let ui: MountedPreview | undefined;
 try {
-  const api = async (method: string, path: string, body?: unknown) => {
-    const response = await fetch(`${fixture.info.url}${path}`, {
-      method, headers: { "content-type": "application/json" },
-      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
-    });
-    const result = await response.json();
-    if (!response.ok) throw new Error(`${method} ${path}: ${JSON.stringify(result)}`);
-    return result;
-  };
+  const api = fixtureApi(fixture.info.url);
   const home = fixture.info.dataDir;
   const configDir = join(home, "claude-account");
   const authenticated = join(configDir, "authenticated");
@@ -58,20 +50,11 @@ try {
   if (account?.snapshot.account?.email !== "ada@example.test" || !account.authentication?.signOut) {
     throw new Error(`Offline account not ready: ${JSON.stringify(account)}`);
   }
-  ui = await createServer({
-    root: fileURLToPath(new URL("..", import.meta.url)),
-    server: { host: "127.0.0.1", port: 0, proxy: { "/api": { target: fixture.info.url } } },
-    plugins: [{ name: "isolated-claude-account", configureServer(server) {
-      server.middlewares.use((req, res, next) => {
-        if (req.url !== "/__claude-account.html") return next();
-        void server.transformIndexHtml(req.url, '<!doctype html><html><head><meta charset="utf-8"><title>Claude account — offline fixture</title></head><body><div id="root"></div><script type="module" src="/scripts/testing/threads-preview.tsx"></script></body></html>')
-          .then((html) => { res.setHeader("content-type", "text/html"); res.end(html); }).catch(next);
-      });
-    } }],
+  ui = await mountPreview(fixture, {
+    entry: "/scripts/testing/threads-preview.tsx", route: "/__claude-account.html", title: "Claude account — offline fixture",
   });
-  await ui.listen();
-  console.log(JSON.stringify({ ...fixture.info, commandLog, failLogoutMarker, previewUrl: `${ui.resolvedUrls!.local[0]}__claude-account.html` }));
-  await new Promise<void>((resolve) => { process.once("SIGINT", resolve); process.once("SIGTERM", resolve); });
+  console.log(JSON.stringify({ ...fixture.info, commandLog, failLogoutMarker, previewUrl: ui.previewUrl }));
+  await parkUntilSignal();
 } finally {
   await ui?.close();
   await fixture.close();

--- a/scripts/verify-cloud-preview.ts
+++ b/scripts/verify-cloud-preview.ts
@@ -1,40 +1,19 @@
 // Real ComputerPanel + isolated fake-engine server, with only its cloud
 // transport simulated. No Box account or user's app data is contacted.
 // Run: node --experimental-strip-types scripts/verify-cloud-preview.ts
-import { fileURLToPath } from "node:url";
-import { createServer } from "vite";
 import { launchVerificationServer, runControlOmb } from "./control-omb.ts";
+import { mountPreview, parkUntilSignal, type MountedPreview } from "./testing/preview-fixture.ts";
 
-const root = fileURLToPath(new URL("..", import.meta.url));
 const fixture = await launchVerificationServer();
-let ui: Awaited<ReturnType<typeof createServer>> | undefined;
-const close = async () => {
-  await ui?.close();
-  await fixture.close();
-};
+let ui: MountedPreview | undefined;
 try {
   await runControlOmb(["new-bot", "--name", "Box Preview Test", "--url", fixture.info.url]);
-  ui = await createServer({
-    root,
-    server: { host: "127.0.0.1", port: 0, proxy: { "/api": { target: fixture.info.url } } },
-    plugins: [{
-      name: "isolated-cloud-preview",
-      configureServer(server) {
-        server.middlewares.use((req, res, next) => {
-          if (req.url !== "/__cloud-preview.html") return next();
-          void server.transformIndexHtml(req.url, '<html><head><title>Isolated Box Preview Test</title></head><body><div id="root"></div><script type="module" src="/scripts/testing/cloud-preview.tsx"></script></body></html>')
-            .then((html) => { res.setHeader("content-type", "text/html"); res.end(html); })
-            .catch(next);
-        });
-      },
-    }],
+  ui = await mountPreview(fixture, {
+    entry: "/scripts/testing/cloud-preview.tsx", route: "/__cloud-preview.html", title: "Isolated Box Preview Test",
   });
-  await ui.listen();
-  console.log(JSON.stringify({ ...fixture.info, previewUrl: `${ui.resolvedUrls!.local[0]}__cloud-preview.html` }, null, 2));
-  await new Promise<void>((resolve) => {
-    process.once("SIGINT", resolve);
-    process.once("SIGTERM", resolve);
-  });
+  console.log(JSON.stringify({ ...fixture.info, previewUrl: ui.previewUrl }, null, 2));
+  await parkUntilSignal();
 } finally {
-  await close();
+  await ui?.close();
+  await fixture.close();
 }

--- a/scripts/verify-codex-account.ts
+++ b/scripts/verify-codex-account.ts
@@ -3,21 +3,13 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { createServer } from "vite";
 import { launchVerificationServer, runControlOmb } from "./control-omb.ts";
+import { fixtureApi, mountPreview, parkUntilSignal, type MountedPreview } from "./testing/preview-fixture.ts";
 
 const fixture = await launchVerificationServer();
-let ui: Awaited<ReturnType<typeof createServer>> | undefined;
+let ui: MountedPreview | undefined;
 try {
-  const api = async (method: string, path: string, body?: unknown) => {
-    const response = await fetch(`${fixture.info.url}${path}`, {
-      method, headers: { "content-type": "application/json" },
-      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
-    });
-    const result = await response.json();
-    if (!response.ok) throw new Error(`${method} ${path}: ${JSON.stringify(result)}`);
-    return result;
-  };
+  const api = fixtureApi(fixture.info.url);
   const fixtureHome = fixture.info.dataDir;
   const codexDir = join(fixtureHome, ".codex");
   const wrapper = join(fixtureHome, "offline-codex-account.mjs");
@@ -59,20 +51,11 @@ try {
     throw new Error(`Synthetic account not ready: ${JSON.stringify(codex?.snapshot)}`);
   }
 
-  ui = await createServer({
-    root: fileURLToPath(new URL("..", import.meta.url)),
-    server: { host: "127.0.0.1", port: 0, proxy: { "/api": { target: fixture.info.url } } },
-    plugins: [{ name: "isolated-codex-account", configureServer(server) {
-      server.middlewares.use((req, res, next) => {
-        if (req.url !== "/__codex-account.html") return next();
-        void server.transformIndexHtml(req.url, '<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Codex account — offline fixture</title></head><body><div id="root"></div><script type="module" src="/scripts/testing/threads-preview.tsx"></script></body></html>')
-          .then((html) => { res.setHeader("content-type", "text/html"); res.end(html); }).catch(next);
-      });
-    } }],
+  ui = await mountPreview(fixture, {
+    entry: "/scripts/testing/threads-preview.tsx", route: "/__codex-account.html", title: "Codex account — offline fixture",
   });
-  await ui.listen();
-  console.log(JSON.stringify({ ...fixture.info, launcherPid: process.pid, commandLog, failLogoutMarker, previewUrl: `${ui.resolvedUrls!.local[0]}__codex-account.html` }));
-  await new Promise<void>((resolve) => { process.once("SIGINT", resolve); process.once("SIGTERM", resolve); });
+  console.log(JSON.stringify({ ...fixture.info, launcherPid: process.pid, commandLog, failLogoutMarker, previewUrl: ui.previewUrl }));
+  await parkUntilSignal();
 } finally {
   await ui?.close();
   await fixture.close();

--- a/scripts/verify-mentions.ts
+++ b/scripts/verify-mentions.ts
@@ -1,23 +1,26 @@
 // Real chat views and composer against a disposable fake-engine server.
-import { writeFile } from "node:fs/promises";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { removeTempDir } from "../server/testing/cleanup.ts";
 import { launchVerificationServer, runControlOmb } from "./control-omb.ts";
 import { mountPreview, parkUntilSignal, type MountedPreview } from "./testing/preview-fixture.ts";
 
-const fixture = await launchVerificationServer();
+// Opt in to an actual fake-engine reply containing peer mentions. A shared
+// counter makes subsequent replies plain, so channel handoffs stay bounded; it
+// lives in this launcher's own scratch directory because the fixture home does
+// not exist until the server is up. The launcher forwards FAKE_CLAUDE_*.
+const reply = "@Juniper please review. @調査担当 確認してください。 @Atlas final check.\n\nReverse: @調査担当 then @Juniper.\n\nPlain prefixes: @調査担当者 @everyone調査. Neutral: @everyone.";
+const scratch = process.argv.includes("--bot-mentions") ? mkdtempSync(join(tmpdir(), "openmausbot-verify-mentions-")) : undefined;
+const fixture = await launchVerificationServer({
+  ...process.env,
+  ...(scratch ? { FAKE_CLAUDE_REPLIES: JSON.stringify([reply]), FAKE_CLAUDE_REPLY_STATE: join(scratch, "mention-replies.txt") } : {}),
+}).catch(async (error) => {
+  if (scratch) await removeTempDir(scratch);
+  throw error;
+});
 let ui: MountedPreview | undefined;
 try {
-  // Opt in to an actual fake-engine reply containing peer mentions. A shared
-  // counter makes subsequent replies plain, so channel handoffs stay bounded.
-  if (process.argv.includes("--bot-mentions")) {
-    const cli = join(fixture.info.dataDir, "mention-reply.mjs");
-    const reply = "@Juniper please review. @調査担当 確認してください。 @Atlas final check.\n\nReverse: @調査担当 then @Juniper.\n\nPlain prefixes: @調査担当者 @everyone調査. Neutral: @everyone.";
-    await writeFile(cli, `#!/usr/bin/env node\nprocess.env.FAKE_CLAUDE_REPLIES = ${JSON.stringify(JSON.stringify([reply]))};\nprocess.env.FAKE_CLAUDE_REPLY_STATE = ${JSON.stringify(join(fixture.info.dataDir, "mention-replies.txt"))};\nawait import(${JSON.stringify(new URL("../server/testing/fake-claude-cli.ts", import.meta.url).href)});\n`, { mode: 0o755 });
-    const response = await fetch(`${fixture.info.url}/api/instances/claude`, {
-      method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ cli }),
-    });
-    if (!response.ok) throw new Error(`Could not configure mention reply fixture: ${response.status}`);
-  }
   for (const name of ["Atlas", "Juniper", "調査担当"]) {
     await runControlOmb(["new-bot", "--name", name, "--url", fixture.info.url]);
   }
@@ -31,4 +34,5 @@ try {
 } finally {
   await ui?.close();
   await fixture.close();
+  if (scratch) await removeTempDir(scratch);
 }

--- a/scripts/verify-mentions.ts
+++ b/scripts/verify-mentions.ts
@@ -1,12 +1,11 @@
 // Real chat views and composer against a disposable fake-engine server.
-import { fileURLToPath } from "node:url";
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { createServer } from "vite";
 import { launchVerificationServer, runControlOmb } from "./control-omb.ts";
+import { mountPreview, parkUntilSignal, type MountedPreview } from "./testing/preview-fixture.ts";
 
 const fixture = await launchVerificationServer();
-let ui: Awaited<ReturnType<typeof createServer>> | undefined;
+let ui: MountedPreview | undefined;
 try {
   // Opt in to an actual fake-engine reply containing peer mentions. A shared
   // counter makes subsequent replies plain, so channel handoffs stay bounded.
@@ -24,23 +23,11 @@ try {
   }
   const { bots } = await fetch(`${fixture.info.url}/api/bots`).then((r) => r.json()) as { bots: Array<{ id: string; name: string }> };
   await runControlOmb(["new-channel", "--name", "Design review", "--members", bots.map((b) => b.id).join(","), "--url", fixture.info.url]);
-  ui = await createServer({
-    root: fileURLToPath(new URL("..", import.meta.url)),
-    server: { host: "127.0.0.1", port: 0, proxy: { "/api": { target: fixture.info.url } } },
-    plugins: [{ name: "isolated-mentions", configureServer(server) {
-      server.middlewares.use((req, res, next) => {
-        if (req.url !== "/__mentions.html") return next();
-        void server.transformIndexHtml(req.url, '<html><head><meta name="viewport" content="width=device-width, initial-scale=1"><title>Isolated mention verification</title></head><body><div id="root"></div><script type="module" src="/src/testing/mentions.tsx"></script></body></html>')
-          .then((html) => { res.setHeader("content-type", "text/html"); res.end(html); }).catch(next);
-      });
-    } }],
+  ui = await mountPreview(fixture, {
+    entry: "/src/testing/mentions.tsx", route: "/__mentions.html", title: "Isolated mention verification",
   });
-  await ui.listen();
-  console.log(JSON.stringify({ ...fixture.info, previewUrl: `${ui.resolvedUrls!.local[0]}__mentions.html` }));
-  await new Promise<void>((resolve) => {
-    process.once("SIGINT", resolve);
-    process.once("SIGTERM", resolve);
-  });
+  console.log(JSON.stringify({ ...fixture.info, previewUrl: ui.previewUrl }));
+  await parkUntilSignal();
 } finally {
   await ui?.close();
   await fixture.close();

--- a/scripts/verify-routines.ts
+++ b/scripts/verify-routines.ts
@@ -4,24 +4,18 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { createServer } from "vite";
 import { launchVerificationServer, runControlOmb } from "./control-omb.ts";
+import { fixtureApi, mountPreview, parkUntilSignal, type MountedPreview } from "./testing/preview-fixture.ts";
 import { waitForExit } from "../server/testing/cleanup.ts";
 
 const root = fileURLToPath(new URL("..", import.meta.url));
 const fixture = await launchVerificationServer();
-let ui: Awaited<ReturnType<typeof createServer>> | undefined;
+let ui: MountedPreview | undefined;
 const evidence: unknown[] = [];
-const api = async (method: string, path: string, body?: unknown) => {
-  const response = await fetch(fixture.info.url + path, {
-    method, headers: { "content-type": "application/json", origin: fixture.info.url },
-    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
-  });
-  const value = await response.json();
-  if (!response.ok) throw new Error(`${method} ${path}: ${JSON.stringify(value)}`);
-  if (method !== "GET") evidence.push({ method, path, status: response.status });
-  return value;
-};
+const api = fixtureApi(fixture.info.url, {
+  headers: { origin: fixture.info.url },
+  observe: (call) => { if (call.method !== "GET") evidence.push(call); },
+});
 async function until(check: () => boolean | Promise<boolean>) {
   const deadline = Date.now() + 20_000;
   while (!await check()) {
@@ -102,19 +96,11 @@ try {
     name: "Automatic scheduled check", prompt: "Verify the scheduler dispatches without Run now.", botId: pepper.id,
     enabled: true, schedule: { type: "once", at: Date.now() + 12_000 },
   });
-  ui = await createServer({
-    root, server: { host: "127.0.0.1", port: 0, proxy: { "/api": { target: fixture.info.url } } },
-    plugins: [{ name: "isolated-routines", configureServer(server) {
-      server.middlewares.use((req, res, next) => {
-        if (req.url !== "/__routines.html") return next();
-        void server.transformIndexHtml(req.url, '<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>Isolated OpenMaus Routines</title></head><body><div id="root"></div><script type="module" src="/scripts/testing/threads-preview.tsx"></script></body></html>')
-          .then((html) => { res.setHeader("content-type", "text/html"); res.end(html); }).catch(next);
-      });
-    } }],
+  ui = await mountPreview(fixture, {
+    entry: "/scripts/testing/threads-preview.tsx", route: "/__routines.html", title: "Isolated OpenMaus Routines",
   });
-  await ui.listen();
-  console.log(JSON.stringify({ ...fixture.info, previewUrl: `${ui.resolvedUrls!.local[0]}__routines.html`, pepperId: pepper.id, misoId: miso.id, scheduledRoutineId: scheduled.routine.id, manualRoutineId: manual.routine.id, resultsThreadId: resultsTask.threadId, resultsFolderId: resultsFolder.id }));
-  await new Promise<void>((resolve) => { process.once("SIGINT", resolve); process.once("SIGTERM", resolve); });
+  console.log(JSON.stringify({ ...fixture.info, previewUrl: ui.previewUrl, pepperId: pepper.id, misoId: miso.id, scheduledRoutineId: scheduled.routine.id, manualRoutineId: manual.routine.id, resultsThreadId: resultsTask.threadId, resultsFolderId: resultsFolder.id }));
+  await parkUntilSignal();
 } finally {
   const final = await api("GET", "/api/routines").catch(() => null);
   // Ctrl-C can reach the child before this owner reads its API. Preserve the

--- a/scripts/verify-sidebar.ts
+++ b/scripts/verify-sidebar.ts
@@ -1,31 +1,18 @@
 // Actual Sidebar against a disposable fake-engine server; never the live app.
-import { fileURLToPath } from "node:url";
-import { createServer } from "vite";
 import { launchVerificationServer, runControlOmb } from "./control-omb.ts";
+import { mountPreview, parkUntilSignal, type MountedPreview } from "./testing/preview-fixture.ts";
 
 const fixture = await launchVerificationServer();
-let ui: Awaited<ReturnType<typeof createServer>> | undefined;
+let ui: MountedPreview | undefined;
 try {
   for (const name of ["Sidebar Atlas", "Sidebar Juniper"]) {
     await runControlOmb(["new-bot", "--name", name, "--url", fixture.info.url]);
   }
-  ui = await createServer({
-    root: fileURLToPath(new URL("..", import.meta.url)),
-    server: { host: "127.0.0.1", port: 0, proxy: { "/api": { target: fixture.info.url } } },
-    plugins: [{ name: "isolated-sidebar-preview", configureServer(server) {
-      server.middlewares.use((req, res, next) => {
-        if (req.url !== "/__sidebar-preview.html") return next();
-        void server.transformIndexHtml(req.url, '<html><head><title>Isolated Sidebar Test</title></head><body><div id="root"></div><script type="module" src="/scripts/testing/sidebar-preview.tsx"></script></body></html>')
-          .then((html) => { res.setHeader("content-type", "text/html"); res.end(html); }).catch(next);
-      });
-    } }],
+  ui = await mountPreview(fixture, {
+    entry: "/scripts/testing/sidebar-preview.tsx", route: "/__sidebar-preview.html", title: "Isolated Sidebar Test",
   });
-  await ui.listen();
-  console.log(JSON.stringify({ ...fixture.info, previewUrl: `${ui.resolvedUrls!.local[0]}__sidebar-preview.html` }));
-  await new Promise<void>((resolve) => {
-    process.once("SIGINT", resolve);
-    process.once("SIGTERM", resolve);
-  });
+  console.log(JSON.stringify({ ...fixture.info, previewUrl: ui.previewUrl }));
+  await parkUntilSignal();
 } finally {
   await ui?.close();
   await fixture.close();

--- a/scripts/verify-threads.ts
+++ b/scripts/verify-threads.ts
@@ -2,21 +2,13 @@
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { createServer } from "vite";
 import { launchVerificationServer, runControlOmb } from "./control-omb.ts";
+import { fixtureApi, mountPreview, parkUntilSignal, type MountedPreview } from "./testing/preview-fixture.ts";
 
 const fixture = await launchVerificationServer();
-let ui: Awaited<ReturnType<typeof createServer>> | undefined;
+let ui: MountedPreview | undefined;
 try {
-  const api = async (method: string, path: string, body?: unknown) => {
-    const response = await fetch(`${fixture.info.url}${path}`, {
-      method, headers: { "content-type": "application/json" },
-      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
-    });
-    const result = await response.json();
-    if (!response.ok) throw new Error(`${method} ${path}: ${JSON.stringify(result)}`);
-    return result;
-  };
+  const api = fixtureApi(fixture.info.url);
   const control = (args: string[]) => runControlOmb([...args, "--url", fixture.info.url]);
   await control(["new-bot", "--name", "Pepper"]);
   await control(["new-bot", "--name", "Miso"]);
@@ -57,23 +49,11 @@ try {
     `await import(${JSON.stringify(pathToFileURL(fileURLToPath(new URL("../server/testing/fake-claude-cli.ts", import.meta.url))).href)});`,
   ].join("\n"), { mode: 0o700 });
   await api("PATCH", "/api/instances/claude", { cli: wrapper });
-  ui = await createServer({
-    root: fileURLToPath(new URL("..", import.meta.url)),
-    server: { host: "127.0.0.1", port: 0, proxy: { "/api": { target: fixture.info.url } } },
-    plugins: [{ name: "isolated-threads", configureServer(server) {
-      server.middlewares.use((req, res, next) => {
-        if (req.url !== "/__threads.html") return next();
-        void server.transformIndexHtml(req.url, '<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>Isolated OpenMaus Threads</title></head><body><div id="root"></div><script type="module" src="/scripts/testing/threads-preview.tsx"></script></body></html>')
-          .then((html) => { res.setHeader("content-type", "text/html"); res.end(html); }).catch(next);
-      });
-    } }],
+  ui = await mountPreview(fixture, {
+    entry: "/scripts/testing/threads-preview.tsx", route: "/__threads.html", title: "Isolated OpenMaus Threads",
   });
-  await ui.listen();
-  console.log(JSON.stringify({ ...fixture.info, previewUrl: `${ui.resolvedUrls!.local[0]}__threads.html`, finishGate }));
-  await new Promise<void>((resolve) => {
-    process.once("SIGINT", resolve);
-    process.once("SIGTERM", resolve);
-  });
+  console.log(JSON.stringify({ ...fixture.info, previewUrl: ui.previewUrl, finishGate }));
+  await parkUntilSignal();
 } finally {
   await ui?.close();
   await fixture.close();

--- a/server/control-omb.test.ts
+++ b/server/control-omb.test.ts
@@ -180,12 +180,14 @@ describe("control-omb isolated verification loop", () => {
   });
 
   it("launches, drives a real fake-engine turn, and removes only its test data", async () => {
-    const session = await launchVerificationServer({
+    const parentEnv = {
       ...process.env,
       COMPOSIO_API_KEY: "must-not-reach-the-fixture",
       OMB_SKILLS_DIR: "/must/not/reach/the/fixture",
       XAI_API_KEY: "must-not-reach-the-fixture",
-    });
+      FAKE_CLAUDE_PROBE: "fixture-scripting-knob",
+    };
+    const session = await launchVerificationServer(parentEnv);
     const env = { OPENMAUSBOT_URL: session.info.url };
     try {
       const doctor = await runControlOmb(["doctor"], { env }) as any;
@@ -204,10 +206,34 @@ describe("control-omb isolated verification loop", () => {
       expect(fixtureEnv).not.toHaveProperty("OMB_SKILLS_DIR");
       expect(fixtureEnv).not.toHaveProperty("XAI_API_KEY");
       expect(JSON.stringify(fixtureEnv)).not.toContain("must-not-reach-the-fixture");
+      // The fake engine's own knobs are the one thing that crosses.
+      expect(fixtureEnv.FAKE_CLAUDE_PROBE).toBe("fixture-scripting-knob");
     } finally {
       await session.close();
     }
     expect(existsSync(session.info.dataDir)).toBe(false);
     expect(existsSync(session.info.logPath)).toBe(true);
+  }, 30_000);
+
+  it("scripts the fake engine's tool calls from the launcher's environment", async () => {
+    const session = await launchVerificationServer({
+      ...process.env,
+      FAKE_CLAUDE_TOOL_CALLS: '[{"name":"Bash","input":{"command":"pnpm control:omb doctor"},"ok":true},{"name":"Bash","input":{"command":"false"},"ok":false}]',
+    });
+    const env = { OPENMAUSBOT_URL: session.info.url };
+    try {
+      const created = await runControlOmb(["new-bot", "--name", "Tool Script Probe"], { env }) as any;
+      const botId = created.bot.id as string;
+      await runControlOmb(["send", "--bot", botId, "--text", "run both commands"], { env });
+      const settled = await runControlOmb(["wait", "--bot", botId, "--timeout", "20"], { env }) as any;
+      expect(settled.status).toBe("settled");
+      const transcript = await runControlOmb(["messages", "--bot", botId, "--limit", "10"], { env }) as any;
+      const tools = transcript.messages
+        .filter((message: { kind?: string }) => message.kind === "activity")
+        .map((message: { tool?: { name?: string; ok?: boolean } }) => ({ name: message.tool?.name, ok: message.tool?.ok }));
+      expect(tools).toEqual([{ name: "Bash", ok: true }, { name: "Bash", ok: false }]);
+    } finally {
+      await session.close();
+    }
   }, 30_000);
 });

--- a/server/testing/fake-claude-cli.ts
+++ b/server/testing/fake-claude-cli.ts
@@ -24,6 +24,11 @@
 //                      bounded multi-turn orchestration deterministic.
 //   FAKE_CLAUDE_REPLY_STATE Optional counter file shared by fresh CLI
 //                      processes so scripted replies keep their order.
+//   FAKE_CLAUDE_TOOL_CALLS JSON array of {name, input?, ok?}: the tool calls
+//                      each turn makes, in order and before its reply text —
+//                      one tool_use (fresh id, that name and input) followed
+//                      by its tool_result (is_error unless ok, default true).
+//                      Unset, a turn makes the single default Bash call.
 //   FAKE_CLAUDE_AUTH   in (default) | out | unsupported | malformed |
 //                      inherited-api-key — what `auth status` reports
 //
@@ -42,6 +47,26 @@ const scriptedReplies = (() => {
     return [];
   }
 })();
+type ScriptedToolCall = { name: string; input: Record<string, unknown>; ok: boolean };
+// null = unset (or unparseable): keep the single default Bash call.
+const scriptedToolCalls: ScriptedToolCall[] | null = (() => {
+  const raw = process.env.FAKE_CLAUDE_TOOL_CALLS;
+  if (raw === undefined) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    return parsed
+      .filter((call): call is { name: string; input?: unknown; ok?: unknown } => typeof call?.name === "string")
+      .map((call) => ({
+        name: call.name,
+        input: call.input && typeof call.input === "object" && !Array.isArray(call.input) ? call.input as Record<string, unknown> : {},
+        ok: call.ok !== false,
+      }));
+  } catch {
+    return null;
+  }
+})();
+let toolUseCount = 0;
 let scriptedReplyIndex = 0;
 const nextScriptedReply = (): string[] => {
   const stateFile = process.env.FAKE_CLAUDE_REPLY_STATE;
@@ -287,20 +312,25 @@ const playTurn = (prompt: JsonValue) => {
   }
 
   const replyParts = nextScriptedReply();
-  replyParts.forEach((text, index) => {
-    const content: Array<
-      { type: "text"; text: string } | { type: "tool_use"; id: string; name: string }
-    > = [{ type: "text", text }];
-    if (index === replyParts.length - 1) content.push({ type: "tool_use", id: "tu-1", name: "Bash" });
-    out({
-      type: "assistant",
-      message: {
-        content,
-        usage: { input_tokens: 10, cache_read_input_tokens: 2, output_tokens: 5 },
-      },
+  const usage = { input_tokens: 10, cache_read_input_tokens: 2, output_tokens: 5 };
+  if (scriptedToolCalls) {
+    // scripted calls come first, each settled before the reply text
+    for (const call of scriptedToolCalls) {
+      const id = `tu-${++toolUseCount}`;
+      out({ type: "assistant", message: { content: [{ type: "tool_use", id, name: call.name, input: call.input }], usage } });
+      out({ type: "user", message: { content: [{ type: "tool_result", tool_use_id: id, is_error: !call.ok }] } });
+    }
+    for (const text of replyParts) out({ type: "assistant", message: { content: [{ type: "text", text }], usage } });
+  } else {
+    replyParts.forEach((text, index) => {
+      const content: Array<
+        { type: "text"; text: string } | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> }
+      > = [{ type: "text", text }];
+      if (index === replyParts.length - 1) content.push({ type: "tool_use", id: "tu-1", name: "Bash", input: { command: "echo hi" } });
+      out({ type: "assistant", message: { content, usage } });
     });
-  });
-  out({ type: "user", message: { content: [{ type: "tool_result", tool_use_id: "tu-1", is_error: false }] } });
+    out({ type: "user", message: { content: [{ type: "tool_result", tool_use_id: "tu-1", is_error: false }] } });
+  }
 
   const finish = () => {
     out({ type: "result", is_error: false, stop_reason: "end_turn", total_cost_usd: 0.01, usage: { input_tokens: 10, cache_read_input_tokens: 2, output_tokens: 5 } });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       "companion/**/*.test.ts",
       "enterprise/**/*.test.ts",
       "scripts/**/*.test.mjs",
+      "scripts/**/*.test.ts",
     ],
     setupFiles: ["server/testing/setup.ts"],
     // the suite spawns fake provider CLIs and a real harness server;


### PR DESCRIPTION
Three commits, one concern each; review them in order.

## What changed

**1. One preview fixture instead of eleven copies.** `scripts/testing/preview-fixture.ts` exports `mountPreview` (Vite dev server on a free port, `/api` proxied to the isolated harness, one plugin serving the isolated HTML plus optional extra routes), `parkUntilSignal`, and `fixtureApi`. The eleven `launchVerificationServer` fixtures now use it; roughly 270 pasted lines gone. Printed output, evidence writes and cleanup order are unchanged. `verify-server-connection.mjs` (the Electron family) is untouched.

**2. Scriptable fake engine and `FAKE_CLAUDE_*` passthrough.** `FAKE_CLAUDE_TOOL_CALLS` is a JSON array of `{ name, input?, ok? }`; when set, the fake emits one `tool_use`/`tool_result` pair per entry, in order, before the reply. Unset, the frames are byte-identical to before except the default Bash call now carries `input: { command: "echo hi" }`. `launchVerificationServer` forwards every `FAKE_CLAUDE_*` key from the parent environment into the otherwise hermetic child env, which lets the mentions and bidi fixtures drop their wrapper-CLI hack. The threads and routines wrappers stay: they compute per-process values (a dump path per thread, a mode per bot) that are not static env.

**3. Docs drift test.** `scripts/testing/verification-docs.test.ts` asserts, over every `docs/verification/*.md`: each `pnpm control:omb <verb>` is a real verb (parsed from the now-exported `HELP`); each referenced source or test file exists; each literal `/api/...` route is registered in `server/index.ts` (string or route regex); the README links every recipe file; relative links and anchors resolve. On first run it caught the dead `server/browser-connection.test.ts` citation in `claude-tool-lifecycle.md` and nine recipes missing from the README; both are fixed here. `vite.config.ts` gains `scripts/**/*.test.ts` so the test runs in the required check.

## Why

The verification README describes one control surface, but each fixture carried its own copy of the preview server and its own way to script the fake engine, and nothing noticed when a recipe referenced a file that no longer existed. This is the groundwork for a `control-omb ui` command that drives the real renderer headlessly (next PR).

## How it was verified

```
pnpm typecheck (+ ad-hoc tsc over scripts/testing and the 11 fixtures)   exit 0 per commit
vitest server/control-omb.test.ts scripts/testing/verification-docs.test.ts
       server/steer-e2e.test.ts server/drivers/claude.test.ts                 all passing
oxlint scripts server/testing                                                  no findings on changed lines
```
Fixture smoke: sidebar, bot-settings, avatar-providers, threads, bidi, mentions, codex-account and cloud-preview each launched, served their `<title>` and module script, answered `GET /api/health` through the proxy with `"app":"openmausbot"`, and on SIGINT exited in about two seconds with the harness child gone and the temp data directory removed.

Mutation checks: the fake ignoring `ok` fails the new two-call test; reintroducing the dead test reference fails two drift assertions; removing one README link fails the README assertion.

One timing flake observed once in `steer-e2e` while typecheck ran concurrently; it passes alone and is untouched by this change.

## Checklist

- [x] `pnpm typecheck` and targeted `pnpm test` files pass locally
- [x] Test-only change; no server behavior change
- [x] No `dist-server/` edits
- [x] No `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an `edit` command for updating bot messages, with validation and dry-run support.
  - Added support for scripting multiple successful or failed tool calls in fake Claude scenarios.

- **Documentation**
  - Expanded verification guidance for launcher variables, Claude and Codex workflows, browser tools, account setup, desktop connections, sidebar checks, interval restrictions, and sandbox testing.
  - Updated regression-test instructions and clarified turn-boundary verification coverage.
  - Revised bot-mentions verification steps.

- **Testing**
  - Added validation for verification recipes, citations, links, commands, and referenced routes.
  - Standardized preview, API, and shutdown handling across verification checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->