### PR TITLE
fix(browser): repair live input and reconnect handling

### DIFF
--- a/docs/verification/browser-live.md
+++ b/docs/verification/browser-live.md
@@ -16,11 +16,17 @@ UI and harness, then removes its temporary data; the server log remains.
 
 1. The panel contains two browser-chrome rows and a live blank page. There is
    no “coming next” card. Navigation/input are disabled while just watching.
-2. Use the hand icon to take control, enter the printed test-page URL, and
-   press Enter. Click the page's name field, type, and click Say hello.
-   Verify both the streamed result and the native page's resulting text.
+2. Click **Take control**, enter the printed test-page URL, and press Enter.
+   In the name field, type `AdaX`, press Backspace, then Enter. The streamed
+   page must show `Hello, Ada`. Check arrows and Delete, Tab into the notes
+   field and enter multiple lines, then open the dialog and close it with
+   Escape. These must affect the remote page, not only the surrounding UI.
+   Shift+Escape returns focus to the address field without sending Escape to
+   the page; keyboard-only users must still be able to reach the toolbar.
 3. Return to bot. Reconnect the view, then leave it connected for at least
    30 seconds on the same static image. It must not stall waiting for an ACK.
+   The page remains intact and watch-only; take control again and confirm
+   editing and Enter still work after reconnecting.
 4. The single profile button opens the switcher. Create a shared profile,
    switch to it (a clean browser), then back to Own browser. The previous page
    remains. Rename a shared profile without changing its identity. Confirmed
@@ -39,10 +45,12 @@ pnpm exec vitest run server/browser-engine.test.ts server/browser-runtime.test.t
   server/browser-proxy.test.ts server/browser-live.test.ts \
   server/browser-live-routes.test.ts server/browser-codex-path.integration.test.ts \
   src/lib/browser-input-queue.test.ts src/lib/browser-profiles.test.ts \
-  src/components/BrowserProfilesManager.test.ts
+  src/components/BrowserProfilesManager.test.ts src/components/BrowserViewport.test.ts \
+  src/components/BrowserPanel.test.ts
 ```
 
 Those tests cover native transport lifecycle, owner/session scoping, gate races,
-stale list edits, bounded input/backpressure, revoked capabilities, and exact
-saved-state cleanup. Native workflow testing is still required: a green mocked
+stale list/stream events, native key routing, bounded input/backpressure,
+revoked capabilities, and exact saved-state cleanup. Native workflow testing
+is still required: a green mocked
 frame test alone does not prove browser input or restoration works.

--- a/scripts/testing/browser-test-page.html
+++ b/scripts/testing/browser-test-page.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<title>OpenMausBot browser test</title>
+<style>
+  body { font: 18px system-ui; background: #faf9f6; color: #282923; padding: 50px; }
+  h1 { font-size: 42px; letter-spacing: -2px; }
+  input, textarea, button { font: inherit; padding: 12px; border: 1px solid #ccc; border-radius: 10px; margin: 5px; }
+  button { background: #242721; color: white; }
+  p { color: #666; }
+  textarea { display: block; width: 360px; }
+  dialog { border: 1px solid #ccc; border-radius: 12px; }
+</style>
+<h1>A browser for your bots.</h1>
+<p>Isolated live-view test. No real accounts or credentials.</p>
+<form id="greeting">
+  <input id="name" aria-label="Test name" placeholder="Your name" autocomplete="off">
+  <button>Say hello</button>
+</form>
+<p><output id="result" aria-live="polite">Ready</output></p>
+<textarea aria-label="Test notes" placeholder="Test Enter, arrows, Backspace and Delete here" rows="2"></textarea>
+<button id="open-dialog" type="button">Open dialog</button>
+<p><output id="dialog-result">Dialog not opened</output></p>
+<dialog id="test-dialog">
+  <p>Press Escape to close this remote page dialog.</p>
+  <form method="dialog"><button>Close dialog</button></form>
+</dialog>
+<script>
+  document.querySelector('#greeting').addEventListener('submit', (event) => {
+    event.preventDefault();
+    document.querySelector('#result').textContent = 'Hello, ' + document.querySelector('#name').value;
+  });
+  const dialog = document.querySelector('#test-dialog');
+  document.querySelector('#open-dialog').addEventListener('click', () => {
+    document.querySelector('#dialog-result').textContent = 'Dialog open';
+    dialog.showModal();
+  });
+  dialog.addEventListener('close', () => { document.querySelector('#dialog-result').textContent = 'Dialog closed'; });
+</script>
+</html>

--- a/scripts/verify-browser-live.ts
+++ b/scripts/verify-browser-live.ts
@@ -1,5 +1,6 @@
 // Actual browser + actual BrowserPanel, always in a disposable fixture HOME.
 import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
 import { createServer } from "vite";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
@@ -22,7 +23,7 @@ try {
       server.middlewares.use((req, res, next) => {
         if (req.url === "/__browser-test-page") {
           res.setHeader("content-type", "text/html");
-          res.end('<!doctype html><title>OpenMausBot</title><style>body{font:18px system-ui;background:#faf9f6;color:#282923;padding:70px}h1{font-size:42px;letter-spacing:-2px}input,button{font:inherit;padding:12px;border:1px solid #ccc;border-radius:10px;margin:5px}button{background:#242721;color:white}p{color:#666}</style><h1>A browser for your bots.</h1><p>Isolated live-view test. No real accounts or credentials.</p><input aria-label="Test name" placeholder="Your name"><button onclick="document.querySelector(\'output\').textContent=\'Hello, \'+document.querySelector(\'input\').value">Say hello</button><p><output>Ready</output></p>');
+          res.end(readFileSync(new URL("./testing/browser-test-page.html", import.meta.url), "utf8"));
           return;
         }
         if (req.url !== "/__browser-preview.html") return next();

--- a/server/browser-live.test.ts
+++ b/server/browser-live.test.ts
@@ -114,7 +114,7 @@ describe("browser viewer protocol boundary", () => {
     expect(parseBrowserLiveAction({ type: "tab-new" })).toEqual({ type: "command", args: ["tab", "new"] });
     expect(parseBrowserLiveAction({ type: "tab-select", tabId: "t2" })).toEqual({ type: "command", args: ["tab", "t2"] });
     for (const url of ["javascript:alert(1)", "file:///etc/passwd", "data:text/html,x", "--cdp=9222", "https://a:secret@example.com", "https://example.com\n--headed", "http:\\example.com"]) expect(() => parseBrowserLiveAction({ type: "navigate", url })).toThrow();
-    for (const body of [{ type: "eval", script: "1" }, { type: "tab-close", tabId: "--all" }, { type: "tab-select", tabId: 1 }, { type: "config", port: 1 }]) expect(() => parseBrowserLiveAction(body)).toThrow();
+    for (const body of [{ type: "eval", script: "1" }, { type: "press", key: "Control+a" }, { type: "tab-close", tabId: "--all" }, { type: "tab-select", tabId: 1 }, { type: "config", port: 1 }]) expect(() => parseBrowserLiveAction(body)).toThrow();
   });
   it("bounds input coordinates, text and modifiers, and strips arbitrary CDP fields", () => {
     expect(parseBrowserLiveAction({ type: "input_mouse", eventType: "mousePressed", x: 12, y: 20, button: "left", clickCount: 1, method: "Runtime.evaluate" })).toEqual({ type: "input", message: { type: "input_mouse", eventType: "mousePressed", x: 12, y: 20, button: "left", clickCount: 1, deltaX: 0, deltaY: 0, modifiers: 0 } });
@@ -289,6 +289,86 @@ describe("authenticated browser viewer relay", () => {
       { action: "keyboard", subaction: "insertText", text: "--cdp=secret\nhello" }, { action: "press", key: "Control+a" },
     ]);
   });
+  it.each(["Backspace", "Enter", "Tab", "Escape", "Delete", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Home", "End", "PageUp", "PageDown"])("uses an acknowledged native press for %s without a duplicate key release", async (key) => {
+    const a = await open(); await a.action({ type: "take" });
+    await a.action({ type: "input_keyboard", eventType: "keyDown", key, code: key });
+    await a.action({ type: "input_keyboard", eventType: "keyUp", key, code: key });
+    expect(nativeInput.mock.calls.map(([, options]) => JSON.parse(options.body))).toEqual([{ action: "press", key }]);
+    await a.action({ type: "release" });
+    expect(runtime.abandonHumanInput).not.toHaveBeenCalled();
+  });
+  it.each([
+    { key: "a", code: "KeyA", modifiers: 2, chord: "Control+a" },
+    { key: "a", code: "KeyA", modifiers: 4, chord: "Meta+a" },
+    { key: "Tab", code: "Tab", modifiers: 8, chord: "Shift+Tab" },
+    { key: "ArrowLeft", code: "ArrowLeft", modifiers: 3, chord: "Alt+Control+ArrowLeft" },
+  ])("does not resend $chord when its modifiers change before keyUp", async ({ key, code, modifiers, chord }) => {
+    const a = await open(); await a.action({ type: "take" });
+    await a.action({ type: "input_keyboard", eventType: "keyDown", key, code, modifiers });
+    await a.action({ type: "input_keyboard", eventType: "keyUp", key, code, modifiers: 0 });
+    expect(nativeInput.mock.calls.map(([, options]) => JSON.parse(options.body))).toEqual([{ action: "press", key: chord }]);
+  });
+  it("preserves printable text and releases raw held keys even if modifiers change", async () => {
+    const a = await open(); await a.action({ type: "take" });
+    await a.action({ type: "input_keyboard", eventType: "keyDown", key: "+", code: "Equal", text: "+", modifiers: 8 });
+    await a.action({ type: "input_keyboard", eventType: "keyUp", key: "=", code: "Equal", modifiers: 2 });
+    await a.action({ type: "input_keyboard", eventType: "keyDown", key: "a", code: "KeyA", text: "a" });
+    await a.action({ type: "input_keyboard", eventType: "keyUp", key: "a", code: "KeyA" });
+    expect(nativeInput.mock.calls.map(([, options]) => JSON.parse(options.body))).toEqual([
+      { action: "input_keyboard", type: "keyDown", key: "+", code: "Equal", text: "+" },
+      { action: "input_keyboard", type: "keyUp", key: "=", code: "Equal" },
+      { action: "input_keyboard", type: "keyDown", key: "a", code: "KeyA", text: "a" },
+      { action: "input_keyboard", type: "keyUp", key: "a", code: "KeyA" },
+    ]);
+    await a.action({ type: "release" });
+    expect(runtime.abandonHumanInput).not.toHaveBeenCalled();
+  });
+  it("keeps unknown raw key names literal instead of interpreting them as chords or commands", async () => {
+    const a = await open(); await a.action({ type: "take" });
+    await a.action({ type: "input_keyboard", eventType: "keyDown", key: "Control+a", command: "eval", script: "private" });
+    expect(nativeInput.mock.calls.map(([, options]) => JSON.parse(options.body))).toEqual([
+      { action: "input_keyboard", type: "keyDown", key: "Control+a" },
+    ]);
+  });
+  it("handles repeated discrete keyDowns once each and does not mark them held", async () => {
+    const a = await open(); await a.action({ type: "take" });
+    await a.action({ type: "input_keyboard", eventType: "keyDown", key: "Backspace", code: "Backspace" });
+    await a.action({ type: "input_keyboard", eventType: "keyDown", key: "Backspace", code: "Backspace" });
+    await a.action({ type: "release" });
+    expect(nativeInput.mock.calls.map(([, options]) => JSON.parse(options.body))).toEqual([
+      { action: "press", key: "Backspace" }, { action: "press", key: "Backspace" },
+    ]);
+    expect(runtime.abandonHumanInput).not.toHaveBeenCalled();
+  });
+  it("clears a formerly raw held key after an acknowledged repeat becomes a shortcut", async () => {
+    const a = await open(); await a.action({ type: "take" });
+    await a.action({ type: "input_keyboard", eventType: "keyDown", key: "a", code: "KeyA", text: "a" });
+    await a.action({ type: "input_keyboard", eventType: "keyDown", key: "a", code: "KeyA", modifiers: 2 });
+    await a.action({ type: "input_keyboard", eventType: "keyUp", key: "a", code: "KeyA", modifiers: 0 });
+    await a.action({ type: "release" });
+    expect(nativeInput.mock.calls.map(([, options]) => JSON.parse(options.body))).toEqual([
+      { action: "input_keyboard", type: "keyDown", key: "a", code: "KeyA", text: "a" }, { action: "press", key: "Control+a" },
+    ]);
+    expect(runtime.abandonHumanInput).not.toHaveBeenCalled();
+  });
+  it("still requires restart when a held modifier has not been released after a chord", async () => {
+    runtime = new BrowserRuntime(); live = new BrowserLive({ runtime });
+    const a = await open(); await a.action({ type: "take" });
+    await a.action({ type: "input_keyboard", eventType: "keyDown", key: "Shift", code: "ShiftLeft", modifiers: 8 });
+    await a.action({ type: "input_keyboard", eventType: "keyDown", key: "Tab", code: "Tab", modifiers: 8 });
+    await a.action({ type: "input_keyboard", eventType: "keyUp", key: "Tab", code: "Tab", modifiers: 8 });
+    await a.action({ type: "release" });
+    await expect(runtime.withAgentAction("profile-a", async () => true)).rejects.toThrow("Restart");
+  });
+  it("keeps uncertain discrete key presses behind the existing restart barrier and hides raw failures", async () => {
+    runtime = new BrowserRuntime(); live = new BrowserLive({ runtime });
+    const a = await open(); await a.action({ type: "take" });
+    nativeInput.mockImplementationOnce(async () => Response.json({ success: false, error: "password=private" }));
+    await expect(a.action({ type: "input_keyboard", eventType: "keyDown", key: "Enter" })).rejects.toThrow("could not confirm this input");
+    expect(JSON.parse(nativeInput.mock.calls[0]![1].body)).toEqual({ action: "press", key: "Enter" });
+    await a.action({ type: "release" });
+    await expect(runtime.withAgentAction("profile-a", async () => true)).rejects.toThrow("Restart");
+  });
   it("releases Shift-only printable keys even when keyUp contains no text", async () => {
     const a = await open(); await a.action({ type: "take" });
     await a.action({ type: "input_keyboard", eventType: "keyDown", key: "A", code: "KeyA", text: "A", modifiers: 8 });
@@ -319,12 +399,15 @@ describe("authenticated browser viewer relay", () => {
     await a.action({ type: "release" });
     await expect(runtime.withAgentAction("profile-a", async () => true)).resolves.toBe(true);
   });
-  it.each(["release", "disconnect"])("does not admit bot work on %s until native human input is confirmed", async (ending) => {
+  it.each(["release", "disconnect"].flatMap((ending) => [
+    { ending, name: "pasted text", body: { type: "input_keyboard", eventType: "char", text: "private" } },
+    { ending, name: "discrete press", body: { type: "input_keyboard", eventType: "keyDown", key: "Enter" } },
+  ]))("does not admit bot work on $ending until native $name is confirmed", async ({ ending, body }) => {
     runtime = new BrowserRuntime(); live = new BrowserLive({ runtime });
     const a = await open(); await a.action({ type: "take" });
     let finish!: (value: Response) => void;
     nativeInput.mockImplementationOnce(() => new Promise<Response>((resolve) => { finish = resolve; }));
-    const input = a.action({ type: "input_keyboard", eventType: "char", text: "private" });
+    const input = a.action(body);
     await vi.waitFor(() => expect(nativeInput).toHaveBeenCalled());
     if (ending === "release") await a.action({ type: "release" }); else a.socket.close();
     await expect(runtime.withAgentAction("profile-a", async () => true)).rejects.toThrow("paused");

--- a/server/browser-live.ts
+++ b/server/browser-live.ts
@@ -9,6 +9,9 @@ const execute = promisify(execFile);
 const MAX_FRAME = 3 * 1024 * 1024;
 const MAX_BUFFER = 4 * 1024 * 1024;
 const HEARTBEAT_MS = 10_000;
+// The native press resolver supplies the virtual key codes and Enter/Tab text
+// that its raw input_keyboard relay omits. Keep unknown keys literal.
+const DISCRETE_KEYS = new Set(["Backspace", "Enter", "Tab", "Escape", "Delete", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Home", "End", "PageUp", "PageDown"]);
 
 export class BrowserLiveError extends Error {
   readonly status: number;
@@ -270,20 +273,22 @@ export class BrowserLive {
     if (!viewer.port) throw new BrowserLiveError("The browser stream is not connected.", 409);
     let command: ObjectValue;
     const { type, eventType, ...fields } = message;
+    const key = String(fields.code || fields.key);
     const shortcut = Number(fields.modifiers) > 0 && !["Alt", "Control", "Meta", "Shift"].includes(String(fields.key))
       && !(fields.modifiers === 8 && text(fields.key, 64) && [...fields.key].length === 1);
-    if (type === "input_keyboard" && eventType === "keyUp" && shortcut) return; // press already releases the chord.
+    // press already released the key. Match raw held keys, not the modifiers
+    // on keyUp: they may have changed, or blur may flush releases with zero.
+    if (type === "input_keyboard" && eventType === "keyUp" && !viewer.pressedKeys.has(key)) return;
     if (type === "input_mouse") command = { action: "input_mouse", type: eventType, ...fields };
     else if (eventType === "char") command = { action: "keyboard", subaction: "insertText", text: fields.text };
-    else if (eventType === "keyDown" && shortcut) {
-      // The native input_keyboard handler omits CDP modifiers. Its press
-      // action resolves chords and awaits the complete key-down/up pair.
+    else if (eventType === "keyDown" && (shortcut || DISCRETE_KEYS.has(String(fields.key)))) {
+      // press resolves virtual key codes, required text and modifiers, and
+      // acknowledges the complete key-down/up pair before hand-back.
       const modifiers = fields.modifiers as number;
       const chord = [[1, "Alt"], [2, "Control"], [4, "Meta"], [8, "Shift"]] as const;
       command = { action: "press", key: [...chord.filter(([bit]) => modifiers & bit).map(([, key]) => key), fields.key].join("+") };
     } else command = { action: "input_keyboard", type: eventType, key: fields.key,
       ...(fields.code === undefined ? {} : { code: fields.code }), ...(fields.text === undefined ? {} : { text: fields.text }) };
-    const key = String(fields.code || fields.key);
     if (command.action === "input_keyboard" && eventType === "keyDown") {
       if (viewer.pressedKeys.size >= 64 && !viewer.pressedKeys.has(key)) throw new BrowserLiveError("Too many keys are held. Restart the browser before continuing.", 409);
       viewer.pressedKeys.add(key);
@@ -304,7 +309,7 @@ export class BrowserLive {
         chunks.push(chunk);
       }
       if (object(JSON.parse(Buffer.concat(chunks).toString("utf8")))?.success !== true) throw new Error("input failed");
-      if (command.action === "input_keyboard" && eventType === "keyUp") viewer.pressedKeys.delete(key);
+      if (command.action === "press" || (command.action === "input_keyboard" && eventType === "keyUp")) viewer.pressedKeys.delete(key);
       if (type === "input_mouse" && eventType === "mouseReleased") viewer.pressedButtons.delete(String(fields.button));
     } catch { throw new BrowserLiveError("The browser could not confirm this input. Restart the browser before continuing.", 503); }
   }

--- a/src/components/BrowserPanel.test.ts
+++ b/src/components/BrowserPanel.test.ts
@@ -1,0 +1,128 @@
+import { Children, createElement, isValidElement, type EffectCallback, type ReactElement, type ReactNode, type RefObject } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Bot } from "@/state/store";
+
+const fixture = vi.hoisted(() => ({
+  effects: [] as EffectCallback[],
+  refs: [] as RefObject<unknown>[],
+  control: { held: false, controlling: false, owned: false },
+  frame: null as { seq: number; data: string } | null,
+  queues: [] as Array<{ enqueue: ReturnType<typeof vi.fn>; clear: ReturnType<typeof vi.fn>; drain: ReturnType<typeof vi.fn> }>,
+}));
+vi.mock("react", async (importOriginal) => {
+  const react = await importOriginal<typeof import("react")>();
+  return { ...react,
+    useEffect: (effect: EffectCallback) => { fixture.effects.push(effect); },
+    useRef: (value: unknown) => { const ref = react.useRef(value); fixture.refs.push(ref); return ref; },
+    useState: (value: unknown) => react.useState(value === null ? fixture.frame : value && typeof value === "object" && "controlling" in value ? fixture.control : value),
+  };
+});
+vi.mock("@/state/store", () => ({ api: vi.fn().mockResolvedValue({}), useStore: () => ({ state: { config: { browserProfiles: [] } } }) }));
+vi.mock("./BrowserProfilesManager", () => ({ BrowserProfilesManager: () => null }));
+vi.mock("@/lib/browser-input-queue", () => ({ createBrowserInputQueue: () => {
+  const queue = { enqueue: vi.fn(), clear: vi.fn(), drain: vi.fn().mockResolvedValue(undefined) };
+  fixture.queues.push(queue); return queue;
+} }));
+import { LiveBrowser } from "./BrowserPanel";
+import { BrowserViewport } from "./BrowserViewport";
+
+class FixtureEventSource {
+  static instances: FixtureEventSource[] = [];
+  listeners = new Map<string, Array<(event: MessageEvent) => void>>();
+  close = vi.fn();
+  constructor(readonly url: string) { FixtureEventSource.instances.push(this); }
+  addEventListener(name: string, listener: (event: MessageEvent) => void) {
+    this.listeners.set(name, [...this.listeners.get(name) ?? [], listener]);
+  }
+  emit(name: string, data: unknown) {
+    for (const listener of this.listeners.get(name) ?? []) listener(new MessageEvent(name, { data: JSON.stringify(data) }));
+  }
+}
+const bot = { id: "pepper", name: "Pepper" } as Bot;
+const render = () => renderToStaticMarkup(createElement(LiveBrowser, { bot }));
+beforeEach(() => {
+  fixture.effects = []; fixture.refs = []; fixture.queues = [];
+  fixture.control = { held: false, controlling: false, owned: false };
+  fixture.frame = null;
+  FixtureEventSource.instances = [];
+  vi.stubGlobal("EventSource", FixtureEventSource);
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe("live browser connection lifecycle", () => {
+  it("does not let an old source error discard the replacement viewer or input queue", () => {
+    render();
+    // Replay the real connection effect's cleanup/setup, as on reconnect or
+    // StrictMode, while retaining the same component refs.
+    const connect = fixture.effects[2]!;
+    const firstCleanup = connect();
+    const first = FixtureEventSource.instances[0]!;
+    first.emit("ready", { viewerId: "old-viewer" });
+    const viewer = fixture.refs.find((ref) => ref.current === "old-viewer")!;
+    expect(viewer).toBeDefined();
+    firstCleanup?.();
+    expect(fixture.queues[0]!.clear).toHaveBeenCalledOnce();
+    const secondCleanup = connect();
+    const second = FixtureEventSource.instances[1]!;
+    second.emit("ready", { viewerId: "new-viewer" });
+    first.emit("error", { message: "delayed old disconnect" });
+    expect(viewer.current).toBe("new-viewer");
+    expect(fixture.queues[1]!.clear).not.toHaveBeenCalled();
+    expect(second.close).not.toHaveBeenCalled();
+    secondCleanup?.();
+  });
+
+  it("still clears input and closes the current source on a real connection error", () => {
+    render();
+    const cleanup = fixture.effects[2]!();
+    const source = FixtureEventSource.instances[0]!;
+    source.emit("ready", { viewerId: "current-viewer" });
+    const viewer = fixture.refs.find((ref) => ref.current === "current-viewer")!;
+    source.emit("error", { message: "connection ended" });
+    expect(viewer.current).toBe("");
+    expect(fixture.queues[0]!.clear).toHaveBeenCalledOnce();
+    expect(source.close).toHaveBeenCalledOnce();
+    source.emit("ready", { viewerId: "late-viewer" });
+    expect(viewer.current).toBe("");
+    expect(fixture.queues).toHaveLength(1);
+    cleanup?.();
+  });
+});
+
+describe("live browser control affordance", () => {
+  it("returns viewport focus to the existing browser address field", () => {
+    fixture.frame = { seq: 1, data: "fixture" };
+    let tree!: ReturnType<typeof LiveBrowser>;
+    function Capture() { tree = LiveBrowser({ bot }); return tree; }
+    renderToStaticMarkup(createElement(Capture));
+    type Node = ReactElement<{ children?: ReactNode; "aria-label"?: string; ref?: RefObject<HTMLInputElement | null>; onReturnToToolbar?: () => void }>;
+    const elements = (node: ReactNode): Node[] => {
+      if (!isValidElement(node)) return [];
+      const element = node as Node;
+      return [element, ...Children.toArray(element.props.children).flatMap(elements)];
+    };
+    const nodes = elements(tree);
+    const address = nodes.find((node) => node.props["aria-label"] === "Browser address")!;
+    const viewport = nodes.find((node) => node.type === BrowserViewport)!;
+    const focus = vi.fn();
+    address.props.ref!.current = { focus } as unknown as HTMLInputElement;
+    viewport.props.onReturnToToolbar!();
+    expect(focus).toHaveBeenCalledOnce();
+  });
+
+  it("visibly labels takeover in the existing toolbar", () => {
+    const html = render();
+    expect(html).toContain('<span>Take control</span>');
+    expect(html).toContain('aria-label="Take control" aria-pressed="false"');
+    expect(html).toContain('aria-label="Browser profiles"');
+  });
+
+  it("visibly labels hand-back when this viewer owns control", () => {
+    fixture.control = { held: true, controlling: true, owned: true };
+    const html = render();
+    expect(html).toContain('<span>Return to bot</span>');
+    expect(html).toContain('aria-label="Return to bot" aria-pressed="true"');
+    expect(html).not.toContain('<span>Take control</span>');
+  });
+});

--- a/src/components/BrowserPanel.tsx
+++ b/src/components/BrowserPanel.tsx
@@ -11,7 +11,7 @@ const button = "rounded-md p-1.5 text-ink-secondary hover:bg-inset hover:text-in
 
 /** Closing a panel releases its lease. A new connection never silently
  * restores permission to type, and never replays old browser frames. */
-function LiveBrowser({ bot }: { bot: Bot }) {
+export function LiveBrowser({ bot }: { bot: Bot }) {
   const { state } = useStore();
   const [attempt, setAttempt] = useState(0);
   const [frame, setFrame] = useState<BrowserFrame | null>(null);
@@ -26,6 +26,7 @@ function LiveBrowser({ bot }: { bot: Bot }) {
   const [viewport, setViewport] = useState({ width: 1280, height: 720 });
   const viewer = useRef("");
   const panel = useRef<HTMLDivElement>(null);
+  const addressInput = useRef<HTMLInputElement>(null);
   const profilesDialog = useRef<HTMLDialogElement>(null);
   const typingDialog = useRef<HTMLDialogElement>(null);
   const inputQueue = useRef<ReturnType<typeof createBrowserInputQueue> | null>(null);
@@ -75,9 +76,13 @@ function LiveBrowser({ bot }: { bot: Bot }) {
       if (data.held && !data.controlling) { setFrame(null); setTabs([]); setAddress(""); }
     });
     source.addEventListener("error", (event) => {
+      // A closed source may still deliver its queued error after a profile
+      // switch or reconnect. It must not clear the replacement viewer/input.
+      if (stopped) return;
+      stopped = true;
       let message = "Browser connection ended. Reconnect to continue watching.";
       if (event instanceof MessageEvent) { try { message = JSON.parse(event.data).message || message; } catch { /* Network error fallback. */ } }
-      if (!stopped) { setError(message); setConnected(false); setFrame(null); setControl({ held: false, controlling: false, owned: false }); }
+      setError(message); setConnected(false); setFrame(null); setControl({ held: false, controlling: false, owned: false });
       viewer.current = ""; inputQueue.current?.clear(); source.close();
     });
     return () => { stopped = true; viewer.current = ""; inputQueue.current?.clear(); source.close(); };
@@ -110,9 +115,10 @@ function LiveBrowser({ bot }: { bot: Bot }) {
         <button type="button" className={button} disabled={!driving} aria-label="Forward" onClick={() => void execute({ type: "forward" })}><ArrowRight size={17} /></button>
         <button type="button" className={button} disabled={!driving} aria-label="Reload page" onClick={() => void execute({ type: "reload" })}><RotateCw size={17} /></button>
       </div>
-      <input aria-label="Browser address" readOnly={!driving} value={address} onChange={(e) => setAddress(e.target.value)} onFocus={(e) => { urlEditing.current = true; if (driving) e.target.select(); }} onBlur={() => { urlEditing.current = false; }} placeholder={connected ? "about:blank" : "Connecting…"} spellCheck={false} className="mx-1 min-w-0 flex-1 rounded-lg bg-transparent px-2 py-1.5 text-center text-[12px] outline-none placeholder:text-ink-secondary focus:bg-inset focus:text-left" />
-      <button type="button" disabled={!connected || pending || (control.held && !control.owned)} onClick={() => void execute({ type: control.owned ? "release" : "take" })} title={control.owned ? "Return to bot — browser tools are paused while you control this profile" : control.held ? "This profile is controlled in another window" : "Take control to click, type, or sign in"} aria-label={control.owned ? "Return to bot" : "Take control"} aria-pressed={control.owned} className={`${button} ${control.owned ? "bg-accent/15 text-accent" : ""}`}>
-        {pending ? <Loader2 size={16} className="animate-spin" /> : <Hand size={16} />}
+      <input ref={addressInput} aria-label="Browser address" readOnly={!driving} value={address} onChange={(e) => setAddress(e.target.value)} onFocus={(e) => { urlEditing.current = true; if (driving) e.target.select(); }} onBlur={() => { urlEditing.current = false; }} placeholder={connected ? "about:blank" : "Connecting…"} spellCheck={false} className="mx-1 min-w-0 flex-1 rounded-lg bg-transparent px-2 py-1.5 text-center text-[12px] outline-none placeholder:text-ink-secondary focus:bg-inset focus:text-left" />
+      <button type="button" disabled={!connected || pending || (control.held && !control.owned)} onClick={() => void execute({ type: control.owned ? "release" : "take" })} title={control.owned ? "Return to bot — browser tools are paused while you control this profile" : control.held ? "This profile is controlled in another window" : "Take control to click, type, or sign in"} aria-label={control.owned ? "Return to bot" : "Take control"} aria-pressed={control.owned} className={`${button} flex shrink-0 items-center gap-1.5 whitespace-nowrap text-[11px] sm:text-[12px] ${control.owned ? "bg-accent/15 text-accent" : ""}`}>
+        {pending ? <Loader2 size={16} className="animate-spin" /> : <Hand size={16} className="hidden sm:block" />}
+        <span>{control.owned ? "Return to bot" : "Take control"}</span>
       </button>
       <details className="relative shrink-0">
         <summary className={`${button} list-none cursor-pointer [&::-webkit-details-marker]:hidden`} aria-label="Browser menu" title="Browser menu"><EllipsisVertical size={17} /></summary>
@@ -130,6 +136,7 @@ function LiveBrowser({ bot }: { bot: Bot }) {
     {error && <div role="alert" className="flex items-center justify-between gap-2 border-b border-hairline/30 px-3 py-2 text-[12px] text-danger"><span>{error}</span>{!connected && <button className="shrink-0 underline" onClick={() => setAttempt((value) => value + 1)}>Reconnect</button>}</div>}
     <div className="min-h-48 flex-1 overflow-auto bg-inset/40">
       {frame ? <BrowserViewport frame={frame} {...viewport} driving={driving} input={input}
+        onReturnToToolbar={() => addressInput.current?.focus()}
         acknowledge={(seq) => { if (viewer.current) void action({ type: "ack", seq }).catch(() => {}); }}
         onDecodeError={() => setError("A browser frame could not be decoded. Close and reopen the panel to reconnect.")} />
         : <div className="flex min-h-64 flex-col items-center justify-center gap-3 p-6 text-center text-[13px] text-ink-secondary">{connected && control.held ? <Hand size={24} /> : error ? <Globe size={24} /> : <Loader2 size={24} className="animate-spin" />}<span>{control.held ? "Live view paused for human control" : error ? "Browser disconnected" : "Opening the live browser…"}</span></div>}

--- a/src/components/BrowserViewport.test.ts
+++ b/src/components/BrowserViewport.test.ts
@@ -1,9 +1,78 @@
+import { Children, createElement, type ImgHTMLAttributes, type KeyboardEvent, type PointerEvent, type ReactElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
-import { createBrowserPressedInputs } from "./BrowserViewport";
+import { BrowserViewport, createBrowserPressedInputs } from "./BrowserViewport";
 
 const key = (eventType: string, value = "a", modifiers = 0) => ({
   type: "input_keyboard", eventType, key: value, code: value === "Shift" ? "ShiftLeft" : "KeyA", modifiers,
   ...(eventType === "keyDown" && value.length === 1 ? { text: value } : {}),
+});
+
+function viewport(driving = true) {
+  const input = vi.fn();
+  const onReturnToToolbar = vi.fn();
+  let image!: ReactElement<ImgHTMLAttributes<HTMLImageElement>>;
+  function Capture() {
+    const tree = BrowserViewport({ frame: { seq: 1, data: "fixture" }, width: 1280, height: 720,
+      driving, input, acknowledge: vi.fn(), onDecodeError: vi.fn(), onReturnToToolbar });
+    image = Children.only(tree.props.children) as typeof image;
+    return tree;
+  }
+  renderToStaticMarkup(createElement(Capture));
+  return { input, onReturnToToolbar, props: image.props };
+}
+
+describe("browser viewport input forwarding", () => {
+  it("forwards Escape down and up to the remote page without blurring it", () => {
+    const { input, onReturnToToolbar, props } = viewport();
+    const blur = vi.fn();
+    const preventDefault = vi.fn();
+    const event = { key: "Escape", code: "Escape", keyCode: 27, altKey: false, ctrlKey: false,
+      metaKey: false, shiftKey: false, nativeEvent: { isComposing: false }, currentTarget: { blur }, preventDefault } as unknown as KeyboardEvent<HTMLImageElement>;
+    props.onKeyDown!(event); props.onKeyUp!(event);
+    expect(input.mock.calls.map(([body]) => body)).toEqual([
+      { type: "input_keyboard", eventType: "keyDown", key: "Escape", code: "Escape", windowsVirtualKeyCode: 27, modifiers: 0 },
+      { type: "input_keyboard", eventType: "keyUp", key: "Escape", code: "Escape", windowsVirtualKeyCode: 27, modifiers: 0 },
+    ]);
+    expect(preventDefault).toHaveBeenCalledTimes(2);
+    expect(blur).not.toHaveBeenCalled();
+    expect(onReturnToToolbar).not.toHaveBeenCalled();
+  });
+
+  it("releases held input before Shift+Escape returns focus to the toolbar", () => {
+    const { input, onReturnToToolbar, props } = viewport();
+    const event = { key: "Shift", code: "ShiftLeft", keyCode: 16, altKey: false, ctrlKey: false,
+      metaKey: false, shiftKey: true, nativeEvent: { isComposing: false }, preventDefault: vi.fn(), stopPropagation: vi.fn() } as unknown as KeyboardEvent<HTMLImageElement>;
+    props.onKeyDown!(event);
+    onReturnToToolbar.mockImplementation(() => {
+      expect(input).toHaveBeenLastCalledWith({ type: "input_keyboard", eventType: "keyUp", key: "Shift", code: "ShiftLeft", windowsVirtualKeyCode: 16, modifiers: 0 });
+    });
+    const escape = { ...event, key: "Escape", code: "Escape", keyCode: 27 };
+    props.onKeyDown!(escape); props.onKeyUp!(escape);
+    expect(onReturnToToolbar).toHaveBeenCalledOnce();
+    expect(input.mock.calls.map(([body]) => [body.eventType, body.key])).toEqual([["keyDown", "Shift"], ["keyUp", "Shift"]]);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(2);
+    expect(props["aria-keyshortcuts"]).toBe("Shift+Escape");
+    expect(props["aria-description"]).toContain("return to the browser address bar");
+    expect(props.title).toContain("Shift+Escape");
+  });
+
+  it.each([[0, "none"], [1, "left"], [2, "right"], [4, "middle"], [8, "none"]])("preserves the held mouse button for movement (buttons=%s)", (buttons, button) => {
+    const { input, props } = viewport();
+    props.onPointerMove!({ buttons, clientX: 20, clientY: 30, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false } as PointerEvent<HTMLImageElement>);
+    expect(input).toHaveBeenCalledExactlyOnceWith({ type: "input_mouse", eventType: "mouseMoved", x: 0, y: 0, button, modifiers: 0 });
+  });
+
+  it("does not send keyboard or pointer input while just watching", () => {
+    const { input, onReturnToToolbar, props } = viewport(false);
+    const event = { key: "Escape", nativeEvent: { isComposing: false } } as KeyboardEvent<HTMLImageElement>;
+    props.onKeyDown!(event); props.onKeyUp!(event);
+    props.onKeyDown!({ ...event, shiftKey: true }); props.onKeyUp!({ ...event, shiftKey: true });
+    props.onPointerMove!({ buttons: 2 } as PointerEvent<HTMLImageElement>);
+    expect(input).not.toHaveBeenCalled();
+    expect(onReturnToToolbar).not.toHaveBeenCalled();
+    expect(props["aria-keyshortcuts"]).toBeUndefined();
+  });
 });
 
 describe("browser focus-loss cleanup", () => {

--- a/src/components/BrowserViewport.tsx
+++ b/src/components/BrowserViewport.tsx
@@ -30,9 +30,9 @@ export function createBrowserPressedInputs(input: BrowserInput) {
   };
 }
 
-export function BrowserViewport({ frame, width, height, driving, input: sendInput, acknowledge, onDecodeError }: {
+export function BrowserViewport({ frame, width, height, driving, input: sendInput, acknowledge, onDecodeError, onReturnToToolbar }: {
   frame: BrowserFrame; width: number; height: number; driving: boolean;
-  input: BrowserInput; acknowledge: (seq: number) => void; onDecodeError: () => void;
+  input: BrowserInput; acknowledge: (seq: number) => void; onDecodeError: () => void; onReturnToToolbar: () => void;
 }) {
   const screen = useRef<HTMLImageElement>(null);
   const pressed = useMemo(() => createBrowserPressedInputs(sendInput), [sendInput]);
@@ -73,6 +73,9 @@ export function BrowserViewport({ frame, width, height, driving, input: sendInpu
   }, [driving, input, width, height]);
   return <>
     <img ref={screen} src={`data:image/${frame.format === "png" ? "png" : "jpeg"};base64,${frame.data}`} alt="Live bot browser" draggable={false} tabIndex={driving ? 0 : -1}
+      title={driving ? "Shift+Escape returns to the browser address bar." : undefined}
+      aria-description={driving ? "Keyboard input goes to the remote page. Press Shift+Escape to return to the browser address bar." : undefined}
+      aria-keyshortcuts={driving ? "Shift+Escape" : undefined}
       className={`block h-auto w-full select-none outline-none focus:ring-2 focus:ring-inset focus:ring-accent ${driving ? "cursor-default touch-none" : "cursor-not-allowed"}`}
       onLoad={rendered} onError={onDecodeError}
       onBlur={pressed.release}
@@ -88,17 +91,20 @@ export function BrowserViewport({ frame, width, height, driving, input: sendInpu
         input({ type: "input_mouse", eventType: "mouseReleased", ...point(e.clientX, e.clientY), button: e.button === 2 ? "right" : e.button === 1 ? "middle" : "left", clickCount: e.detail || 1, modifiers: modifiers(e) });
       }}
       onPointerCancel={pressed.release}
-      onPointerMove={(e) => { if (driving) input({ type: "input_mouse", eventType: "mouseMoved", ...point(e.clientX, e.clientY), button: e.buttons ? "left" : "none", modifiers: modifiers(e) }); }}
+      onPointerMove={(e) => { if (driving) input({ type: "input_mouse", eventType: "mouseMoved", ...point(e.clientX, e.clientY), button: e.buttons & 1 ? "left" : e.buttons & 2 ? "right" : e.buttons & 4 ? "middle" : "none", modifiers: modifiers(e) }); }}
       onKeyDown={(e) => {
         if (!driving || e.nativeEvent.isComposing) return;
-        if (e.key === "Escape") { e.currentTarget.blur(); return; }
+        if (e.key === "Escape" && e.shiftKey) {
+          e.preventDefault(); e.stopPropagation(); pressed.release(); onReturnToToolbar(); return;
+        }
         // Native paste supplies actual clipboard text via onPaste below.
         if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "v") return;
         e.preventDefault();
         input({ type: "input_keyboard", eventType: "keyDown", key: e.key, code: e.code, windowsVirtualKeyCode: e.keyCode, modifiers: modifiers(e), ...(e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey ? { text: e.key } : {}) });
       }}
       onKeyUp={(e) => {
-        if (!driving || e.key === "Escape" || ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "v")) return;
+        if (!driving || ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "v")) return;
+        if (e.key === "Escape" && e.shiftKey) { e.preventDefault(); e.stopPropagation(); return; }
         e.preventDefault(); input({ type: "input_keyboard", eventType: "keyUp", key: e.key, code: e.code, windowsVirtualKeyCode: e.keyCode, modifiers: modifiers(e) });
       }}
       onPaste={(e) => { if (driving) { e.preventDefault(); input({ type: "input_keyboard", eventType: "char", text: e.clipboardData.getData("text/plain").slice(0, 4096) }); } }}


### PR DESCRIPTION
## What changed

- Route Backspace, Enter, Tab, Escape, Delete, navigation keys and modified shortcuts through agent-browser's acknowledged native key resolver. Avoid duplicate releases while preserving input draining and the existing restart barrier for uncertain input.
- Ignore late events from an old live connection so reconnect/profile switches cannot clear the replacement viewer.
- Forward Escape into the remote page; provide Shift+Escape to release held input and return keyboard focus to the address bar.
- Preserve right/middle mouse buttons during movement and label the existing Take control / Return to bot button.
- Expand the disposable browser fixture and regression tests. No new dependencies or browser engine changes.

## Why

The real live widget accepted text but Backspace did nothing: the native raw-key relay omits the virtual key codes its press resolver supplies. Escape was intercepted locally, and a stale stream error could invalidate a replacement connection.

## How it was verified

- 173 tests across all 11 browser-related test files passed.
- Post-rebase type checks, strict zero-warning lint, locale validation and packaged-server build passed. The production frontend build also passed.
- Real BrowserPanel exercised in a disposable HOME with the installed agent-browser 0.37.0 and Chrome for Testing 152.0.7977.82: navigation, typing, Backspace/Enter/Tab/arrows/Delete, remote dialog Escape, hand-back/reconnect/retake, and clean shared-profile switching with original-page restoration.
- Shift+Escape → address bar → Tab → Return to bot tested using only keyboard input.
- Installed browser-bundle smoke passed cold start, navigation, input, restart, PNG capture, and two-bot cookie/localStorage isolation.
- After rebasing onto main at `1ce7b1f2`, full `pnpm test` passed: 441 test files / 5,471 tests passed (39 skipped, 1 todo), plus 8 broker tests, 155 Electron tests, and the packaged-server boot/proxy/MCP smoke. CI must pass before merge.
- No live user bots, browser profiles, credentials, or conversations were modified. Fixture processes and temporary data were cleaned up.

## UI verification

The two-row browser layout remains unchanged. The existing hand icon now has a visible Take control / Return to bot label; the keyboard exit hint is exposed through a tooltip and accessibility attributes, with no additional panels.

| Before | After |
| --- | --- |
| Backspace left a typed character unchanged | Backspace removes it; Enter submits the native form |
| Escape left the remote dialog open | Escape closes it; Shift+Escape returns to the toolbar |
| A late old-stream error could clear the replacement viewer | Reconnect preserves the page and new viewer |

Native screenshots and accessibility snapshots were inspected during fixture verification; they are not attached here. Windows and the full desktop shell were not manually exercised in this macOS fixture.

## Checklist

- [x] Full `pnpm test` and post-rebase checks complete
- [x] Server behavior changes have regression tests
- [x] No build output or dependency changes
- [x] No new platform-specific behavior or shell command construction
- [x] No secrets in logs, responses, events, or argv
