### PR TITLE
fix(connected-apps): let remote clients disconnect their own accounts

### DIFF
--- a/companion/src/routes.ts
+++ b/companion/src/routes.ts
@@ -168,12 +168,16 @@ const ALLOWED: ReadonlyArray<{ method: string; path: RegExp }> = [
   { method: "POST", path: /^\/api\/routine-runs\/[\w-]+\/(?:cancel|seen)$/ },
 
   // Multi-account Composio management exposes opaque ids and aliases only.
-  // Revocation stays on the host: the account DELETE route is deliberately
-  // absent — a paired client can see and add accounts, never remove one.
+  // Account-level removal is allowed: the handler still proves the account
+  // belongs to the host's own user before revoking, and a paired client can
+  // already add accounts — connectable but not disconnectable is the bug
+  // being fixed here. The whole-service DELETE stays denied: it belongs to
+  // the host.
   { method: "GET", path: /^\/api\/connectors\/catalog$/ },
   { method: "GET", path: /^\/api\/connectors\/connected$/ },
   { method: "GET", path: /^\/api\/connectors$/ },
   { method: "POST", path: /^\/api\/connectors\/[\w-]+\/authorize$/ },
+  { method: "DELETE", path: /^\/api\/connectors\/[\w-]+\/accounts\/[\w-]+$/ },
   // Inline connector cards are scoped by bot, transcript message, and
   // thread. They expose the same opaque OAuth authorization already allowed
   // above, then only poll, resume, or dismiss that exact pending card.

--- a/companion/test/routes.test.ts
+++ b/companion/test/routes.test.ts
@@ -99,6 +99,7 @@ describe("what the app may do", () => {
     ["GET", "/api/connectors/connected"],
     ["GET", "/api/connectors"],
     ["POST", "/api/connectors/slack/authorize"],
+    ["DELETE", "/api/connectors/slack/accounts/ca_123"],
     ["GET", "/api/bots/bot_123/connector-cards/msg_2/status"],
     ["POST", "/api/bots/bot_123/connector-cards/msg_2/authorize"],
     ["POST", "/api/bots/bot_123/connector-cards/msg_2/resume"],
@@ -219,9 +220,10 @@ describe("what it may not", () => {
     expect(allowed("POST", "/api/routine-runs/run_1/retry")).toBe(false);
     expect(allowed("DELETE", "/api/connectors/slack")).toBe(false);
     expect(allowed("GET", "/api/connectors/connected/all")).toBe(false);
-    // revocation is a host-only affordance: a paired client can list and add
-    // accounts but the account DELETE route is deliberately not allowed
-    expect(allowed("DELETE", "/api/connectors/slack/accounts/ca_123")).toBe(false);
+    // per-account removal is allowed (the server proves ownership before
+    // revoking); removing the whole service binding stays host-only
+    expect(allowed("DELETE", "/api/connectors/slack/accounts/ca_123")).toBe(true);
+    expect(allowed("DELETE", "/api/connectors/slack/accounts/../gmail")).toBe(false);
     expect(allowed("POST", "/api/bots/bot_123/secret-cards/msg_2/provided")).toBe(false);
     expect(allowed("PATCH", "/api/groups/room-1")).toBe(false);
   });

--- a/src/components/PluginsPanel.test.ts
+++ b/src/components/PluginsPanel.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  connectedAppsMayDisconnect,
   connectedInventoryCopy,
   connectorActionLabel,
   disconnectAccountConfirmation,
@@ -12,13 +11,6 @@ import {
   type ConnectorStatus,
 } from "./PluginsPanel";
 import { managedConnectorUnavailableReason } from "../../shared/connector-availability";
-
-describe("connected-app remote permissions", () => {
-  it("allows pairing and status remotely but keeps revocation on the host", () => {
-    expect(connectedAppsMayDisconnect(false)).toBe(true);
-    expect(connectedAppsMayDisconnect(true)).toBe(false);
-  });
-});
 
 describe("connected-app status races", () => {
   it("offers status recovery for a pending authorization whose URL was lost on remount", () => {

--- a/src/components/PluginsPanel.tsx
+++ b/src/components/PluginsPanel.tsx
@@ -87,10 +87,6 @@ export function disconnectAccountConfirmation(
   return t("connectors.disconnectConfirm", { identity, service });
 }
 
-export function connectedAppsMayDisconnect(remoteClient: boolean): boolean {
-  return !remoteClient;
-}
-
 export function requiresAccountAlias(message: string) {
   return /account alias.*existing connection.*not replaced/i.test(message);
 }
@@ -213,7 +209,6 @@ function ServiceIcon({ card }: { card: ToolkitCard }) {
 export function PluginsPanel() {
   const { state, dispatch } = useStore();
   const remoteClient = window.ogb?.remoteClient?.active === true;
-  const mayDisconnect = connectedAppsMayDisconnect(remoteClient);
   const dialogRef = useRef<HTMLDivElement>(null);
   const surface = state.pluginsSurface;
   const [cards, setCards] = useState<ToolkitCard[] | null>(null);
@@ -743,23 +738,21 @@ export function PluginsPanel() {
                                 {account.alias ? `${account.id} · ` : ""}{account.status.toLowerCase()}
                               </div>
                             </div>
-                            {mayDisconnect && (
-                              <button
-                                type="button"
-                                disabled={busy}
-                                onClick={() => {
-                                  if (!window.confirm(disconnectAccountConfirmation(card.label, account))) return;
-                                  disconnectAccount(card.slug, account.id);
-                                }}
-                                className="rounded-md px-2 py-1 text-[11px] text-ink-secondary transition-colors hover:bg-danger/10 hover:text-danger disabled:opacity-40"
-                                aria-label={t("connectors.disconnectAria", {
-                                  account: account.alias || account.id,
-                                  service: card.label,
-                                })}
-                              >
-                                {t("connectors.disconnect")}
-                              </button>
-                            )}
+                            <button
+                              type="button"
+                              disabled={busy}
+                              onClick={() => {
+                                if (!window.confirm(disconnectAccountConfirmation(card.label, account))) return;
+                                disconnectAccount(card.slug, account.id);
+                              }}
+                              className="rounded-md px-2 py-1 text-[11px] text-ink-secondary transition-colors hover:bg-danger/10 hover:text-danger disabled:opacity-40"
+                              aria-label={t("connectors.disconnectAria", {
+                                account: account.alias || account.id,
+                                service: card.label,
+                              })}
+                            >
+                              {t("connectors.disconnect")}
+                            </button>
                           </div>
                         );
                       })}


### PR DESCRIPTION
Refs #1048

## What changed

The Connected apps account row now shows its **Disconnect** button for remote
(desktop companion) clients too, and the companion sidecar allowlists the
per-account route it calls:

- `companion/src/routes.ts` — `DELETE /api/connectors/:slug/accounts/:id` is
  added to `ALLOWED`.
- `src/components/PluginsPanel.tsx` — the `{mayDisconnect && …}` gate is
  removed (and the now-unused `connectedAppsMayDisconnect` helper with it), so
  every listed account offers Disconnect.
- Tests updated for the new contract.

## Why

A user who connects an account from a paired remote client gets a card that
shows the account but no way to remove it — the UI hid the button and the
companion boundary would have denied the DELETE anyway. The asymmetry was
already there for *adding* (`POST …/authorize` is allowlisted), so a remote
client could connect but never disconnect.

The revocation exclusion predates desktop remote access and was scoped to the
phone companion ("a paired phone … never remove one"). Two notes on the
boundary change, for review:

- `removeAccount` still proves the account belongs to the host's own Composio
  user before revoking, so a paired device can only remove accounts it could
  already see and add.
- The whole-service `DELETE /api/connectors/:slug` stays denied; only the
  per-account route the panel actually calls is opened.

## How it was verified

- `pnpm typecheck` — clean.
- `pnpm exec vitest run companion/test/routes.test.ts src/components/PluginsPanel.test.ts src/components/PluginsPanel.i18n.test.ts` — 99/99 pass, including the new "allows DELETE …/accounts/:id" case and a path-traversal denial case.
- Full `pnpm exec vitest run` — 5798 pass, 9 unrelated environment-dependent failures (linux-after-install tmpdir, control-omb fake-engine, browser-bundle linux-arm64, engine-install npm PATH).

## Screenshots (UI changes)

n/a — restores a control that already renders for non-remote clients.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally
- [x] Server behavior changes come with tests (see CONTRIBUTING.md → Tests)
- [x] No `dist-server/` edits (it's build output)
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Remote clients can now disconnect individual accounts from connected apps.
  - Account-specific disconnect controls are available consistently across clients, with confirmation prompts retained.
  - Connected-app panels now support viewing accounts beyond marketplace-card limits.

- **Bug Fixes**
  - Improved connected-app status recovery, loading behavior, and handling of stale or empty responses.
  - Added safeguards to prevent invalid or path-traversal account removal requests.
  - Whole-service connector removal remains restricted to the host.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->