### PR TITLE
control-omb edit: rewind a thread from the control surface

### DIFF
--- a/scripts/control-omb.ts
+++ b/scripts/control-omb.ts
@@ -14,7 +14,7 @@ import { freePortBlock } from "../server/testing/ports.ts";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const FAKE_CLI = join(ROOT, "server", "testing", "fake-claude-cli.ts");
-const MUTATING = new Set(["new-bot", "new-channel", "send", "send-channel", "interrupt", "set-model"]);
+const MUTATING = new Set(["new-bot", "new-channel", "send", "send-channel", "interrupt", "set-model", "edit"]);
 
 export class ControlOmbError extends Error {
   readonly hint?: string;
@@ -53,6 +53,7 @@ mutating (an explicit --url or OPENMAUSBOT_URL/OMB_PORT is required):
   send-channel --channel ID --text TEXT [--task ID] [--dry-run] [--url URL]
   interrupt --bot ID [--task ID] [--dry-run] [--url URL]
   interrupt --channel ID [--task ID] [--dry-run] [--url URL]
+  edit --bot ID --message ID --text TEXT [--task ID] [--dry-run] [--url URL]
   set-model --bot ID --instance ID --model ID [--task ID] [--effort LEVEL] [--dry-run] [--url URL]
 
 isolated fixture:
@@ -224,6 +225,25 @@ export async function runControlOmb(
     return dryRun(command, values, tool, input) ?? call(tool, input, values.url);
   }
 
+  if (command === "edit") {
+    // The rewind a person performs in the composer: edit an earlier user
+    // message, fork the thread there, and answer again. It is the only
+    // mapped way to make the harness REBUILD a thread rather than resume
+    // the provider's session, which is what a replay path needs to be
+    // observable from the control surface at all.
+    const values = parse(command, args, {
+      bot: { type: "string" }, message: { type: "string" }, text: { type: "string" },
+      task: { type: "string" }, "dry-run": { type: "boolean", default: false },
+    });
+    const input = {
+      bot_id: required(values.bot, "--bot"),
+      message_id: required(values.message, "--message"),
+      text: required(values.text, "--text"),
+      ...(values.task !== undefined ? { task_id: required(values.task, "--task") } : {}),
+    };
+    return dryRun(command, values, "edit_bot_message", input) ?? call("edit_bot_message", input, values.url);
+  }
+
   if (command === "set-model") {
     const values = parse(command, args, {
       bot: { type: "string" }, task: { type: "string" }, instance: { type: "string" },
@@ -339,7 +359,11 @@ export async function launchVerificationServer(
     OMB_DATA_DIR: dataDir,
     OMB_PORT: String(port),
     OMB_WEBHOOK_PORT: String(port + 1),
-    FAKE_CLAUDE_MODE: "happy",
+    // The fixture's default CLI behaviour; a caller that sets
+    // FAKE_CLAUDE_MODE explicitly overrides it below to drive the CLI's
+    // failure paths (exit-early, dead-session, hang...) through the real
+    // server. Nothing else from the parent shell reaches the fixture.
+    FAKE_CLAUDE_MODE: parentEnv.FAKE_CLAUDE_MODE || "happy",
     FAKE_CLAUDE_DUMP: fixtureDumpPath,
     // Keep the environment hermetic while allowing POSIX to resolve the
     // fake CLI's `#!/usr/bin/env node` shebang. Windows resolves that same

--- a/scripts/mcp-server.ts
+++ b/scripts/mcp-server.ts
@@ -410,6 +410,26 @@ export const TOOLS: McpToolDefinition[] = [
     annotations: MUTATING,
   },
   {
+    name: "edit_bot_message",
+    description:
+      "Edit an earlier user message, which forks the conversation from that point and answers again. "
+      + "This is the rewind a person performs in the composer, and the only mapped way to make the "
+      + "harness rebuild a thread's context instead of resuming the provider's own session. "
+      + "Refused while the thread is working.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        bot_id: { type: "string", description: "The ID of the bot." },
+        message_id: { type: "string", description: "The user message to replace." },
+        text: { type: "string", description: "What that message should say instead." },
+        task_id: { type: "string", description: "Optional owned task/thread ID. Defaults to the bot's selected task." },
+      },
+      required: ["bot_id", "message_id", "text"],
+      additionalProperties: false,
+    },
+    annotations: MUTATING,
+  },
+  {
     name: "list_available_models",
     description: "List configured model instances and capabilities without exposing local executable paths.",
     inputSchema: {
@@ -1132,6 +1152,31 @@ export async function handleToolCall(
         body: JSON.stringify({ modelSelection: selection, requireAvailableModel: true }),
       });
       return { success: true, bot: projectBot(res.bot) };
+    }
+
+    case "edit_bot_message": {
+      const botId = idArg(args, "bot_id");
+      const messageId = idArg(args, "message_id");
+      const text = String(args.text ?? "").trim();
+      if (!text) throw new Error("text is required");
+      const current = await fleet(fetcher);
+      const bot = records(current.bots).find((candidate) => candidate.id === botId);
+      if (!bot) throw new Error(`Bot not found: ${botId}`);
+      let threadId: string | undefined;
+      if (args.task_id !== undefined) {
+        threadId = idArg(args, "task_id");
+        if (!taskBelongsTo(bot, threadId)) throw new Error(`Task '${threadId}' does not belong to bot '${botId}'`);
+        if (botTaskState(bot, threadId).busy) throw new Error("Interrupt the task or let it finish before editing a message");
+      } else if (bot.busy) {
+        // the server refuses a rewind under a live turn — branching beneath
+        // a dying turn is how a thread ends up with two tails
+        throw new Error("Interrupt the bot or let it finish before editing a message");
+      }
+      const res = await fetcher(
+        `/api/bots/${encodeURIComponent(botId)}/messages/${encodeURIComponent(messageId)}/edit`,
+        { method: "POST", body: JSON.stringify({ text, ...(threadId ? { threadId } : {}) }) },
+      );
+      return { success: true, botId, message: res?.message ?? null };
     }
 
     case "list_available_models": {

--- a/server/control-omb.test.ts
+++ b/server/control-omb.test.ts
@@ -89,6 +89,54 @@ describe("control-omb command mapping", () => {
     expect(callTool).toHaveBeenCalledTimes(1);
   });
 
+  it("maps the rewind that makes the harness rebuild instead of resume", async () => {
+    // `edit` is the composer rewind. It is the only mapped way to reach a
+    // replay path, which is what compaction needs to be observable at all —
+    // a cleanly resumed turn never compacts.
+    const callTool = vi.fn(async (name: string, args: Record<string, unknown>) => ({ name, args }));
+    const env = { OPENMAUSBOT_URL: "http://127.0.0.1:19999" };
+    await expect(runControlOmb(
+      ["edit", "--bot", "bot-1", "--message", "msg-9", "--text", "say that again"],
+      { callTool: callTool as any, env },
+    )).resolves.toEqual({
+      name: "edit_bot_message",
+      args: { bot_id: "bot-1", message_id: "msg-9", text: "say that again" },
+    });
+    await expect(runControlOmb(
+      ["edit", "--bot", "bot-1", "--message", "msg-9", "--text", "again", "--task", "task-2", "--dry-run"],
+      { callTool: callTool as any, env: {} },
+    )).resolves.toMatchObject({
+      dryRun: true,
+      tool: "edit_bot_message",
+      arguments: { bot_id: "bot-1", message_id: "msg-9", text: "again", task_id: "task-2" },
+    });
+    expect(callTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats edit as mutating, so it cannot reach a silently discovered app", async () => {
+    // it forks a live conversation and starts a turn; it must never land on
+    // whatever instance happened to be running
+    await expect(runControlOmb(["edit", "--bot", "b", "--message", "m", "--text", "x"], {
+      callTool: vi.fn() as any,
+      env: {},
+    })).rejects.toMatchObject({
+      message: "mutating commands require an explicit OpenMausBot instance",
+    });
+  });
+
+  it("requires every part of an edit before calling the shared tool", async () => {
+    const callTool = vi.fn();
+    const env = { OPENMAUSBOT_URL: "http://127.0.0.1:19999" };
+    for (const args of [
+      ["edit", "--message", "m", "--text", "x"],
+      ["edit", "--bot", "b", "--text", "x"],
+      ["edit", "--bot", "b", "--message", "m"],
+    ]) {
+      await expect(runControlOmb(args, { callTool: callTool as any, env })).rejects.toThrow(/is required/);
+    }
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
   it("rejects invalid bounds before the shared tool is called", async () => {
     const callTool = vi.fn();
     await expect(runControlOmb(["wait", "--bot", "bot-1", "--timeout", "0"], {

--- a/server/mcp-server.test.ts
+++ b/server/mcp-server.test.ts
@@ -330,6 +330,63 @@ describe("MCP tool execution", () => {
     expect(result.hits).toHaveLength(1);
   });
 
+  it("rewinds a thread by editing an earlier message, and refuses while busy", async () => {
+    // The composer rewind. It forks the conversation and answers again,
+    // which is the only mapped way to make the harness REBUILD context
+    // rather than resume the provider's own session.
+    const busyFetcher = vi.fn(async () => ({ bots: [{ id: "bot-1", busy: true }] }));
+    await expect(handleToolCall("edit_bot_message", {
+      bot_id: "bot-1", message_id: "m-9", text: "say that again",
+    }, busyFetcher)).rejects.toThrow("let it finish");
+
+    const fetcher = vi.fn(async (path: string, options?: RequestInit) => {
+      if (path === "/api/bots?messages=0") return { bots: [{ id: "bot-1", busy: false }] };
+      if (path === "/api/bots/bot-1/messages/m-9/edit") {
+        expect(options?.method).toBe("POST");
+        expect(JSON.parse(String(options?.body))).toEqual({ text: "say that again" });
+        return { ok: true, message: { id: "m-new", role: "user", text: "say that again" } };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+    const result: any = await handleToolCall("edit_bot_message", {
+      bot_id: "bot-1", message_id: "m-9", text: "say that again",
+    }, fetcher);
+    expect(result).toMatchObject({ success: true, botId: "bot-1", message: { id: "m-new" } });
+  });
+
+  it("edits inside a named task only when that task is idle and owned", async () => {
+    const bot = {
+      id: "bot-1", busy: true, threadId: "task-1",
+      tasks: [{ threadId: "task-1", busy: true }, { threadId: "task-2", busy: false }],
+    };
+    const fetcher = vi.fn(async (path: string, options?: RequestInit) => {
+      if (path === "/api/bots?messages=0") return { bots: [bot] };
+      if (path === "/api/bots/bot-1/messages/m-9/edit") {
+        expect(JSON.parse(String(options?.body))).toEqual({ text: "again", threadId: "task-2" });
+        return { ok: true, message: { id: "m-new" } };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+    // the bot is busy on task-1, but task-2 is idle: the edit lands there
+    await expect(handleToolCall("edit_bot_message", {
+      bot_id: "bot-1", message_id: "m-9", text: "again", task_id: "task-2",
+    }, fetcher)).resolves.toMatchObject({ success: true });
+    await expect(handleToolCall("edit_bot_message", {
+      bot_id: "bot-1", message_id: "m-9", text: "again", task_id: "task-1",
+    }, fetcher)).rejects.toThrow("let it finish");
+    await expect(handleToolCall("edit_bot_message", {
+      bot_id: "bot-1", message_id: "m-9", text: "again", task_id: "task-9",
+    }, fetcher)).rejects.toThrow("does not belong");
+  });
+
+  it("will not rewind to an empty message", async () => {
+    const fetcher = vi.fn();
+    await expect(handleToolCall("edit_bot_message", {
+      bot_id: "bot-1", message_id: "m-9", text: "   ",
+    }, fetcher as never)).rejects.toThrow("text is required");
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
   it("requires an exact available model and refuses changes while busy", async () => {
     const busyFetcher = vi.fn(async () => ({ bots: [{ id: "bot-1", busy: true }] }));
     await expect(handleToolCall("set_bot_model", {


### PR DESCRIPTION
Lifted from #760 by @aivsomkar — the `control-omb edit` command, the `edit_bot_message` MCP tool, and the `FAKE_CLAUDE_MODE` forwarding in `launchVerificationServer` — rebased onto current `main`. The `OMB_CONTEXT_WINDOW` forwarding from that PR is deliberately left out: it needs #759's context runtime, which is being split into smaller PRs (#1038 is the first).

## What it does

`control-omb edit --bot ID --message ID --text TEXT [--task ID] [--dry-run]` and the `edit_bot_message` tool call the existing `POST /api/bots/:id/messages/:mid/edit` route: the rewind a person performs in the composer. It forks the thread at that message and answers again, which is the only mapped way to make the harness **rebuild** a thread's context instead of resuming the provider's session — the thing any replay/compaction path needs before it can be verified from the control surface.

- Mutating: requires an explicit instance (`--url` / `OPENMAUSBOT_URL`), never a silently discovered app.
- Refused while the bot, or the named task, is working — the same refusal the server makes, so the thread never grows two tails.
- Takes the optional `task_id` its neighbours (`set_bot_model`, `interrupt`) take, with the same ownership check.
- `launchVerificationServer` honours an explicitly set `FAKE_CLAUDE_MODE` (default still `happy`) so `exit-early` / `dead-session` / `hang` can be driven through the real server; nothing else from the parent shell reaches the fixture.

## Platforms

Control surface only (`scripts/`); no app, route, or wire change. iOS/Android/companion: n/a.

## Test plan

- `server/control-omb.test.ts` (+3): maps `edit` to the tool incl. `--task` and `--dry-run`; edit is mutating; every part is required before the tool is called.
- `server/mcp-server.test.ts` (+3): calls the route and refuses while busy; a named task must be idle and owned; empty text is refused before any request.
- Mutation-checked: dropping the busy check, dropping `edit` from `MUTATING`, and dropping the task-ownership check each fail a test.
- `FAKE_CLAUDE_MODE` forwarding is a one-line env default and has no unit test: `launchVerificationServer` boots a real server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for editing bot messages through the control command and MCP tool.
  * Supports bot, message, text, and optional task selection, along with dry-run mode.
  * Prevents edits while the selected bot task is busy and returns the updated message.

* **Bug Fixes**
  * Added validation for required identifiers and non-empty message text.
  * Added safeguards against editing unowned or active tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->