### PR TITLE
fix(codex): keep helper completion from ending the parent run

### DIFF
--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -43,6 +43,7 @@ Use only mapped, tested commands:
 - [Engines and Doctor](engines.md)
 - [Claude coordination and turn-scoped tools](claude-tool-lifecycle.md)
 - [Codex bot instructions](codex-instructions.md)
+- [Codex helper event isolation](codex-helpers.md)
 - [Qwen model route selection](qwen-models.md)
 - [Team backups](team-backups.md)
 - [Fleet: many workspaces on one server](fleet.md)

--- a/docs/verification/codex-helpers.md
+++ b/docs/verification/codex-helpers.md
@@ -1,0 +1,27 @@
+# Codex helper event isolation
+
+The app-server streams events from both the requested parent and native helper
+threads. Only the exact parent thread and turn returned by the start handshake
+may update the parent transcript, usage, or completion. Scoped child/stale errors
+are excluded too; connection-level errors still surface. Approval requests
+continue through the existing broker, including requests from helpers.
+
+Run `pnpm exec vitest run server/drivers/codex.test.ts` for interleaved helper,
+stale-turn, missing-scope and early-notification regression checks. The helper
+test fails on the old driver: it emits the child's final and kills the parent
+before its next approval. The fixed driver answers that approval and completes
+only after the parent final, with parent usage.
+
+For the real chat path, run `node scripts/verify-codex-helpers.ts` in the foreground
+and open its printed preview URL. This uses the standard isolated launcher and
+an offline Codex protocol fixture; no real provider or user account is used.
+Select **Codex Helper Fixture**, send a message, and check that **echo parent
+continues** requests approval after the simulated helpers have completed.
+No **FOREIGN** text, reasoning, tool, error or usage should enter the chat.
+Approve once: the parent returns **done from fake codex** and then settles.
+Repeat and deny the approval to verify that rejection remains answerable and
+does not leave the run stuck. Read the console and retain screenshots plus the
+fixture log. Stop the foreground launcher with Ctrl-C for scoped cleanup.
+
+This proves the renderer/harness workflow with scripted native events, not
+authenticated model behavior or activation in the installed desktop app.

--- a/scripts/verify-codex-helpers.ts
+++ b/scripts/verify-codex-helpers.ts
@@ -1,0 +1,38 @@
+// Real chat renderer and harness; offline, scripted Codex protocol only.
+// No user data, provider credentials or authenticated inference are involved.
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { launchVerificationServer, runControlOmb } from "./control-omb.ts";
+import { fixtureApi, mountPreview, parkUntilSignal, type MountedPreview } from "./testing/preview-fixture.ts";
+
+const fixture = await launchVerificationServer();
+let ui: MountedPreview | undefined;
+try {
+  const api = fixtureApi(fixture.info.url);
+  const wrapper = join(fixture.info.dataDir, "offline-codex-helpers.mjs");
+  writeFileSync(wrapper, [
+    "#!/usr/bin/env node",
+    'process.env.FAKE_CODEX_MODE = "helper-events";',
+    `await import(${JSON.stringify(pathToFileURL(join(process.cwd(), "server/testing/fake-codex-app-server.ts")).href)});`,
+  ].join("\n"), { mode: 0o700 });
+  const configPath = join(fixture.info.dataDir, "config.json");
+  const config = JSON.parse(readFileSync(configPath, "utf8"));
+  config.instances.codex = {
+    driver: "codex", displayName: "Codex", config: { cli: wrapper },
+    environment: { HOME: fixture.info.dataDir, USERPROFILE: fixture.info.dataDir, CODEX_HOME: join(fixture.info.dataDir, ".codex") },
+  };
+  writeFileSync(configPath, JSON.stringify(config, null, 2), { mode: 0o600 });
+  await api("PUT", "/api/config", { defaultModelSelection: { instanceId: "codex", model: "gpt-6-astra" } });
+  await runControlOmb(["new-bot", "--name", "Codex Helper Fixture", "--url", fixture.info.url]);
+  ui = await mountPreview(fixture, {
+    entry: "/scripts/testing/threads-preview.tsx", route: "/__codex-helpers.html", title: "Codex helper isolation — offline fixture",
+  });
+  const info = { ...fixture.info, launcherPid: process.pid, previewUrl: ui.previewUrl };
+  console.log(JSON.stringify(info));
+  if (process.env.OMB_HELPER_EVIDENCE) writeFileSync(process.env.OMB_HELPER_EVIDENCE, JSON.stringify(info, null, 2));
+  await parkUntilSignal();
+} finally {
+  await ui?.close();
+  await fixture.close();
+}

--- a/scripts/verify-codex-helpers.ts
+++ b/scripts/verify-codex-helpers.ts
@@ -23,10 +23,12 @@ try {
     environment: { HOME: fixture.info.dataDir, USERPROFILE: fixture.info.dataDir, CODEX_HOME: join(fixture.info.dataDir, ".codex") },
   };
   writeFileSync(configPath, JSON.stringify(config, null, 2), { mode: 0o600 });
-  await api("PUT", "/api/config", { defaultModelSelection: { instanceId: "codex", model: "gpt-6-astra" } });
-  await runControlOmb(["new-bot", "--name", "Codex Helper Fixture", "--url", fixture.info.url]);
+  await api("PUT", "/api/config", { defaultModelSelection: { instanceId: "codex", model: "gpt-fake-default" } });
+  const created = await runControlOmb(["new-bot", "--name", "Codex Helper Fixture", "--url", fixture.info.url]) as { bot: { id: string } };
+  await runControlOmb(["set-model", "--bot", created.bot.id, "--instance", "codex", "--model", "gpt-fake-default", "--url", fixture.info.url]);
   ui = await mountPreview(fixture, {
     entry: "/scripts/testing/threads-preview.tsx", route: "/__codex-helpers.html", title: "Codex helper isolation — offline fixture",
+    extraRoutes: [{ path: "/favicon.ico", handler: (_req, res) => { res.writeHead(204); res.end(); } }],
   });
   const info = { ...fixture.info, launcherPid: process.pid, previewUrl: ui.previewUrl };
   console.log(JSON.stringify(info));

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -200,6 +200,31 @@ describe("CodexDriver turns (fake app-server)", () => {
     expect(recorder.events.some((event) => event.type === "request.opened")).toBe(false);
   });
 
+  it("keeps the parent working after helper completion and ignores foreign output and usage", async () => {
+    await create({ mode: "helper-events" });
+    await instance.adapter.sendTurn({ threadId: "t-helper-events", text: "use a helper then continue" });
+    const permission = await recorder.until((event) => event.type === "request.opened");
+    expect(permission).toMatchObject({ summary: "echo parent continues" });
+    expect(recorder.events.some((event) => event.type === "turn.completed")).toBe(false);
+    expect(JSON.stringify(recorder.events)).not.toContain("FOREIGN");
+    expect(recorder.events.some((event) => event.type === "thread.token-usage.updated")).toBe(false);
+    await instance.adapter.respondToRequest("t-helper-events", permission.requestId!, { behavior: "allow" });
+    await recorder.until((event) => event.type === "turn.completed");
+    expect(recorder.events.filter((event) => event.type === "turn.completed")).toHaveLength(1);
+    expect(recorder.events.at(-1)).toMatchObject({ ok: true, usage: { input: 7, output: 3 } });
+    expect(recorder.events.find((event) => event.type === "item.completed" && event.itemType === "assistant_text")).toMatchObject({ text: "done from fake codex" });
+    expect(JSON.stringify(recorder.events)).not.toContain("FOREIGN");
+  });
+
+  it("retains parent notifications delivered before the turn/start response", async () => {
+    await create({ mode: "early-turn-events" });
+    await instance.adapter.sendTurn({ threadId: "t-early-events", text: "finish quickly" });
+    await recorder.until((event) => event.type === "turn.completed");
+    expect(recorder.events.at(-1)).toMatchObject({ ok: true });
+    expect(recorder.events.filter((event) => event.type === "turn.completed")).toHaveLength(1);
+    expect(recorder.events.find((event) => event.type === "item.completed" && event.itemType === "assistant_text")).toMatchObject({ text: "done from fake codex" });
+  });
+
   it.each([
     ["ask", "on-request", "workspace-write", "workspaceWrite"],
     ["auto", "on-request", "workspace-write", "workspaceWrite"],

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -214,6 +214,17 @@ describe("CodexDriver turns (fake app-server)", () => {
     expect(recorder.events.at(-1)).toMatchObject({ ok: true, usage: { input: 7, output: 3 } });
     expect(recorder.events.find((event) => event.type === "item.completed" && event.itemType === "assistant_text")).toMatchObject({ text: "done from fake codex" });
     expect(JSON.stringify(recorder.events)).not.toContain("FOREIGN");
+
+    const repeat = await instance.adapter.sendTurn({
+      threadId: "t-helper-events", resumeCursor: "codex-thread-1", text: "continue and deny the next request",
+    });
+    const denied = await recorder.until((event) => event.turnId === repeat.turnId && event.type === "request.opened");
+    await instance.adapter.respondToRequest("t-helper-events", denied.requestId!, { behavior: "deny" });
+    await recorder.until((event) => event.turnId === repeat.turnId && event.type === "turn.completed");
+    expect(recorder.events.filter((event) => event.type === "turn.completed")).toHaveLength(2);
+    expect(recorder.events.at(-1)).toMatchObject({ ok: true });
+    expect(recorder.events.find((event) => event.turnId === repeat.turnId && event.type === "request.resolved")).toMatchObject({ behavior: "deny" });
+    expect(JSON.stringify(recorder.events)).not.toContain("FOREIGN");
   });
 
   it("retains parent notifications delivered before the turn/start response", async () => {

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -591,6 +591,10 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
         });
 
       let abandoned = false;
+      let codexThreadId: string | null = null;
+      let codexTurnId: string | null = null;
+      let startingNativeTurn = false;
+      const earlyNotifications: any[] = [];
       const state = {
         settled: false,
         lastText: "",
@@ -631,6 +635,20 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
           rpcPending.set(id, {
             resolve: (v) => {
               clearTimeout(timer);
+              if (method === "turn/start") {
+                if (typeof v?.turn?.id !== "string" || !v.turn.id) {
+                  reject(new Error("Codex did not return a native turn id"));
+                  return;
+                }
+                // Bind synchronously: a single stdout chunk can contain the
+                // response, streamed events, completion and a late request.
+                codexTurnId = v.turn.id;
+                startingNativeTurn = false;
+                for (const notification of earlyNotifications.splice(0)) {
+                  if (state.settled) break;
+                  handleNotification(notification);
+                }
+              }
               resolve(v);
             },
             reject: (e) => {
@@ -789,6 +807,30 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
 
       const handleNotification = (msg: any) => {
         const p = msg.params ?? {};
+        // An app-server also emits notifications for native helper threads.
+        // Only this request's parent may write its transcript/usage or settle
+        // its run. Requests still use the approval broker above, including
+        // helper requests; ignoring child *notifications* must not grant tools.
+        const connectionError = msg.method === "error" &&
+          !("threadId" in p) && !("turnId" in p);
+        if (!connectionError) {
+          if (!codexThreadId || p.threadId !== codexThreadId) return;
+          if (!codexTurnId) {
+            // Some servers stream before acknowledging turn/start. Retain a
+            // bounded prefix, then filter against the authoritative response.
+            if (startingNativeTurn) {
+              if (earlyNotifications.length >= 1024) {
+                void settle(false, "too_many_events_before_turn_start");
+              } else {
+                earlyNotifications.push(msg);
+              }
+            }
+            return;
+          }
+          const eventTurnId = msg.method === "turn/started" || msg.method === "turn/completed"
+            ? p.turn?.id : p.turnId;
+          if (eventTurnId !== codexTurnId) return;
+        }
         switch (msg.method) {
           // token-level chat text; the item/completed frame follows with the
           // whole message, so its delta is only a fallback when none streamed
@@ -1025,7 +1067,6 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
         // on start AND resume so Codex owns their lifetime through compaction.
         // Removed bot rules are cleared without dropping native configured rules.
         const cursor = typeof turn.resumeCursor === "string" ? turn.resumeCursor : null;
-        let codexThreadId: string | null = null;
         let startedModel: string | null = null;
         if (cursor) {
           try {
@@ -1081,7 +1122,9 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
           ...(promptText ? [{ type: "text" as const, text: promptText }] : []),
           ...(turn.images ?? []).map((image) => ({ type: "localImage" as const, path: image.path })),
         ];
-        const startTurn = () => request("turn/start", {
+        const startTurn = () => {
+          startingNativeTurn = true;
+          return request("turn/start", {
             threadId: codexThreadId,
             input: turnInput,
             ...approvalParams.turn,
@@ -1096,6 +1139,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
             // thread rather than the current one.
             ...(turn.effort ? { effort: turn.effort } : {}),
           });
+        };
         try {
           await startTurn();
         } catch (error) {

--- a/server/testing/fake-codex-app-server.ts
+++ b/server/testing/fake-codex-app-server.ts
@@ -37,7 +37,17 @@ let decision: unknown = null;
 let experimentalApi = false;
 
 const out = (obj: unknown) => process.stdout.write(JSON.stringify(obj) + "\n");
-const notify = (method: string, params: unknown) => out({ jsonrpc: "2.0", method, params });
+let nativeThreadId = "codex-thread-1";
+const nativeTurnId = "turn-1";
+const notify = (method: string, params: any) => out({
+  jsonrpc: "2.0", method,
+  params: {
+    threadId: nativeThreadId,
+    ...(method.startsWith("turn/") ? {} : { turnId: nativeTurnId }),
+    ...params,
+    ...(params.turn ? { turn: { id: nativeTurnId, ...params.turn } } : {}),
+  },
+});
 
 const dump = () => {
   if (process.env.FAKE_CODEX_DUMP) {
@@ -216,6 +226,7 @@ process.stdin.on("data", (chunk) => {
         }
         break;
       case "turn/start": {
+        nativeThreadId = msg.params?.threadId ?? nativeThreadId;
         if (msg.params?.permissions && (!experimentalApi || mode === "config-profile-unsupported")) {
           out({ jsonrpc: "2.0", id: msg.id, error: { code: -32602, message: "experimental API required for permissions" } });
           break;
@@ -245,7 +256,7 @@ process.stdin.on("data", (chunk) => {
           writeFileSync(process.env.FAKE_CODEX_STATE, String(launched + 1));
           if (launched < quota) {
             if (process.env.FAKE_CODEX_PARTIAL_FAILS) {
-              out({ jsonrpc: "2.0", id: msg.id, result: { ok: true } });
+              out({ jsonrpc: "2.0", id: msg.id, result: { turn: { id: nativeTurnId } } });
               notify("item/agentMessage/delta", { itemId: "m1", delta: "half an answer" });
               notify("turn/completed", { turn: { status: "failed", error: { message: "provider overloaded, try again" } } });
               break;
@@ -258,7 +269,31 @@ process.stdin.on("data", (chunk) => {
             break;
           }
         }
-        out({ jsonrpc: "2.0", id: msg.id, result: { ok: true } });
+        if (mode === "early-turn-events") finishTurn();
+        out({ jsonrpc: "2.0", id: msg.id, result: { turn: { id: nativeTurnId } } });
+        if (mode === "early-turn-events") break;
+        if (mode === "helper-events") {
+          // Interleave child and stale-parent traffic with the active parent.
+          // A child completion must not kill the process or answer for the parent.
+          for (const scope of [
+            { threadId: "helper-thread", turnId: "helper-turn" },
+            { threadId: nativeThreadId, turnId: "previous-turn" },
+            { threadId: null, turnId: null },
+          ]) {
+            notify("item/agentMessage/delta", { ...scope, delta: "FOREIGN answer" });
+            notify("item/reasoning/textDelta", { ...scope, delta: "FOREIGN reasoning" });
+            notify("item/started", { ...scope, item: { id: "foreign-tool", type: "commandExecution", command: "FOREIGN command" } });
+            notify("item/completed", { ...scope, item: { type: "agentMessage", text: "FOREIGN final" } });
+            notify("thread/tokenUsage/updated", { ...scope, tokenUsage: { total: { inputTokens: 999, outputTokens: 999 } } });
+            notify("error", { ...scope, message: "FOREIGN error" });
+            notify("turn/completed", { ...scope, turn: { id: scope.turnId, status: "completed" } });
+            notify("turn/completed", { ...scope, turn: { id: scope.turnId, status: "failed" } });
+          }
+          // This request proves that the parent is still able to do work after
+          // the child finished. Wait for the real adapter approval response.
+          out({ jsonrpc: "2.0", id: 100, method: "execCommandApproval", params: { command: "echo parent continues" } });
+          break;
+        }
         const command = mode === "windows-command"
           ? [
               "\"C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\"",

--- a/server/testing/fake-codex-app-server.ts
+++ b/server/testing/fake-codex-app-server.ts
@@ -204,7 +204,7 @@ process.stdin.on("data", (chunk) => {
       case "thread/resume":
         if (msg.params?.permissions && (!experimentalApi || mode === "config-profile-unsupported")) {
           out({ jsonrpc: "2.0", id: msg.id, error: { code: -32602, message: "experimental API required for permissions" } });
-        } else if (mode === "resume" || mode === "instructions-unsupported" || mode === "config-profile" || mode === "config-profile-unsupported") {
+        } else if (mode === "resume" || mode === "helper-events" || mode === "instructions-unsupported" || mode === "config-profile" || mode === "config-profile-unsupported") {
           out({ jsonrpc: "2.0", id: msg.id, result: { thread: { id: msg.params?.threadId } } });
         } else {
           out({ jsonrpc: "2.0", id: msg.id, error: { code: -1, message: "no such thread" } });


### PR DESCRIPTION
Native Codex helper completion currently ends the parent OpenMausBot run. The app-server multiplexes notifications from parent and helper threads, but the driver attributes all of them to the parent and settles on any `turn/completed`. This also puts helper replies and usage into the parent's transcript. Observed in three real runs: a helper completion was followed by canonical parent completion within 6–10 ms, while the parent native turn was still unfinished.

Bind notification handling to the parent native thread and the exact turn ID returned by `turn/start`. Ignore helper, stale-turn and missing-scope notifications; retain connection-level errors and existing approval handling. Buffer a bounded prefix when notifications arrive before the start response, and bind synchronously so completion still rejects later requests in the same stdout chunk.

The regression reproduces the original premature stop before the fix. After the fix, the helper finishes, the parent performs another approval round trip, and only the parent's final completes the run. Tests also cover stale/missing scope, helper text/reasoning/tools/errors/usage, early parent notifications, and a second resumed turn whose approval is denied. The offline CLI fixture now emits realistic native thread/turn identifiers.

Validation: 84 Codex/instruction tests; all driver tests across Claude, Codex and Grok (852 passed, one existing skip); server typecheck; scoped lint; generated server bundle. Packaged startup smoke passed outside node_modules, including all12 proxy paths and final MCP frames. Real-renderer Playwright MCP walkthrough passed on fc452ade418338c3e9e23a0c6057a6801edd5694: approval remained usable after helper completions, Allow once produced the parent final, a second send in the same conversation resumed successfully, Deny was handled, and the second parent final settled the UI. No foreign helper content, zero console errors/warnings. Screenshots and packet were independently inspected. The reproducible offline fixture and walkthrough recipe are included.

No installed desktop binary or user data was modified. Browser/protocol fixtures use synthetic offline responses, not authenticated model inference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Codex event handling so helper-thread and stale-turn activity no longer appears in the parent conversation or affects its usage and completion.
  - Preserved parent notifications received early during turn startup.
  - Approval requests from helper activity continue to resolve correctly, including after resumed turns.

- **Documentation**
  - Added verification guidance and an offline fixture workflow for testing Codex helper event isolation, approvals, and denial handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->