### PR TITLE
message-db: a clear error when SQLite has no FTS5

### DIFF
--- a/server/message-db.test.ts
+++ b/server/message-db.test.ts
@@ -6,8 +6,7 @@ import { DatabaseSync } from "node:sqlite";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { DATA_DIR } from "./config.ts";
-import {
-  closeMessageDb,
+import { closeMessageDb,
   deleteThread,
   insertMessage,
   readMessageText,
@@ -15,8 +14,7 @@ import {
   recallMessages,
   searchMessages,
   setActiveLeaf,
-  updateMessage,
-} from "./message-db.ts";
+  updateMessage, describeMissingFts5 } from "./message-db.ts";
 import { withPeerProvenance } from "./peer-provenance.ts";
 import { Store, type Message } from "./store.ts";
 import type { ModelSelection } from "./contracts.ts";
@@ -271,5 +269,19 @@ describe("message-db", () => {
     expect(path.at(-1)?.text).toBe("edited");
     // both branches survive in the tree
     expect(reloaded.messagesFor(bot.threadId).filter((m) => m.parentId === first.parentId)).toHaveLength(2);
+  });
+});
+
+describe("describeMissingFts5", () => {
+  it("turns SQLite's bare module error into one that names the fix", () => {
+    const described = describeMissingFts5(new Error("no such module: fts5"));
+    expect(described?.message).toMatch(/Node 24/);
+    expect(described?.message).toContain(process.version);
+    expect(described?.message).toContain("no such module: fts5");
+  });
+
+  it("leaves every other error alone", () => {
+    expect(describeMissingFts5(new Error("database is locked"))).toBeNull();
+    expect(describeMissingFts5("disk I/O error")).toBeNull();
   });
 });

--- a/server/message-db.ts
+++ b/server/message-db.ts
@@ -63,14 +63,34 @@ function open(): DatabaseSync {
 // is no more of a dependency than the table it indexes. The sidebar's LIKE
 // search below stays as it is — substring find over a single thread wants
 // every occurrence, not a relevance ranking.
+/** FTS5 is in every runtime OpenMausBot supports — node:sqlite on Node ≥ 24
+ * (package.json engines) and the Node inside Electron 43 — so a SQLite
+ * without it is a mis-installed runtime, not a mode to run in. Say that,
+ * instead of surfacing SQLite's own "no such module: fts5" from deep inside
+ * open() with nothing about what to do. Anything else is rethrown as-is. */
+export function describeMissingFts5(error: unknown): Error | null {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!/no such module:\s*fts5/i.test(message)) return null;
+  return new Error(
+    `OpenMausBot needs SQLite with FTS5, which is built into Node 24 and newer (and into the app). ` +
+    `This Node (${process.version}) has none: install Node 24 or newer. (${message})`,
+  );
+}
+
 function ensureRecallIndex(db: DatabaseSync): void {
   const existed = db
     .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'messages_fts'")
     .get();
+  try {
+    db.exec(`
+      CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+        text, content='messages', content_rowid='rowid', tokenize='unicode61'
+      );
+    `);
+  } catch (error) {
+    throw describeMissingFts5(error) ?? error;
+  }
   db.exec(`
-    CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
-      text, content='messages', content_rowid='rowid', tokenize='unicode61'
-    );
     CREATE TRIGGER IF NOT EXISTS messages_fts_ai AFTER INSERT ON messages BEGIN
       INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
     END;


### PR DESCRIPTION
Prompted by #814 (@Viewofmind), which found the real rough edge: on a Node without FTS5, `open()` throws SQLite's bare `no such module: fts5` from deep inside the message store, and the whole transcript store fails with no hint about why.

Every runtime OpenMausBot supports has FTS5 — `node:sqlite` on Node ≥ 24 (`package.json` engines) and the Node inside Electron 43 — so a SQLite without it is a mis-installed runtime rather than a mode to run in. This wraps the one `CREATE VIRTUAL TABLE … USING fts5` and rethrows a message that names the fix and the running Node version; every other error is rethrown untouched.

## Test plan

- `server/message-db.test.ts`: 14 passed (+2: the module error becomes one naming Node 24 and `process.version`; any other error is left alone).
- `tsc -p tsconfig.server.json` clean, oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
