### PR TITLE
ci(verify): let Chrome build its sandbox in the ui-smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,12 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Let Chrome build its sandbox on this runner
+        # Ubuntu 24.04's AppArmor profile blocks unprivileged user namespaces,
+        # so the downloaded Chrome for Testing dies with "No usable sandbox".
+        # This is Chrome's own documented fix for 23.10+; a developer machine
+        # needs nothing, and the sandbox itself stays on.
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
       - name: Drive the real renderer through control-omb ui
         env:
           OMB_UI_E2E: "1"


### PR DESCRIPTION
## What changed

One step in the advisory `ui-smoke` job, before the renderer recipe runs: `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0`.

## Why

The job's first run on #1043 failed at browser start. Chrome for Testing exited with `No usable sandbox! If you are running on Ubuntu 23.10+ …` because the runner's AppArmor profile blocks unprivileged user namespaces. This is Chrome's own documented fix for those Ubuntu releases and keeps the sandbox on, rather than passing `--no-sandbox`. A developer machine needs nothing; the recipe passes on macOS as is.

## How it was verified

Cannot be reproduced on macOS. The job itself is the verification: it is advisory and runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Chrome-based renderer smoke test reliability on Ubuntu 24.04 by allowing the browser sandbox to initialize correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->