### PR TITLE
Recover a thread whose resume never answers

### DIFF
--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -179,6 +179,12 @@ export interface SendTurnInput {
   model?: string;
   effort?: EffortLevel;
   resumeCursor?: unknown;
+  /** The turn with the conversation so far replayed inline, attached only
+   * alongside resumeCursor. A cursor-resuming driver sends it once, on a
+   * fresh session, when the provider refuses the cursor before reading the
+   * prompt (server/resume-recovery.ts) — so a session the provider lost
+   * does not brick the thread, and the new session is not blank. */
+  recoveryText?: string;
   /** Prior turns for transcript-replay providers (API-backed drivers). */
   transcript?: Array<{ role: "user" | "assistant"; text: string }>;
   /** Bot persona (name/title/description) as a system prompt. */

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -1593,6 +1593,112 @@ describe("ClaudeDriver turns (fake CLI)", () => {
 // on macOS the OAuth tokens live in the login Keychain, so the old
 // ~/.claude/.credentials.json check reported signed-in users as signed out
 // and disabled the model picker with them (#108).
+describe("ClaudeDriver resume recovery (fake CLI)", () => {
+  let instance: ProviderInstance;
+  let recorder: EventRecorder;
+  let scratch: string;
+
+  const REBUILD = "[rebuild]\n\nUser: my dog is Biscuit\n\nwhat now?";
+
+  beforeEach(async () => {
+    ensureDirs();
+    chmodSync(FAKE_CLI, 0o755);
+    scratch = mkdtempSync(join(tmpdir(), "omb-claude-recover-"));
+    process.env.FAKE_CLAUDE_MODE = "dead-session";
+    instance = await ClaudeDriver.create({
+      instanceId: "claude-test",
+      displayName: "Claude Test",
+      environment: {},
+      enabled: true,
+      config: { cli: FAKE_CLI, permissionMode: "auto" } as never,
+    });
+    recorder = recordEvents(instance.adapter);
+  });
+
+  afterEach(async () => {
+    delete process.env.FAKE_CLAUDE_MODE;
+    delete process.env.FAKE_CLAUDE_DUMP;
+    recorder?.stop();
+    await instance?.dispose();
+    await removeTempDir(scratch);
+  });
+
+  it("starts a fresh session carrying the rebuild when --resume is refused", async () => {
+    // Was a bricked thread: the CLI exits before `init`, the failure is
+    // terminal so nothing retries, and the dead cursor is never cleared —
+    // so every later turn resumed the same missing session and failed
+    // identically, with no way back except switching engines.
+    const dump = join(scratch, "recovered.json");
+    process.env.FAKE_CLAUDE_DUMP = dump;
+    await instance.adapter.sendTurn({
+      threadId: "t-dead",
+      text: "what now?",
+      resumeCursor: "a-session-claude-no-longer-has",
+      recoveryText: REBUILD,
+    });
+    await recorder.until((e) => e.type === "turn.completed");
+
+    expect(recorder.events.filter((e) => e.type === "turn.completed").at(-1)).toMatchObject({ ok: true });
+    expect(recorder.events.find((e) => e.type === "turn.retrying")).toMatchObject({ reason: "resume_rejected" });
+    // it started a NEW session, so the harness records a live cursor again
+    const started = recorder.events.filter((e) => e.type === "session.started");
+    expect(started.length).toBeGreaterThan(0);
+    expect(started.at(-1)).not.toMatchObject({ sessionId: "a-session-claude-no-longer-has" });
+    // and the new session is not blank: the prompt is the rebuild, once
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.argv).not.toContain("--resume");
+    const content = seen.prompt.message.content;
+    const text = typeof content === "string" ? content : content.map((c: any) => c.text ?? "").join("");
+    expect(text).toBe(REBUILD);
+  });
+
+  it("recovers only once, then fails visibly", async () => {
+    // exit-early refuses every launch, resumed or fresh: the recovery is
+    // spent on the first relaunch and the turn must then settle as failed
+    // rather than relaunching forever
+    process.env.FAKE_CLAUDE_MODE = "exit-early";
+    await instance.adapter.sendTurn({ threadId: "t-always-dead", text: "what now?", resumeCursor: "gone", recoveryText: REBUILD });
+    await recorder.until((e) => e.type === "turn.completed");
+    expect(recorder.events.filter((e) => e.type === "turn.completed").at(-1)).toMatchObject({ ok: false });
+    expect(recorder.events.filter((e) => e.type === "turn.retrying")).toHaveLength(1);
+  });
+
+  it("never resends a turn the CLI accepted before dying", async () => {
+    // the resumed session emitted `init` — it read the prompt, and may have
+    // run tools on it — and then died with no output. That is the far side
+    // of the acceptance boundary: replaying here is a duplicate side effect
+    process.env.FAKE_CLAUDE_MODE = "resume-dies-after-init";
+    await instance.adapter.sendTurn({ threadId: "t-accepted", text: "what now?", resumeCursor: "accepted-then-died", recoveryText: REBUILD });
+    await recorder.until((e) => e.type === "turn.completed");
+    expect(recorder.events.filter((e) => e.type === "turn.completed").at(-1)).toMatchObject({ ok: false });
+    expect(recorder.events.some((e) => e.type === "turn.retrying" && e.reason === "resume_rejected")).toBe(false);
+  });
+
+  it("never treats a crash on a fresh launch as a refused resume", async () => {
+    // no cursor was offered, so there is no resume to have been rejected:
+    // this is an ordinary terminal failure, not a licence to send the turn
+    // again
+    process.env.FAKE_CLAUDE_MODE = "exit-early";
+    await instance.adapter.sendTurn({ threadId: "t-fresh-crash", text: "what now?", recoveryText: REBUILD });
+    await recorder.until((e) => e.type === "turn.completed");
+    expect(recorder.events.filter((e) => e.type === "turn.completed").at(-1)).toMatchObject({ ok: false });
+    expect(recorder.events.some((e) => e.type === "turn.retrying" && e.reason === "resume_rejected")).toBe(false);
+  });
+
+  it("does not rebuild when there was no session to resume", async () => {
+    process.env.FAKE_CLAUDE_MODE = "happy";
+    const dump = join(scratch, "fresh.json");
+    process.env.FAKE_CLAUDE_DUMP = dump;
+    await instance.adapter.sendTurn({ threadId: "t-fresh", text: "what now?", recoveryText: REBUILD });
+    await recorder.until((e) => e.type === "turn.completed");
+    expect(recorder.events.filter((e) => e.type === "turn.completed").at(-1)).toMatchObject({ ok: true });
+    expect(recorder.events.some((e) => e.type === "turn.retrying")).toBe(false);
+    const content = JSON.parse(readFileSync(dump, "utf8")).prompt.message.content;
+    const text = typeof content === "string" ? content : content.map((c: any) => c.text ?? "").join("");
+    expect(text).toBe("what now?");
+  });
+});
+
 describe("ClaudeDriver snapshot auth (fake CLI)", () => {
   let instance: ProviderInstance;
 

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -17,6 +17,7 @@ import { join, dirname, isAbsolute, normalize } from "node:path";
 import { DATA_DIR, stripWorkspaceCredentialEnv } from "../config.ts";
 import { augmentedPath } from "../env-path.ts";
 import { brokerSocketPath, describeSpawnFailure, execCli, killCliTree, spawnCli } from "../procs.ts";
+import { classifyResumeFailure, mayReplay, recoveryPromptFor } from "../resume-recovery.ts";
 import { ClaudeLoginController } from "./claude-login-auth.ts";
 
 import type {
@@ -697,6 +698,10 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       argsKey: string;
       /** the CLI's session id from `init`, what --resume takes later */
       sessionId: string | null;
+      /** the CLI emitted its `init` frame — it accepted the session and
+       * began the turn. The acceptance boundary for --resume: before it,
+       * nothing was submitted and the turn has caused nothing. */
+      sawInit: boolean;
       /** the running turn, or null between turns */
       turn: { turnId: string; settled: boolean; sawStreamDelta: boolean; authFailed?: boolean } | null;
       idleTimer: ReturnType<typeof setTimeout> | null;
@@ -1077,6 +1082,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         systemPromptPath,
         argsKey,
         sessionId: sessionId ?? newSessionId,
+        sawInit: false,
         turn: { turnId, settled: false, sawStreamDelta: false },
         idleTimer: null,
         closing: false,
@@ -1131,6 +1137,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         switch (o.type) {
           case "system":
             if (o.subtype === "init") {
+              session.sawInit = true;
               if (typeof o.session_id === "string") session.sessionId = o.session_id;
               emit({ ...base(threadId, currentTurnId()), type: "session.started", sessionId: o.session_id, model: o.model });
             } else if (o.subtype === "thinking_tokens") {
@@ -1330,6 +1337,65 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
                   stopReason: "exit_before_result",
                   cost: null,
                 });
+              }
+            })();
+            return;
+          }
+          // A --resume that the CLI never acknowledged: it exited without
+          // an `init` frame, so it never read the prompt and this turn has
+          // caused nothing. Without this the thread is BRICKED — the dead
+          // cursor is never cleared, so every later turn resumes the same
+          // missing session and fails identically, and the user has no way
+          // back except switching engines. One fresh session, carrying the
+          // harness's rebuild of the conversation. Exactly one: the relaunch
+          // offers no cursor, so `attempted` is false there and a second
+          // failure is reported like any other.
+          const resumeFailure = classifyResumeFailure({
+            attempted: Boolean(sessionId),
+            rejected: !session.sawInit,
+            promptSubmitted: session.sawInit,
+            producedOutput: session.turn.sawStreamDelta,
+          });
+          if (mayReplay(resumeFailure) && !retry.cancelled) {
+            const recovery = recoveryPromptFor({
+              recoveryText: turn.recoveryText,
+              currentText: turn.text,
+              failure: resumeFailure,
+            });
+            session.broker?.close();
+            session.broker = undefined;
+            if (session.mcpConfigPath) {
+              try {
+                rmSync(dirname(session.mcpConfigPath), { recursive: true, force: true });
+              } catch {}
+              session.mcpConfigPath = null;
+            }
+            if (session.systemPromptPath) {
+              removePrivateTempDir(session.systemPromptPath);
+              session.systemPromptPath = null;
+            }
+            sessions.delete(threadId);
+            session.turn = null;
+            active.delete(threadId);
+            emit({
+              ...base(threadId, turnId),
+              type: "turn.retrying",
+              attempt: retry.attempt + 1,
+              delayMs: 0,
+              reason: "resume_rejected",
+            });
+            void (async () => {
+              try {
+                // no cursor: a fresh session, carrying the rebuild
+                await sendTurn({ ...turn, resumeCursor: undefined, recoveryText: undefined, text: recovery.text });
+              } catch (e) {
+                retryState.delete(threadId);
+                emit({
+                  ...base(threadId, turnId),
+                  type: "runtime.error",
+                  message: e instanceof Error ? e.message : String(e),
+                });
+                emit({ ...base(threadId, turnId), type: "turn.completed", ok: false, stopReason: "exit_before_result", cost: null });
               }
             })();
             return;

--- a/server/index.ts
+++ b/server/index.ts
@@ -213,7 +213,7 @@ import {
 } from "./store.ts";
 import * as tts from "./tts/index.ts";
 import { narrateTool, toUtterances } from "./tts/speech-text.ts";
-import { buildTurnContext, engineIsFresh } from "./turn-context.ts";
+import { buildRecoveryText, buildTurnContext, engineIsFresh } from "./turn-context.ts";
 import { extractTurnImages } from "./turn-images.ts";
 import { TurnWatchdog } from "./turn-watchdog.ts";
 import { TurnResources, workspaceResource, type TurnOwner } from "./turn-resources.ts";
@@ -4424,6 +4424,10 @@ async function startTurn(
   // this already-built turn must either keep its old session or replay on the
   // following turn, never start a blank session with no transcript.
   const resumeCursor = resume ? task.resumeCursors[instanceId] : undefined;
+  // A cursor the provider no longer honours must not brick the thread: the
+  // driver may fall back to ONE fresh session, and this is what it sends
+  // there, so the new session is not blank (server/resume-recovery.ts).
+  const recoveryText = resumeCursor !== undefined ? buildRecoveryText({ text: turnText, transcript }) : undefined;
 
   const persona = [
     `You are ${bot.name}, a personal bot in OpenMausBot.`,
@@ -4885,6 +4889,7 @@ async function startTurn(
         // the active task's own session — another task's cursor would
         // resume the wrong conversation and defeat the context bubble
         resumeCursor,
+        ...(recoveryText !== undefined ? { recoveryText } : {}),
         transcript,
         system: prompt.text,
         integrations,

--- a/server/resume-recovery.test.ts
+++ b/server/resume-recovery.test.ts
@@ -1,0 +1,82 @@
+// Whether a turn may be sent twice.
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyResumeFailure,
+  mayReplay,
+  recoveryPromptFor,
+  type ResumeAttemptState,
+} from "./resume-recovery.ts";
+
+const state = (over: Partial<ResumeAttemptState> = {}): ResumeAttemptState => ({
+  attempted: true,
+  rejected: true,
+  promptSubmitted: false,
+  producedOutput: false,
+  ...over,
+});
+
+describe("classifyResumeFailure", () => {
+  it("is before-accept when a resume was rejected and nothing was sent", () => {
+    expect(classifyResumeFailure(state())).toBe("before-accept");
+    expect(mayReplay("before-accept")).toBe(true);
+  });
+
+  it("is after-accept once the prompt was submitted", () => {
+    expect(classifyResumeFailure(state({ promptSubmitted: true }))).toBe("after-accept");
+    expect(mayReplay("after-accept")).toBe(false);
+  });
+
+  it("is after-accept once ANYTHING streamed, whatever the bookkeeping says", () => {
+    // output is the strongest evidence available: if the model spoke, the
+    // prompt landed, and the tools it called have already run
+    expect(classifyResumeFailure(state({ promptSubmitted: false, producedOutput: true }))).toBe("after-accept");
+  });
+
+  it("is unknown when no resume was attempted, or none was rejected", () => {
+    expect(classifyResumeFailure(state({ attempted: false }))).toBe("unknown");
+    expect(classifyResumeFailure(state({ rejected: false }))).toBe("unknown");
+  });
+
+  it("never permits a replay on an unproven boundary", () => {
+    // an unproven guess is not a licence to repeat side effects
+    expect(mayReplay("unknown")).toBe(false);
+  });
+
+  it("classifies from state alone — no error text is consulted", () => {
+    // the whole input surface is booleans; there is nowhere for a provider's
+    // prose to change the outcome
+    for (const value of Object.values(state())) expect(typeof value).toBe("boolean");
+  });
+});
+
+describe("recoveryPromptFor", () => {
+  const replay = "[rebuild]\n\nUser: my dog is Biscuit\n\nwhat now?";
+
+  it("rebuilds history for a safe failure", () => {
+    const out = recoveryPromptFor({ recoveryText: replay, currentText: "what now?", failure: "before-accept" });
+    expect(out).toEqual({ text: replay, replayed: true });
+  });
+
+  it("sends the turn UNCHANGED after acceptance, never a second copy", () => {
+    for (const failure of ["after-accept", "unknown"] as const) {
+      expect(recoveryPromptFor({ recoveryText: replay, currentText: "what now?", failure }))
+        .toEqual({ text: "what now?", replayed: false });
+    }
+  });
+
+  it("falls back to the current text when the harness attached no rebuild", () => {
+    expect(recoveryPromptFor({ recoveryText: undefined, currentText: "what now?", failure: "before-accept" }))
+      .toEqual({ text: "what now?", replayed: false });
+  });
+
+  it("does not replay a thread whose only history is the message being sent", () => {
+    expect(recoveryPromptFor({ recoveryText: "what now?", currentText: "what now?", failure: "before-accept" }))
+      .toEqual({ text: "what now?", replayed: false });
+  });
+
+  it("carries the current message exactly once", () => {
+    const out = recoveryPromptFor({ recoveryText: replay, currentText: "what now?", failure: "before-accept" });
+    expect(out.text.match(/what now\?/g)).toHaveLength(1);
+  });
+});

--- a/server/resume-recovery.ts
+++ b/server/resume-recovery.ts
@@ -1,0 +1,84 @@
+// Deciding whether a turn may be sent a second time.
+//
+// When a native session cannot be resumed, the harness still holds the
+// canonical transcript and can rebuild the conversation. The question is not
+// whether it CAN — it is whether doing so is safe. If the provider already
+// accepted the prompt, the model may have run tools, written files, or sent
+// messages. Replaying that turn would do it all again.
+//
+// So the boundary is classified from the driver's own protocol state — which
+// request was in flight, whether the prompt was submitted, whether anything
+// streamed — and never from error text. Provider error strings are prose:
+// they get reworded between releases, they are localized, and a retry
+// decision that turns on a regex over them is a duplicate side effect
+// waiting for a vendor copy-edit.
+//
+// Lifted from #759 (aivsomkar), where the rebuild came from a context plan;
+// here it is the recovery text the harness attaches to a resuming turn.
+
+export type ResumeFailureClass =
+  /** the session was rejected before the provider saw the prompt. The turn
+   * has caused nothing, so it is safe to start fresh and send it once. */
+  | "before-accept"
+  /** the provider had the prompt. It may already have acted on it. */
+  | "after-accept"
+  /** the driver cannot prove which side of the boundary it is on. Treated
+   * exactly like after-accept: an unproven guess is not a licence to repeat
+   * side effects. */
+  | "unknown";
+
+export interface ResumeAttemptState {
+  /** the provider was asked to continue an existing session. */
+  attempted: boolean;
+  /** that request came back rejected, or returned nothing usable. */
+  rejected: boolean;
+  /** the user's prompt has been handed to the provider. */
+  promptSubmitted: boolean;
+  /** the provider emitted any turn-scoped output — text, reasoning, a tool
+   * call, usage. Output means the prompt was not merely accepted but acted
+   * on, whatever the driver believes about its own submission bookkeeping. */
+  producedOutput: boolean;
+}
+
+export function classifyResumeFailure(state: ResumeAttemptState): ResumeFailureClass {
+  // Output is the strongest evidence available and outranks everything: if
+  // the model spoke, the prompt landed.
+  if (state.producedOutput || state.promptSubmitted) return "after-accept";
+  if (state.attempted && state.rejected) return "before-accept";
+  return "unknown";
+}
+
+/** Whether this failure may be recovered by sending the turn again. */
+export function mayReplay(failure: ResumeFailureClass): boolean {
+  return failure === "before-accept";
+}
+
+export interface RecoveryPromptInput {
+  /** the turn with the conversation so far replayed inline, when the
+   * harness attached one (SendTurnInput.recoveryText). */
+  recoveryText: string | undefined;
+  /** what the driver would otherwise send. */
+  currentText: string;
+  failure: ResumeFailureClass;
+}
+
+export interface RecoveryPrompt {
+  text: string;
+  /** true when history was rebuilt into the prompt. */
+  replayed: boolean;
+}
+
+/** The prompt a recovered turn should carry.
+ *
+ * A fresh session started after a rejected resume has NO history: sending
+ * only the current message drops the entire conversation silently, which
+ * looks to the user like the bot forgot everything. The recovery text is the
+ * rebuild, and it already contains the current message exactly once. */
+export function recoveryPromptFor(input: RecoveryPromptInput): RecoveryPrompt {
+  if (!mayReplay(input.failure)) return { text: input.currentText, replayed: false };
+  const replay = input.recoveryText?.trim();
+  // No rebuild, or one with nothing to replay (a thread whose only history
+  // is the message being sent): the current text is already the whole turn.
+  if (!replay || replay === input.currentText.trim()) return { text: input.currentText, replayed: false };
+  return { text: replay, replayed: true };
+}

--- a/server/testing/fake-claude-cli.ts
+++ b/server/testing/fake-claude-cli.ts
@@ -4,7 +4,10 @@
 // scripted session. Failure modes are toggled by env var, mirroring how
 // the real thing misbehaves:
 //
-//   FAKE_CLAUDE_MODE   happy (default) | exit-early | hang | malformed
+//   FAKE_CLAUDE_MODE   happy (default) | exit-early | hang | malformed |
+//                      dead-session (fails only when --resume is passed)
+//                      | resume-dies-after-init (a --resume launch emits
+//                        init, then exits without result or output)
 //                      | stream (partial-message text deltas before the
 //                        whole-message frame, plus subagent noise to drop)
 //                      | not-logged-in (the frames a signed-out CLI really
@@ -184,6 +187,14 @@ const playTurn = (prompt: JsonValue) => {
     );
   }
 
+  // A resumed session the CLI no longer has: it exits before any `init`
+  // frame, so the prompt on stdin is never read. A FRESH launch (--session-id)
+  // works normally, which is what makes recovery observable.
+  if (mode === "dead-session" && argv.includes("--resume")) {
+    process.stderr.write(`fake-claude: No conversation found with session ID: ${argAfter("--resume")}\n`);
+    process.exit(1);
+  }
+
   if (mode === "exit-early") {
     process.stderr.write("fake-claude: simulated crash before result\n");
     process.exit(3);
@@ -214,6 +225,14 @@ const playTurn = (prompt: JsonValue) => {
 
   // the real CLI re-announces init on every turn of a live process
   out({ type: "system", subtype: "init", session_id: sessionId, model });
+
+  // The CLI accepted the resumed session — it read the prompt — and then
+  // died with nothing to show. The prompt may already have run tools, so
+  // the driver must NOT send it again.
+  if (mode === "resume-dies-after-init" && argv.includes("--resume")) {
+    process.stderr.write("fake-claude: simulated crash after accepting the resumed session\n");
+    process.exit(3);
+  }
 
   if (mode === "hang") {
     // stay alive until killed — lets tests exercise interrupt + the

--- a/server/turn-context.test.ts
+++ b/server/turn-context.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildTurnContext, engineIsFresh } from "./turn-context.ts";
+import { buildTurnContext, engineIsFresh, buildRecoveryText } from "./turn-context.ts";
 
 const transcript = [
   { role: "user" as const, text: "my dog is named Biscuit" },
@@ -105,5 +105,26 @@ describe("engineIsFresh", () => {
     expect(
       engineIsFresh({ instanceId: "claude", lastInstanceId: undefined, resumeCursors: { claude: "s1", antigravity: "s2" }, transcript: withUser }),
     ).toBe(true);
+  });
+});
+
+describe("buildRecoveryText", () => {
+  it("replays the active branch and ends in the user's message, once", () => {
+    const text = buildRecoveryText({
+      text: "what now?",
+      transcript: [
+        { role: "user", text: "my dog is Biscuit" },
+        { role: "assistant", text: "Noted." },
+      ],
+    });
+    expect(text).toContain("could not be resumed");
+    expect(text).toContain("User: my dog is Biscuit");
+    expect(text).toContain("Assistant: Noted.");
+    expect(text?.endsWith("what now?")).toBe(true);
+    expect(text?.match(/what now\?/g)).toHaveLength(1);
+  });
+
+  it("is undefined when there is nothing to replay", () => {
+    expect(buildRecoveryText({ text: "hi", transcript: [] })).toBeUndefined();
   });
 });

--- a/server/turn-context.ts
+++ b/server/turn-context.ts
@@ -50,6 +50,29 @@ const FRESH_PREAMBLE =
 const EXTERNAL_UPDATE_PREAMBLE =
   "[This conversation received an update outside your provider session. The complete current history follows so you can use that update in your next response:]";
 
+const RECOVERED_PREAMBLE =
+  "[Your previous session for this conversation could not be resumed, so this is a new session. The conversation so far:]";
+
+/** The turn a cursor-resuming driver falls back to when the provider refuses
+ * its session before reading the prompt (server/resume-recovery.ts): the
+ * active branch replayed inline, ending in the user's message. Undefined
+ * when there is nothing to replay — the bare text is then the whole turn. */
+export function buildRecoveryText(input: {
+  text: string;
+  transcript: Array<{ role: "user" | "assistant"; text: string }>;
+}): string | undefined {
+  if (input.transcript.length === 0) return undefined;
+  return [
+    RECOVERED_PREAMBLE,
+    "",
+    ...input.transcript.map((m) => `${m.role === "user" ? "User" : "Assistant"}: ${m.text}`),
+    "",
+    "[Now reply to the user's latest message:]",
+    "",
+    input.text,
+  ].join("\n");
+}
+
 export function buildTurnContext(input: TurnContextInput): {
   turnText: string;
   /** false when the native session must not be resumed */


### PR DESCRIPTION
Lifted from #759 by @aivsomkar — the `server/context/resume-recovery.ts` module and its `drivers/claude.ts` hunk — and adapted to current `main`. The design, the classify-from-protocol-state rule, and the tests' shape are theirs; the adaptation is only that the rebuild the recovered turn carries comes from a small `recoveryText` field the harness attaches instead of that branch's context plan.

## The bug

A `--resume` the CLI never acknowledged bricked the thread. The CLI exited before its `init` frame (for example "No conversation found with session ID"), `classifyError` judged that terminal so the transient retry never ran, and the dead cursor was never cleared — so every later turn resumed the same missing session and failed identically. The only way out was switching the bot's engine.

## The fix

`server/resume-recovery.ts` classifies the failure from the driver's own protocol state — a resume was offered, no `init` arrived, nothing streamed — and never from error text (provider strings get reworded and localized; a retry decision on a regex over them is a duplicate side effect waiting for a copy-edit). Only that **before-accept** case is replayed, on one fresh session, and exactly once by construction: the relaunch offers no cursor, so a second failure is reported like any other. A resumed session that emitted `init` and then died may already have run tools, so it is not resent.

The fresh session is not blank. `index.ts` attaches `SendTurnInput.recoveryText` alongside every `resumeCursor` — the active branch replayed inline via `turn-context.ts` `buildRecoveryText`, with its own preamble ("your previous session could not be resumed") rather than the fresh-engine one — and that is what the recovered turn carries. The harness records the new session's cursor from `session.started` exactly as before, so the thread is live again. A `turn.retrying` with `reason: "resume_rejected"` is emitted so the UI shows the relaunch.

## Platforms

Shared server code, no platform gate; no `/api/*` route, event payload, or wire shape changed (`recoveryText` is an internal driver input). iOS/Android/companion: n/a.

## Test plan

- `server/resume-recovery.test.ts` (11), `server/turn-context.test.ts` (+2), `server/drivers/claude.test.ts` (+5 in a new "resume recovery" describe): refused resume recovers with the rebuild on a fresh launch; a launch that fails every time settles as failed after one relaunch; a resumed session that emitted `init` then died is never resent; a crash on a launch that offered no cursor is never treated as a refused resume; a fresh turn never rebuilds. New fake-CLI modes `dead-session` and `resume-dies-after-init`.
- Mutation-checked: sending the bare text instead of the rebuild, treating every failure as a refused resume, and never recording `init` each fail a test.
- `index.test.ts` resume/cursor/fresh/rewound cases pass; `tsc -p tsconfig.server.json` clean; oxlint clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved conversation recovery when a resumed session is rejected before processing the prompt.
  - Automatically retries the turn in a fresh session using the relevant conversation context.
  - Prevents duplicate messages and avoids replaying turns that were already accepted.
  - Limits recovery to a single retry and preserves failure handling for other session crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->