### PR TITLE
#1031 follow-ups: CLI flag floor and release note

### DIFF
--- a/docs/custom-mcp-servers.md
+++ b/docs/custom-mcp-servers.md
@@ -12,6 +12,31 @@ needed.
 This first version supports local stdio commands. It deliberately does not
 accept remote MCP URLs or shell command strings.
 
+## What a Claude bot sees, and what it no longer sees
+
+A bot on the Claude engine gets the tools and instructions its owner gave it:
+the servers above, its integrations (computer, browser, agents, phone), and
+its own project's `<cwd>/.mcp.json`. It **no longer inherits this machine's
+Claude Code setup** — the MCP servers and claude.ai connectors in your user or
+local Claude config, your skills and agents, your hooks, and your personal
+`~/.claude/CLAUDE.md`. Those were being mounted into every turn of every bot
+(one measured desktop added 407 tools, ~10k tokens per model call) and were
+reachable by the bot.
+
+If a bot genuinely depended on a user- or local-scope server, the supported
+fix is to add that server here or to the bot project's `.mcp.json`. The escape
+hatch back to the old launch is the environment variable
+`OMB_CLAUDE_INHERIT_USER_CONFIG=1` on the OpenMausBot process; it restores
+everything above, for every Claude bot, until you remove it.
+
+This isolation uses the CLI flags `--strict-mcp-config` (Claude Code 1.0.60+)
+and `--setting-sources project` (1.0.122+); the harness also picks the
+session's compaction window with `--autocompact` (2.1.122+). OpenMausBot reads
+`claude --version` whenever it lists engines (app load, the Engines page, after
+an update) and only passes each flag to a CLI that accepts it, so an older CLI
+keeps working — without the controls it predates — and the Engines page shows
+an update notice with the exact command. `claude update` clears it.
+
 ## Advanced: edit the file
 
 The same registry lives in `~/.openmausbot/config.json`:

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -16,7 +16,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ensureDirs, NATIVE_DIR } from "../config.ts";
 import type { ProviderInstance } from "../contracts.ts";
 import { recordEvents, type EventRecorder } from "../testing/events.ts";
-import { autoCompactWindow, brokerSocketCandidates, ClaudeDriver, createPermissionBroker, permissionSocketPath, type ClaudeConfig } from "./claude.ts";
+import {
+  autoCompactWindow,
+  brokerSocketCandidates,
+  claudeCliSupports,
+  claudeCliUpdate,
+  ClaudeDriver,
+  createPermissionBroker,
+  parseClaudeCliVersion,
+  permissionSocketPath,
+  type ClaudeConfig,
+} from "./claude.ts";
 import { removeTempDir } from "../testing/cleanup.ts";
 import * as procs from "../procs.ts";
 
@@ -772,6 +782,87 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     const seen = JSON.parse(readFileSync(dump, "utf8"));
     expect(seen.argv).not.toContain("--strict-mcp-config");
     expect(seen.argv).not.toContain("--setting-sources");
+  });
+
+  it("withholds a flag from a CLI that predates it, instead of failing every turn", async () => {
+    // 2.1.100 knows --strict-mcp-config and --setting-sources but not
+    // --autocompact (first shipped in 2.1.122): an unknown flag is a hard
+    // argument error, so the turn must run without it rather than not at all
+    const dump = join(scratch, "old-cli.json");
+    await create(undefined, { FAKE_CLAUDE_DUMP: dump, FAKE_CLAUDE_VERSION: "2.1.100" });
+    // the harness snapshots every instance before any turn (app load, the
+    // Engines page); that is where the driver learns the version
+    await instance.snapshot();
+    await instance.adapter.sendTurn({ threadId: "t-old-cli", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.argv).not.toContain("--autocompact");
+    expect(seen.argv).toContain("--strict-mcp-config");
+    expect(seen.argv[seen.argv.indexOf("--setting-sources") + 1]).toBe("project");
+    // and the Engines page says what the older CLI is missing
+    expect(await instance.snapshot()).toMatchObject({
+      state: "available",
+      version: "2.1.100 (Claude Code)",
+      update: { title: "Update Claude Code for context controls", command: expect.stringContaining("update") },
+    });
+  });
+
+  it("keeps only the isolation flag a very old CLI accepts", async () => {
+    // 1.0.100: --strict-mcp-config exists (1.0.60), --setting-sources does
+    // not yet (1.0.122)
+    const dump = join(scratch, "very-old-cli.json");
+    await create(undefined, { FAKE_CLAUDE_DUMP: dump, FAKE_CLAUDE_VERSION: "1.0.100" });
+    await instance.snapshot();
+    await instance.adapter.sendTurn({ threadId: "t-very-old-cli", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.argv).toContain("--strict-mcp-config");
+    expect(seen.argv).not.toContain("--setting-sources");
+    expect(seen.argv).not.toContain("--autocompact");
+  });
+
+  it("passes every flag to a current CLI and raises no update notice", async () => {
+    await create();
+    expect((await instance.snapshot()).update).toBeUndefined();
+  });
+
+  it("assumes a current CLI on a turn that runs before any snapshot", async () => {
+    // no CLI start-up of its own: the flags are the default, and the next
+    // snapshot corrects an older install
+    const dump = join(scratch, "unsnapshotted.json");
+    await create(undefined, { FAKE_CLAUDE_DUMP: dump, FAKE_CLAUDE_VERSION: "2.1.100" });
+    await instance.adapter.sendTurn({ threadId: "t-unsnapshotted", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed");
+    expect(JSON.parse(readFileSync(dump, "utf8")).argv).toContain("--autocompact");
+  });
+
+  it("maps a CLI version onto the flags it accepts", () => {
+    expect(parseClaudeCliVersion("2.1.232 (Claude Code)")).toEqual([2, 1, 232]);
+    expect(parseClaudeCliVersion("banner\n1.0.60 (Claude Code)")).toEqual([1, 0, 60]);
+    expect(parseClaudeCliVersion("")).toBeNull();
+    expect(parseClaudeCliVersion(null)).toBeNull();
+
+    expect(claudeCliSupports([2, 1, 122], "--autocompact")).toBe(true);
+    expect(claudeCliSupports([2, 1, 121], "--autocompact")).toBe(false);
+    expect(claudeCliSupports([3, 0, 0], "--autocompact")).toBe(true);
+    expect(claudeCliSupports([1, 0, 122], "--setting-sources")).toBe(true);
+    expect(claudeCliSupports([1, 0, 120], "--setting-sources")).toBe(false);
+    expect(claudeCliSupports([1, 0, 60], "--strict-mcp-config")).toBe(true);
+    expect(claudeCliSupports([1, 0, 0], "--strict-mcp-config")).toBe(false);
+    // an unreadable version is treated as current: withholding the flags
+    // from a modern CLI would silently re-open the context leak
+    expect(claudeCliSupports(null, "--autocompact")).toBe(true);
+
+    expect(claudeCliUpdate("2.1.122 (Claude Code)", "claude")).toBeUndefined();
+    expect(claudeCliUpdate(null, "claude")).toBeUndefined();
+    expect(claudeCliUpdate("2.1.121 (Claude Code)", "claude")).toMatchObject({
+      command: "claude update",
+      message: expect.stringContaining("--autocompact"),
+    });
+    expect(claudeCliUpdate("1.0.100 (Claude Code)", "/opt/bin/claude")?.message).toContain("this machine's own Claude Code setup");
+    expect(claudeCliUpdate("1.0.100 (Claude Code)", "/opt/bin/claude")?.command).toBe("/opt/bin/claude update");
   });
 
   it("forwards the bot project's own .mcp.json, which strict mode would drop", async () => {

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -233,6 +233,74 @@ export function autoCompactWindow(env: NodeJS.ProcessEnv): string | null {
  * threads never reach it; this is the backstop for the ones that do. */
 const DEFAULT_AUTOCOMPACT_TOKENS = 200_000;
 
+/** The Claude CLI version that first accepted each flag the harness passes
+ * for context control. An unknown flag is a hard argument error, so passing
+ * one to an older CLI would fail every turn rather than degrade; each flag
+ * is therefore only passed to a CLI known to accept it.
+ *
+ * Verified against the published binaries, not the changelog (which never
+ * records `--autocompact`): `--strict-mcp-config` is present in 1.0.60 and
+ * absent from 1.0.0; `--setting-sources` first appears in 1.0.122 (1.0.120
+ * lacks it); `--autocompact` first appears in 2.1.122 (2.1.121 lacks it). */
+export const CLAUDE_FLAG_FLOORS = {
+  "--strict-mcp-config": [1, 0, 60],
+  "--setting-sources": [1, 0, 122],
+  "--autocompact": [2, 1, 122],
+} as const satisfies Record<string, ClaudeCliVersion>;
+
+export type ClaudeCliVersion = readonly [number, number, number];
+
+/** The newest floor above: a CLI at or past it accepts everything the
+ * harness sends. Below it the engine still works, minus the flags the CLI
+ * predates, and the Engines page suggests an update. */
+export const CLAUDE_CONTEXT_CONTROL_MIN_VERSION: ClaudeCliVersion = CLAUDE_FLAG_FLOORS["--autocompact"];
+
+/** `claude --version` prints "2.1.232 (Claude Code)"; the first dotted triple
+ * is the version. Null when nothing parses, e.g. a wrapper that prints its
+ * own banner first — see claudeCliSupports for how that is treated. */
+export function parseClaudeCliVersion(stdout: string | null | undefined): ClaudeCliVersion | null {
+  const match = /(\d+)\.(\d+)\.(\d+)/.exec(stdout ?? "");
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function versionAtLeast(installed: ClaudeCliVersion, floor: ClaudeCliVersion): boolean {
+  for (let i = 0; i < 3; i += 1) {
+    if (installed[i] !== floor[i]) return installed[i] > floor[i];
+  }
+  return true;
+}
+
+/** Whether a CLI reporting `version` accepts `flag`. A version that could
+ * not be parsed counts as current: every CLI that predates a floor prints a
+ * plain "x.y.z (Claude Code)", so an unreadable version is far more likely
+ * a newer wrapper than an old build, and withholding the flags from a modern
+ * CLI would silently re-open the context leak this file exists to close. */
+export function claudeCliSupports(version: ClaudeCliVersion | null, flag: keyof typeof CLAUDE_FLAG_FLOORS): boolean {
+  return version === null || versionAtLeast(version, CLAUDE_FLAG_FLOORS[flag]);
+}
+
+/** The Engines-page notice for a CLI older than the newest floor. The engine
+ * keeps working: turns run without the flags the CLI predates, which means
+ * no harness-picked compaction window and, on a very old CLI, no isolation
+ * from this machine's own Claude Code setup. */
+export function claudeCliUpdate(version: string | null, cli: string): ProviderSnapshot["update"] | undefined {
+  const parsed = parseClaudeCliVersion(version);
+  if (!parsed || versionAtLeast(parsed, CLAUDE_CONTEXT_CONTROL_MIN_VERSION)) return undefined;
+  const floor = CLAUDE_CONTEXT_CONTROL_MIN_VERSION.join(".");
+  const missing = (Object.keys(CLAUDE_FLAG_FLOORS) as (keyof typeof CLAUDE_FLAG_FLOORS)[])
+    .filter((flag) => !claudeCliSupports(parsed, flag));
+  return {
+    title: "Update Claude Code for context controls",
+    message:
+      `Claude Code ${parsed.join(".")} predates ${floor}, so bots run without ${missing.join(", ")}: ` +
+      "no compaction window picked by OpenMausBot" +
+      (missing.includes("--setting-sources") ? ", and bots still see this machine's own Claude Code setup" : "") +
+      ". Update it, then refresh Engines.",
+    command: cli === "claude" ? "claude update" : `${cli} update`,
+  };
+}
+
 const DRIVER_KIND = "claudeAgent";
 
 export interface ClaudeConfig {
@@ -752,6 +820,16 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       }
     };
     await refreshModels();
+
+    // The installed CLI's version as snapshot() last read it, so a flag the
+    // CLI does not know is never passed to it (CLAUDE_FLAG_FLOORS). The
+    // harness snapshots every instance whenever it describes them — app
+    // load, the Engines page, and right after `claude update`, which is
+    // exactly when the answer changes — so a turn normally finds it filled.
+    // A turn before any snapshot assumes a current CLI rather than paying a
+    // CLI start-up of its own: the flags are the default, the exception is
+    // the older install, and the next snapshot corrects it.
+    let cliVersion: ClaudeCliVersion | null = null;
     const listeners = new Set<RuntimeEventListener>();
     // one active turn per thread; a second send while busy is a caller bug
     const active = new Map<string, { stop: () => void; turnId: string; broker?: Awaited<ReturnType<typeof createPermissionBroker>> }>();
@@ -905,11 +983,15 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         // measured desktop mounted 407 extra tools, ~10k tokens), its skill
         // and agent listings, its hooks, and its personal CLAUDE.md. Every
         // model call in the session then re-reads all of it.
-        args.push("--strict-mcp-config");
-        args.push("--setting-sources", "project");
+        // Each flag only on a CLI that accepts it: an unknown flag is an
+        // argument error that would fail every turn (CLAUDE_FLAG_FLOORS).
+        if (claudeCliSupports(cliVersion, "--strict-mcp-config")) args.push("--strict-mcp-config");
+        if (claudeCliSupports(cliVersion, "--setting-sources")) args.push("--setting-sources", "project");
       }
       const compactWindow = autoCompactWindow(turnEnvironment);
-      if (compactWindow) args.push("--autocompact", compactWindow);
+      if (compactWindow && claudeCliSupports(cliVersion, "--autocompact")) {
+        args.push("--autocompact", compactWindow);
+      }
       const turnModel = await resolveClaudeTurnModel(turn.model, turnEnvironment);
       const injected = applyClaudeInject({ ...turnEnvironment }, turnModel);
       if (injected.model) args.push("--model", injected.model);
@@ -1524,11 +1606,13 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         );
       });
       if (!version) return { state: "unavailable", reason: `\`${config.cli}\` CLI not found` };
+      cliVersion = parseClaudeCliVersion(version);
       const auth = await claudeAuthStatus(config.cli, env);
       // claudeEnvironment strips ANTHROPIC_API_KEY, so turns run on the
       // CLI's own login (Pro/Max): the cost it reports is what the call
       // WOULD bill, not a charge
-      return { state: "available", version, ...auth, billing: "subscription" };
+      const update = claudeCliUpdate(version, config.cli);
+      return { state: "available", version, ...auth, ...(update ? { update } : {}), billing: "subscription" };
     };
 
     /** One-shot Claude call with the prompt on stdin, never argv. Approval

--- a/server/testing/fake-claude-cli.ts
+++ b/server/testing/fake-claude-cli.ts
@@ -65,7 +65,9 @@ const out = (obj: unknown) => process.stdout.write(JSON.stringify(obj) + "\n");
 
 // Snapshot probes: both answer on argv alone and exit without reading stdin.
 if (argv[0] === "--version") {
-  process.stdout.write("2.1.232 (Claude Code)\n");
+  // FAKE_CLAUDE_VERSION lets a test stand in for an older CLI: the driver
+  // withholds flags that version predates (CLAUDE_FLAG_FLOORS).
+  process.stdout.write(`${process.env.FAKE_CLAUDE_VERSION ?? "2.1.232"} (Claude Code)\n`);
   process.exit(0);
 }
 


### PR DESCRIPTION
Stacks on #1031 (`perf/context-isolation`, @aivsomkar): this branch is that PR's head plus two commits, so the diff against `main` shows #1031's changes too. The two commits on top are the ones to review here; the intent is to merge #1031 and then this.

## 1. Pass each context-control flag only to a CLI that accepts it

#1031 launches every turn with `--strict-mcp-config`, `--setting-sources project` and `--autocompact`. An unknown flag is a hard argument error in the Claude CLI, so on an older CLI every turn would fail rather than degrade, and the harness had no version floor anywhere (`server/claude-update.ts` only reads the version back after an update).

Which version introduced each flag, verified by grepping the published binaries, because the Claude Code changelog never records `--autocompact` being added:

| Flag | First version | Checked |
|---|---|---|
| `--strict-mcp-config` | ≤ 1.0.60 | present in 1.0.60, absent from 1.0.0 |
| `--setting-sources` | 1.0.122 | absent from 1.0.120 (bisected over npm `cli.js`) |
| `--autocompact` | 2.1.122 | absent from 2.1.121 (bisected over the `claude-code-darwin-arm64` payloads) |

The driver keeps the version `snapshot()` last read and withholds each flag the installed CLI predates. The harness snapshots every instance whenever it describes them (`registry.describe()` behind `/api/instances`: app load, the Engines page, and right after `claude update`), so a turn normally finds the version filled; a turn before any snapshot assumes a current CLI rather than paying a CLI start-up of its own. A version that cannot be parsed counts as current: every CLI older than a floor prints a plain `x.y.z (Claude Code)`, and withholding the flags from a modern CLI would silently re-open the leak #1031 closes.

Below 2.1.122 the engine keeps working and `snapshot()` carries the existing `ProviderSnapshot.update` notice (already rendered by `EngineUpdateNotice` on the Engines page and the model picker), naming the missing controls and the exact update command.

## 2. Release note

`docs/custom-mcp-servers.md` gains a section on what a Claude bot no longer sees (user/local-scope MCP servers and connectors, skills, agents, hooks, personal `CLAUDE.md`), the supported fix (add the server in Plugins → MCP servers, or the bot project's `.mcp.json`), the escape hatch `OMB_CLAUDE_INHERIT_USER_CONFIG=1`, and the CLI version each flag needs. `docs/releasing.md` says release bodies are generated from PR titles, so this PR's title is written to read as the release line.

## Test plan

- `server/drivers/claude.test.ts`, `claude-accounts.test.ts`, `claude-login-auth.test.ts`, `server/claude-update.test.ts`: 115 passed / 1 skipped. New: an old fake CLI (`FAKE_CLAUDE_VERSION=2.1.100`) gets isolation without `--autocompact` and raises the notice; a very old one (`1.0.100`) keeps only `--strict-mcp-config`; a current one gets everything and no notice; a turn before any snapshot gets everything; the floor table itself.
- Mutation-checked: lowering the `--autocompact` floor, pushing either flag unconditionally, and never caching the version each fail a test.
- The first push probed `--version` inside the turn path and shifted the recorded call order in `claude-accounts.test.ts` ("preserves explicit custom endpoints…"); reading the version from `snapshot()` instead fixes that and avoids a CLI start-up per first turn.
- `tsc -p tsconfig.server.json` clean; `oxlint` reports only the three pre-existing `no-useless-spread` warnings already on #1031's head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude-engine bots now support version-aware configuration, automatically using available context and MCP controls based on the installed Claude CLI version.
  * Older CLI versions receive an update notice when required features are unavailable.

* **Documentation**
  * Updated MCP server documentation to explain configuration options, isolation settings, inheritance controls, and supported CLI requirements.

* **Bug Fixes**
  * Prevented unsupported CLI options from causing errors when running bots with older Claude Code versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->