### PR TITLE
fix(server): drop redundant pattern from memory tool text schemas

### DIFF
--- a/server/drivers/agents-proxy.test.ts
+++ b/server/drivers/agents-proxy.test.ts
@@ -854,7 +854,13 @@ describe("agents-proxy MCP surface", () => {
     }
     const tools = await rpc("tools/list");
     const schema = tools.result.tools.find((tool: { name: string }) => tool.name === "memory_update").inputSchema;
-    expect(schema.properties.text).toMatchObject({ minLength: 1, pattern: "\\S" });
+    // No pattern on free-text params: servings that constrain-decode
+    // function-call arguments collapse a patterned free-text field to a
+    // minimal satisfier instead of the intended text — the same class of
+    // failure as the schema-conversion issues behind the flat-schema rule.
+    // Blank text is still rejected by the handler (asserted above).
+    expect(schema.properties.text).toMatchObject({ minLength: 1 });
+    expect(schema.properties.text).not.toHaveProperty("pattern");
     memoryStatus = 409;
     memoryResponse = { error: "oldText must match exactly once in the latest memory." };
     const stale = await callTool("memory_update", { action: "remove", old_text: "missing" });
@@ -902,6 +908,7 @@ describe("agents-proxy MCP surface", () => {
     expect(tool.description).toContain("what happened, not what is true");
     expect(tool.description).toContain("Logs are never loaded into your prompt");
     expect(tool.inputSchema.required).toEqual(["text"]);
+    expect(tool.inputSchema.properties.text).not.toHaveProperty("pattern");
     const logged = await callTool("memory_log", { text: "shipped 0.1.70", fromBotId: "spoofed" });
     expect(logged.result.isError).toBe(false);
     expect(logged.result.content[0].text).toBe('Logged to memory/log/2026-09-10.md: - 14:03 · from chat "Deploy" · shipped 0.1.70');

--- a/server/drivers/agents-proxy.ts
+++ b/server/drivers/agents-proxy.ts
@@ -560,7 +560,7 @@ const TOOLS = [
       additionalProperties: false,
       properties: {
         action: { type: "string", enum: ["append", "replace", "remove", "supersede"] },
-        text: { type: "string", minLength: 1, pattern: "\\S", description: "Non-blank new text for append, replace, or supersede: the fact itself, without a date or bullet. Omit for remove; use remove to delete a passage." },
+        text: { type: "string", minLength: 1, description: "Non-blank new text for append, replace, or supersede: the fact itself, without a date or bullet. Omit for remove; use remove to delete a passage." },
         old_text: { type: "string", minLength: 1, description: "Exact unique existing passage for replace, supersede, or remove. Omit for append." },
       },
       required: ["action"],
@@ -574,7 +574,7 @@ const TOOLS = [
       type: "object",
       additionalProperties: false,
       properties: {
-        text: { type: "string", minLength: 1, pattern: "\\S", description: "One line about what happened, in plain words." },
+        text: { type: "string", minLength: 1, description: "One line about what happened, in plain words." },
       },
       required: ["text"],
     },


### PR DESCRIPTION
## What changed

- Dropped `pattern: "\S"` from the `text` parameter schema of `memory_update` and `memory_log` (`server/drivers/agents-proxy.ts`), the only two pattern-bearing parameters in the tool surface.
- Updated the contract test that asserted the pattern's presence: it now asserts `minLength: 1` and guards that `pattern` stays out of both text params.

## Why

The pattern enforced nothing the handler does not already enforce — blank text is rejected by a trim check before anything is written, and `minLength: 1` remains — but it is not harmless. Tool `inputSchema`s travel through every engine's MCP-to-provider conversion, and some provider servings apply schema-constrained decoding to function-call arguments. On such servings a patterned free-text field collapses to a minimal satisfier of the regex (a single character plus padding) instead of the intended text, silently corrupting memory writes.

Observed in the field on a GLM-5.3 (non-flash) serving via OpenRouter: every `text` argument on those two tools arrived collapsed to a fragment, while every other parameter in the same calls — including `memory_update.old_text`, which differs only in not carrying `pattern` — arrived intact, and the same model's flash variant through the identical schema was unaffected. Same failure class as the schema-conversion issues behind the flat-schema rule (#544); `pattern` belongs on the avoid list with `oneOf`/`anyOf`/`allOf`/`const`/`format`.

## How it was verified

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm exec vitest run server/drivers/agents-proxy.test.ts` — 65/65 passed, including the flipped pattern guards
- Full `vitest run` on Windows: blocked by this machine's environment — it runs the app under test, so the suite's discovery probes resolve against the live instance (that test fails identically at the comparison base `cdb25df`). CI runs the complete suite on clean runners.

Prepared on a fork: base `e9840ed` (current `main`, #1070), branch `fix/memory-tool-text-pattern`. Typecheck, lint, and the contract suite re-verified on that base after rebase.

AI assistance: this change was prepared with AI assistance (GLM-5.3, Z.ai) under human direction; the submitter reviewed the diff and verified all checks.

## Screenshots (UI changes)

None — server-side tool schema change only.

## Checklist

- [x] `pnpm typecheck` and `pnpm test` pass locally (typecheck, lint, and this change's contract suite; the wider suite cannot complete on this machine — see verification above — and CI covers the full matrix)
- [x] Server behavior changes come with tests
- [x] No `dist-server/` edits
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with providers that process tool inputs by relaxing text-format validation for memory updates and logs.
  * Blank text remains rejected through minimum-length validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->