### PR TITLE
fix(computer): recover VPS previews and compress remote frames

### DIFF
--- a/docs/verification/cloud-preview.md
+++ b/docs/verification/cloud-preview.md
@@ -34,8 +34,37 @@ Verify these transitions with computer use:
 7. While **slow** is pending, switch to **connected** and **Reconnect panel**.
    The new connection must display immediately; the cancelled request must
    neither block it nor overwrite its frame later.
+8. Select **held**, turn **Busy** on, and wait for the next poll. Toggle
+   **Busy** off: the pending capture must not be canceled. **Reconnect panel**
+   does cancel its client request, but the simulated host capture continues.
+   The replacement preview must retry contention without a disconnect alert.
+   Select **connected**, then **Release held capture**; the preview recovers
+   automatically and the old capture never overwrites it.
+9. From a connected frame, select **failed** and turn **Busy** on. After the
+   error appears, select **contended** and **Retry preview**. The last frame
+   stays visible while retrying. After ten seconds the continuing contention
+   becomes an actionable error, but retries continue: select **connected** to
+   recover without clicking Retry again.
+10. Open the live desktop. The fixture holds its join until **Release desktop
+    join**; screenshot polling must pause throughout that wait. Repeat with
+    **Panel → Remote desktop**. The viewer is simulated, never a native window.
+11. Select **unconfigured** while **Busy** is on. Its permanent HTTP409 must
+    show **VPS is not configured** with Retry, not an endless connecting state.
+
+The automated browser regression runs these contention, cancellation, decoded
+frame retention, and join-pause checks against the same fixture:
+
+```sh
+OMB_UI_E2E=1 node node_modules/vitest/vitest.mjs run scripts/testing/cloud-preview.e2e.test.ts
+```
+
+It reuses the standard isolated UI harness and prints the temporary data path
+and persistent server log. To reuse already installed test binaries, set
+`OMB_AGENT_BROWSER_PATH` and `AGENT_BROWSER_EXECUTABLE_PATH` explicitly.
 
 The fixture tests actual image decoding, request cancellation, fresh frame
-selection, and renderer feedback. It does not prove real Box provisioning,
-native viewer windows, or account authentication. Test those separately with
-an explicitly isolated provider fixture when changing those paths.
+selection, and renderer feedback. Host work continuing after cancellation is
+simulated in-page; `server/vps-routing.test.ts` separately covers the real HTTP
+route with fake SSH/Docker. Neither fixture proves a real VPS connection, Box
+provisioning, native viewer windows, or account authentication. Test those
+separately with an explicitly isolated provider fixture when changing those paths.

--- a/scripts/testing/cloud-preview.e2e.test.ts
+++ b/scripts/testing/cloud-preview.e2e.test.ts
@@ -1,0 +1,155 @@
+// The real panels, image decoder and fetch cancellation in a disposable
+// browser/server. Only the cloud provider transport is simulated.
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, expect, it } from "vitest";
+import { resolveAgentBrowserBinary } from "../../server/browser-engine.ts";
+import { waitForExit } from "../../server/testing/cleanup.ts";
+import { runControlOmb } from "../control-omb.ts";
+import { UI_TOOLS_DIR } from "./control-omb-ui.ts";
+import { mountPreview, type MountedPreview } from "./preview-fixture.ts";
+
+const ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const enabled = process.env.OMB_UI_E2E === "1" || Boolean(resolveAgentBrowserBinary({ dataDir: UI_TOOLS_DIR, env: process.env }));
+interface FixtureInfo { ui: string; url: string; dataDir: string; logPath: string }
+
+describe("cloud preview recovery in the real renderer", () => {
+  let child: ChildProcess | undefined;
+  let preview: MountedPreview | undefined;
+  afterAll(async () => {
+    await waitForExit(child, { signal: "SIGINT", graceMs: 30_000 });
+    await preview?.close();
+  });
+
+  (enabled ? it : it.skip)("retains frames, retries contention, and pauses capture during desktop opening", async () => {
+    let stdout = "";
+    let stderr = "";
+    let info: FixtureInfo;
+    child = spawn(process.execPath, ["--experimental-strip-types", join(ROOT, "scripts/control-omb.ts"), "ui", "launch"], {
+      cwd: ROOT, env: process.env, stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stdout!.on("data", (chunk: Buffer) => { stdout += String(chunk); });
+    child.stderr!.on("data", (chunk: Buffer) => { stderr += String(chunk); });
+    child.on("error", (error) => { stderr += error.message; });
+    await expect.poll(() => {
+      if (child!.exitCode !== null || child!.signalCode !== null) throw new Error(`UI launcher exited: ${stderr}`);
+      try { info = JSON.parse(stdout); return Boolean(info.ui); } catch { return false; }
+    }, { timeout: 600_000, interval: 250 }).toBe(true);
+    const ui = (verb: string, ...args: string[]) => runControlOmb(["ui", verb, "--ui", info.ui, ...args]) as Promise<Record<string, any>>;
+    const evaluate = async (js: string) => (await ui("eval", "--js", js)).result;
+    const click = (name: string) => ui("click", "--name", name);
+    const snapshot = async () => (await ui("snapshot")).snapshot as string;
+    const select = (name: string, value: string) => evaluate(`(() => {
+      const select = document.querySelector('select[aria-label=${JSON.stringify(name)}]');
+      select.value = ${JSON.stringify(value)};
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+      return true;
+    })()`);
+    const currentFrame = () => evaluate("document.querySelector('aside img, img[alt^=\"Screen of\"]')?.getAttribute('src') ?? document.querySelector('img')?.getAttribute('src') ?? null");
+    const frameVisible = () => evaluate("Array.from(document.querySelectorAll('img')).some(img => img.src === window.cloudPreviewFixture.screenshot && img.complete && img.naturalWidth > 1 && getComputedStyle(img).visibility === 'visible')");
+    const stat = (key: string) => evaluate(`window.cloudPreviewFixture.${key}`);
+    const pause = (ms: number) => evaluate(`new Promise(resolve => setTimeout(() => resolve(true), ${ms}))`);
+
+    preview = await mountPreview({ info: { url: info!.url } }, {
+      entry: "/scripts/testing/cloud-preview.tsx", route: "/__cloud-preview.html", title: "Isolated cloud preview regression", logLevel: "silent",
+    });
+    await evaluate(`location.href = ${JSON.stringify(preview.previewUrl)}; true`);
+    await expect.poll(frameVisible, { timeout: 20_000 }).toBe(true);
+
+    // Busy changes must not cancel an expensive capture. A real abort does
+    // not terminate its simulated host work; the next generation sees409.
+    await select("Screenshot response", "held");
+    await click("Busy: false");
+    await expect.poll(() => stat("capturing"), { timeout: 6000 }).toBe(true);
+    const requests = await stat("requests");
+    await click("Busy: true");
+    await pause(200);
+    expect(await stat("aborted")).toBe(0);
+    expect(await stat("requests")).toBe(requests);
+    await click("Reconnect panel");
+    await expect.poll(() => stat("conflicts"), { timeout: 5000 }).toBeGreaterThan(0);
+    expect(await stat("aborted")).toBe(1);
+    expect(await snapshot()).not.toContain("Couldn't connect to the screen");
+    await select("Screenshot response", "connected");
+    await click("Release held capture");
+    await expect.poll(frameVisible, { timeout: 5000 }).toBe(true);
+    expect(await currentFrame()).toBe(await stat("screenshot"));
+
+    // Retrying an error preserves the decoded image.409 is quiet for a
+    // short recovery window, then becomes actionable without stopping retries.
+    await select("Screenshot response", "failed");
+    await click("Busy: false");
+    await expect.poll(snapshot, { timeout: 6000 }).toContain("Retry preview");
+    expect(await frameVisible()).toBe(true);
+    await select("Screenshot response", "contended");
+    await click("Retry preview");
+    await expect.poll(snapshot, { timeout: 3000 }).not.toContain("Retry preview");
+
+    expect(await frameVisible()).toBe(true);
+    await expect.poll(snapshot, { timeout: 14_000 }).toContain("Retry preview");
+    expect(await frameVisible()).toBe(true);
+    await select("Screenshot response", "connected");
+    await expect.poll(snapshot, { timeout: 5000 }).not.toContain("Retry preview");
+    await select("Screenshot response", "unconfigured");
+    await expect.poll(snapshot, { timeout: 6000 }).toContain("VPS is not configured");
+    expect(await frameVisible()).toBe(true);
+    await select("Screenshot response", "connected");
+    await click("Retry preview");
+    await expect.poll(snapshot, { timeout: 3000 }).not.toContain("Retry preview");
+
+    // An undecodable frame is not worth preserving: retry starts a clean
+    // loader rather than redisplaying the old corrupt image's error.
+    await select("Screenshot response", "corrupt");
+    await expect.poll(snapshot, { timeout: 6000 }).toContain("Retry preview");
+    await select("Screenshot response", "slow");
+    await click("Retry preview");
+    expect(await snapshot()).toContain("Connecting to the screen…");
+    expect(await snapshot()).not.toContain("Retry preview");
+    await select("Screenshot response", "connected");
+    await expect.poll(frameVisible, { timeout: 15_000 }).toBe(true);
+
+    // Desktop join/control owns the UI while it is pending. Neither panel
+    // should continue issuing screenshot polls into that operation.
+    for (const panel of ["computer", "remote"]) {
+      if (panel === "remote") {
+        await select("Panel", "remote");
+        await expect.poll(frameVisible, { timeout: 5000 }).toBe(true);
+        await select("Screenshot response", "held");
+        await expect.poll(() => stat("capturing"), { timeout: 6000 }).toBe(true);
+        const aborted = await stat("aborted");
+        const requested = await stat("requests");
+        await click("Busy: true");
+        await pause(200);
+        expect(await stat("aborted")).toBe(aborted);
+        expect(await stat("requests")).toBe(requested);
+        await click("Reconnect panel");
+        await expect.poll(() => stat("aborted"), { timeout: 3000 }).toBe(aborted + 1);
+        expect(await snapshot()).not.toContain("Preview unavailable");
+        await select("Screenshot response", "connected");
+        await click("Release held capture");
+        await expect.poll(frameVisible, { timeout: 5000 }).toBe(true);
+        await click("Busy: false");
+      }
+      await expect.poll(frameVisible, { timeout: 5000 }).toBe(true);
+      const state = await ui("snapshot", "--interactive");
+      const target = Object.entries(state.refs as Record<string, { role: string; name: string }>)
+        .find(([, entry]) => entry.role === "button" && entry.name.startsWith("Open ") && entry.name.endsWith("live desktop"));
+      expect(target).toBeDefined();
+      await ui("click", "--ref", `@${target![0]}`);
+      await expect.poll(() => stat("joining"), { timeout: 5000 }).toBe(true);
+      const before = await stat("requests");
+      await pause(4500);
+      expect(await stat("requests")).toBe(before);
+      expect(await stat("duringJoin")).toBe(0);
+      await click("Release desktop join");
+      await expect.poll(() => stat("joining")).toBe(false);
+    }
+    process.stdout.write(`${JSON.stringify({ fixture: info!, previewUrl: preview.previewUrl, transport: "simulated; panels and browser real" })}\n`);
+    await waitForExit(child, { signal: "SIGINT", graceMs: 30_000 });
+    expect(child.exitCode).toBe(0);
+    expect(existsSync(info!.dataDir)).toBe(false);
+    expect(existsSync(info!.logPath)).toBe(true);
+  }, 720_000);
+});

--- a/scripts/testing/cloud-preview.tsx
+++ b/scripts/testing/cloud-preview.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { ComputerPanel } from "../../src/components/ComputerPanel";
+import { RemoteDesktopPanel } from "../../src/components/remote-desktop-panel";
 import { StoreProvider, useStore } from "../../src/state/store";
 import { applySkin, readSkin } from "../../src/lib/skins";
 import "../../src/styles.css";
@@ -22,6 +23,27 @@ function frame(label: string, color: string) {
 }
 const screenshot = frame("Cloud screen connected", "#134e4a");
 let mode = "connected";
+// A host capture outlives an aborted renderer fetch. Keep this work pending
+// until explicitly released, so reconnects exercise real lifecycle contention.
+const transport = {
+  requests: 0, aborted: 0, conflicts: 0, capturing: false,
+  joining: false, duringJoin: 0, controlCalls: 0,
+  releaseCapture: () => {}, releaseJoin: () => {},
+  screenshot: `data:image/png;base64,${screenshot}`,
+};
+Object.assign(window, { cloudPreviewFixture: transport });
+const viewerListeners = new Set<(state: { open: boolean; contextId: string }) => void>();
+Object.assign(window, { ogb: { desktopViewer: {
+  currentState: async () => ({ open: false, contextId: "" }),
+  onState: (listener: (state: { open: boolean; contextId: string }) => void) => {
+    viewerListeners.add(listener);
+    return () => viewerListeners.delete(listener);
+  },
+  open: async (_url: string, _title: string, contextId: string) => {
+    for (const listener of viewerListeners) listener({ open: true, contextId });
+    return true;
+  },
+} } });
 const originalFetch = window.fetch.bind(window);
 window.fetch = async (input, init) => {
   const path = typeof input === "string" ? input : "";
@@ -31,7 +53,27 @@ window.fetch = async (input, init) => {
   if (/^\/api\/bots\/[\w-]+\/computer$/.test(path)) return json({ configured: true, box: { state: "idle" } });
   if (path.endsWith("/computer/provision")) return json({ state: "idle" });
   if (path.endsWith("/computer/screenshot")) {
+    transport.requests++;
+    if (transport.joining) transport.duringJoin++;
     const selectedMode = mode;
+    if (transport.capturing || selectedMode === "contended") {
+      transport.conflicts++;
+      return json({ error: "this bot's cloud computer is being changed — wait for it to finish" }, 409);
+    }
+    if (selectedMode === "held") {
+      transport.capturing = true;
+      await new Promise<void>((resolve, reject) => {
+        const abort = () => { transport.aborted++; reject(init?.signal?.reason); };
+        transport.releaseCapture = () => {
+          transport.capturing = false;
+          init?.signal?.removeEventListener("abort", abort);
+          resolve();
+        };
+        if (init?.signal?.aborted) abort();
+        else init?.signal?.addEventListener("abort", abort, { once: true });
+      });
+      return json({ png: frame("Released old capture", "#881337"), format: "png" });
+    }
     if (selectedMode === "slow" || selectedMode === "timeout") {
       await new Promise<void>((resolve, reject) => {
         const abort = () => { clearTimeout(timer); reject(init?.signal?.reason); };
@@ -44,10 +86,22 @@ window.fetch = async (input, init) => {
       });
     }
     if (selectedMode === "failed") return json({ error: "The computer is temporarily unavailable" }, 503);
+    if (selectedMode === "unconfigured") return json({ error: "VPS is not configured" }, 409);
     return json({ png: selectedMode === "corrupt" ? "bm90IGFuIGltYWdl" : screenshot, format: "png" });
   }
-  // Never allow the fixture's viewer/sleep actions to reach a real provider.
-  if (path.endsWith("/computer/join") || path.endsWith("/computer/sleep")) {
+  if (path.endsWith("/computer/control") && init?.method === "POST") {
+    transport.controlCalls++;
+    return json({ held: JSON.parse(String(init.body)).action === "take", helpReason: null });
+  }
+  if (path.endsWith("/computer/join")) {
+    transport.joining = true;
+    await new Promise<void>((resolve) => {
+      transport.releaseJoin = () => { transport.joining = false; resolve(); };
+    });
+    return json({ joinUrl: "/vps-viewer/fixture/" });
+  }
+  // Never allow the fixture's lifecycle actions to reach a real provider.
+  if (path.endsWith("/computer/sleep")) {
     return json({ error: "This fixture tests previews only" }, 409);
   }
   return originalFetch(input, init);
@@ -58,6 +112,7 @@ function Fixture() {
   const bot = state.bots[0];
   const [busy, setBusy] = useState(false);
   const [generation, setGeneration] = useState(0);
+  const [panel, setPanel] = useState("computer");
   useEffect(() => {
     if (bot) {
       dispatch({ type: "screenFrame", botId: bot.id, png: blank, mime: "image/png" });
@@ -67,13 +122,21 @@ function Fixture() {
   return <div className="flex h-screen justify-center">
     <div className="fixed left-2 top-2 grid max-w-32 gap-3 text-sm">
       <label>Screenshot response<select aria-label="Screenshot response" defaultValue={mode} onChange={(e) => { mode = e.target.value; }}>
-        {["connected", "slow", "failed", "corrupt", "timeout"].map((value) => <option key={value}>{value}</option>)}
+        {["connected", "slow", "held", "contended", "failed", "unconfigured", "corrupt", "timeout"].map((value) => <option key={value}>{value}</option>)}
+      </select></label>
+      <label>Panel<select aria-label="Panel" value={panel} onChange={(event) => setPanel(event.target.value)}>
+        <option value="computer">Computer</option><option value="remote">Remote desktop</option>
       </select></label>
       <button onClick={() => setGeneration((n) => n + 1)}>Reconnect panel</button>
       <button onClick={() => setBusy(!busy)}>Busy: {String(busy)}</button>
+      <button onClick={() => transport.releaseCapture()}>Release held capture</button>
+      <button onClick={() => transport.releaseJoin()}>Release desktop join</button>
       <button disabled={!bot} onClick={() => dispatch({ type: "screenFrame", botId: bot.id, png: frame("New live frame", "#312e81"), mime: "image/png" })}>Publish live frame</button>
     </div>
-    {bot ? <ComputerPanel key={generation} bot={{ ...bot, busy }} /> : "Loading fixture…"}
+    {bot ? panel === "computer"
+      ? <ComputerPanel key={generation} bot={{ ...bot, busy }} />
+      : <RemoteDesktopPanel key={generation} bot={{ ...bot, busy }} />
+      : "Loading fixture…"}
   </div>;
 }
 applySkin(readSkin());

--- a/server/index.ts
+++ b/server/index.ts
@@ -3004,6 +3004,9 @@ let localVmProvisionBusy = false;
 let localVmModeChangeBusy = false;
 const activeVpsThreads = new Map<string, string>();
 const boxLifecycleBusyBots = new Set<string>();
+// A refresh is a reader, not a lifecycle change. Keep its reservation until
+// the provider settles even if the HTTP client leaves, and share it on retry.
+const vpsPreviewRequests = new Map<string, ReturnType<typeof vps.vpsComputerScreenshot>>();
 const orphanBoxLifecycleBusyIds = new Set<string>();
 const boxInventoryRequestsBusyIds = new Set<string>();
 type RemoteComputerProvider = "box" | "vps";
@@ -3058,7 +3061,7 @@ function providerOperationConflict(provider: RemoteComputerProvider): string | n
   if (managedBoxOwners().some((owner) => owner.inUse)) {
     return `stop active bot work and computer control before changing ${provider === "box" ? "the Box account" : "the VPS connection"}`;
   }
-  if (boxLifecycleBusyBots.size > 0) {
+  if (boxLifecycleBusyBots.size > 0 || vpsPreviewRequests.size > 0) {
     return "wait for cloud computer actions to finish before changing provider settings";
   }
   if (provider === "box") {
@@ -3117,12 +3120,16 @@ function claimManagedBoxMutation(instance: box.ManagedBoxInventoryInstance): () 
   return claimBotComputerLifecycle(ownerBotId);
 }
 
-/** One synchronous lane for every Box lifecycle consumer. Both Settings and
+/** One synchronous lane for cloud lifecycle consumers. Both Settings and
  * bot-scoped actions use it, so whichever operation starts first excludes the
- * other instead of relying on a stale check made before a provider await. */
-function claimBotComputerLifecycle(botId: string): () => void {
+ * other instead of relying on a stale check made before a provider await.
+ * Only opening an existing VPS viewer may coexist with its pending preview. */
+function claimBotComputerLifecycle(botId: string, allowPreview = false): () => void {
   if (boxLifecycleBusyBots.has(botId)) {
     throw Object.assign(new Error("this bot's cloud computer is being changed — wait for it to finish"), { status: 409 });
+  }
+  if (!allowPreview && vpsPreviewRequests.has(botId)) {
+    throw Object.assign(new Error("a screen preview is still refreshing — wait before changing this computer"), { status: 409 });
   }
   boxLifecycleBusyBots.add(botId);
   return () => boxLifecycleBusyBots.delete(botId);
@@ -8507,7 +8514,7 @@ const workspaceBackupRoutes = createWorkspaceBackupRoutes({
     idle: () => !providerFleetReloading && !providerAuthSessions.active && !browserEngineInstall &&
       !routines?.isTicking && !calendarCalls?.isTicking &&
       !localVmImageBusy && !localVmProvisionBusy && !localVmModeChangeBusy &&
-      !localVmLifecycleBusy.size && !boxLifecycleBusyBots.size && !orphanBoxLifecycleBusyIds.size &&
+      !localVmLifecycleBusy.size && !boxLifecycleBusyBots.size && !vpsPreviewRequests.size && !orphanBoxLifecycleBusyIds.size &&
       !computerProviderConfigTransitions.size && !checkpointRestoreLeases.size &&
       store.bots.every((bot) => !botHasActiveTurn(bot.id) && !routines?.activeRunForBot(bot.id) && !computerControl.snapshot(bot.id).held) &&
       store.groups.every((group) => !groupIsWorking(group)),
@@ -14683,7 +14690,19 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
         return json(res, 409, { error: "this bot's cloud computer is being changed — wait for it to finish" });
       }
       if (bot.cloudBackend === "vps") {
-        const releaseComputerLifecycle = claimBotComputerLifecycle(botId);
+        if (m[2] === "screenshot") {
+          let preview = vpsPreviewRequests.get(botId);
+          if (!preview) {
+            preview = vps.vpsComputerScreenshot(cfg, botId).finally(() => {
+              vpsPreviewRequests.delete(botId);
+            });
+            vpsPreviewRequests.set(botId, preview);
+          }
+          return json(res, 200, await preview);
+        }
+        // Opening the existing SSH viewer can coexist with a capture. Start,
+        // stop, remove and Settings deletion still exclude pending previews.
+        const releaseComputerLifecycle = claimBotComputerLifecycle(botId, m[2] === "join");
         try {
           if (m[2] === "exec") {
             return json(res, 409, { error: "the VPS console is available to the bot through its scoped computer tools" });
@@ -14697,7 +14716,6 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
           if (m[2] === "join") {
             return json(res, 200, await vps.vpsComputerJoin(cfg, botId));
           }
-          if (m[2] === "screenshot") return json(res, 200, await vps.vpsComputerScreenshot(cfg, botId));
           const action = m[2] === "provision" ? "provision" : m[2] === "remove" ? "remove" : "stop";
           return json(res, 200, await vps.vpsComputerAction(action, cfg, botId));
         } finally {

--- a/server/vps-computer.test.ts
+++ b/server/vps-computer.test.ts
@@ -1,4 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough, Writable } from "node:stream";
+
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
+vi.mock("node:child_process", async () => ({
+  ...(await vi.importActual<typeof import("node:child_process")>("node:child_process")),
+  spawn: spawnMock,
+}));
 
 import {
   BASE_IMAGE,
@@ -27,6 +39,7 @@ import {
   vpsContainerRunArgs,
   vpsDockerArgs,
   vpsDriverError,
+  vpsLifecycleBusy,
   vpsSshTunnelArgs,
   reuseVps,
   type VpsCommandRunner,
@@ -41,6 +54,11 @@ const screenshot = Buffer.concat([
   Buffer.alloc(600),
   Buffer.from("IEND", "ascii"),
 ]);
+const hasPillow = (() => {
+  if (process.platform === "win32") return false;
+  try { execFileSync("python3", ["-I", "-c", "from PIL import Image"], { stdio: "ignore" }); return true; }
+  catch { return false; }
+})();
 
 function fixture({
   image = true,
@@ -185,7 +203,7 @@ function fixture({
       // only the pixel-carrying screenshot call fails; the status path's
       // plain get_desktop_state readiness probe keeps answering
       if (screenshotCaptureFails && args.includes("--screenshot-out-file")) throw new Error("capture failed");
-      if (args.includes("base64")) return { stdout: screenshotValid ? screenshot.toString("base64") : "not-an-image", stderr: "" };
+      if (args.includes("openmausbot-preview")) return { stdout: screenshotValid ? screenshot.toString("base64") : "not-an-image", stderr: "" };
       if (args.includes("tail")) {
         return { stdout: "X display :1 did not become ready within 45 seconds\n", stderr: "" };
       }
@@ -290,7 +308,7 @@ describe("VPS computer", () => {
     // The status poll must never transfer pixels: readiness is the driver
     // answering get_desktop_state, and pixel validation belongs to the
     // screenshot path alone.
-    expect(fake.calls.some(({ args }) => args.includes("base64"))).toBe(false);
+    expect(fake.calls.some(({ args }) => args.includes("openmausbot-preview"))).toBe(false);
     expect(fake.calls.some(({ args }) => args.includes("--screenshot-out-file"))).toBe(false);
   });
 
@@ -488,7 +506,12 @@ describe("VPS computer", () => {
     const frame = await vpsComputerScreenshot(CONFIG, BOT_ID, fake.runner);
     expect(frame).toEqual({ png: screenshot.toString("base64"), format: "png" });
     expect(fake.calls.some(({ args }) => args.includes("get_desktop_state"))).toBe(true);
-    expect(fake.calls.some(({ args }) => args.includes("base64") && args.includes("-u") && args.includes("cua"))).toBe(true);
+    const transfer = fake.calls.find(({ args }) => args.includes("openmausbot-preview"))!.args;
+    expect(transfer.slice(2)).toEqual([
+      "exec", "-u", "cua", "-e", "HOME=/home/cua", CONTAINER_ID,
+      "sh", "-c", expect.stringContaining('quality=70'), "openmausbot-preview", "/tmp/openmausbot-vps-preview.png",
+    ]);
+    expect(transfer[transfer.indexOf("-c") + 1]).toContain("image.thumbnail((1280, 1280))");
     expect(fake.calls.some(({ args }) => args.includes("rm") && args.includes("-f"))).toBe(true);
 
     await expect(vpsComputerScreenshot(CONFIG, BOT_ID, fixture({ screenshotValid: false }).runner)).rejects.toThrow(/incomplete/);
@@ -496,6 +519,194 @@ describe("VPS computer", () => {
     const failedCapture = fixture({ screenshotCaptureFails: true });
     await expect(vpsComputerScreenshot(CONFIG, BOT_ID, failedCapture.runner)).rejects.toThrow(/capture failed/);
     expect(failedCapture.calls.some(({ args }) => args.includes("rm") && args.includes("-f"))).toBe(true);
+  });
+
+  it.skipIf(!hasPillow)("transfers real JPEG previews at quality 70, within 1280px without upscaling", async () => {
+    const fake = fixture();
+    await vpsComputerScreenshot(CONFIG, BOT_ID, fake.runner);
+    const transfer = fake.calls.find(({ args }) => args.includes("openmausbot-preview"))!.args;
+    // Execute the exact in-container script, substituting only the local
+    // Pillow interpreter and a disposable input image. No Docker or SSH.
+    const script = transfer[transfer.indexOf("-c") + 1].replace("/opt/venv/bin/python", "python3");
+    const scratch = mkdtempSync(join(tmpdir(), "omb-vps-preview-image-"));
+    try {
+      for (const [width, height, expected] of [[2560, 1600, [1280, 800]], [1600, 2560, [800, 1280]], [320, 200, [320, 200]]] as const) {
+        const original = execFileSync("python3", ["-I", "-c", `from PIL import Image; import sys; Image.effect_noise((${width}, ${height}), 64).convert("RGBA").save(sys.stdout.buffer, format="PNG")`], { maxBuffer: 32 * 1024 * 1024 });
+        const path = join(scratch, "preview.png");
+        writeFileSync(path, original);
+        const encoded = execFileSync("sh", ["-c", script, "openmausbot-preview", path], { encoding: "utf8", maxBuffer: 16 * 1024 * 1024 });
+        const jpeg = Buffer.from(encoded, "base64");
+        const decoded = execFileSync("python3", ["-I", "-c", [
+          "from PIL import Image",
+          "import io, json, sys",
+          "image = Image.open(io.BytesIO(sys.stdin.buffer.read()))",
+          "image.load()",
+          "reference = io.BytesIO()",
+          "Image.new('RGB', (1, 1)).save(reference, format='JPEG', quality=70)",
+          "print(json.dumps(dict(format=image.format, size=image.size, mode=image.mode, quality70=image.quantization == Image.open(reference).quantization)))",
+        ].join("\n")], { input: jpeg, encoding: "utf8" });
+        expect(JSON.parse(decoded)).toEqual({ format: "JPEG", size: expected, mode: "RGB", quality70: true });
+        expect(jpeg.length).toBeLessThan(original.length / 2);
+        expect(readFileSync(path).equals(original)).toBe(true);
+        const frame = await vpsComputerScreenshot(CONFIG, BOT_ID, async (args, options) => args.includes("openmausbot-preview")
+          ? { stdout: encoded, stderr: "" }
+          : fake.runner(args, options));
+        expect(frame).toEqual({ png: encoded, format: "jpeg" });
+      }
+    } finally { rmSync(scratch, { recursive: true, force: true }); }
+  });
+
+  it.skipIf(process.platform === "win32")("falls back to the original PNG when conversion is unavailable or fails", async () => {
+    const fake = fixture();
+    await vpsComputerScreenshot(CONFIG, BOT_ID, fake.runner);
+    const transfer = fake.calls.find(({ args }) => args.includes("openmausbot-preview"))!.args;
+    const originalScript = transfer[transfer.indexOf("-c") + 1];
+    const scratch = mkdtempSync(join(tmpdir(), "omb-vps-preview-fallback-"));
+    try {
+      const path = join(scratch, "preview.png");
+      writeFileSync(path, screenshot);
+      // A missing interpreter and a failed conversion must both preserve
+      // the previous PNG behavior, never return a partial JPEG plus a PNG.
+      for (const interpreter of [join(scratch, "missing-python"), "false"]) {
+        const script = originalScript.replace("/opt/venv/bin/python", interpreter);
+        const encoded = execFileSync("sh", ["-c", script, "openmausbot-preview", path], { encoding: "utf8" });
+        expect(encoded).toBe(screenshot.toString("base64"));
+      }
+    } finally { rmSync(scratch, { recursive: true, force: true }); }
+  });
+
+  it("shares overlapping captures of the same target through cleanup", async () => {
+    const fake = fixture();
+    let release!: () => void;
+    let entered!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const capturing = new Promise<void>((resolve) => { entered = resolve; });
+    const runner: VpsCommandRunner = async (args, options) => {
+      if (args.includes("--screenshot-out-file")) { entered(); await gate; }
+      return fake.runner(args, options);
+    };
+    const first = vpsComputerScreenshot(CONFIG, BOT_ID, runner);
+    await capturing;
+    const second = vpsComputerScreenshot(CONFIG, BOT_ID, runner);
+    expect(vpsLifecycleBusy()).toBe(true);
+    release();
+    const frames = await Promise.all([first, second]);
+    expect(frames[0]).toEqual(frames[1]);
+    expect(fake.calls.filter(({ args }) => args.includes("--screenshot-out-file"))).toHaveLength(1);
+    expect(fake.calls.filter(({ args }) => args.includes("openmausbot-preview"))).toHaveLength(1);
+    expect(fake.calls.filter(({ args }) => args.includes("rm"))).toHaveLength(1);
+    expect(vpsLifecycleBusy()).toBe(false);
+  });
+
+  it("pins the capture alias and never shares its frame with a different VPS", async () => {
+    const cfg: AppConfig = { vps: { sshAlias: "first-preview-vps" } };
+    const fake = fixture();
+    let release!: () => void;
+    let entered!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const capturing = new Promise<void>((resolve) => { entered = resolve; });
+    const runner: VpsCommandRunner = async (args, options) => {
+      if (args[1] === "ssh://first-preview-vps" && args.includes("--screenshot-out-file")) { entered(); await gate; }
+      return fake.runner(args, options);
+    };
+    const first = vpsComputerScreenshot(cfg, BOT_ID, runner);
+    await capturing;
+    cfg.vps!.sshAlias = "second-preview-vps";
+    await vpsComputerScreenshot(cfg, BOT_ID, runner);
+    release();
+    await first;
+    for (const alias of ["first-preview-vps", "second-preview-vps"]) {
+      expect(fake.calls.filter(({ args }) => args[1] === `ssh://${alias}` && args.includes("--screenshot-out-file"))).toHaveLength(1);
+      expect(fake.calls.filter(({ args }) => args[1] === `ssh://${alias}` && args.includes("openmausbot-preview"))).toHaveLength(1);
+    }
+  });
+
+  it("bounds the complete slow preview, holds its lock through timed-out cleanup, and recovers", async () => {
+    vi.useFakeTimers();
+    try {
+      const fake = fixture();
+      const calls: Array<{ args: string[]; timeoutMs: number }> = [];
+      const runner: VpsCommandRunner = async (args, options) => {
+        const timeoutMs = options?.timeoutMs ?? 120_000;
+        calls.push({ args, timeoutMs });
+        if (args.includes("openmausbot-preview") || args.includes("rm")) {
+          // Match defaultRunner: time out, terminate, then wait its 5s kill
+          // grace before settling. Nothing races ahead of this outstanding work.
+          await new Promise((resolve) => setTimeout(resolve, timeoutMs + 5_000));
+          throw new Error("Docker-over-SSH command timed out");
+        }
+        await new Promise((resolve) => setTimeout(resolve, args.includes("--screenshot-out-file") ? 4_000 : 2_000));
+        return fake.runner(args, options);
+      };
+      const start = Date.now();
+      let settled = false;
+      const first = vpsComputerScreenshot(CONFIG, BOT_ID, runner).finally(() => { settled = true; });
+      const rejected = expect(first).rejects.toMatchObject({ status: 504 });
+      await vi.advanceTimersByTimeAsync(35_000);
+      expect(calls.find(({ args }) => args.includes("openmausbot-preview"))?.timeoutMs).toBe(14_000);
+      expect(calls.find(({ args }) => args.includes("rm"))?.timeoutMs).toBe(5_000);
+      expect(vpsLifecycleBusy()).toBe(true);
+      expect(settled).toBe(false);
+      const joined = expect(vpsComputerScreenshot(CONFIG, BOT_ID, runner)).rejects.toMatchObject({ status: 504 });
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      await Promise.all([rejected, joined]);
+      expect(Date.now() - start).toBe(45_000);
+      expect(calls.filter(({ args }) => args.includes("--screenshot-out-file"))).toHaveLength(1);
+      expect(vpsLifecycleBusy()).toBe(false);
+      await expect(vpsComputerScreenshot(CONFIG, BOT_ID, fixture().runner)).resolves.toMatchObject({ format: "png" });
+    } finally { vi.useRealTimers(); }
+  });
+
+  it("shares cold status work with a capture and refreshes cache after a slow frame, not before it", async () => {
+    vi.useFakeTimers();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    try {
+      const fake = fixture();
+      const cfg: AppConfig = { vps: { sshAlias: "cache-preview-vps" } };
+      let entered!: () => void;
+      const capturing = new Promise<void>((resolve) => { entered = resolve; });
+      let captures = 0;
+      // Exercise the real defaultRunner/cache path, but replace only the
+      // child transport. No Docker or SSH process reaches a real provider.
+      spawnMock.mockImplementation((_command: string, args: string[]) => {
+        const child = Object.assign(new EventEmitter(), {
+          stdin: new Writable({ write: (_chunk, _encoding, callback) => callback() }),
+          stdout: new PassThrough(), stderr: new PassThrough(),
+          kill: () => true,
+        });
+        queueMicrotask(() => {
+          void (async () => {
+            if (args.includes("--screenshot-out-file") && ++captures === 1) { entered(); await gate; }
+            const output = await fake.runner(args);
+            child.stdout.end(output.stdout);
+            child.stderr.end(output.stderr);
+            child.emit("close", 0, null);
+          })().catch((error: Error) => {
+            child.stderr.end(error.message);
+            child.emit("close", 1, null);
+          });
+        });
+        return child;
+      });
+      const frame = vpsComputerScreenshot(cfg, BOT_ID);
+      await capturing;
+      const status = vpsComputerStatus(cfg, BOT_ID);
+      await vi.advanceTimersByTimeAsync(12_000); // longer than the old 10s cache
+      expect(fake.calls.filter(({ args }) => args[2] === "image")).toHaveLength(1);
+      release();
+      await expect(frame).resolves.toMatchObject({ format: "png" });
+      await expect(status).resolves.toMatchObject({ ready: true });
+      await vpsComputerScreenshot(cfg, BOT_ID);
+      expect(captures).toBe(2);
+      expect(fake.calls.filter(({ args }) => args[2] === "image")).toHaveLength(1);
+      // A real lifecycle transition still invalidates this fresh cache.
+      await vpsComputerAction("stop", cfg, BOT_ID);
+      await expect(vpsComputerScreenshot(cfg, BOT_ID)).rejects.toThrow(/stopped|running/);
+      expect(captures).toBe(2);
+    } finally { release(); spawnMock.mockReset(); vi.useRealTimers(); }
   });
 
   it("fails clearly for BoxAgent and engines without computer MCP", () => {

--- a/server/vps-computer.ts
+++ b/server/vps-computer.ts
@@ -54,6 +54,17 @@ const MANAGED_VPS_CONTAINER_NAME = /^openmausbot-vps-[a-z0-9]{1,12}-[a-f0-9]{12}
 const IMAGE_ID = /^sha256:[a-f0-9]{64}$/i;
 const PIDS_LIMIT = 512;
 const SCREENSHOT_PATH = "/tmp/openmausbot-vps-preview.png";
+// The Cua XFCE base includes Pillow in its existing Python environment. Keep
+// this panel-only conversion in the transfer exec: no extra SSH round trip,
+// image rebuild, driver settings change, or second temporary image. Older
+// containers without Pillow can still return the original PNG.
+const SCREENSHOT_TRANSFER = `/opt/venv/bin/python -I -c 'import base64, io, sys
+from PIL import Image
+with Image.open(sys.argv[1]) as image:
+    image.thumbnail((1280, 1280))
+    output = io.BytesIO()
+    image.convert("RGB").save(output, format="JPEG", quality=70)
+sys.stdout.write(base64.b64encode(output.getvalue()).decode("ascii"))' "$1" 2>/dev/null || { base64 < "$1" | tr -d "\\n"; }`;
 const INTERNAL_VIEWER_PORT = 6901;
 const VIEWER_VERSION = "1";
 const lifecycleLocks = new Map<string, Promise<void>>();
@@ -81,6 +92,10 @@ const LOCK_ACQUIRE_TIMEOUT_MS = 5_000;
 // pattern as container-computer's screenshotStatusCache, and the same TTL.
 const STATUS_CACHE_TTL_MS = 10_000;
 const statusCache = new Map<string, { status: VpsComputerStatus; expiresAt: number }>();
+const SCREENSHOT_BUDGET_MS = 45_000;
+const SCREENSHOT_CLEANUP_BUDGET_MS = 10_000;
+type VpsScreenshot = { png: string; format: "png" | "jpeg" };
+const pendingScreenshots = new Map<string, Promise<VpsScreenshot>>();
 const viewerConnections = new Map<string, { privateIp: string; password: string }>();
 const desktopTunnels = new Map<
   string,
@@ -620,6 +635,9 @@ export async function vpsComputerStatus(
   const key = vpsLockKey(cfg, botId);
   const cacheable = runner === defaultRunner && key !== null;
   if (cacheable) {
+    // A capture already checks this exact target. Let it finish instead of
+    // opening another six SSH connections while its readiness check is cold.
+    await pendingScreenshots.get(key)?.catch(() => {});
     const cached = statusCache.get(key);
     if (cached && cached.expiresAt > Date.now()) return cached.status;
   }
@@ -1240,13 +1258,33 @@ export async function vpsComputerScreenshot(
   cfg: AppConfig,
   botId: string,
   runner: VpsCommandRunner = defaultRunner,
-): Promise<{ png: string; format: "png" | "jpeg" }> {
+): Promise<VpsScreenshot> {
   cfg = snapshotVpsConfig(cfg);
   const alias = vpsSshAlias(cfg);
   if (!alias) throw Object.assign(new Error("VPS is not configured"), { status: 409 });
   const key = `${alias}:${vpsContainerName(botId)}`;
+  const pending = pendingScreenshots.get(key);
+  if (pending) return pending;
   const cacheable = runner === defaultRunner;
-  return withVpsLifecycleLock(key, async () => {
+  const deadline = Date.now() + SCREENSHOT_BUDGET_MS;
+  const workDeadline = deadline - SCREENSHOT_CLEANUP_BUDGET_MS;
+  let budgetExpired = false;
+  const timeoutError = () => Object.assign(new Error("The VPS screen preview timed out. Retry the preview when the connection recovers."), { status: 504 });
+  // Clamp each command and wait through the runner's termination grace,
+  // rather than racing its promise and releasing the lock before cleanup.
+  const boundedRunner: VpsCommandRunner = async (args, options = {}) => {
+    const remaining = workDeadline - Date.now() - COMMAND_TIMEOUT_KILL_GRACE_MS;
+    if (remaining <= 0) { budgetExpired = true; throw timeoutError(); }
+    try {
+      const result = await runner(args, { ...options, timeoutMs: Math.min(options.timeoutMs ?? 120_000, remaining) });
+      if (Date.now() >= workDeadline) { budgetExpired = true; throw timeoutError(); }
+      return result;
+    } catch (error) {
+      if (Date.now() >= workDeadline - COMMAND_TIMEOUT_KILL_GRACE_MS) budgetExpired = true;
+      throw budgetExpired ? timeoutError() : error;
+    }
+  };
+  const capture = withVpsLifecycleLock(key, async () => {
     // Same shape as containerComputerScreenshot's screenshotStatusCache: the
     // poller runs every few seconds, and re-verifying the whole container
     // between frames multiplied every frame's SSH cost.
@@ -1254,12 +1292,17 @@ export async function vpsComputerScreenshot(
     const status =
       cached && cached.expiresAt > Date.now()
         ? cached.status
-        : await computeVpsComputerStatus(cfg, botId, runner);
+        : await computeVpsComputerStatus(cfg, botId, boundedRunner);
+    // Status converts transport errors into displayable state. A deadline is
+    // still a timeout, not evidence that this container became incompatible.
+    if (budgetExpired) {
+      if (cacheable) statusCache.delete(key);
+      throw timeoutError();
+    }
     if (!status.ready) {
       if (cacheable) statusCache.delete(key);
       throw Object.assign(new Error(status.problem ?? "The VPS computer is not ready"), { status: 409 });
     }
-    if (cacheable) statusCache.set(key, { status, expiresAt: Date.now() + STATUS_CACHE_TTL_MS });
     const containerRef = status.container_id ?? status.container_name;
     // The ref goes straight into docker argv, and a cached status is one
     // more step removed from the inspect that produced it — revalidate the
@@ -1267,8 +1310,9 @@ export async function vpsComputerScreenshot(
     if (!CONTAINER_ID.test(containerRef) && !CONTAINER_NAME.test(containerRef)) {
       throw Object.assign(new Error("the VPS container reference is malformed"), { status: 409 });
     }
+    let frame: VpsScreenshot;
     try {
-      await runner(
+      await boundedRunner(
         vpsDockerArgs(
           alias,
           cuaExecArgs(
@@ -1278,29 +1322,39 @@ export async function vpsComputerScreenshot(
         ),
         { timeoutMs: 30_000 },
       );
-      const encoded = (await runner(vpsDockerArgs(alias, [
+      const encoded = (await boundedRunner(vpsDockerArgs(alias, [
         "exec",
         "-u",
         "cua",
         "-e",
         "HOME=/home/cua",
         containerRef,
-        "base64",
-        "-w0",
+        "sh",
+        "-c",
+        SCREENSHOT_TRANSFER,
+        "openmausbot-preview",
         SCREENSHOT_PATH,
       ]), { timeoutMs: 30_000 })).stdout.trim();
       const checked = wholeScreenshot(Buffer.from(encoded, "base64"));
       if (!checked.ok) throw Object.assign(new Error("Cua Driver returned an incomplete VPS screenshot"), { status: 502 });
-      return { png: encoded, format: checked.mime === "image/jpeg" ? "jpeg" : "png" };
+      frame = { png: encoded, format: checked.mime === "image/jpeg" ? "jpeg" : "png" };
     } catch (error) {
       // The failure may mean the world changed (container stopped, link
       // dropped); a cached "ready" would keep the poller failing for a TTL.
       if (cacheable) statusCache.delete(key);
       throw error;
     } finally {
-      await runner(vpsDockerArgs(alias, ["exec", "-u", "cua", containerRef, "rm", "-f", SCREENSHOT_PATH]), {
-        timeoutMs: 10_000,
+      const cleanupMs = Math.min(5_000, deadline - Date.now() - COMMAND_TIMEOUT_KILL_GRACE_MS);
+      if (cleanupMs > 0) await runner(vpsDockerArgs(alias, ["exec", "-u", "cua", containerRef, "rm", "-f", SCREENSHOT_PATH]), {
+        timeoutMs: cleanupMs,
       }).catch(() => {});
     }
+    // Start the TTL after transfer and cleanup; a slow but healthy frame must
+    // not return with its own readiness cache already expired.
+    if (cacheable) statusCache.set(key, { status, expiresAt: Date.now() + STATUS_CACHE_TTL_MS });
+    return frame;
   });
+  pendingScreenshots.set(key, capture);
+  try { return await capture; }
+  finally { if (pendingScreenshots.get(key) === capture) pendingScreenshots.delete(key); }
 }

--- a/server/vps-routing.test.ts
+++ b/server/vps-routing.test.ts
@@ -12,7 +12,7 @@
 // reply carries the FULL prompt and whose gate file gives a deterministic
 // busy window — no sleeps anywhere.
 import { spawn, type ChildProcess } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -121,7 +121,11 @@ case "$*" in
   *" container inspect "*) name=$(cat "$FAKE_DOCKER_DIR/container.name"); sed "s|__NAME__|$name|g" "$FAKE_DOCKER_DIR/container.json.tpl" ;;
   *" image inspect "*) cat "$FAKE_DOCKER_DIR/image.json" ;;
   *" exec "*"--version"*) echo "cua-driver ${CUA_DRIVER_VERSION}" ;;
-  *" exec "*"--screenshot-out-file"*) echo "{}" ;;
+  *" exec "*"--screenshot-out-file"*)
+    : > "$FAKE_DOCKER_DIR/capture-started"
+    while [ -f "$FAKE_DOCKER_DIR/hold-capture" ]; do sleep 0.05; done
+    if [ -f "$FAKE_DOCKER_DIR/fail-capture" ]; then echo "fixture capture failed" >&2; exit 1; fi
+    echo "{}" ;;
   *" exec "*"health_report"*) echo '{"schema_version":"1","overall":"ok","checks":[]}' ;;
   *" exec "*"get_desktop_state"*) echo "{}" ;;
   *" exec "*"base64"*) cat "$FAKE_DOCKER_DIR/screenshot.b64" ;;
@@ -175,6 +179,15 @@ posixOnly("VPS turn routing e2e (fake ACP fleet + fake docker over SSH)", () => 
 
     writeFileSync(join(fakeBin, "docker"), FAKE_DOCKER, { mode: 0o755 });
     chmodSync(join(fakeBin, "docker"), 0o755);
+    // Only the viewer's local listening socket is simulated; no SSH network
+    // or real VPS is contacted. The provider owns and closes this child.
+    writeFileSync(join(fakeBin, "ssh"), `#!${process.execPath}
+import { createServer } from 'node:net';
+const args = process.argv.slice(2);
+const forward = args[args.indexOf('-L') + 1];
+const port = Number(forward.split(':')[1]);
+createServer(socket => socket.end()).listen(port, '127.0.0.1');
+`, { mode: 0o755 });
     writeFileSync(join(fakeBin, "image.json"), imageInspectJson());
     writeFileSync(join(fakeBin, "container.json.tpl"), containerInspectTemplate());
     const png = Buffer.concat([
@@ -232,6 +245,69 @@ posixOnly("VPS turn routing e2e (fake ACP fleet + fake docker over SSH)", () => 
     await waitForExit(child, { signal: "SIGTERM" });
     await removeTempDir(home);
   });
+
+  it("shares a canceled preview with retries and opens control without racing destructive actions", async () => {
+    expect((await api("PUT", "/api/config", { vps: { sshAlias: "production-vps" } })).status).toBe(200);
+    const bot = (await api("POST", "/api/bots")).body.bot;
+    await api("PATCH", `/api/bots/${bot.id}`, { computer: "cloud", cloudBackend: "vps" });
+    const fixtureDir = dirname(dockerLog);
+    const hold = join(fixtureDir, "hold-capture");
+    const started = join(fixtureDir, "capture-started");
+    const failed = join(fixtureDir, "fail-capture");
+    const captures = () => readFileSync(dockerLog, "utf8").split("\n").filter(line => line.includes("--screenshot-out-file")).length;
+    const path = `/api/bots/${bot.id}/computer`;
+    let retries: Array<Promise<{ status: number; body: any }>> = [];
+    try {
+      writeFileSync(hold, "hold");
+      rmSync(started, { force: true });
+      const before = captures();
+      const cancel = new AbortController();
+      const first = fetch(`${BASE}${path}/screenshot`, {
+        method: "POST", headers: { "content-type": "application/json" }, body: "{}", signal: cancel.signal,
+      });
+      await until(async () => existsSync(started), "the pending preview");
+      cancel.abort();
+      await expect(first).rejects.toThrow();
+      retries = [api("POST", `${path}/screenshot`, {}), api("POST", `${path}/screenshot`, {})];
+
+      // These must still exclude the capture even after its HTTP client left.
+      for (const action of ["provision", "sleep", "remove"]) {
+        const blocked = await api("POST", `${path}/${action}`, {});
+        expect(blocked.status, action).toBe(409);
+        expect(blocked.body.error).toMatch(/preview.*refreshing/);
+      }
+      expect((await api("DELETE", `/api/bots/${bot.id}`)).status).toBe(409);
+      expect((await api("PUT", "/api/config", { vps: { sshAlias: "other-vps" } })).status).toBe(409);
+
+      // A preview is not a computer change: opening the existing viewer is
+      // safe, and cannot be rejected merely because a frame is slow.
+      expect((await api("POST", `${path}/control`, { action: "take" })).status).toBe(200);
+      const joined = await api("POST", `${path}/join`, {});
+      expect(joined.status, JSON.stringify(joined.body)).toBe(200);
+      expect(joined.body.joinUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/vnc\.html#/);
+      expect(captures() - before).toBe(1);
+      rmSync(hold, { force: true });
+      for (const result of await Promise.all(retries)) {
+        expect(result.status).toBe(200);
+        expect(result.body).toMatchObject({ format: "png", png: expect.any(String) });
+      }
+      expect(captures() - before).toBe(1);
+
+      // A failed capture must also release its reservation for later retries.
+      writeFileSync(failed, "fail");
+      const failure = await api("POST", `${path}/screenshot`, {});
+      expect(failure.status).toBe(500);
+      expect(failure.body.error).toMatch(/fixture capture failed/);
+      rmSync(failed, { force: true });
+      expect((await api("POST", `${path}/screenshot`, {})).status).toBe(200);
+    } finally {
+      rmSync(hold, { force: true });
+      rmSync(failed, { force: true });
+      await Promise.allSettled(retries);
+      await api("POST", `${path}/viewer-close`, {});
+      await api("POST", `${path}/control`, { action: "release" });
+    }
+  }, 30_000);
 
   it(
     "mounts the VPS computer on the turn, tells the model, reuses without provisioning, and clears the claim",

--- a/src/components/CloudScreenPreview.tsx
+++ b/src/components/CloudScreenPreview.tsx
@@ -1,26 +1,29 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Loader2, Maximize2, Monitor } from "lucide-react";
 
 import { t } from "@/lib/i18n";
 
 /** A connection is only visible once the browser has decoded its first frame. */
-export function CloudScreenPreview({ src, name, error, starting, opening, disabled, onOpen, onRetry }: {
+export function CloudScreenPreview({ src, name, error, starting, opening, disabled, refreshing = false, retry = 0, onOpen, onRetry }: {
   src: string | null;
   name: string;
   error: string | null;
   starting: boolean;
   opening: boolean;
   disabled: boolean;
+  refreshing?: boolean;
+  retry?: number;
   onOpen: () => void;
-  onRetry: () => void;
+  onRetry: (discardFrame: boolean) => void;
 }) {
   const [loaded, setLoaded] = useState<string | null>(null);
   const [failed, setFailed] = useState<string | null>(null);
+  useEffect(() => { setFailed(null); }, [retry]);
   const visible = Boolean(src && loaded === src && failed !== src);
   const problem = error ?? (src && failed === src ? t("computer.preview.imageFailed") : null);
 
   return (
-    <div className="relative h-full w-full" aria-busy={!problem && (!visible || opening)}>
+    <div className="relative h-full w-full" aria-busy={!problem && (!visible || opening || refreshing)}>
       {src && (
         <button
           type="button"
@@ -31,6 +34,7 @@ export function CloudScreenPreview({ src, name, error, starting, opening, disabl
           title={t("computer.openLiveDesktop")}
         >
           <img
+            key={retry}
             src={src}
             alt={t("computer.screenOf", { name })}
             onLoad={() => { setLoaded(src); setFailed(null); }}
@@ -51,11 +55,17 @@ export function CloudScreenPreview({ src, name, error, starting, opening, disabl
           {starting ? t("computer.phase.starting") : t("computer.preview.connectingScreen")}
         </div>
       )}
+      {visible && refreshing && !problem && (
+        <div role="status" className="absolute bottom-2 left-2 flex items-center gap-1 rounded-md bg-black/70 px-2 py-1 text-[11px] text-white">
+          <Loader2 size={12} className="animate-spin" />
+          {t("computer.preview.connectingScreen")}
+        </div>
+      )}
       {problem && (
         <div role="alert" className={`absolute inset-x-0 flex flex-col items-center justify-center gap-2 bg-card/95 p-4 text-center text-[12px] text-ink-secondary ${visible ? "bottom-0" : "inset-y-0"}`}>
           {!visible && <Monitor size={22} />}
           <span>{visible ? t("computer.preview.paused") : t("computer.preview.cantConnect")} {problem}</span>
-          <button type="button" onClick={onRetry} className="rounded-md bg-control px-3 py-1.5 text-ink hover:bg-control-hover">
+          <button type="button" onClick={() => onRetry(!visible)} className="rounded-md bg-control px-3 py-1.5 text-ink hover:bg-control-hover">
             {t("computer.preview.retry")}
           </button>
         </div>

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -25,12 +25,13 @@ import {
   Smartphone,
   X,
 } from "lucide-react";
-import { api, useStore, type Bot } from "@/state/store";
+import { api, ApiError, useStore, type Bot } from "@/state/store";
 import type { CloudBackend } from "../../server/contracts.ts";
 import { ApiKeyRow } from "./ApiKeys";
 import { cn } from "@/lib/cn";
 import { usePageVisible } from "@/lib/page-visible";
 import { CloudScreenPreview } from "./CloudScreenPreview";
+import { isRemoteScreenshotContention } from "@/lib/remote-desktop";
 import { CloudBackendPicker } from "./CloudBackendPicker";
 import { useDesktopCapabilities } from "./DesktopCapabilities";
 import { RoutinesSection } from "./bot-settings/RoutinesSection";
@@ -251,6 +252,7 @@ export function ComputerPanel({
   const [boxState, setBoxState] = useState<string | null>(null);
   const [polledFrame, setPolledFrame] = useState<{ png: string; mime: string } | null>(null);
   const [previewError, setPreviewError] = useState<Error | string | null>(null);
+  const [previewRefreshing, setPreviewRefreshing] = useState(false);
   const [previewRetry, setPreviewRetry] = useState(0);
   const [vmFrame, setVmFrame] = useState<string | null>(null);
   // The Local VM's interactive noVNC viewer (passworded, autoconnect). The
@@ -612,6 +614,8 @@ export function ComputerPanel({
   const pageVisible = usePageVisible();
   const live = state.screens[bot.id];
   const latestLive = useRef({ frame: live, at: 0 });
+  const previewBusy = useRef(bot.busy);
+  useEffect(() => { previewBusy.current = bot.busy; }, [bot.busy]);
   useEffect(() => {
     if (!cloudPreviewReady) {
       latestLive.current = { frame: live, at: 0 };
@@ -623,20 +627,27 @@ export function ComputerPanel({
       latestLive.current.at = Date.now();
       setPolledFrame(live);
       setPreviewError(null);
+      setPreviewRefreshing(false);
     }
   }, [live, cloudPreviewReady]);
 
   useEffect(() => {
-    if (panelView !== "computer" || !cloudPreviewReady || viewerOpen || !pageVisible) return;
+    if (panelView !== "computer" || !cloudPreviewReady || viewerOpen || !pageVisible || pending || controlPending) return;
     let inFlight = false;
+    let lastAttemptAt = -Infinity;
+    let retryDelay: number | null = null;
+    let contentionSince: number | null = null;
     const controller = new AbortController();
     setPreviewError(null);
+    setPreviewRefreshing(true);
     const shoot = async () => {
-      if (inFlight) return;
+      if (inFlight || controller.signal.aborted) return;
+      if (Date.now() - lastAttemptAt < (retryDelay ?? (previewBusy.current ? 4000 : 30_000))) return;
       // Resume polling if a busy bot stops publishing frames. A single old
       // SSE event is not evidence of a working stream for the whole turn.
-      if (bot.busy && Date.now() - latestLive.current.at < 10_000) return;
+      if (previewBusy.current && Date.now() - latestLive.current.at < 10_000) return;
       inFlight = true;
+      retryDelay = null;
       const startedAt = Date.now();
       try {
         const { png, format } = await api(`/api/bots/${bot.id}/computer/screenshot`, {
@@ -647,24 +658,41 @@ export function ComputerPanel({
           if (typeof png !== "string" || !png.trim()) throw new LocalizedPanelError("computer.err.emptyFrame");
           setPolledFrame({ png, mime: format === "jpeg" ? "image/jpeg" : "image/png" });
           setPreviewError(null);
+          setPreviewRefreshing(false);
+          contentionSince = null;
         }
       } catch (e) {
         if (!controller.signal.aborted && latestLive.current.at <= startedAt) {
-          setPreviewError(e instanceof Error && e.name === "TimeoutError"
-            ? new LocalizedPanelError("computer.err.frameTimeout")
-            : e instanceof Error ? e : new LocalizedPanelError("computer.err.screenUnavailable"));
+          // A canceled client request can leave its capture running on the
+          // host. Contention is temporary, not a disconnected computer.
+          if (e instanceof ApiError && isRemoteScreenshotContention(e)) {
+            retryDelay = 1000;
+            contentionSince ??= Date.now();
+            const prolonged = Date.now() - contentionSince >= 10_000;
+            setPreviewError(prolonged ? e : null);
+            setPreviewRefreshing(!prolonged);
+          } else {
+            contentionSince = null;
+            setPreviewRefreshing(false);
+            setPreviewError(e instanceof Error && e.name === "TimeoutError"
+              ? new LocalizedPanelError("computer.err.frameTimeout")
+              : e instanceof Error ? e : new LocalizedPanelError("computer.err.screenUnavailable"));
+          }
         }
       } finally {
         inFlight = false;
+        lastAttemptAt = Date.now();
       }
     };
     void shoot();
-    const timer = setInterval(shoot, bot.busy ? 4000 : 30_000);
+    // Read the current cadence without aborting a capture on every busy
+    // transition. Only connection/action changes replace its generation.
+    const timer = setInterval(shoot, 1000);
     return () => {
       controller.abort();
       clearInterval(timer);
     };
-  }, [panelView, cloudPreviewReady, bot.id, cloudBackend, viewerOpen, pageVisible, bot.busy, previewRetry]);
+  }, [panelView, cloudPreviewReady, bot.id, cloudBackend, viewerOpen, pageVisible, pending, controlPending, previewRetry]);
 
   // Local VM preview comes directly from Cua Driver through the harness. It
   // does not use the password-protected noVNC viewer or cloud endpoints.
@@ -1086,18 +1114,21 @@ export function ComputerPanel({
         <div className="relative flex aspect-[16/10] w-full items-center justify-center overflow-hidden rounded-xl bg-card">
           {cloudPreviewReady || (bot.computer === "cloud" && phase === "starting") ? (
             <CloudScreenPreview
-              key={`${bot.id}:${cloudBackend}:${previewRetry}`}
+              key={`${bot.id}:${cloudBackend}`}
               src={frameSrc}
               name={bot.name}
               error={panelErrorText(previewError)}
+              refreshing={previewRefreshing}
+              retry={previewRetry}
               starting={phase === "starting"}
               opening={pending === "join"}
               disabled={controlPending}
               onOpen={() => void openDesktop()}
-              onRetry={() => {
+              onRetry={(discardFrame) => {
                 latestLive.current.at = 0;
-                setPolledFrame(null);
+                if (discardFrame) setPolledFrame(null);
                 setPreviewError(null);
+                setPreviewRefreshing(true);
                 setPreviewRetry((n) => n + 1);
               }}
             />

--- a/src/components/remote-desktop-panel.test.ts
+++ b/src/components/remote-desktop-panel.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from "vitest";
 
-import { remoteScreenshotSource } from "@/lib/remote-desktop";
+import { isRemoteScreenshotContention, remoteScreenshotSource } from "@/lib/remote-desktop";
 
 describe("remote VPS preview", () => {
+  it("retries only known transient contention, not permanent 409 failures", () => {
+    expect(isRemoteScreenshotContention({ status: 409, message: "this bot's cloud computer is being changed — wait for it to finish" })).toBe(true);
+    expect(isRemoteScreenshotContention({ status: 409, message: "the VPS is being prepared — try again shortly" })).toBe(true);
+    for (const message of ["VPS is not configured", "The VPS computer is not ready", "Choose Cloud before changing or opening this Box. Auto only checks existing computer state."]) {
+      expect(isRemoteScreenshotContention({ status: 409, message })).toBe(false);
+    }
+    expect(isRemoteScreenshotContention({ status: 503, message: "this bot's cloud computer is being changed — wait for it to finish" })).toBe(false);
+  });
   it("accepts only validated screenshot response shapes", () => {
     expect(remoteScreenshotSource({ png: "aGVsbG8=", format: "png" }))
       .toBe("data:image/png;base64,aGVsbG8=");

--- a/src/components/remote-desktop-panel.tsx
+++ b/src/components/remote-desktop-panel.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { CalendarClock, CalendarDays, ImageOff, Loader2, Monitor, Plus, X } from "lucide-react";
 
 import { cn } from "@/lib/cn";
 import { usePageVisible } from "@/lib/page-visible";
-import { remoteScreenshotSource } from "@/lib/remote-desktop";
+import { isRemoteScreenshotContention, remoteScreenshotSource } from "@/lib/remote-desktop";
 import type { Routine } from "@/lib/routines";
-import { api, useStore, type Bot } from "@/state/store";
+import { api, ApiError, useStore, type Bot } from "@/state/store";
 import { RoutineEditor } from "./RoutinesPage";
 
 function viewerAddress(raw: unknown): string {
@@ -62,6 +62,8 @@ export function RemoteDesktopPanel({ bot }: { bot: Bot }) {
   const [previewUnavailable, setPreviewUnavailable] = useState(false);
   const [viewerOpen, setViewerOpen] = useState(false);
   const pageVisible = usePageVisible();
+  const previewBusy = useRef(bot.busy);
+  useEffect(() => { previewBusy.current = bot.busy; }, [bot.busy]);
   const [creatingRoutine, setCreatingRoutine] = useState(false);
   const botRoutines = state.routines
     .filter((routine) => routine.botId === bot.id)
@@ -99,37 +101,56 @@ export function RemoteDesktopPanel({ bot }: { bot: Bot }) {
   }, [bot.id]);
 
   useEffect(() => {
-    if (!pageVisible || viewerOpen) return;
-    let alive = true;
+    if (!pageVisible || viewerOpen || pending) return;
+    const controller = new AbortController();
     let requestRunning = false;
+    let lastAttemptAt = -Infinity;
+    let retryDelay: number | null = null;
+    let contentionSince: number | null = null;
     const shoot = async () => {
-      if (requestRunning) return;
+      if (requestRunning || controller.signal.aborted) return;
+      if (Date.now() - lastAttemptAt < (retryDelay ?? (previewBusy.current ? 4000 : 30_000))) return;
       requestRunning = true;
+      retryDelay = null;
       try {
         const source = remoteScreenshotSource(await api(`/api/bots/${bot.id}/computer/screenshot`, {
           method: "POST",
           body: "{}",
+          signal: AbortSignal.any([controller.signal, AbortSignal.timeout(90_000)]),
         }));
-        if (alive && source) {
+        if (!controller.signal.aborted && source) {
           setFrame(source);
           setPreviewUnavailable(false);
-        } else if (alive) {
+          contentionSince = null;
+        } else if (!controller.signal.aborted) {
           setPreviewUnavailable(true);
         }
-      } catch {
-        if (alive) setPreviewUnavailable(true);
+      } catch (cause) {
+        if (!controller.signal.aborted) {
+          if (cause instanceof ApiError && isRemoteScreenshotContention(cause)) {
+            retryDelay = 1000;
+            contentionSince ??= Date.now();
+            const prolonged = Date.now() - contentionSince >= 10_000;
+            setPreviewUnavailable(prolonged);
+            setPreviewPending(!prolonged);
+          } else {
+            contentionSince = null;
+            setPreviewUnavailable(true);
+          }
+        }
       } finally {
-        if (alive) setPreviewPending(false);
+        if (!controller.signal.aborted && retryDelay === null) setPreviewPending(false);
         requestRunning = false;
+        lastAttemptAt = Date.now();
       }
     };
     void shoot();
-    const timer = window.setInterval(shoot, bot.busy ? 4_000 : 30_000);
+    const timer = window.setInterval(shoot, 1000);
     return () => {
-      alive = false;
+      controller.abort();
       window.clearInterval(timer);
     };
-  }, [bot.busy, bot.id, pageVisible, viewerOpen]);
+  }, [bot.id, pageVisible, viewerOpen, pending]);
 
   const open = async () => {
     setPending(true);

--- a/src/lib/remote-desktop.ts
+++ b/src/lib/remote-desktop.ts
@@ -1,3 +1,14 @@
+/** Older hosts return only a message/status pair. Do not hide unrelated
+ * 409s such as missing configuration or an incompatible desktop image. */
+export function isRemoteScreenshotContention(error: { status: number; message: string }): boolean {
+  return error.status === 409 && [
+    "this bot's cloud computer is being changed — wait for it to finish",
+    "the VPS is being prepared — try again shortly",
+    "VPS connection settings are being updated — wait for them to finish",
+    "Box account settings are being updated — wait for them to finish",
+  ].includes(error.message);
+}
+
 export function remoteScreenshotSource(raw: unknown): string | null {
   if (!raw || typeof raw !== "object") return null;
   const frame = raw as { png?: unknown; format?: unknown };


### PR DESCRIPTION
## What changed

- Coalesce overlapping VPS preview requests; a cancelled HTTP request no longer makes the next preview fail with a misleading “computer is being changed” error.
- Keep Take control usable during capture, while still preventing stop/delete/reconfigure operations until capture and cleanup finish.
- Bound slow captures to a 45-second overall budget and recover automatically from temporary contention without discarding a valid displayed frame.
- Compress preview frames on the VPS before transfer: JPEG quality 70, at most 1280×1280, preserving aspect ratio and never upscaling. Older containers fall back to the original image if their converter is unavailable.

No new dependency, base-image change, or settings knob. Agent-tool screenshots and live VNC are unchanged. No version bump or release in this PR.

## Why

Screenshot polling and computer lifecycle operations shared one exclusive lock. A slow capture could outlive a cancelled UI request and leave subsequent previews/Take control returning HTTP 409. This addresses that preview contention, not unrelated application-tunnel connectivity.

## How it was verified

All mutation tests used disposable fixture data, never the live app or a customer's VPS.

- Node 24 server/API regression run: 240 tests passed.
- Final provider, runner, and HTTP routing tests after compression: 31 passed, including real Pillow conversion, dimensions/quality, fallback, cancellation, timeout cleanup and lifecycle fencing.
- Real-browser fixture plus component tests: 20 passed across 6 files. Covers both panels, held captures, busy toggles, join, automatic recovery, permanent errors, corrupt-image Retry and cleanup.
- Manually exercised those recovery flows in the isolated browser fixture.
- Build, lint and packaged-server smoke passed; no new dependencies.

The full cross-platform suite runs in CI. A real remote VPS was not used; transport was controlled by the test fixtures. This is a behavior-only UI change, with the reproducible flow documented in `docs/verification/cloud-preview.md`.

## Checklist

- [x] Server behavior changes include regression tests and an isolated API fixture
- [x] Renderer recovery verified in a real browser with disposable data
- [x] No build-output edits, credentials, or dependency/lockfile churn
- [x] Stop/delete/configuration protections preserved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cloud computer and remote desktop previews now recover more smoothly from temporary contention, with automatic retries.
  - Retrying a failed preview can preserve the last successfully loaded image.
  - Corrupt preview frames now start a clean loading state.
  - Preview polling pauses while desktop joining, control, or other conflicting actions are in progress.
  - Preview captures are optimized for faster transfer, with image-format fallback support.

- **Bug Fixes**
  - Prevented overlapping captures and conflicting lifecycle actions.
  - Improved cleanup and recovery after timed-out or failed captures.
  - Added clearer handling for unavailable or unconfigured cloud computers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->