### PR TITLE
feat(fleet): many client workspaces on one server, each its own account, service and site

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -309,6 +309,45 @@ that makes one read-only request to the provider from the server.
   always uses a personal ChatGPT login.
 - **xAI API key**: the Grok API engine and xAI image generation.
 
+## Many client workspaces on one server
+
+`openmausbot fleet` runs one workspace per client on a single Linux server,
+each as its own OS user, its own `openmausbot@<name>` service on its own
+loopback ports, its own data folder, brand, sign-in list and provider key,
+reached at `<name>.<your domain>` through the system Caddy. Bots of one
+workspace cannot read another's files or reach its API: the data lives in a
+private home, the unit runs with a private `/tmp`, no new privileges and a
+read-only system, and an nftables rule keeps each workspace's ports to its
+own user, Caddy and root.
+
+Once, as root, with the package installed permanently and a wildcard DNS
+record (`*.example.com`) pointing at the server:
+
+```sh
+openmausbot fleet init --domain example.com
+```
+
+That writes the template unit, the fence and its unit, the workspace folders,
+and adds `import /etc/caddy/omb.d/*.caddy` to `/etc/caddy/Caddyfile`. Then per
+client:
+
+```sh
+openmausbot fleet create acme --admin owner@acme.test --member @acme.test \
+  --brand /root/acme-brand.json --anthropic-key-file /root/acme-anthropic.key \
+  --cap 50 --memory 1G
+openmausbot fleet users acme add bob@acme.test --chat-only
+openmausbot fleet list
+openmausbot fleet suspend acme      # 503 page, service stopped; resume undoes it
+openmausbot fleet upgrade           # new release, then every running workspace restarted in turn
+openmausbot fleet delete acme --yes # add --keep-data to keep the home folder
+```
+
+`https://acme.example.com` is up when `create` returns; the first admin signs
+in with an emailed code. `OMB_LICENSE_KEY` in the environment (or
+`--license-key`) is carried into every workspace so a partner's white-label
+key covers them all. Not root? Every command prints the exact steps to run as
+root instead, and `--dry-run` always prints.
+
 ## Signing the engines in without a terminal
 
 On a hosted server, the engine CLIs sign in from Settings → Engines:

--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -45,6 +45,7 @@ Use only mapped, tested commands:
 - [Codex bot instructions](codex-instructions.md)
 - [Qwen model route selection](qwen-models.md)
 - [Team backups](team-backups.md)
+- [Fleet: many workspaces on one server](fleet.md)
 - [Usage ledger](usage-ledger.md)
 - [Spend cap and sell prices](spend-cap.md)
 

--- a/docs/verification/fleet.md
+++ b/docs/verification/fleet.md
@@ -1,0 +1,66 @@
+# Fleet: many workspaces on one server
+
+## Sub-features
+
+- `fleet init`: template unit, loopback fence and its unit, workspace folders,
+  registry, and the Caddy import, once per server.
+- `fleet create`: a workspace as its own OS user with private data, its
+  sign-in list, brand, provider key and cap seeded, fenced ports, a service
+  started now and at boot, a site block, and a health wait.
+- `fleet users`, `suspend`, `resume`, `delete` (with `--yes`, optionally
+  `--keep-data`), `upgrade` (rolling restarts), `list`.
+- Plans, never shell strings: fixed argument lists as root, or printed for an
+  operator; `--dry-run` always prints.
+
+## User path
+
+An operator runs the commands on the server. A client's admin gets a link to
+`https://<name>.<domain>` and signs in with an emailed code.
+
+## Driving it
+
+The planners and the command are proven offline:
+
+```sh
+pnpm exec vitest run server/fleet.test.ts server/fleet-cli.test.ts server/cli.test.ts
+```
+
+These pin the rendered template unit (per-slug user, private `/tmp`, no new
+privileges, read-only system, the `${OMB_PORT}`-style expansion), the
+nftables fence rules, the running and suspended Caddy site blocks, the
+environment file, the seeded config, the argument lists and their order for
+every operation, the registry kept in step, the health wait placement, the
+exact root-shell rendering of a plan, and the CLI stopping at the first
+failed step without repeating the tool's output beyond its last lines.
+
+Dry-run on any machine, to read what a real run would do:
+
+```sh
+openmausbot fleet init --domain example.test --dry-run
+openmausbot fleet create acme --admin owner@acme.test --dry-run
+```
+
+## A real server
+
+Not proven in this repository's CI: it needs root, systemd, nftables and
+Caddy. The recipe for a disposable VPS (the same shape as the Hetzner launch
+record):
+
+1. Fresh Ubuntu 24.04 or newer, Caddy from apt, `npm install -g openmausbot`,
+   Claude Code installed once as root, a wildcard DNS record at the server.
+2. `openmausbot fleet init --domain <domain>`; check `systemctl status
+   openmausbot-fence` and `nft list table inet openmausbot`.
+3. `openmausbot fleet create alpha --admin you@example.test --cap 1` and the
+   same for `beta`; both `https://alpha.<domain>` and `https://beta.<domain>`
+   must show the pair page with a certificate.
+4. Isolation: as `omb-alpha` (`runuser -u omb-alpha -- curl -s
+   http://127.0.0.1:<beta port>/api/health`) the connection must be refused;
+   as root it must answer. `ls /var/lib/openmausbot/beta` as `omb-alpha` must
+   be denied.
+5. `fleet users alpha add other@example.test --chat-only`, sign in as that
+   address, confirm chat-only scope.
+6. `fleet suspend beta` shows the 503 page; `fleet resume beta` restores it.
+7. `fleet upgrade` after a release restarts both in turn; `fleet delete beta
+   --yes` removes the account and site.
+
+Record the run as a dated file next to this one.

--- a/server/cli.test.ts
+++ b/server/cli.test.ts
@@ -21,6 +21,16 @@ describe("openmausbot command line", () => {
     expect(serve).toMatchObject({ command: "serve", port: 9001, dataDir: resolve("/tmp/x"), label: "cab mini", tailscale: true, pair: false });
     expect(parseArgs(["pair", "--client", "--public-url", "https://h/"], {})).toMatchObject({ command: "pair", client: true, publicUrl: "https://h" });
     expect(parseArgs(["sessions", "revoke", "abc"], {})).toMatchObject({ command: "sessions", revoke: "abc" });
+    expect(parseArgs(["fleet", "create", "acme", "--admin", "ada@example.test", "--member", "@acme.test", "--member", "bob@acme.test", "--cap", "40", "--memory", "1G", "--dry-run"], {})).toMatchObject({
+      command: "fleet", fleetAction: "create", slug: "acme", admins: ["ada@example.test"], members: ["@acme.test", "bob@acme.test"], cap: 40, memory: "1G", dryRun: true,
+    });
+    expect(parseArgs(["fleet", "users", "acme", "add", "bob@acme.test", "--chat-only"], {})).toMatchObject({ command: "fleet", fleetAction: "users", slug: "acme", fleetUserAction: "add", email: "bob@acme.test", chatOnly: true });
+    expect(parseArgs(["fleet", "delete", "acme", "--yes", "--keep-data"], {})).toMatchObject({ fleetAction: "delete", slug: "acme", yes: true, keepData: true });
+    expect(parseArgs(["fleet", "init", "--domain", "AgentAda.cc"], {})).toMatchObject({ fleetAction: "init", domain: "agentada.cc" });
+    expect(parseArgs(["fleet"], {})).toMatchObject({ error: expect.stringContaining("fleet needs one of") });
+    expect(parseArgs(["fleet", "create"], {})).toMatchObject({ error: "fleet create needs a workspace name" });
+    expect(parseArgs(["fleet", "users", "acme"], {})).toMatchObject({ error: expect.stringContaining("add|remove") });
+    expect(parseArgs(["fleet", "create", "acme", "--cap", "-5"], {})).toMatchObject({ error: expect.stringContaining("--cap") });
     expect(parseArgs([], { OMB_PORT: "8123" })).toMatchObject({ command: "start", port: 8123 });
     expect(parseArgs(["--port", "8125", "--no-open", "--local"], {})).toMatchObject({ command: "start", port: 8125, open: false, local: true });
     expect(parseArgs(["--help"], {})).toMatchObject({ command: "help" });

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -34,6 +34,7 @@ import { parseAllowList } from "./account-signin.ts";
 import { writeFileAtomic } from "./atomic.ts";
 import { ensureCaddy, normalizeDomainOption, startCaddy, type RunningCaddy } from "./caddy.ts";
 import { runServiceCommand } from "./service-cli.ts";
+import { runFleetCommand, type FleetInput } from "./fleet-cli.ts";
 import { explainTailscaleFailure, tailscaleServe, tailscaleServeOff, tailscaleStatus, type TailscaleStatus } from "./tailscale.ts";
 import { defaultSetupIo, SetupCancelled, type SetupIo } from "./cli-prompts.ts";
 import { normalizePhoneOrigin, phonePairingInstructions, runPhoneSetup } from "./cli-phone-setup.ts";
@@ -59,7 +60,7 @@ import {
 const HERE = dirname(fileURLToPath(import.meta.url));
 
 export interface CliOptions {
-  command: "setup" | "start" | "serve" | "pair" | "sessions" | "status" | "login" | "logout" | "access" | "service" | "browser" | "help";
+  command: "setup" | "start" | "serve" | "pair" | "sessions" | "status" | "login" | "logout" | "access" | "service" | "browser" | "fleet" | "help";
   port: number;
   dataDir: string;
   label?: string;
@@ -79,6 +80,20 @@ export interface CliOptions {
   email?: string;
   /** `browser install [--with-deps]` */
   browserAction?: "install" | "status";
+  /** `fleet init|create|list|users|suspend|resume|delete|upgrade` */
+  fleetAction?: FleetInput["action"];
+  slug?: string;
+  admins?: string[];
+  members?: string[];
+  brandFile?: string;
+  anthropicKeyFile?: string;
+  cap?: number;
+  licenseKey?: string;
+  memory?: string;
+  dryRun?: boolean;
+  yes?: boolean;
+  keepData?: boolean;
+  fleetUserAction?: "add" | "remove";
   withDeps?: boolean;
   json: boolean;
   /** Explicitly ignore saved remote access for this launch. */
@@ -89,7 +104,7 @@ export interface CliOptions {
   phone?: "ios" | "android";
 }
 
-const COMMANDS = ["setup", "start", "serve", "pair", "sessions", "status", "login", "logout", "access", "service", "browser", "help", "--help", "-h"];
+const COMMANDS = ["setup", "start", "serve", "pair", "sessions", "status", "login", "logout", "access", "service", "browser", "fleet", "help", "--help", "-h"];
 
 export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): CliOptions | { error: string } {
   const implicitStart = !argv.length || (argv[0]!.startsWith("--") && argv[0] !== "--help");
@@ -143,6 +158,20 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
       else if (options.command === "service" && !options.serviceAction && (arg === "install" || arg === "uninstall")) options.serviceAction = arg;
       else if (options.command === "browser" && (arg === "install" || arg === "status")) options.browserAction = arg;
       else if (options.command === "browser" && arg === "--with-deps") options.withDeps = true;
+      else if (options.command === "fleet" && !options.fleetAction && ["init", "create", "list", "users", "suspend", "resume", "delete", "upgrade"].includes(arg)) options.fleetAction = arg as FleetInput["action"];
+      else if (options.command === "fleet" && options.fleetAction && options.fleetAction !== "init" && options.fleetAction !== "list" && options.fleetAction !== "upgrade" && !options.slug && !arg.startsWith("--")) options.slug = arg;
+      else if (options.command === "fleet" && options.fleetAction === "users" && options.slug && !options.fleetUserAction && (arg === "add" || arg === "remove")) { options.fleetUserAction = arg; options.email = value(); }
+      else if (options.command === "fleet" && arg === "--admin") options.admins = [...(options.admins ?? []), value()];
+      else if (options.command === "fleet" && arg === "--member") options.members = [...(options.members ?? []), value()];
+      else if (options.command === "fleet" && arg === "--brand") options.brandFile = resolve(value());
+      else if (options.command === "fleet" && arg === "--anthropic-key-file") options.anthropicKeyFile = resolve(value());
+      else if (options.command === "fleet" && arg === "--cap") options.cap = Number(value());
+      else if (options.command === "fleet" && arg === "--license-key") options.licenseKey = value();
+      else if (options.command === "fleet" && arg === "--memory") options.memory = value();
+      else if (options.command === "fleet" && arg === "--dry-run") options.dryRun = true;
+      else if (options.command === "fleet" && arg === "--yes") options.yes = true;
+      else if (options.command === "fleet" && arg === "--keep-data") options.keepData = true;
+      else if (options.command === "fleet" && arg === "--chat-only") options.chatOnly = true;
       else return { error: `unknown argument "${arg}"` };
     } catch (error) {
       return { error: error instanceof Error ? error.message : String(error) };
@@ -156,6 +185,12 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
   if (options.domain && (options.tailscale || options.tunnel || options.publicUrl)) return { error: "--domain already gives the server its address; drop --tailscale, --tunnel and --public-url" };
   if (options.local && (options.tailscale || options.tunnel || options.publicUrl)) return { error: "--local cannot be combined with a remote-access option" };
   if (options.command === "browser" && !options.browserAction) return { error: "browser needs an action: install or status" };
+  if (options.command === "fleet") {
+    if (!options.fleetAction) return { error: "fleet needs one of: init --domain HOST, create NAME --admin EMAIL, list, users NAME add|remove EMAIL, suspend NAME, resume NAME, delete NAME --yes, upgrade" };
+    if (["create", "users", "suspend", "resume", "delete"].includes(options.fleetAction) && !options.slug) return { error: `fleet ${options.fleetAction} needs a workspace name` };
+    if (options.fleetAction === "users" && !options.fleetUserAction) return { error: "fleet users needs: NAME add|remove EMAIL [--chat-only]" };
+    if (options.cap !== undefined && (!Number.isFinite(options.cap) || options.cap < 0)) return { error: "--cap must be a dollar amount of 0 or more" };
+  }
   return options;
 }
 
@@ -174,6 +209,10 @@ export const USAGE = `openmausbot — your team of AI bots, ready in a few steps
   openmausbot access list | add EMAIL [--chat-only] | remove EMAIL
   openmausbot service install [--domain HOST | --tunnel | --tailscale] [--port N] [--data-dir DIR] | uninstall
   openmausbot browser install [--with-deps] | status
+  openmausbot fleet init --domain HOST | create NAME --admin EMAIL [--member EMAIL] [--brand FILE]
+                    [--anthropic-key-file FILE] [--cap USD] [--license-key KEY] [--memory 1G]
+                  | list | users NAME add|remove EMAIL [--chat-only] | suspend NAME | resume NAME
+                  | delete NAME --yes [--keep-data] | upgrade   (all take --dry-run)
 
 setup   choose AI access and optional phone access; keep existing bots and chats
 start   same as openmausbot: use your saved settings and open the workspace
@@ -197,6 +236,10 @@ browser install: the bots' browser engine (agent-browser, pinned) into the
         the Linux libraries Chrome needs (run as root once). Then run
         browser install as the user running serve, from that user's home.
         status: what the current user and data directory have.
+fleet   many client workspaces on one Linux server, each its own account,
+        service, data folder, brand, sign-in list and keys at NAME.HOST
+        behind the system Caddy. Plans are printed unless run as root;
+        --dry-run always prints. Install the package permanently first.
 
 --tailscale  serve over your tailnet: Tailscale terminates HTTPS and the
              link uses this machine's MagicDNS name (needs Tailscale signed in
@@ -1009,6 +1052,27 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
         label: options.label,
         script: process.argv[1] ?? "",
         node: process.execPath,
+      }, { log: (line) => console.log(line), error: (line) => console.error(line) });
+    case "fleet":
+      return runFleetCommand({
+        action: options.fleetAction!,
+        slug: options.slug,
+        domain: options.domain,
+        admins: options.admins ?? [],
+        members: options.members ?? [],
+        brandFile: options.brandFile,
+        anthropicKeyFile: options.anthropicKeyFile,
+        cap: options.cap,
+        licenseKey: options.licenseKey ?? process.env.OMB_LICENSE_KEY,
+        memory: options.memory,
+        dryRun: options.dryRun ?? false,
+        yes: options.yes ?? false,
+        keepData: options.keepData ?? false,
+        userAction: options.fleetUserAction,
+        email: options.email,
+        chatOnly: options.chatOnly,
+        node: process.execPath,
+        script: process.argv[1] ?? "",
       }, { log: (line) => console.log(line), error: (line) => console.error(line) });
     case "logout":
       return runLogout(options);

--- a/server/fleet-cli.test.ts
+++ b/server/fleet-cli.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { runFleetCommand, type FleetDeps, type FleetInput } from "./fleet-cli.ts";
+import { emptyRegistry } from "./fleet.ts";
+
+// A machine that records what the CLI would do to it. Nothing here touches
+// the real filesystem, systemd, nftables or Caddy.
+function machine(options: { root?: boolean; files?: Record<string, string>; failing?: string[] } = {}) {
+  const files = new Map(Object.entries(options.files ?? {}));
+  const calls: string[] = [];
+  const deps: FleetDeps = {
+    isRoot: () => options.root ?? false,
+    run: async (argv) => {
+      calls.push(`run ${argv.join(" ")}`);
+      const failing = options.failing?.some((prefix) => argv.join(" ").startsWith(prefix));
+      if (argv[0] === "systemctl" && argv[1] === "is-active") return { code: 0, output: "active\n" };
+      return failing ? { code: 1, output: "Failed to start: boom secret-token\n" } : { code: 0, output: "" };
+    },
+    readText: (path) => files.get(path) ?? null,
+    writeText: (path, content, mode) => { calls.push(`write ${path} ${mode.toString(8)}`); files.set(path, content); },
+    mkdir: (path, mode) => { calls.push(`mkdir ${path} ${mode.toString(8)}`); },
+    appendOnce: (path, line) => { calls.push(`append ${path} ${line}`); },
+    remove: (path) => { calls.push(`remove ${path}`); files.delete(path); },
+    health: async (url) => { calls.push(`health ${url}`); return !options.failing?.includes("health"); },
+  };
+  return { deps, calls, files };
+}
+
+const io = () => {
+  const out: string[] = [];
+  const err: string[] = [];
+  return { io: { log: (line: string) => out.push(line), error: (line: string) => err.push(line) }, out, err };
+};
+
+const base: FleetInput = {
+  action: "list", admins: [], members: [], dryRun: false, yes: false, keepData: false,
+  node: "/usr/bin/node", script: "/usr/lib/node_modules/openmausbot/cli.js", root: "/",
+};
+const registryFile = "/etc/openmausbot/fleet.json";
+const withRegistry = (workspaces = {}) => ({ [registryFile]: JSON.stringify({ ...emptyRegistry("agentada.cc"), workspaces }) });
+
+describe("openmausbot fleet", () => {
+  it("prints the plan instead of acting when not root, and on --dry-run even as root", async () => {
+    const { deps, calls } = machine();
+    const { io: log, out } = io();
+    expect(await runFleetCommand({ ...base, action: "init", domain: "agentada.cc" }, log, deps)).toBe(0);
+    expect(out[0]).toBe("not running as root; run these as root:");
+    expect(out.join("\n")).toContain("cat > /etc/systemd/system/openmausbot@.service <<'OMB_EOF'");
+    expect(out.join("\n")).toContain("systemctl enable --now openmausbot-fence.service");
+    expect(calls).toEqual([]);
+
+    const rooted = machine({ root: true, files: withRegistry() });
+    const dry = io();
+    expect(await runFleetCommand({ ...base, action: "create", slug: "acme", admins: ["ada@example.test"], dryRun: true }, dry.io, rooted.deps)).toBe(0);
+    expect(dry.out[0]).toBe("dry run; run these as root:");
+    expect(dry.out.join("\n")).toContain("useradd --system --create-home --home-dir /var/lib/openmausbot/acme");
+    expect(rooted.calls).toEqual([]);
+  });
+
+  it("refuses an npx cache as the unit's script and asks for the domain", async () => {
+    const { deps } = machine({ root: true });
+    const bad = io();
+    expect(await runFleetCommand({ ...base, action: "init", domain: "agentada.cc", script: "/root/.npm/_npx/abc/node_modules/openmausbot/cli.js" }, bad.io, deps)).toBe(2);
+    expect(bad.err[0]).toMatch(/npx|permanently/);
+    const missing = io();
+    expect(await runFleetCommand({ ...base, action: "init" }, missing.io, deps)).toBe(2);
+    expect(missing.err[0]).toContain("--domain");
+  });
+
+  it("creates a workspace as root in order, and stops at the first failed step without repeating secrets", async () => {
+    const { deps, calls, files } = machine({ root: true, files: { ...withRegistry(), "/srv/brand.json": '{"name":"Acme"}', "/srv/key.txt": "sk-ant-fixture\n" } });
+    const { io: log, out } = io();
+    const code = await runFleetCommand({ ...base, action: "create", slug: "acme", admins: ["ada@example.test"], members: ["@acme.test"], brandFile: "/srv/brand.json", anthropicKeyFile: "/srv/key.txt", cap: 40, licenseKey: "omb1.k" }, log, deps);
+    expect(code).toBe(0);
+    expect(calls.slice(0, 4)).toEqual([
+      "run useradd --system --create-home --home-dir /var/lib/openmausbot/acme --shell /usr/sbin/nologin --user-group omb-acme",
+      "mkdir /var/lib/openmausbot/acme/.openmausbot 700",
+      "run chown omb-acme:omb-acme /var/lib/openmausbot/acme/.openmausbot",
+      "write /var/lib/openmausbot/acme/.openmausbot/config.json 600",
+    ]);
+    expect(JSON.parse(files.get("/var/lib/openmausbot/acme/.openmausbot/config.json")!)).toEqual({
+      signIn: { admins: ["ada@example.test"], members: ["@acme.test"] }, anthropic: { key: "sk-ant-fixture" }, budgets: { monthlyUsd: 40 },
+    });
+    expect(files.get("/var/lib/openmausbot/acme/.openmausbot/brand.json")).toBe('{"name":"Acme"}');
+    expect(files.get("/etc/openmausbot/instances/acme.env")).toContain("OMB_LICENSE_KEY=omb1.k");
+    expect(calls).toContain("health http://127.0.0.1:8810/api/health");
+    expect(calls.at(-1)).toBe(`write ${registryFile} 600`);
+    expect(JSON.parse(files.get(registryFile)!).workspaces.acme).toMatchObject({ port: 8810, host: "acme.agentada.cc" });
+    expect(out.at(-1)).toContain("https://acme.agentada.cc is ready");
+
+    const broken = machine({ root: true, files: withRegistry(), failing: ["systemctl enable"] });
+    const failed = io();
+    expect(await runFleetCommand({ ...base, action: "create", slug: "beta", admins: ["b@example.test"] }, failed.io, broken.deps)).toBe(1);
+    expect(failed.err[0]).toContain("could not start the workspace now and at boot");
+    expect(failed.err.join("\n")).toContain("boom");
+    expect(broken.calls.some((call) => call.startsWith("health"))).toBe(false);
+    expect(broken.files.get(registryFile)).toBe(withRegistry()[registryFile]);
+  });
+
+  it("needs an initialised fleet, a known workspace, and --yes before deleting", async () => {
+    const { deps } = machine({ root: true });
+    const none = io();
+    expect(await runFleetCommand({ ...base, action: "create", slug: "acme", admins: ["a@b.test"] }, none.io, deps)).toBe(2);
+    expect(none.err[0]).toContain("fleet init");
+    const ready = machine({ root: true, files: withRegistry({ acme: { slug: "acme", host: "acme.agentada.cc", port: 8810, webhookPort: 8811, status: "running", createdAt: "" } }) });
+    const unknown = io();
+    expect(await runFleetCommand({ ...base, action: "suspend", slug: "nope" }, unknown.io, ready.deps)).toBe(2);
+    expect(unknown.err[0]).toContain('no workspace "nope"');
+    const unconfirmed = io();
+    expect(await runFleetCommand({ ...base, action: "delete", slug: "acme" }, unconfirmed.io, ready.deps)).toBe(2);
+    expect(unconfirmed.err[0]).toContain("--yes");
+    expect(ready.calls).toEqual([]);
+    const confirmed = io();
+    expect(await runFleetCommand({ ...base, action: "delete", slug: "acme", yes: true, keepData: true }, confirmed.io, ready.deps)).toBe(0);
+    expect(ready.calls).toContain("run userdel omb-acme");
+    expect(JSON.parse(ready.files.get(registryFile)!).workspaces).toEqual({});
+  });
+
+  it("edits a workspace's sign-in list in place, owned by the workspace, and lists what runs", async () => {
+    const dataFile = "/var/lib/openmausbot/acme/.openmausbot/config.json";
+    const ready = machine({ root: true, files: { ...withRegistry({ acme: { slug: "acme", host: "acme.agentada.cc", port: 8810, webhookPort: 8811, status: "running", createdAt: "" } }), [dataFile]: '{"signIn":{"admins":["ada@example.test"]}}' } });
+    const added = io();
+    expect(await runFleetCommand({ ...base, action: "users", slug: "acme", userAction: "add", email: "Bob@Acme.test", chatOnly: true }, added.io, ready.deps)).toBe(0);
+    expect(JSON.parse(ready.files.get(dataFile)!).signIn).toEqual({ admins: ["ada@example.test"], members: ["bob@acme.test"] });
+    expect(ready.calls).toContain(`run chown omb-acme:omb-acme ${dataFile}`);
+    expect(added.out.at(-1)).toContain("bob@acme.test can sign in");
+    const listed = io();
+    expect(await runFleetCommand({ ...base, action: "list" }, listed.io, ready.deps)).toBe(0);
+    expect(listed.out[0]).toMatch(/^acme\s+https:\/\/acme\.agentada\.cc\s+:8810\s+active$/);
+  });
+});

--- a/server/fleet-cli.ts
+++ b/server/fleet-cli.ts
@@ -1,0 +1,262 @@
+// `openmausbot fleet`: many client workspaces on one Linux server. The plans
+// come from fleet.ts; this runs them as root with fixed argument lists, or
+// prints them for an operator to paste into a root shell, and never builds
+// a shell command from user input.
+import { spawn } from "node:child_process";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { posix } from "node:path";
+import { unstableInstallWarning } from "./service-unit.ts";
+import {
+  applySignIn,
+  assertSlug,
+  createPlan,
+  deletePlan,
+  describeSteps,
+  fleetLayout,
+  fleetUser,
+  initPlan,
+  parseRegistry,
+  resumePlan,
+  suspendPlan,
+  upgradePlan,
+  workspaceDataDir,
+  type FleetLayout,
+  type FleetRegistry,
+  type FleetStep,
+} from "./fleet.ts";
+
+export interface FleetInput {
+  action: "init" | "create" | "list" | "users" | "suspend" | "resume" | "delete" | "upgrade";
+  slug?: string;
+  domain?: string;
+  admins: string[];
+  members: string[];
+  brandFile?: string;
+  anthropicKeyFile?: string;
+  cap?: number;
+  licenseKey?: string;
+  memory?: string;
+  dryRun: boolean;
+  yes: boolean;
+  keepData: boolean;
+  userAction?: "add" | "remove";
+  email?: string;
+  chatOnly?: boolean;
+  /** This CLI's own entry and node, for the template unit. */
+  node: string;
+  script: string;
+  /** Filesystem root for the layout; "/" outside tests. */
+  root?: string;
+}
+
+export interface FleetIo {
+  log(line: string): void;
+  error(line: string): void;
+}
+
+/** Everything that touches the machine, so tests can run the CLI dry. */
+export interface FleetDeps {
+  isRoot(): boolean;
+  run(argv: string[]): Promise<{ code: number | null; output: string }>;
+  readText(path: string): string | null;
+  writeText(path: string, content: string, mode: number): void;
+  mkdir(path: string, mode: number): void;
+  appendOnce(path: string, line: string): void;
+  remove(path: string): void;
+  health(url: string, timeoutMs: number): Promise<boolean>;
+}
+
+export function defaultFleetDeps(): FleetDeps {
+  return {
+    isRoot: () => typeof process.getuid === "function" && process.getuid() === 0,
+    run: (argv) =>
+      new Promise((resolve) => {
+        const [command, ...args] = argv;
+        let output = "";
+        try {
+          const child = spawn(command!, args, { stdio: ["ignore", "pipe", "pipe"] });
+          const receive = (chunk: Buffer) => { if (output.length < 16_384) output += chunk.toString("utf8"); };
+          child.stdout.on("data", receive);
+          child.stderr.on("data", receive);
+          child.once("error", (error) => resolve({ code: null, output: `${output}${error.message}` }));
+          child.once("close", (code) => resolve({ code, output }));
+        } catch (error) {
+          resolve({ code: null, output: error instanceof Error ? error.message : String(error) });
+        }
+      }),
+    readText: (path) => (existsSync(path) ? readFileSync(path, "utf8") : null),
+    writeText: (path, content, mode) => writeFileSync(path, content, { mode }),
+    mkdir: (path, mode) => mkdirSync(path, { recursive: true, mode }),
+    appendOnce: (path, line) => {
+      const current = existsSync(path) ? readFileSync(path, "utf8") : "";
+      if (!current.split("\n").some((existing) => existing.trim() === line)) appendFileSync(path, `${current.endsWith("\n") || !current ? "" : "\n"}\n${line}\n`);
+    },
+    remove: (path) => rmSync(path, { force: true }),
+    health: async (url, timeoutMs) => {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        try {
+          const response = await fetch(url, { signal: AbortSignal.timeout(2000) });
+          if (response.ok) return true;
+        } catch {
+          /* not up yet */
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+      return false;
+    },
+  };
+}
+
+const HEALTH_TIMEOUT_MS = 60_000;
+
+async function execute(steps: FleetStep[], deps: FleetDeps, io: FleetIo): Promise<number> {
+  for (const step of steps) {
+    switch (step.kind) {
+      case "mkdir":
+        deps.mkdir(step.path, step.mode);
+        if (step.owner) {
+          const chown = await deps.run(["chown", `${step.owner}:${step.owner}`, step.path]);
+          if (chown.code !== 0) return failed(io, `chown ${step.path}`, chown.output);
+        }
+        break;
+      case "write":
+        deps.writeText(step.path, step.content, step.mode);
+        if (step.owner) {
+          const chown = await deps.run(["chown", `${step.owner}:${step.owner}`, step.path]);
+          if (chown.code !== 0) return failed(io, `chown ${step.path}`, chown.output);
+        }
+        break;
+      case "append-once":
+        deps.appendOnce(step.path, step.line);
+        break;
+      case "remove":
+        deps.remove(step.path);
+        break;
+      case "run": {
+        const result = await deps.run(step.argv);
+        if (result.code !== 0) return failed(io, `${step.why} (${step.argv[0]} exited ${result.code ?? "without a code"})`, result.output);
+        break;
+      }
+      case "health":
+        if (!(await deps.health(step.url, HEALTH_TIMEOUT_MS))) return failed(io, step.why, `${step.url} did not answer within ${HEALTH_TIMEOUT_MS / 1000}s; check journalctl -u openmausbot@<slug>`);
+        break;
+      case "note":
+        io.log(step.text);
+        break;
+    }
+  }
+  return 0;
+}
+
+function failed(io: FleetIo, what: string, output: string): number {
+  io.error(`fleet: could not ${what}`);
+  const tail = output.trim().split("\n").slice(-6).join("\n");
+  if (tail) io.error(tail);
+  return 1;
+}
+
+function printPlan(steps: FleetStep[], io: FleetIo, reason: string): number {
+  io.log(`${reason}; run these as root:`);
+  io.log("");
+  for (const line of describeSteps(steps)) io.log(line);
+  return 0;
+}
+
+function loadRegistry(layout: FleetLayout, deps: FleetDeps): FleetRegistry {
+  const text = deps.readText(layout.registryFile);
+  if (text === null) throw new Error(`no fleet on this server yet: run \`openmausbot fleet init --domain your.domain\` first`);
+  return parseRegistry(text);
+}
+
+export async function runFleetCommand(input: FleetInput, io: FleetIo, deps: FleetDeps = defaultFleetDeps()): Promise<number> {
+  const layout = fleetLayout(input.root ?? "/");
+  const asRoot = deps.isRoot() && !input.dryRun;
+  const apply = (steps: FleetStep[], reason: string) => (asRoot ? execute(steps, deps, io) : Promise.resolve(printPlan(steps, io, reason)));
+  try {
+    switch (input.action) {
+      case "init": {
+        if (!input.domain) throw new Error("fleet init needs --domain, the domain whose subdomains the workspaces live at");
+        const warning = unstableInstallWarning(input.script);
+        if (warning) throw new Error(warning);
+        if (deps.readText(layout.registryFile) !== null && !input.yes) throw new Error(`${layout.registryFile} exists; pass --yes to rewrite the template unit and fence (workspaces are kept)`);
+        const existing = deps.readText(layout.registryFile);
+        const plan = initPlan({ domain: input.domain, node: input.node, script: input.script, layout });
+        if (existing) {
+          // Keep the workspaces already registered; only the domain and templates are rewritten.
+          const kept = parseRegistry(existing);
+          plan.registry.workspaces = kept.workspaces;
+          plan.registry.nextPort = kept.nextPort;
+          plan.steps = plan.steps.map((step) => (step.kind === "write" && step.path === layout.registryFile ? { ...step, content: `${JSON.stringify(plan.registry, null, 2)}\n` } : step));
+        }
+        return apply(plan.steps, input.dryRun ? "dry run" : "not running as root");
+      }
+      case "create": {
+        if (!input.slug) throw new Error("fleet create needs a workspace name");
+        const registry = loadRegistry(layout, deps);
+        const brandJson = input.brandFile ? deps.readText(input.brandFile) : undefined;
+        if (input.brandFile && brandJson === null) throw new Error(`${input.brandFile} not found`);
+        if (brandJson) JSON.parse(brandJson);
+        const anthropicKey = input.anthropicKeyFile ? deps.readText(input.anthropicKeyFile)?.trim() : undefined;
+        if (input.anthropicKeyFile && !anthropicKey) throw new Error(`${input.anthropicKeyFile} is missing or empty`);
+        const plan = createPlan({
+          registry,
+          slug: input.slug,
+          seed: { admins: input.admins, members: input.members, ...(anthropicKey ? { anthropicKey } : {}), ...(input.cap !== undefined ? { monthlyCapUsd: input.cap } : {}), ...(brandJson ? { brandJson } : {}) },
+          ...(input.licenseKey ? { licenseKey: input.licenseKey } : {}),
+          ...(input.memory ? { memoryMax: input.memory } : {}),
+          layout,
+        });
+        return apply(plan.steps, input.dryRun ? "dry run" : "not running as root");
+      }
+      case "list": {
+        const registry = loadRegistry(layout, deps);
+        const rows = Object.values(registry.workspaces).sort((a, b) => a.slug.localeCompare(b.slug));
+        if (!rows.length) {
+          io.log(`no workspaces yet on ${registry.domain}; create one with: openmausbot fleet create NAME --admin you@example.com`);
+          return 0;
+        }
+        for (const workspace of rows) {
+          const live = asRoot ? (await deps.run(["systemctl", "is-active", `openmausbot@${workspace.slug}.service`])).output.trim() : workspace.status;
+          io.log(`${workspace.slug.padEnd(24)} https://${workspace.host.padEnd(40)} :${String(workspace.port).padEnd(6)} ${live}`);
+        }
+        return 0;
+      }
+      case "users": {
+        if (!input.slug || !input.userAction || !input.email) throw new Error("fleet users needs: NAME add|remove EMAIL [--chat-only]");
+        assertSlug(input.slug);
+        const registry = loadRegistry(layout, deps);
+        if (!registry.workspaces[input.slug]) throw new Error(`no workspace "${input.slug}"`);
+        const file = posix.join(workspaceDataDir(layout, input.slug), "config.json");
+        const current = deps.readText(file) ?? "{}";
+        const next = applySignIn(current, input.userAction, input.email, Boolean(input.chatOnly));
+        const steps: FleetStep[] = [
+          { kind: "write", path: file, content: next.config, mode: 0o600, owner: fleetUser(input.slug) },
+          { kind: "note", text: next.summary },
+        ];
+        return apply(steps, input.dryRun ? "dry run" : "not running as root");
+      }
+      case "suspend":
+      case "resume": {
+        if (!input.slug) throw new Error(`fleet ${input.action} needs a workspace name`);
+        const registry = loadRegistry(layout, deps);
+        const plan = input.action === "suspend" ? suspendPlan({ registry, slug: input.slug, layout }) : resumePlan({ registry, slug: input.slug, layout });
+        return apply(plan.steps, input.dryRun ? "dry run" : "not running as root");
+      }
+      case "delete": {
+        if (!input.slug) throw new Error("fleet delete needs a workspace name");
+        if (!input.yes) throw new Error(`fleet delete removes the workspace's account${input.keepData ? "" : " and all of its data"}; pass --yes to confirm${input.keepData ? "" : ", or --keep-data to keep the home folder"}`);
+        const registry = loadRegistry(layout, deps);
+        const plan = deletePlan({ registry, slug: input.slug, keepData: input.keepData, layout });
+        return apply(plan.steps, input.dryRun ? "dry run" : "not running as root");
+      }
+      case "upgrade": {
+        const registry = loadRegistry(layout, deps);
+        return apply(upgradePlan({ registry }), input.dryRun ? "dry run" : "not running as root");
+      }
+    }
+  } catch (error) {
+    io.error(`fleet: ${error instanceof Error ? error.message : String(error)}`);
+    return 2;
+  }
+}

--- a/server/fleet.test.ts
+++ b/server/fleet.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import {
+  allocatePort,
+  applySignIn,
+  assertSlug,
+  caddySite,
+  createPlan,
+  deletePlan,
+  describeSteps,
+  emptyRegistry,
+  fenceRules,
+  fleetLayout,
+  initPlan,
+  initialConfig,
+  instanceEnv,
+  parseRegistry,
+  resumePlan,
+  suspendPlan,
+  templateUnit,
+  upgradePlan,
+  type FleetStep,
+  type FleetWorkspace,
+} from "./fleet.ts";
+
+const layout = fleetLayout("/");
+const now = new Date("2026-09-10T08:00:00Z");
+const argvOf = (steps: FleetStep[]) => steps.flatMap((step) => (step.kind === "run" ? [step.argv.join(" ")] : []));
+const writesOf = (steps: FleetStep[]) => steps.flatMap((step) => (step.kind === "write" ? [step.path] : []));
+
+describe("fleet naming", () => {
+  it("accepts DNS-label workspace names and refuses the rest", () => {
+    for (const ok of ["acme", "globex-2", "a1"]) expect(() => assertSlug(ok)).not.toThrow();
+    for (const bad of ["Acme", "-acme", "a", "acme_inc", "a".repeat(32), "acme.co", "../etc"]) expect(() => assertSlug(bad)).toThrow("not a workspace name");
+  });
+
+  it("allocates loopback ports in strides and skips ones already taken", () => {
+    const registry = emptyRegistry("agentada.cc");
+    expect(allocatePort(registry)).toEqual({ port: 8810, next: 8820 });
+    registry.workspaces.acme = { slug: "acme", host: "acme.agentada.cc", port: 8810, webhookPort: 8811, status: "running", createdAt: "" };
+    registry.nextPort = 8810;
+    expect(allocatePort(registry)).toEqual({ port: 8820, next: 8830 });
+    expect(() => parseRegistry('{"version":2}')).toThrow("registry");
+    expect(parseRegistry(JSON.stringify(registry)).workspaces.acme?.port).toBe(8810);
+  });
+});
+
+describe("rendered files", () => {
+  it("renders one template unit for every workspace, hardened and parameterised by slug", () => {
+    const unit = templateUnit({ node: "/usr/bin/node", script: "/usr/lib/node_modules/openmausbot/cli.js", layout });
+    expect(unit).toContain("User=omb-%i");
+    expect(unit).toContain("EnvironmentFile=/etc/openmausbot/instances/%i.env");
+    expect(unit).toContain("ExecStart=/usr/bin/node /usr/lib/node_modules/openmausbot/cli.js serve --port ${OMB_PORT} --data-dir ${OMB_DATA_DIR} --public-url ${OMB_PUBLIC_URL} --label %i --no-pair");
+    for (const line of ["PrivateTmp=yes", "NoNewPrivileges=yes", "ProtectSystem=strict", "ReadWritePaths=/var/lib/openmausbot/%i"]) expect(unit).toContain(line);
+    expect(templateUnit({ node: "/usr/bin/node", script: "/src/server/cli.ts", layout })).toContain("--experimental-strip-types /src/server/cli.ts");
+  });
+
+  it("fences each workspace's loopback ports to its own user, Caddy and root", () => {
+    const rules = fenceRules([
+      { slug: "globex", host: "globex.x", port: 8820, webhookPort: 8821, status: "running", createdAt: "" },
+      { slug: "acme", host: "acme.x", port: 8810, webhookPort: 8811, status: "running", createdAt: "" },
+    ]);
+    expect(rules).toContain("add table inet openmausbot\nflush table inet openmausbot");
+    expect(rules.indexOf("omb-acme")).toBeLessThan(rules.indexOf("omb-globex"));
+    expect(rules).toContain("oif lo tcp dport { 8810, 8811 } meta skuid != { omb-acme, caddy, root } reject");
+    expect(fenceRules([])).not.toContain("reject");
+  });
+
+  it("serves a running workspace and answers 503 for a suspended one", () => {
+    const running = caddySite({ host: "acme.agentada.cc", port: 8810, webhookPort: 8811, status: "running" });
+    expect(running).toContain("acme.agentada.cc {");
+    expect(running).toContain("reverse_proxy 127.0.0.1:8811");
+    expect(running).toContain("reverse_proxy 127.0.0.1:8810 {");
+    expect(running).toContain("flush_interval -1");
+    expect(caddySite({ host: "acme.agentada.cc", port: 8810, webhookPort: 8811, status: "suspended" })).toContain('respond "This workspace is suspended." 503');
+  });
+
+  it("writes the environment, the first config and the sign-in edits the server reads live", () => {
+    const workspace: FleetWorkspace = { slug: "acme", host: "acme.agentada.cc", port: 8810, webhookPort: 8811, status: "running", createdAt: "" };
+    expect(instanceEnv({ workspace, dataDir: "/var/lib/openmausbot/acme/.openmausbot", licenseKey: "omb1.k" })).toBe(
+      "OMB_DATA_DIR=/var/lib/openmausbot/acme/.openmausbot\nOMB_PORT=8810\nOMB_WEBHOOK_PORT=8811\nOMB_PUBLIC_URL=https://acme.agentada.cc\nOMB_LICENSE_KEY=omb1.k\n",
+    );
+    expect(JSON.parse(initialConfig({ admins: ["ada@example.test"], members: ["@acme.test"], anthropicKey: "sk-ant-x", monthlyCapUsd: 50 }))).toEqual({
+      signIn: { admins: ["ada@example.test"], members: ["@acme.test"] }, anthropic: { key: "sk-ant-x" }, budgets: { monthlyUsd: 50 },
+    });
+    const added = applySignIn('{"anthropic":{"key":"k"},"signIn":{"admins":["ada@example.test"]}}', "add", "Bob@Acme.test", true);
+    expect(JSON.parse(added.config)).toEqual({ anthropic: { key: "k" }, signIn: { admins: ["ada@example.test"], members: ["bob@acme.test"] } });
+    expect(added.summary).toContain("chat and approvals");
+    const removed = applySignIn(added.config, "remove", "bob@acme.test", false);
+    expect(JSON.parse(removed.config).signIn).toEqual({ admins: ["ada@example.test"], members: [] });
+    expect(() => applySignIn(added.config, "remove", "nobody@acme.test", false)).toThrow("not on the list");
+    expect(() => applySignIn("{}", "add", "not an email", false)).toThrow("email");
+  });
+});
+
+describe("plans", () => {
+  it("initialises the server once: folders, registry, templates, fence, the Caddy import, and reloads", () => {
+    const { steps, registry } = initPlan({ domain: "AgentAda.cc", node: "/usr/bin/node", script: "/usr/lib/node_modules/openmausbot/cli.js", layout });
+    expect(registry).toEqual({ version: 1, domain: "agentada.cc", nextPort: 8810, workspaces: {} });
+    expect(writesOf(steps)).toEqual(["/etc/openmausbot/fleet.json", "/etc/systemd/system/openmausbot@.service", "/etc/openmausbot/fence.nft", "/etc/systemd/system/openmausbot-fence.service"]);
+    expect(steps.find((step) => step.kind === "append-once")).toEqual({ kind: "append-once", path: "/etc/caddy/Caddyfile", line: "import /etc/caddy/omb.d/*.caddy" });
+    expect(argvOf(steps)).toEqual(["systemctl daemon-reload", "systemctl enable --now openmausbot-fence.service", "systemctl reload caddy"]);
+    expect(() => initPlan({ domain: "not a domain", node: "n", script: "s", layout })).toThrow("domain name");
+  });
+
+  it("creates a workspace as its own account with private data, a fenced port, a unit and a site", () => {
+    const registry = emptyRegistry("agentada.cc");
+    const plan = createPlan({ registry, slug: "acme", seed: { admins: ["ada@example.test"], members: [] }, licenseKey: "omb1.k", memoryMax: "1G", now, layout });
+    expect(plan.workspace).toEqual({ slug: "acme", host: "acme.agentada.cc", port: 8810, webhookPort: 8811, status: "running", createdAt: now.toISOString() });
+    expect(plan.registry.nextPort).toBe(8820);
+    expect(argvOf(plan.steps)).toEqual([
+      "useradd --system --create-home --home-dir /var/lib/openmausbot/acme --shell /usr/sbin/nologin --user-group omb-acme",
+      "nft -f /etc/openmausbot/fence.nft",
+      "systemctl daemon-reload",
+      "systemctl enable --now openmausbot@acme.service",
+      "systemctl reload caddy",
+    ]);
+    const config = plan.steps.find((step) => step.kind === "write" && step.path.endsWith("/acme/.openmausbot/config.json"));
+    expect(config).toMatchObject({ mode: 0o600, owner: "omb-acme" });
+    const env = plan.steps.find((step) => step.kind === "write" && step.path === "/etc/openmausbot/instances/acme.env");
+    expect(env).toMatchObject({ mode: 0o600 });
+    // root keeps the environment file: it carries the licence key
+    expect(env).not.toHaveProperty("owner");
+    expect(plan.steps.find((step) => step.kind === "write" && step.path.endsWith("limits.conf"))).toMatchObject({ content: "[Service]\nMemoryMax=1G\n" });
+    expect(plan.steps.find((step) => step.kind === "health")).toMatchObject({ url: "http://127.0.0.1:8810/api/health" });
+    // the health wait sits between starting the unit and exposing it through Caddy
+    const sequence = plan.steps.flatMap((step) => (step.kind === "run" ? [step.argv[0] === "systemctl" ? step.argv.slice(0, 2).join(" ") : step.argv[0]] : step.kind === "health" ? ["health"] : []));
+    expect(sequence).toEqual(["useradd", "nft", "systemctl daemon-reload", "systemctl enable", "health", "systemctl reload"]);
+    expect(plan.steps.at(-1)).toMatchObject({ kind: "note", text: expect.stringContaining("https://acme.agentada.cc is ready") });
+    expect(() => createPlan({ registry: plan.registry, slug: "acme", seed: { admins: ["x@y.test"], members: [] }, layout })).toThrow("already exists");
+    expect(() => createPlan({ registry, slug: "beta", seed: { admins: [], members: [] }, layout })).toThrow("at least one admin");
+    expect(() => createPlan({ registry, slug: "beta", seed: { admins: ["x@y.test"], members: [] }, memoryMax: "lots", layout })).toThrow("--memory");
+  });
+
+  it("suspends, resumes, deletes and upgrades with the registry kept in step", () => {
+    const created = createPlan({ registry: emptyRegistry("agentada.cc"), slug: "acme", seed: { admins: ["a@b.test"], members: [] }, now, layout });
+    const suspended = suspendPlan({ registry: created.registry, slug: "acme", layout });
+    expect(suspended.registry.workspaces.acme?.status).toBe("suspended");
+    expect(argvOf(suspended.steps)).toEqual(["systemctl disable --now openmausbot@acme.service", "systemctl reload caddy"]);
+    expect(suspended.steps.find((step) => step.kind === "write" && step.path.endsWith("acme.caddy"))).toMatchObject({ content: expect.stringContaining("503") });
+    const resumed = resumePlan({ registry: suspended.registry, slug: "acme", layout });
+    expect(resumed.registry.workspaces.acme?.status).toBe("running");
+    expect(argvOf(resumed.steps)).toEqual(["systemctl enable --now openmausbot@acme.service", "systemctl reload caddy"]);
+    const kept = deletePlan({ registry: resumed.registry, slug: "acme", keepData: true, layout });
+    expect(kept.registry.workspaces).toEqual({});
+    expect(argvOf(kept.steps)).toContain("userdel omb-acme");
+    expect(argvOf(deletePlan({ registry: resumed.registry, slug: "acme", keepData: false, layout }).steps)).toContain("userdel --remove omb-acme");
+    expect(() => deletePlan({ registry: kept.registry, slug: "acme", keepData: true, layout })).toThrow('no workspace "acme"');
+    const two = createPlan({ registry: created.registry, slug: "globex", seed: { admins: ["g@x.test"], members: [] }, now, layout }).registry;
+    expect(argvOf(upgradePlan({ registry: suspendPlan({ registry: two, slug: "globex", layout }).registry }))).toEqual(["npm install -g openmausbot@latest", "systemctl restart openmausbot@acme.service"]);
+  });
+
+  it("describes a plan as lines a root shell can run, quoting only what needs it", () => {
+    const lines = describeSteps([
+      { kind: "mkdir", path: "/var/lib/openmausbot/acme/.openmausbot", mode: 0o700, owner: "omb-acme" },
+      { kind: "write", path: "/etc/openmausbot/instances/acme.env", content: "OMB_PORT=8810\n", mode: 0o600 },
+      { kind: "run", argv: ["useradd", "--comment", "Acme Inc", "omb-acme"], why: "the account" },
+      { kind: "append-once", path: "/etc/caddy/Caddyfile", line: "import /etc/caddy/omb.d/*.caddy" },
+      { kind: "note", text: "done" },
+    ]);
+    expect(lines).toEqual([
+      "install -d -m 700 -o omb-acme -g omb-acme /var/lib/openmausbot/acme/.openmausbot",
+      "cat > /etc/openmausbot/instances/acme.env <<'OMB_EOF'",
+      "OMB_PORT=8810",
+      "OMB_EOF",
+      "chmod 600 /etc/openmausbot/instances/acme.env",
+      "useradd --comment 'Acme Inc' omb-acme   # the account",
+      "grep -qxF 'import /etc/caddy/omb.d/*.caddy' /etc/caddy/Caddyfile || printf '\\n%s\\n' 'import /etc/caddy/omb.d/*.caddy' >> /etc/caddy/Caddyfile",
+      "# done",
+    ]);
+  });
+});

--- a/server/fleet.ts
+++ b/server/fleet.ts
@@ -1,0 +1,435 @@
+// Many client workspaces on one Linux server: each is its own OS user, its
+// own `openmausbot@<slug>` service on its own loopback ports, its own data
+// folder, brand, sign-in list and keys, reached at <slug>.<domain> through
+// the system Caddy. This module only PLANS: it renders files and fixed
+// argument lists as steps, so what the CLI does as root is inspectable and
+// testable, and nothing here ever builds a shell command string.
+import { posix } from "node:path";
+
+const { join } = posix;
+
+/** A workspace name: DNS label and Unix user suffix at once. */
+export const FLEET_SLUG = /^[a-z][a-z0-9-]{1,30}$/;
+export const FLEET_USER_PREFIX = "omb-";
+export const FLEET_FIRST_PORT = 8810;
+export const FLEET_PORT_STRIDE = 10;
+
+export interface FleetLayout {
+  etcDir: string;
+  registryFile: string;
+  instancesDir: string;
+  unitFile: string;
+  fenceFile: string;
+  fenceUnitFile: string;
+  caddyDir: string;
+  caddyfile: string;
+  homesDir: string;
+}
+
+export function fleetLayout(root = "/"): FleetLayout {
+  const at = (...parts: string[]) => join(root, ...parts);
+  return {
+    etcDir: at("etc", "openmausbot"),
+    registryFile: at("etc", "openmausbot", "fleet.json"),
+    instancesDir: at("etc", "openmausbot", "instances"),
+    unitFile: at("etc", "systemd", "system", "openmausbot@.service"),
+    fenceFile: at("etc", "openmausbot", "fence.nft"),
+    fenceUnitFile: at("etc", "systemd", "system", "openmausbot-fence.service"),
+    caddyDir: at("etc", "caddy", "omb.d"),
+    caddyfile: at("etc", "caddy", "Caddyfile"),
+    homesDir: at("var", "lib", "openmausbot"),
+  };
+}
+
+export interface FleetWorkspace {
+  slug: string;
+  host: string;
+  port: number;
+  webhookPort: number;
+  status: "running" | "suspended";
+  createdAt: string;
+}
+
+export interface FleetRegistry {
+  version: 1;
+  domain: string;
+  nextPort: number;
+  workspaces: Record<string, FleetWorkspace>;
+}
+
+export function emptyRegistry(domain: string): FleetRegistry {
+  return { version: 1, domain, nextPort: FLEET_FIRST_PORT, workspaces: {} };
+}
+
+export function parseRegistry(text: string): FleetRegistry {
+  const value: unknown = JSON.parse(text);
+  const record = value && typeof value === "object" ? (value as Partial<FleetRegistry>) : null;
+  if (!record || record.version !== 1 || typeof record.domain !== "string" || typeof record.nextPort !== "number" || !record.workspaces || typeof record.workspaces !== "object") {
+    throw new Error("fleet.json is not a fleet registry this version understands");
+  }
+  return { version: 1, domain: record.domain, nextPort: record.nextPort, workspaces: { ...record.workspaces } };
+}
+
+export function fleetUser(slug: string): string {
+  return `${FLEET_USER_PREFIX}${slug}`;
+}
+
+export function workspaceHome(layout: FleetLayout, slug: string): string {
+  return join(layout.homesDir, slug);
+}
+
+export function workspaceDataDir(layout: FleetLayout, slug: string): string {
+  return join(workspaceHome(layout, slug), ".openmausbot");
+}
+
+export function assertSlug(slug: string): void {
+  if (!FLEET_SLUG.test(slug)) throw new Error(`"${slug}" is not a workspace name: lowercase letters, digits and dashes, 2 to 31 characters, starting with a letter`);
+}
+
+export function assertDomain(domain: string): void {
+  if (!/^(?=.{1,253}$)([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/i.test(domain)) throw new Error(`"${domain}" is not a domain name`);
+}
+
+export function assertEmailOrDomain(entry: string): void {
+  if (!entry || /\s/.test(entry) || (!entry.startsWith("@") && !entry.includes("@"))) throw new Error(`"${entry}" is not an email address or @domain`);
+}
+
+/** One thing the CLI does as root, or prints for the operator to do. */
+export type FleetStep =
+  | { kind: "mkdir"; path: string; mode: number; owner?: string }
+  | { kind: "write"; path: string; content: string; mode: number; owner?: string }
+  | { kind: "append-once"; path: string; line: string }
+  | { kind: "remove"; path: string }
+  | { kind: "run"; argv: string[]; why: string }
+  | { kind: "health"; url: string; why: string }
+  | { kind: "note"; text: string };
+
+/** The one unit every workspace runs from; `%i` is the slug. */
+export function templateUnit(spec: { node: string; script: string; layout?: FleetLayout }): string {
+  const layout = spec.layout ?? fleetLayout();
+  const strip = spec.script.endsWith(".ts") ? " --experimental-strip-types" : "";
+  return [
+    "# Written by `openmausbot fleet init`. One unit for every workspace: %i is the slug.",
+    "[Unit]",
+    "Description=OpenMausBot workspace %i",
+    "After=network-online.target",
+    "Wants=network-online.target",
+    "",
+    "[Service]",
+    "Type=simple",
+    `User=${FLEET_USER_PREFIX}%i`,
+    `Group=${FLEET_USER_PREFIX}%i`,
+    `WorkingDirectory=${layout.homesDir}/%i`,
+    `EnvironmentFile=${layout.instancesDir}/%i.env`,
+    `Environment=HOME=${layout.homesDir}/%i`,
+    "Environment=PATH=/usr/local/bin:/usr/bin:/bin",
+    `ExecStart=${spec.node}${strip} ${spec.script} serve --port \${OMB_PORT} --data-dir \${OMB_DATA_DIR} --public-url \${OMB_PUBLIC_URL} --label %i --no-pair`,
+    "Restart=always",
+    "RestartSec=3",
+    "KillMode=mixed",
+    "TimeoutStopSec=30",
+    "# Each workspace gets its own temp, cannot gain privileges, and writes only its own home.",
+    "PrivateTmp=yes",
+    "NoNewPrivileges=yes",
+    "ProtectSystem=strict",
+    "ProtectHome=yes",
+    `ReadWritePaths=${layout.homesDir}/%i`,
+    "",
+    "[Install]",
+    "WantedBy=multi-user.target",
+    "",
+  ].join("\n");
+}
+
+export function fenceUnit(layout = fleetLayout()): string {
+  return [
+    "# Written by `openmausbot fleet init`: keeps each workspace's loopback ports to its own user.",
+    "[Unit]",
+    "Description=OpenMausBot per-workspace loopback fence",
+    "Before=openmausbot@.service",
+    "",
+    "[Service]",
+    "Type=oneshot",
+    "RemainAfterExit=yes",
+    `ExecStart=/usr/sbin/nft -f ${layout.fenceFile}`,
+    "",
+    "[Install]",
+    "WantedBy=multi-user.target",
+    "",
+  ].join("\n");
+}
+
+/** nftables rules: only a workspace's own user, Caddy and root may open its
+ * loopback ports, so a shell-capable bot cannot reach a sibling's API.
+ * Written whole each time, so `nft -f` is idempotent. */
+export function fenceRules(workspaces: FleetWorkspace[]): string {
+  const lines = ["#!/usr/sbin/nft -f", "# Written by `openmausbot fleet`; regenerated on every create, suspend, resume and delete.", "add table inet openmausbot", "flush table inet openmausbot", "table inet openmausbot {", "\tchain output {", "\t\ttype filter hook output priority 0; policy accept;"];
+  for (const workspace of [...workspaces].sort((a, b) => a.slug.localeCompare(b.slug))) {
+    lines.push(`\t\toif lo tcp dport { ${workspace.port}, ${workspace.webhookPort} } meta skuid != { ${fleetUser(workspace.slug)}, caddy, root } reject`);
+  }
+  lines.push("\t}", "}", "");
+  return lines.join("\n");
+}
+
+export function caddySite(workspace: Pick<FleetWorkspace, "host" | "port" | "webhookPort" | "status">): string {
+  if (workspace.status === "suspended") {
+    return [`${workspace.host} {`, "\trespond \"This workspace is suspended.\" 503", "}", ""].join("\n");
+  }
+  return [
+    `${workspace.host} {`,
+    "\tencode zstd gzip",
+    "\thandle /hooks/* {",
+    `\t\treverse_proxy 127.0.0.1:${workspace.webhookPort}`,
+    "\t}",
+    "\thandle {",
+    `\t\treverse_proxy 127.0.0.1:${workspace.port} {`,
+    "\t\t\tflush_interval -1",
+    "\t\t}",
+    "\t}",
+    "}",
+    "",
+  ].join("\n");
+}
+
+export function caddyImportLine(layout = fleetLayout()): string {
+  return `import ${layout.caddyDir}/*.caddy`;
+}
+
+export function instanceEnv(input: { workspace: FleetWorkspace; dataDir: string; licenseKey?: string }): string {
+  const lines = [
+    `OMB_DATA_DIR=${input.dataDir}`,
+    `OMB_PORT=${input.workspace.port}`,
+    `OMB_WEBHOOK_PORT=${input.workspace.webhookPort}`,
+    `OMB_PUBLIC_URL=https://${input.workspace.host}`,
+  ];
+  if (input.licenseKey) lines.push(`OMB_LICENSE_KEY=${input.licenseKey}`);
+  return lines.join("\n") + "\n";
+}
+
+export interface WorkspaceSeed {
+  admins: string[];
+  members: string[];
+  anthropicKey?: string;
+  monthlyCapUsd?: number;
+  brandJson?: string;
+}
+
+/** The workspace's first config.json: who may sign in, the key it runs on,
+ * and its cap. Everything else stays the server's defaults. */
+export function initialConfig(seed: WorkspaceSeed): string {
+  const config: Record<string, unknown> = { signIn: { admins: seed.admins, members: seed.members } };
+  if (seed.anthropicKey) config.anthropic = { key: seed.anthropicKey };
+  if (seed.monthlyCapUsd !== undefined) config.budgets = { monthlyUsd: seed.monthlyCapUsd };
+  return `${JSON.stringify(config, null, 2)}\n`;
+}
+
+export function allocatePort(registry: FleetRegistry): { port: number; next: number } {
+  const taken = new Set(Object.values(registry.workspaces).map((workspace) => workspace.port));
+  let port = registry.nextPort;
+  while (taken.has(port)) port += FLEET_PORT_STRIDE;
+  return { port, next: port + FLEET_PORT_STRIDE };
+}
+
+const argvText = (argv: string[]) => argv.join(" ");
+
+export function initPlan(input: { domain: string; node: string; script: string; layout?: FleetLayout }): { steps: FleetStep[]; registry: FleetRegistry } {
+  assertDomain(input.domain);
+  const layout = input.layout ?? fleetLayout();
+  const registry = emptyRegistry(input.domain.toLowerCase());
+  const steps: FleetStep[] = [
+    { kind: "mkdir", path: layout.etcDir, mode: 0o755 },
+    { kind: "mkdir", path: layout.instancesDir, mode: 0o700 },
+    { kind: "mkdir", path: layout.homesDir, mode: 0o755 },
+    { kind: "mkdir", path: layout.caddyDir, mode: 0o755 },
+    { kind: "write", path: layout.registryFile, content: `${JSON.stringify(registry, null, 2)}\n`, mode: 0o600 },
+    { kind: "write", path: layout.unitFile, content: templateUnit({ node: input.node, script: input.script, layout }), mode: 0o644 },
+    { kind: "write", path: layout.fenceFile, content: fenceRules([]), mode: 0o600 },
+    { kind: "write", path: layout.fenceUnitFile, content: fenceUnit(layout), mode: 0o644 },
+    { kind: "append-once", path: layout.caddyfile, line: caddyImportLine(layout) },
+    { kind: "run", argv: ["systemctl", "daemon-reload"], why: "load the workspace template and the fence unit" },
+    { kind: "run", argv: ["systemctl", "enable", "--now", "openmausbot-fence.service"], why: "apply the loopback fence now and at boot" },
+    { kind: "run", argv: ["systemctl", "reload", "caddy"], why: "start serving the workspaces folder" },
+    { kind: "note", text: `point *.${registry.domain} at this server (a wildcard A/AAAA record); each workspace gets its own certificate when created` },
+  ];
+  return { steps, registry };
+}
+
+export function createPlan(input: {
+  registry: FleetRegistry;
+  slug: string;
+  seed: WorkspaceSeed;
+  licenseKey?: string;
+  memoryMax?: string;
+  now?: Date;
+  layout?: FleetLayout;
+}): { steps: FleetStep[]; registry: FleetRegistry; workspace: FleetWorkspace } {
+  assertSlug(input.slug);
+  if (input.registry.workspaces[input.slug]) throw new Error(`workspace "${input.slug}" already exists`);
+  if (!input.seed.admins.length) throw new Error("a workspace needs at least one admin email (--admin)");
+  for (const entry of [...input.seed.admins, ...input.seed.members]) assertEmailOrDomain(entry);
+  if (input.memoryMax !== undefined && !/^\d+[MG]$/.test(input.memoryMax)) throw new Error("--memory takes a size like 1G or 512M");
+  const layout = input.layout ?? fleetLayout();
+  const { port, next } = allocatePort(input.registry);
+  const workspace: FleetWorkspace = {
+    slug: input.slug,
+    host: `${input.slug}.${input.registry.domain}`,
+    port,
+    webhookPort: port + 1,
+    status: "running",
+    createdAt: (input.now ?? new Date()).toISOString(),
+  };
+  const registry: FleetRegistry = { ...input.registry, nextPort: next, workspaces: { ...input.registry.workspaces, [workspace.slug]: workspace } };
+  const user = fleetUser(workspace.slug);
+  const home = workspaceHome(layout, workspace.slug);
+  const dataDir = workspaceDataDir(layout, workspace.slug);
+  const steps: FleetStep[] = [
+    { kind: "run", argv: ["useradd", "--system", "--create-home", "--home-dir", home, "--shell", "/usr/sbin/nologin", "--user-group", user], why: `the workspace's own account` },
+    { kind: "mkdir", path: dataDir, mode: 0o700, owner: user },
+    { kind: "write", path: join(dataDir, "config.json"), content: initialConfig(input.seed), mode: 0o600, owner: user },
+    ...(input.seed.brandJson ? [{ kind: "write" as const, path: join(dataDir, "brand.json"), content: input.seed.brandJson, mode: 0o600, owner: user }] : []),
+    { kind: "write", path: join(layout.instancesDir, `${workspace.slug}.env`), content: instanceEnv({ workspace, dataDir, licenseKey: input.licenseKey }), mode: 0o600 },
+    ...(input.memoryMax
+      ? [
+          { kind: "mkdir" as const, path: join(layout.unitFile.replace(/openmausbot@\.service$/, ""), `openmausbot@${workspace.slug}.service.d`), mode: 0o755 },
+          { kind: "write" as const, path: join(layout.unitFile.replace(/openmausbot@\.service$/, ""), `openmausbot@${workspace.slug}.service.d`, "limits.conf"), content: `[Service]\nMemoryMax=${input.memoryMax}\n`, mode: 0o644 },
+        ]
+      : []),
+    { kind: "write", path: layout.fenceFile, content: fenceRules(Object.values(registry.workspaces)), mode: 0o600 },
+    { kind: "run", argv: ["nft", "-f", layout.fenceFile], why: "fence the new ports to their user" },
+    { kind: "run", argv: ["systemctl", "daemon-reload"], why: "pick up the workspace's environment and limits" },
+    { kind: "run", argv: ["systemctl", "enable", "--now", `openmausbot@${workspace.slug}.service`], why: "start the workspace now and at boot" },
+    { kind: "health", url: `http://127.0.0.1:${workspace.port}/api/health`, why: "wait for the workspace to answer" },
+    { kind: "write", path: join(layout.caddyDir, `${workspace.slug}.caddy`), content: caddySite(workspace), mode: 0o644 },
+    { kind: "run", argv: ["systemctl", "reload", "caddy"], why: `serve https://${workspace.host} and fetch its certificate` },
+    { kind: "write", path: layout.registryFile, content: `${JSON.stringify(registry, null, 2)}\n`, mode: 0o600 },
+    { kind: "note", text: `https://${workspace.host} is ready; ${input.seed.admins[0]} signs in with an emailed code` },
+  ];
+  return { steps, registry, workspace };
+}
+
+function withStatus(registry: FleetRegistry, slug: string, status: FleetWorkspace["status"]): { registry: FleetRegistry; workspace: FleetWorkspace } {
+  assertSlug(slug);
+  const current = registry.workspaces[slug];
+  if (!current) throw new Error(`no workspace "${slug}"`);
+  const workspace = { ...current, status };
+  return { registry: { ...registry, workspaces: { ...registry.workspaces, [slug]: workspace } }, workspace };
+}
+
+export function suspendPlan(input: { registry: FleetRegistry; slug: string; layout?: FleetLayout }): { steps: FleetStep[]; registry: FleetRegistry } {
+  const layout = input.layout ?? fleetLayout();
+  const { registry, workspace } = withStatus(input.registry, input.slug, "suspended");
+  return {
+    registry,
+    steps: [
+      { kind: "run", argv: ["systemctl", "disable", "--now", `openmausbot@${workspace.slug}.service`], why: "stop the workspace and keep it stopped at boot" },
+      { kind: "write", path: join(layout.caddyDir, `${workspace.slug}.caddy`), content: caddySite(workspace), mode: 0o644 },
+      { kind: "run", argv: ["systemctl", "reload", "caddy"], why: "show the suspended page instead" },
+      { kind: "write", path: layout.registryFile, content: `${JSON.stringify(registry, null, 2)}\n`, mode: 0o600 },
+    ],
+  };
+}
+
+export function resumePlan(input: { registry: FleetRegistry; slug: string; layout?: FleetLayout }): { steps: FleetStep[]; registry: FleetRegistry } {
+  const layout = input.layout ?? fleetLayout();
+  const { registry, workspace } = withStatus(input.registry, input.slug, "running");
+  return {
+    registry,
+    steps: [
+      { kind: "run", argv: ["systemctl", "enable", "--now", `openmausbot@${workspace.slug}.service`], why: "start the workspace again" },
+      { kind: "health", url: `http://127.0.0.1:${workspace.port}/api/health`, why: "wait for the workspace to answer" },
+      { kind: "write", path: join(layout.caddyDir, `${workspace.slug}.caddy`), content: caddySite(workspace), mode: 0o644 },
+      { kind: "run", argv: ["systemctl", "reload", "caddy"], why: "serve it again" },
+      { kind: "write", path: layout.registryFile, content: `${JSON.stringify(registry, null, 2)}\n`, mode: 0o600 },
+    ],
+  };
+}
+
+export function deletePlan(input: { registry: FleetRegistry; slug: string; keepData: boolean; layout?: FleetLayout }): { steps: FleetStep[]; registry: FleetRegistry } {
+  assertSlug(input.slug);
+  const layout = input.layout ?? fleetLayout();
+  const workspace = input.registry.workspaces[input.slug];
+  if (!workspace) throw new Error(`no workspace "${input.slug}"`);
+  const { [input.slug]: _gone, ...rest } = input.registry.workspaces;
+  const registry: FleetRegistry = { ...input.registry, workspaces: rest };
+  const unitsDir = layout.unitFile.replace(/openmausbot@\.service$/, "");
+  return {
+    registry,
+    steps: [
+      { kind: "run", argv: ["systemctl", "disable", "--now", `openmausbot@${workspace.slug}.service`], why: "stop the workspace" },
+      { kind: "remove", path: join(layout.caddyDir, `${workspace.slug}.caddy`) },
+      { kind: "run", argv: ["systemctl", "reload", "caddy"], why: "stop serving its address" },
+      { kind: "remove", path: join(layout.instancesDir, `${workspace.slug}.env`) },
+      { kind: "remove", path: join(unitsDir, `openmausbot@${workspace.slug}.service.d`, "limits.conf") },
+      { kind: "write", path: layout.fenceFile, content: fenceRules(Object.values(registry.workspaces)), mode: 0o600 },
+      { kind: "run", argv: ["nft", "-f", layout.fenceFile], why: "drop its fence rule" },
+      { kind: "run", argv: input.keepData ? ["userdel", fleetUser(workspace.slug)] : ["userdel", "--remove", fleetUser(workspace.slug)], why: input.keepData ? "remove the account, keep its home and data" : "remove the account and everything it owned" },
+      { kind: "write", path: layout.registryFile, content: `${JSON.stringify(registry, null, 2)}\n`, mode: 0o600 },
+    ],
+  };
+}
+
+export function upgradePlan(input: { registry: FleetRegistry }): FleetStep[] {
+  const running = Object.values(input.registry.workspaces).filter((workspace) => workspace.status === "running").sort((a, b) => a.slug.localeCompare(b.slug));
+  return [
+    { kind: "run", argv: ["npm", "install", "-g", "openmausbot@latest"], why: "install the release every workspace runs from" },
+    ...running.map((workspace) => ({ kind: "run" as const, argv: ["systemctl", "restart", `openmausbot@${workspace.slug}.service`], why: `restart ${workspace.slug} on the new release` })),
+    ...running.map((workspace) => ({ kind: "health" as const, url: `http://127.0.0.1:${workspace.port}/api/health`, why: `wait for ${workspace.slug}` })),
+  ];
+}
+
+/** A workspace's sign-in list edited from outside, the same shape
+ * `openmausbot access` writes; the server reads it live. */
+export function applySignIn(configText: string, action: "add" | "remove", email: string, chatOnly: boolean): { config: string; summary: string } {
+  const entry = email.trim().toLowerCase();
+  assertEmailOrDomain(entry);
+  let raw: Record<string, unknown> = {};
+  const parsed: unknown = JSON.parse(configText || "{}");
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) raw = { ...(parsed as Record<string, unknown>) };
+  const current = raw.signIn && typeof raw.signIn === "object" ? (raw.signIn as { admins?: unknown; members?: unknown }) : {};
+  const list = (value: unknown) => (Array.isArray(value) ? value.map((item) => String(item).trim().toLowerCase()).filter(Boolean) : []);
+  const without = (items: string[]) => items.filter((item) => item !== entry);
+  const admins = without(list(current.admins));
+  const members = without(list(current.members));
+  if (action === "remove") {
+    if (admins.length + members.length === list(current.admins).length + list(current.members).length) throw new Error(`${entry} is not on the list`);
+    return { config: `${JSON.stringify({ ...raw, signIn: { admins, members } }, null, 2)}\n`, summary: `${entry} can no longer sign in; existing sessions stay until they expire or are revoked` };
+  }
+  const next = chatOnly ? { admins, members: [...members, entry] } : { admins: [...admins, entry], members };
+  return { config: `${JSON.stringify({ ...raw, signIn: next }, null, 2)}\n`, summary: `${entry} can sign in with an emailed code (${chatOnly ? "chat and approvals" : "full access"})` };
+}
+
+function shellQuote(value: string): string {
+  return /^[A-Za-z0-9_@%+=:,./-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+/** The plan as lines an operator can read or paste into a root shell. */
+export function describeSteps(steps: FleetStep[]): string[] {
+  const lines: string[] = [];
+  for (const step of steps) {
+    switch (step.kind) {
+      case "mkdir":
+        lines.push(`install -d -m ${step.mode.toString(8)}${step.owner ? ` -o ${step.owner} -g ${step.owner}` : ""} ${shellQuote(step.path)}`);
+        break;
+      case "write":
+        lines.push(`cat > ${shellQuote(step.path)} <<'OMB_EOF'`, step.content.replace(/\n$/, ""), "OMB_EOF", `chmod ${step.mode.toString(8)} ${shellQuote(step.path)}`);
+        if (step.owner) lines.push(`chown ${step.owner}:${step.owner} ${shellQuote(step.path)}`);
+        break;
+      case "append-once":
+        lines.push(`grep -qxF ${shellQuote(step.line)} ${shellQuote(step.path)} || printf '\\n%s\\n' ${shellQuote(step.line)} >> ${shellQuote(step.path)}`);
+        break;
+      case "remove":
+        lines.push(`rm -f ${shellQuote(step.path)}`);
+        break;
+      case "run":
+        lines.push(`${argvText(step.argv.map(shellQuote))}   # ${step.why}`);
+        break;
+      case "health":
+        lines.push(`until curl -sf ${shellQuote(step.url)} >/dev/null; do sleep 1; done   # ${step.why}`);
+        break;
+      case "note":
+        lines.push(`# ${step.text}`);
+        break;
+    }
+  }
+  return lines;
+}


### PR DESCRIPTION
## Why

Fourth step of the API-based pricing track. A reseller runs one workspace per client on a shared server. Each must be its own OS user with private data, its own service and ports, its own brand, sign-in list and provider key, at its own address, and a bot in one must not reach another. Until now that was a hand-run checklist over SSH.

## What

`openmausbot fleet`, open source:

- `fleet init --domain HOST`: the template unit `openmausbot@.service` (per-slug user, `EnvironmentFile`, private `/tmp`, no new privileges, read-only system, writes only its home), an nftables fence that keeps each workspace's loopback ports to its own user, Caddy and root, applied by a oneshot unit at boot, the workspace folders, the registry, and `import /etc/caddy/omb.d/*.caddy` added once to the Caddyfile.
- `fleet create NAME --admin EMAIL [--member EMAIL] [--brand FILE] [--anthropic-key-file FILE] [--cap USD] [--license-key KEY] [--memory 1G]`: the account, private data seeded with the sign-in list, the key and the cap, the environment file carrying the licence, the fence rule, the unit started now and at boot, a health wait, then the site block and a Caddy reload. Ports are allocated in strides; the registry is kept in step.
- `fleet users NAME add|remove EMAIL [--chat-only]`, `suspend` (503 page, service stopped), `resume`, `delete NAME --yes [--keep-data]`, `upgrade` (new release, then a rolling restart of every running workspace), `list`.
- Everything is a plan of steps: fixed argument lists and file writes, never a shell string. As root the CLI runs the plan and stops at the first failed step, naming it and showing only the tool's last lines. Not root, or `--dry-run`, prints the exact root-shell lines instead.

**Docs**: `docs/self-hosting.md` "Many client workspaces on one server"; `docs/verification/fleet.md` with the offline proof and the disposable-VPS recipe.

## Tests

Rendered files pinned (template unit and its hardening, fence rules ordered by slug, running and suspended site blocks, environment file, seeded config, sign-in edits), port allocation, every plan's argument lists and their order (health after enable, before Caddy), the registry, the exact root-shell rendering with quoting, and the CLI as root, not root, on `--dry-run`, on a failed step, and on `delete` without `--yes`. Mutation-checked: removing the hardening, the fence's user exclusion, or the delete guard each fails a test. Full vitest: 5741 passed, 0 failed.

## Not proven here

A real server: root, systemd, nftables and Caddy. The recipe lists the checks, including the isolation probe (`runuser -u omb-alpha -- curl` against beta's port must be refused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `openmausbot fleet` command for managing multiple client workspaces on one Linux server.
  - Supports workspace initialization, creation, listing, user management, suspension, resumption, deletion, and upgrades.
  - Provides per-workspace isolation for users, services, ports, data, branding, sign-in settings, and provider credentials.
  - Added dry-run planning and safeguards for destructive operations.

- **Documentation**
  - Added self-hosting and verification guides covering fleet setup, operation, and server validation.

- **Tests**
  - Added coverage for fleet command parsing, lifecycle operations, validation, isolation, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->