### PR TITLE
fix(tailscale): detect MagicDNS from standalone macOS installs

### DIFF
--- a/companion/src/listener.ts
+++ b/companion/src/listener.ts
@@ -116,6 +116,15 @@ export const searchPath = (): string =>
     .filter(Boolean)
     .join(delimiter);
 
+/** The macOS app executable chooses GUI or CLI mode from its environment.
+ * Finder-launched sidecars have no shell hints, so explicitly request the CLI.
+ * https://tailscale.com/docs/reference/tailscale-cli?tab=macos */
+export const tailscaleEnvironment = (): NodeJS.ProcessEnv => ({
+  ...process.env,
+  PATH: searchPath(),
+  TAILSCALE_BE_CLI: "1",
+});
+
 /** Ask the Tailscale CLI where it thinks we are.
  *
  * Every failure is survivable — not installed, not logged in, not running all
@@ -157,7 +166,7 @@ async function refreshTailnetNameOnce(
           // Generous, and still a bound: the alternative is a subprocess
           // deciding how much memory this process uses.
           maxBuffer: 16 * 1024 * 1024,
-          env: { ...process.env, PATH: searchPath() },
+          env: tailscaleEnvironment(),
         },
         (error, stdout) => {
           if (error) {
@@ -171,7 +180,9 @@ async function refreshTailnetNameOnce(
             onAttempt?.(cli, trimmed ? `ok: ${trimmed}` : "ran, but no MagicDNS name in status");
             resolve(trimmed);
           } catch {
-            onAttempt?.(cli, "ran, but its output was not JSON");
+            onAttempt?.(cli, /Tailscale GUI failed to start/i.test(stdout)
+              ? "exited successfully in GUI mode instead of CLI mode"
+              : "exited successfully, but status output was not JSON");
             resolve(null);
           }
         },

--- a/companion/test/fixtures/tailscale-cli.mjs
+++ b/companion/test/fixtures/tailscale-cli.mjs
@@ -1,0 +1,21 @@
+// Offline standalone-app double: without CLI mode it exits 0 with GUI text,
+// just like the reported macOS install when launched from a desktop sidecar.
+const mode = process.env.FAKE_TAILSCALE_OUTPUT;
+if (mode === "gui" || process.env.TAILSCALE_BE_CLI !== "1") {
+  console.log("The Tailscale GUI failed to start: private diagnostic omitted");
+} else if (mode === "invalid") {
+  console.log("invalid JSON with private diagnostic omitted");
+} else if (process.argv[2] === "status") {
+  if (process.argv[3] !== "--json") process.exit(2);
+  console.log(JSON.stringify({
+    BackendState: "Running",
+    Self: {
+      DNSName: mode === "no-dns" ? "" : "fixture.tail1234.ts.net.",
+      TailscaleIPs: ["100.64.0.7"],
+    },
+  }));
+} else if (process.argv[2] === "serve") {
+  console.log("Serve configuration updated");
+} else {
+  process.exit(2);
+}

--- a/companion/test/tailscale-cli.test.ts
+++ b/companion/test/tailscale-cli.test.ts
@@ -1,0 +1,134 @@
+import type { ExecFileOptions } from "node:child_process";
+import type { Server } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const standalone = "/Applications/Tailscale.app/Contents/MacOS/Tailscale";
+const fixture = vi.hoisted(() => ({
+  output: "auto",
+  fallback: false,
+  calls: [] as Array<{ cli: string; args: string[]; options: ExecFileOptions }>,
+}));
+
+// Only synthetic network interfaces and an offline child may be reached.
+// Keep real subprocess execution so losing the environment reproduces the bug.
+vi.mock("node:child_process", async (original) => {
+  const native = await original<typeof import("node:child_process")>();
+  const { fileURLToPath } = await import("node:url");
+  const script = fileURLToPath(new URL("./fixtures/tailscale-cli.mjs", import.meta.url));
+  return {
+    ...native,
+    execFile(cli: string, args: string[], options: ExecFileOptions, callback: (error: Error | null, stdout: string, stderr: string) => void) {
+      fixture.calls.push({ cli, args, options });
+      if (cli !== "/Applications/Tailscale.app/Contents/MacOS/Tailscale" && !(fixture.fallback && cli === "/usr/bin/tailscale")) {
+        queueMicrotask(() => callback(Object.assign(new Error("ENOENT"), { code: "ENOENT" }), "", ""));
+        return;
+      }
+      return native.execFile(process.execPath, [script, ...args], {
+        ...options,
+        encoding: "utf8",
+        env: { ...options.env, FAKE_TAILSCALE_OUTPUT: cli === "/usr/bin/tailscale" ? "auto" : fixture.output },
+      }, callback);
+    },
+  };
+});
+
+vi.mock("node:os", async (original) => ({
+  ...await original<typeof import("node:os")>(),
+  networkInterfaces: () => ({
+    utun0: [{ family: "IPv4", internal: false, address: "100.64.0.7" }],
+  }),
+}));
+
+import { createControlServer, type companionState } from "../src/control.ts";
+import { DeviceRegistry } from "../src/devices.ts";
+import { refreshTailnetName, tailnetName } from "../src/listener.ts";
+import { tailscaleServe, tailscaleServeOff, tailscaleStatus } from "../../server/tailscale.ts";
+
+let control: Server | undefined;
+
+beforeEach(() => {
+  fixture.calls = [];
+  fixture.output = "auto";
+  fixture.fallback = false;
+  vi.stubEnv("PATH", "/usr/bin:/bin");
+  for (const name of ["SHLVL", "TERM", "TERM_PROGRAM", "PS1"]) vi.stubEnv(name, undefined);
+  // An inherited GUI preference must not override our explicit CLI request.
+  vi.stubEnv("TAILSCALE_BE_CLI", "0");
+});
+
+afterEach(async () => {
+  if (control) await new Promise<void>((resolve) => control!.close(() => resolve()));
+  control = undefined;
+  vi.unstubAllEnvs();
+});
+
+describe("Tailscale from a shell-less standalone macOS app", () => {
+  it("refreshes the real control endpoint and advertises HTTP on the companion port", async () => {
+    fixture.output = "gui";
+    const attempts: string[] = [];
+    await refreshTailnetName((_cli, outcome) => attempts.push(outcome));
+    expect(tailnetName()).toBeNull();
+    expect(attempts[0]).toBe("exited successfully in GUI mode instead of CLI mode");
+    expect(attempts.join("\n")).not.toContain("private diagnostic");
+
+    fixture.output = "auto";
+    fixture.calls = [];
+    control = createControlServer({
+      devices: new DeviceRegistry(),
+      companionPort: 8787,
+      discovery: () => ({ advertising: false, name: "Fixture" }),
+      hostedUrl: () => "https://fixture.openmausbot.com",
+      refreshTailscale: () => refreshTailnetName(),
+    });
+    await new Promise<void>((resolve) => control!.listen(0, "127.0.0.1", resolve));
+    const { port } = control.address() as { port: number };
+    const response = await fetch(`http://127.0.0.1:${port}/tailscale/refresh`, { method: "POST" });
+    const state = await response.json() as ReturnType<typeof companionState>;
+    expect(response.status).toBe(200);
+    expect(state.tailnetName).toBe("fixture.tail1234.ts.net");
+    expect(state.endpoints).toContainEqual({ url: "http://fixture.tail1234.ts.net:8787", kind: "tailnet", priority: 100 });
+    expect(state.endpoints).toContainEqual({ url: "https://fixture.openmausbot.com", kind: "hosted", priority: 0 });
+    expect(state.endpoints.some((endpoint: { url: string }) => endpoint.url.includes("100.64.0.7"))).toBe(false);
+    expect(state.pairing).toBeNull();
+    expect(fixture.calls).toHaveLength(1);
+    expect(fixture.calls[0].cli).toBe(standalone);
+    expect(fixture.calls[0].options.env?.TAILSCALE_BE_CLI).toBe("1");
+    expect(process.env.TAILSCALE_BE_CLI).toBe("0");
+  });
+
+  it("keeps trying installed CLI paths after a successful GUI-only exit", async () => {
+    fixture.output = "gui";
+    fixture.fallback = true;
+    await refreshTailnetName();
+    expect(tailnetName()).toBe("fixture.tail1234.ts.net");
+    expect(fixture.calls.at(-1)?.cli).toBe("/usr/bin/tailscale");
+  });
+
+  it.each([
+    ["invalid", "exited successfully, but status output was not JSON"],
+    ["no-dns", "ran, but no MagicDNS name in status"],
+  ])("distinguishes %s from GUI mode and clears stale names", async (output, expected) => {
+    await refreshTailnetName();
+    expect(tailnetName()).not.toBeNull();
+    fixture.output = output;
+    const attempts: string[] = [];
+    await refreshTailnetName((_cli, outcome) => attempts.push(outcome));
+    expect(tailnetName()).toBeNull();
+    expect(attempts[0]).toBe(expected);
+    expect(attempts.join("\n")).not.toContain("private diagnostic");
+  });
+
+  it("also forces CLI mode for self-hosted status, HTTPS Serve, and Serve off", async () => {
+    const result = await tailscaleStatus();
+    expect(result).toHaveProperty("status");
+    if (!("status" in result)) throw new Error("fixture CLI not found");
+    expect(await tailscaleServe(result.status, 8799)).toEqual({ origin: "https://fixture.tail1234.ts.net" });
+    await tailscaleServeOff(result.status);
+    expect(fixture.calls.map(({ args }) => args)).toEqual([
+      ["status", "--json"],
+      ["serve", "--bg", "--https=443", "http://127.0.0.1:8799"],
+      ["serve", "--https=443", "off"],
+    ]);
+    expect(fixture.calls.every(({ options }) => options.env?.TAILSCALE_BE_CLI === "1" && !options.shell)).toBe(true);
+  });
+});

--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -61,6 +61,9 @@ entry only after the shared control surface can really drive it.
 The [desktop server connection smoke](desktop-server-connection.md) mounts the
 real Settings connection component in disposable Electron windows.
 
+The [Tailscale discovery fixture](tailscale.md) checks standalone macOS CLI mode
+and HTTP tailnet endpoint refresh without touching a real Tailscale installation.
+
 The [cloud preview fixture](cloud-preview.md) mounts the real Computer panel
 against an isolated server for image decoding, loading, and recovery UI checks.
 

--- a/docs/verification/tailscale.md
+++ b/docs/verification/tailscale.md
@@ -1,0 +1,36 @@
+# Tailscale standalone CLI discovery
+
+The macOS app executable chooses GUI or CLI mode from its environment.
+Finder-launched OMB processes must set `TAILSCALE_BE_CLI=1`, including when
+using the self-hosted server's `tailscale serve` support. No installed wrapper,
+interactive shell, or change to the user's environment is required.
+
+## Offline verification
+
+```sh
+pnpm exec vitest run companion/test/tailscale-cli.test.ts companion/test/listener.test.ts companion/test/endpoints.test.ts companion/test/control.test.ts server/tailscale.test.ts
+```
+
+The fixture starts a real loopback companion control server with disposable
+device storage and synthetic network interfaces. Every CLI launch is routed to
+an offline child process; it never runs the installed Tailscale or changes a
+real tailnet. Without the CLI environment flag the child exits successfully
+with GUI startup text, reproducing the reported failure.
+
+Assertions cover:
+
+- `POST /tailscale/refresh` recovering a MagicDNS name after a failed probe.
+- Advertising `http://fixture.tail1234.ts.net:8787` on the configured companion
+  port while preserving the separate hosted HTTPS endpoint.
+- Not advertising bare CGNAT IPs as phone routes or opening a pairing window.
+- Candidate fallback, clearing stale names, and distinct diagnostics for GUI
+  startup, malformed JSON, and a status with no DNS name. Raw output is not logged.
+- Explicit CLI mode for self-hosted status, HTTPS Serve, and Serve off.
+
+This proves the discovery/control contract, not a particular customer's
+Tailscale installation, iOS transport behavior, or reachability over cellular.
+For an end-to-end acceptance check, use a disposable Mac/phone pairing, verify
+that Remote access reports the MagicDNS name, then switch the phone from Wi-Fi
+to cellular with Tailscale connected on both devices. Keep public tunnel/DNS
+failures separate: a hosted URL returning a deployment 404 is not repaired by
+successful MagicDNS discovery.

--- a/server/tailscale.ts
+++ b/server/tailscale.ts
@@ -4,7 +4,7 @@
 // node names, so failures are classified into a closed set of reasons.
 import { execFile } from "node:child_process";
 
-import { searchPath, tailscaleCandidates } from "../companion/src/listener.ts";
+import { tailscaleCandidates, tailscaleEnvironment } from "../companion/src/listener.ts";
 
 export interface TailscaleStatus {
   cli: string;
@@ -60,7 +60,7 @@ function run(cli: string, args: string[], timeoutMs: number): Promise<{ ok: bool
     execFile(
       cli,
       args,
-      { timeout: timeoutMs, killSignal: "SIGKILL", maxBuffer: 16 * 1024 * 1024, env: { ...process.env, PATH: searchPath() } },
+      { timeout: timeoutMs, killSignal: "SIGKILL", maxBuffer: 16 * 1024 * 1024, env: tailscaleEnvironment() },
       (error, stdout, stderr) => {
         const code = error && "code" in error && typeof error.code === "number" ? error.code : error ? null : 0;
         resolve({ ok: !error, stdout: String(stdout ?? ""), stderr: String(stderr ?? ""), code });


### PR DESCRIPTION
## Summary

- Force `TAILSCALE_BE_CLI=1` for companion MagicDNS probes and self-hosted Tailscale status/Serve/Serve-off calls, preserving the inherited environment and PATH augmentation.
- Use Tailscale's documented script entry point rather than installing a wrapper or spawning a shell: https://tailscale.com/docs/reference/tailscale-cli?tab=macos
- Distinguish an exit-zero GUI startup response from generic malformed JSON and valid status without a DNS name, without logging raw output.
- Add an offline subprocess/control-server regression fixture and verification recipe.

## Why

The standalone macOS Tailscale app chooses GUI or CLI mode from its environment. A Finder-launched OMB sidecar lacks the shell hints, so the app binary can exit 0 with GUI startup text instead of JSON. OMB then fails to discover an otherwise valid MagicDNS name and omits its tailnet endpoint.

The HTTP/HTTPS contract is already correct and stays unchanged: direct companion routes use `http://<name>.ts.net:<companion-port>`, hosted endpoints use HTTPS, and self-hosted Tailscale Serve terminates HTTPS separately. Bare CGNAT IPs are not newly allowed. A hosted domain returning Vercel's `DEPLOYMENT_NOT_FOUND` is a separate infrastructure issue, not fixed by this patch.

## Verification

- 293 tests passed across the companion suite, server Tailscale helpers, pairing UI status and payload tests.
- 6 verification-document checks passed.
- `pnpm typecheck`, `pnpm lint`, `pnpm build:companion`, and `git diff --check` passed.
- Regression sensitivity: removing only `TAILSCALE_BE_CLI` makes all 5 new tests fail; restoring it makes all 5 pass.
- Real isolated control-server fixture: `POST /tailscale/refresh` recovers the name, advertises HTTP on configured port 8787, preserves hosted HTTPS, excludes the bare tailnet IP, and does not open pairing.
- Standard isolated app launcher + `control-omb doctor`: healthy; stopped and temporary data cleaned up afterwards.

No installed Tailscale, user pairing data, DNS records, or real devices were mutated. The fixture uses a real offline child process with synthetic Tailscale responses; actual customer-device cellular reachability remains an acceptance check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Tailscale integration for standalone macOS apps launched without a shell.
  * More reliably detects GUI-mode failures and falls back to available CLI options.
  * Improved tailnet name refresh, including recovery after failed lookups and clearing stale names.
  * Enhanced local endpoint advertisement for Tailscale Serve.

* **Documentation**
  * Added verification guidance for offline Tailscale discovery and macOS CLI behavior.
  * Documented supported verification scenarios and end-to-end testing considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->