### PR TITLE
feat(ios): show bot threads and folders in navigation

### DIFF
--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -88,6 +88,9 @@ keyless local generation, saved-key handling, and safe errors with a local fake 
 The [independent threads fixture](threads.md) checks nested sidebar navigation,
 per-thread models, simultaneous direct conversations and thread-scoped Stop.
 
+The [iOS thread checks](ios-threads.md) cover the native thread tree, folder
+search and draft isolation using disposable simulators and an offline fixture.
+
 The [right-to-left fixture](bidi.md) checks per-block direction in bot replies
 and per-line direction in sent turns, with code pinned left-to-right.
 

--- a/docs/verification/ios-threads.md
+++ b/docs/verification/ios-threads.md
@@ -1,0 +1,69 @@
+# iOS thread navigation
+
+Use disposable simulators and synthetic data. Do not pair these checks with
+the user's running desktop or mutate their conversations.
+
+## Core and existing server contract
+
+From `ios/`, run `swift test`. Thread navigation cases cover folder order,
+search, legacy computers, orphaned folders, routine filtering, unread counts,
+runtime projection and loading full history after a background SSE tail.
+
+From the repository root:
+
+```sh
+pnpm exec vitest run server/paired-thread-targets-api.test.ts server/independent-threads-api.test.ts server/bot-projects-api.test.ts server/thread-capacity-api.test.ts
+```
+
+These server tests launch isolated fake-provider fixtures. They cover thread
+ownership, simultaneous turns, thread-scoped stop/settings, paired requests,
+folders and capacity. They do not drive the native iOS UI.
+
+## Native UI
+
+Generate the Xcode project with `cd ios && xcodegen generate`. Create a fresh
+iPhone or iPad simulator, then run the `OpenMausCompanion` scheme's UI tests
+against that explicit simulator ID. For example, from `ios/`:
+
+```sh
+xcodebuild -project OpenMausCompanion.xcodeproj -scheme OpenMausCompanion \
+  -configuration Debug -destination 'platform=iOS Simulator,id=SIMULATOR_ID' \
+  -derivedDataPath /tmp/omb-ios-threads-build CODE_SIGNING_ALLOWED=NO test
+```
+
+`ThreadNavigationUITests` launches with `-store-preview -threads-preview`.
+`App/ThreadPreview.json` is a synthetic, offline UI fixture: Pepper has two
+threads in Email, one unfiled thread, and one hidden routine run. No companion
+client, tokens or provider process are started. This fixture is separate from
+the captured server contract fixtures under `Tests/CompanionCoreTests/Fixtures`.
+
+Check on iPhone and iPad:
+
+1. Expand Pepper's Threads row and Email folder. Each visible thread opens
+   directly; the routine run is absent. Check working, queued and unread labels.
+2. Search by folder and thread name, then clear the search.
+3. Enter an unsent draft in Gmail, switch to iCloud through the header, and
+   return. iCloud must not inherit Gmail's draft; Gmail must retain it.
+4. Open Updates. Active sibling threads must have distinct entries and titles.
+5. In the thread picker, attempt creation while offline. The sheet must stay
+   open and show an error. Failed renames must retain the entered title.
+
+Keep the `.xcresult` bundle and screenshots as evidence. Shut down and remove
+only the disposable simulators you created.
+
+The offline UI checks do **not** prove real-device pairing, HTTPS/Tailscale,
+live network reconnects, dictation or attachment uploads. Validate those with
+the [iOS end-to-end runbook](../../ios/TESTING.md) against an isolated companion
+before claiming them tested. No new server routes or pairing changes are
+introduced by the thread UI.
+
+## Recorded local pass — 2026-09-11
+
+- Xcode 26.6 Debug simulator build succeeded.
+- 383 CompanionCore tests and 17 isolated server integration tests passed.
+- All five native UI cases passed on iPhone 17 Pro and iPad Pro 13-inch (M5),
+  using disposable iOS 26.5 simulators. Search also preserves the previously
+  expanded bot when it is cancelled.
+- Retained results: `/tmp/omb-ios-threads-iphone-acceptance.xcresult` and
+  `/tmp/omb-ios-threads-ipad-clean.xcresult`, including screenshots.
+- No physical-device, live pairing or provider verification was performed.

--- a/ios/App/BotThreadRow.swift
+++ b/ios/App/BotThreadRow.swift
@@ -1,0 +1,67 @@
+import CompanionCore
+import SwiftUI
+
+/// The compact thread label shared by the roster and the thread picker.
+struct BotThreadRow: View {
+    let task: BotTask
+    var selected = false
+
+    private var runtime: (title: String, icon: String, color: Color)? {
+        switch task.activity {
+        case "waiting-on-you": return ("Waiting on you", "hand.raised.fill", .orange)
+        case "queued": return ("Queued", "clock", .secondary)
+        case "working", "running": return ("Working", "arrow.triangle.2.circlepath", .accentColor)
+        default:
+            return task.busy == true ? ("Working", "arrow.triangle.2.circlepath", .accentColor) : nil
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 5) {
+                Text(verbatim: task.displayTitle)
+                    .font(.body.weight(task.unread == true ? .semibold : .regular))
+                    .foregroundStyle(Color.primary)
+                    .lineLimit(2)
+
+                if runtime != nil || task.unread == true {
+                    HStack(spacing: 10) {
+                        if let runtime {
+                            Label(runtime.title, systemImage: runtime.icon)
+                                .foregroundStyle(runtime.color)
+                        }
+                        if task.unread == true {
+                            Label("Unread", systemImage: "circle.fill")
+                                .foregroundStyle(Color.accentColor)
+                        }
+                    }
+                    .font(.caption.weight(.medium))
+                }
+
+                HStack(spacing: 5) {
+                    if task.createdAt > 0 {
+                        Text(RelativeStamp.list(task.createdAt))
+                    }
+                    if let opener = task.openedByLabel {
+                        if task.createdAt > 0 { Text("·") }
+                        Text(verbatim: opener)
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(Color.secondary)
+                .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if selected {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(Color.accentColor)
+                    .accessibilityHidden(true)
+            }
+        }
+        .padding(.vertical, 3)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(selected ? .isSelected : [])
+    }
+}

--- a/ios/App/BotThreadTree.swift
+++ b/ios/App/BotThreadTree.swift
@@ -1,0 +1,123 @@
+import CompanionCore
+import SwiftUI
+
+/// Observe search and live thread metadata here, independently of the
+/// roster summary's stable bot identity.
+struct BotThreadTree: View {
+    let botID: String
+    @Binding var query: String
+    @Binding var expanded: Bool
+    @Binding var collapsedFolders: Set<String>
+    @Binding var creating: Bool
+    let open: (Chat) -> Void
+    let manage: (Chat) -> Void
+    @EnvironmentObject private var session: Session
+
+    private var searching: Bool {
+        !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        if let bot = session.state.bot(botID) {
+            let isExpanded = searching || expanded
+            let groups = bot.threadGroups(matching: bot.name.localizedCaseInsensitiveContains(query) ? "" : query)
+            let count = bot.threadGroups().reduce(0) { $0 + $1.tasks.count }
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(spacing: 8) {
+                    Button {
+                        Haptics.selection()
+                        expanded.toggle()
+                    } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                                .font(.system(size: 10, weight: .semibold))
+                            Text("Threads")
+                            Text("\(count)").foregroundStyle(.secondary)
+                            Spacer(minLength: 0)
+                        }
+                        .font(.system(size: 13, weight: .medium))
+                        .frame(minHeight: 44)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(bot.name)'s threads")
+                    .accessibilityValue(isExpanded ? "Expanded, \(count) threads" : "Collapsed, \(count) threads")
+                    .accessibilityIdentifier("threads-toggle.\(bot.id)")
+                    .disabled(searching)
+
+                    if isExpanded {
+                        Button { createThread(for: bot) } label: {
+                            Image(systemName: "plus").frame(width: 44, height: 44)
+                        }
+                        .disabled(creating)
+                        .accessibilityLabel("New thread with \(bot.name)")
+                        Button { manage(.bot(bot)) } label: {
+                            Image(systemName: "ellipsis").frame(width: 44, height: 44)
+                        }
+                        .accessibilityLabel("Manage \(bot.name)'s threads")
+                    }
+                }
+                .foregroundStyle(.secondary)
+
+                if isExpanded {
+                    ForEach(groups) { group in
+                        if let folder = group.project {
+                            DisclosureGroup(isExpanded: Binding(
+                                get: { searching || !collapsedFolders.contains("\(botID):\(folder.id)") },
+                                set: { value in
+                                    let key = "\(botID):\(folder.id)"
+                                    if value { collapsedFolders.remove(key) }
+                                    else { collapsedFolders.insert(key) }
+                                }
+                            )) {
+                                threadLinks(group.tasks, bot: bot).padding(.leading, 8)
+                            } label: {
+                                HStack(spacing: 6) {
+                                    if let emoji = folder.emoji, !emoji.isEmpty { Text(emoji) }
+                                    else { Image(systemName: "folder") }
+                                    Text(folder.name).lineLimit(1)
+                                }
+                                .font(.system(size: 13, weight: .medium))
+                                .foregroundStyle(.secondary)
+                                .frame(minHeight: 40)
+                            }
+                        } else {
+                            threadLinks(group.tasks, bot: bot)
+                        }
+                    }
+                }
+            }
+            .padding(.leading, 88)
+            .padding(.trailing, 18)
+            .padding(.bottom, isExpanded ? 12 : 0)
+        }
+    }
+
+    private func threadLinks(_ tasks: [BotTask], bot: Bot) -> some View {
+        ForEach(tasks, id: \.threadId) { task in
+            if let projected = bot.projected(forThread: task.threadId) {
+                NavigationLink(value: Chat.bot(projected)) {
+                    BotThreadRow(task: task)
+                        .padding(.vertical, 8)
+                        .frame(minHeight: 44)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("thread.\(task.threadId)")
+            }
+        }
+    }
+
+    private func createThread(for bot: Bot) {
+        guard !creating else { return }
+        creating = true
+        Task {
+            defer { creating = false }
+            if let created = await session.createTask(for: bot, title: nil) {
+                open(.bot(created))
+            } else if session.actionError == nil {
+                session.actionError = "Couldn't create a thread. Check the connection and try again."
+            }
+        }
+    }
+}

--- a/ios/App/ChatListView.swift
+++ b/ios/App/ChatListView.swift
@@ -21,6 +21,10 @@ struct ChatListView: View {
     @State private var showingUpdates = false
     @State private var showingNewGroup = false
     @State private var showingNewSection = false
+    @State private var expandedBots = Set<String>()
+    @State private var collapsedFolders = Set<String>()
+    @State private var creatingThreads = Set<String>()
+    @State private var managingThreads: Chat?
     @FocusState private var searchFocused: Bool
 
     /// Room for the floating bar, so the last row can scroll clear of it.
@@ -147,6 +151,13 @@ struct ChatListView: View {
             }
             .sheet(isPresented: $showingNewSection) {
                 NewSectionSheet()
+            }
+            .sheet(item: $managingThreads) { chat in
+                TaskManagerView(chat: chat) { threadId in
+                    guard let bot = session.state.bot(forThread: threadId) else { return }
+                    managingThreads = nil
+                    path.append(Chat.bot(bot))
+                }
             }
             .task(id: query) {
                 let expected = query
@@ -308,17 +319,41 @@ struct ChatListView: View {
     @ViewBuilder
     private func botRows(_ rows: [ChatSummary]) -> some View {
         ForEach(Array(rows.enumerated()), id: \.element.id) { index, summary in
-            NavigationLink(value: summary.chat) {
-                ChatRow(
-                    chat: summary.chat,
-                    preview: summary.preview,
-                    at: summary.lastActivity,
-                    state: MausState.forChat(summary.chat, in: session.state),
-                    waiting: waitingChats.contains(summary.chat.id),
-                    last: index == rows.count - 1
-                )
+            VStack(spacing: 0) {
+                NavigationLink(value: summary.chat) {
+                    ChatRow(
+                        chat: summary.chat,
+                        preview: summary.preview,
+                        at: summary.lastActivity,
+                        state: MausState.forChat(summary.chat, in: session.state),
+                        waiting: waitingChats.contains(summary.chat.id),
+                        last: index == rows.count - 1
+                    )
+                }
+                .buttonStyle(.plain)
+                if case let .bot(bot) = summary.chat {
+                    BotThreadTree(
+                        botID: bot.id, query: $query,
+                        expanded: Binding(
+                            get: { expandedBots.contains(bot.id) },
+                            set: { value in
+                                if value { expandedBots.insert(bot.id) } else { expandedBots.remove(bot.id) }
+                            }
+                        ),
+                        collapsedFolders: $collapsedFolders,
+                        creating: Binding(
+                            get: { creatingThreads.contains(bot.id) },
+                            set: { value in
+                                if value { creatingThreads.insert(bot.id) } else { creatingThreads.remove(bot.id) }
+                            }
+                        )
+                    ) { chat in
+                        path.append(chat)
+                    } manage: { chat in
+                        managingThreads = chat
+                    }
+                }
             }
-            .buttonStyle(.plain)
         }
     }
 
@@ -473,7 +508,13 @@ struct ChatListView: View {
             $0.chat.name.localizedCaseInsensitiveContains(query)
                 || $0.chat.subtitle.localizedCaseInsensitiveContains(query)
                 || $0.preview.localizedCaseInsensitiveContains(query)
+                || matchesThread($0.chat)
         }
+    }
+
+    private func matchesThread(_ chat: Chat) -> Bool {
+        guard case let .bot(bot) = chat else { return false }
+        return !bot.threadGroups(matching: query).isEmpty
     }
 
     private func summaries(for bots: [Bot]) -> [ChatSummary] {
@@ -705,6 +746,7 @@ struct UpdatesPill: View {
         .buttonStyle(.plain)
         .glassCapsule()
         .accessibilityLabel("Updates")
+        .accessibilityIdentifier("updates-button")
     }
 
     private var subline: String {

--- a/ios/App/ChatView.swift
+++ b/ios/App/ChatView.swift
@@ -37,6 +37,12 @@ struct ChatView: View {
     @State private var showingFileImporter = false
     @State private var selectedPhotos: [PhotosPickerItem] = []
     @State private var attachments: [PendingMessageAttachment] = []
+    private struct ComposerSnapshot {
+        var text = ""
+        var attachments: [PendingMessageAttachment] = []
+        var error: String?
+    }
+    @State private var threadDrafts: [String: ComposerSnapshot] = [:]
     @State private var preparingAttachments = false
     @State private var sendingMessage = false
     @State private var attachmentError: String?
@@ -354,9 +360,9 @@ struct ChatView: View {
         .onChange(of: selectedThreadWasRemoved) { _, removed in
             if removed { dismiss() }
         }
-        .onChange(of: session.state.messages[threadId] == nil) { _, missing in
+        .onChange(of: session.state.hasLoadedPage(forThread: threadId)) { _, loaded in
             let requestedThread = threadId
-            if missing { Task { await session.loadThreadIfNeeded(requestedThread) } }
+            if !loaded { Task { await session.loadThreadIfNeeded(requestedThread) } }
         }
         .onChange(of: current.unread) { _, unread in
             // A message can arrive while this chat is already on screen. The
@@ -365,7 +371,17 @@ struct ChatView: View {
             let readChat = current
             if unread { Task { await session.markRead(readChat) } }
         }
-        .onChange(of: threadId) { _, _ in
+        .onChange(of: threadId) { previous, next in
+            dictation.stop()
+            threadDrafts[previous] = ComposerSnapshot(text: draft, attachments: attachments, error: attachmentError)
+            let restored = threadDrafts.removeValue(forKey: next) ?? ComposerSnapshot()
+            draft = restored.text
+            attachments = restored.attachments
+            attachmentError = restored.error
+            selectedPhotos = []
+            acceptsNextHardwareLineBreak = false
+            showCommandHUD = false
+            showingPlus = false
             // The local task picker changed threads. A download
             // started in the previous task must not open a sheet (or surface
             // its error) in the new one when the network reply arrives late.
@@ -530,7 +546,7 @@ struct ChatView: View {
                 Color.clear.frame(width: 60, height: 60)
             }
             Button {
-                if case .bot = current { showingProfile = true }
+                if current.supportsTasks { showingTasks = true }
                 else { showingPlus = true }
             } label: {
                 HStack(spacing: 6) {
@@ -538,13 +554,13 @@ struct ChatView: View {
                         .font(.system(size: 15, weight: .semibold))
                         .foregroundStyle(Color.primary)
                         .lineLimit(1)
-                    if !current.subtitle.isEmpty {
-                        Text(current.subtitle)
+                    if current.supportsTasks || !current.subtitle.isEmpty {
+                        Text(current.supportsTasks ? current.threadTitle : current.subtitle)
                             .font(.system(size: 13))
                             .foregroundStyle(Color.secondary)
                             .lineLimit(1)
                     }
-                    Image(systemName: current.isBot ? "gearshape" : "ellipsis")
+                    Image(systemName: current.supportsTasks ? "chevron.down" : "ellipsis")
                         .font(.system(size: 11, weight: .bold))
                         .foregroundStyle(Color.secondary)
                 }
@@ -555,7 +571,10 @@ struct ChatView: View {
             }
             .buttonStyle(.plain)
             .glassCapsule()
-            .accessibilityLabel(current.isBot ? "Open \(current.name) settings" : "Open \(current.name) thread options")
+            .disabled(preparingAttachments || sendingMessage)
+            .accessibilityLabel(current.supportsTasks ? "Switch thread: \(current.threadTitle)" : "Open \(current.name) thread options")
+            .accessibilityHint("Choose a conversation or start a new thread")
+            .accessibilityIdentifier("thread-switcher")
         }
         .padding(.top, -4)
     }
@@ -776,8 +795,17 @@ struct ChatView: View {
             )
             sendingMessage = false
             guard sent else {
-                attachmentError = session.actionError ?? "Couldn't send this message. Try again."
+                let failure = session.actionError ?? "Couldn't send this message. Try again."
+                if threadId == chatAtSend.threadId { attachmentError = failure }
+                else { threadDrafts[chatAtSend.threadId]?.error = failure }
                 session.actionError = nil
+                return
+            }
+            if threadId != chatAtSend.threadId {
+                if threadDrafts[chatAtSend.threadId]?.text == draftAtSend { threadDrafts[chatAtSend.threadId]?.text = "" }
+                if threadDrafts[chatAtSend.threadId]?.attachments.map(\.id) == outgoingAttachments.map(\.id) {
+                    threadDrafts[chatAtSend.threadId]?.attachments = []
+                }
                 return
             }
             // HUD commands expand `/diff` into a longer prompt. Compare with
@@ -796,7 +824,9 @@ struct ChatView: View {
 
     private func importPhotos(_ items: [PhotosPickerItem]) async {
         guard !preparingAttachments, !sendingMessage else { return }
-        let available = AttachmentPolicy.maximumItems - attachments.count
+        let importingThread = threadId
+        let existingAttachments = attachments
+        let available = AttachmentPolicy.maximumItems - existingAttachments.count
         guard items.count <= available else {
             selectedPhotos = []
             attachmentError = "Send up to \(AttachmentPolicy.maximumItems) items at a time."
@@ -845,13 +875,15 @@ struct ChatView: View {
                     mime: mime,
                     kind: .image
                 )
-                try AttachmentPolicy.validate(attachments + imported + [candidate])
+                try AttachmentPolicy.validate(existingAttachments + imported + [candidate])
                 imported.append(candidate)
             }
-            attachments.append(contentsOf: imported)
+            if threadId == importingThread { attachments.append(contentsOf: imported) }
+            else { threadDrafts[importingThread, default: ComposerSnapshot()].attachments.append(contentsOf: imported) }
             Haptics.selection()
         } catch {
-            attachmentError = error.localizedDescription
+            if threadId == importingThread { attachmentError = error.localizedDescription }
+            else { threadDrafts[importingThread]?.error = error.localizedDescription }
         }
     }
 
@@ -866,7 +898,9 @@ struct ChatView: View {
 
     private func importFiles(_ urls: [URL]) async {
         guard !preparingAttachments, !sendingMessage else { return }
-        let available = AttachmentPolicy.maximumItems - attachments.count
+        let importingThread = threadId
+        let existingAttachments = attachments
+        let available = AttachmentPolicy.maximumItems - existingAttachments.count
         guard urls.count <= available else {
             attachmentError = "Send up to \(AttachmentPolicy.maximumItems) items at a time."
             return
@@ -879,18 +913,20 @@ struct ChatView: View {
         do {
             var imported: [PendingMessageAttachment] = []
             for url in urls {
-                let usedBytes = (attachments + imported).reduce(0) { $0 + $1.data.count }
+                let usedBytes = (existingAttachments + imported).reduce(0) { $0 + $1.data.count }
                 let remainingBytes = max(0, AttachmentPolicy.maximumTotalBytes - usedBytes)
                 let candidate = try await Task.detached(priority: .userInitiated) {
                     try Self.readImportedFile(url, remainingBytes: remainingBytes)
                 }.value
-                try AttachmentPolicy.validate(attachments + imported + [candidate])
+                try AttachmentPolicy.validate(existingAttachments + imported + [candidate])
                 imported.append(candidate)
             }
-            attachments.append(contentsOf: imported)
+            if threadId == importingThread { attachments.append(contentsOf: imported) }
+            else { threadDrafts[importingThread, default: ComposerSnapshot()].attachments.append(contentsOf: imported) }
             Haptics.selection()
         } catch {
-            attachmentError = error.localizedDescription
+            if threadId == importingThread { attachmentError = error.localizedDescription }
+            else { threadDrafts[importingThread]?.error = error.localizedDescription }
         }
     }
 
@@ -1179,6 +1215,7 @@ struct ChatView: View {
                             .font(.system(size: 17))
                             .padding(.vertical, 11)
                             .focused($composerFocused)
+                            .accessibilityIdentifier("message-input")
                             .submitLabel(.send)
                             // Partial transcripts rebuild from a frozen base;
                             // prevent competing edits without dimming the text.

--- a/ios/App/Island.swift
+++ b/ios/App/Island.swift
@@ -97,7 +97,7 @@ struct NeedsYouIsland: View {
                             ChatAvatarView(chat: shown.chat, size: 120, state: MausState.forChat(shown.chat, in: session.state), animated: attentionLive, comets: attentionLive)
                         }
                         .buttonStyle(.plain)
-                        .task(id: shown.chat.id) {
+                        .task(id: shown.chat.conversationID) {
                             attentionLive = true
                             try? await Task.sleep(for: .seconds(30))
                             attentionLive = false

--- a/ios/App/Session.swift
+++ b/ios/App/Session.swift
@@ -165,7 +165,10 @@ final class Session: ObservableObject {
 #if DEBUG
         let arguments = ProcessInfo.processInfo.arguments
         if (arguments.contains("-store-preview") || arguments.contains("-computer-switcher-preview")),
-           let url = Bundle.main.url(forResource: "StorePreview", withExtension: "json"),
+           let url = Bundle.main.url(
+               forResource: arguments.contains("-threads-preview") ? "ThreadPreview" : "StorePreview",
+               withExtension: "json"
+           ),
            let data = try? Data(contentsOf: url),
            let fleet = try? JSONDecoder().decode(Fleet.self, from: data) {
             let preview = Connection(
@@ -1498,7 +1501,7 @@ final class Session: ObservableObject {
 
     /// A pinned background thread may not be in a fresh fleet snapshot.
     func loadThreadIfNeeded(_ threadId: String) async {
-        guard let client, state.messages[threadId] == nil else { return }
+        guard let client, !state.hasLoadedPage(forThread: threadId) else { return }
         do {
             let page = try await client.messages(threadId: threadId)
             state.merge(page, intoThread: threadId)
@@ -1577,12 +1580,14 @@ final class Session: ObservableObject {
         } catch { actionError = error.localizedDescription; return nil }
     }
 
-    func renameTask(_ task: BotTask, for bot: Bot, title: String) async {
-        guard let client else { return }
+    @discardableResult
+    func renameTask(_ task: BotTask, for bot: Bot, title: String) async -> Bool {
+        guard let client else { return false }
         do {
             try await client.renameTask(botId: bot.id, threadId: task.threadId, title: title)
             await refresh()
-        } catch { actionError = error.localizedDescription }
+            return true
+        } catch { actionError = error.localizedDescription; return false }
     }
 
     @discardableResult
@@ -1595,30 +1600,36 @@ final class Session: ObservableObject {
         } catch { actionError = error.localizedDescription; return nil }
     }
 
-    func createTask(for room: Room, title: String?) async {
-        guard let client else { return }
-        do { state.apply(.room(try await client.createTask(groupId: room.id, title: title))) }
-        catch { actionError = error.localizedDescription }
+    @discardableResult
+    func createTask(for room: Room, title: String?) async -> Bool {
+        guard let client else { return false }
+        do { state.apply(.room(try await client.createTask(groupId: room.id, title: title))); return true }
+        catch { actionError = error.localizedDescription; return false }
     }
 
-    func switchTask(_ task: BotTask, for room: Room) async {
-        guard let client, task.threadId != room.threadId else { return }
-        do { state.apply(.room(try await client.switchTask(groupId: room.id, threadId: task.threadId))) }
-        catch { actionError = error.localizedDescription }
+    @discardableResult
+    func switchTask(_ task: BotTask, for room: Room) async -> Bool {
+        guard task.threadId != room.threadId else { return true }
+        guard let client else { return false }
+        do { state.apply(.room(try await client.switchTask(groupId: room.id, threadId: task.threadId))); return true }
+        catch { actionError = error.localizedDescription; return false }
     }
 
-    func renameTask(_ task: BotTask, for room: Room, title: String) async {
-        guard let client else { return }
+    @discardableResult
+    func renameTask(_ task: BotTask, for room: Room, title: String) async -> Bool {
+        guard let client else { return false }
         do {
             try await client.renameTask(groupId: room.id, threadId: task.threadId, title: title)
             await refresh()
-        } catch { actionError = error.localizedDescription }
+            return true
+        } catch { actionError = error.localizedDescription; return false }
     }
 
-    func deleteTask(_ task: BotTask, for room: Room) async {
-        guard let client else { return }
-        do { state.apply(.room(try await client.deleteTask(groupId: room.id, threadId: task.threadId))) }
-        catch { actionError = error.localizedDescription }
+    @discardableResult
+    func deleteTask(_ task: BotTask, for room: Room) async -> Bool {
+        guard let client else { return false }
+        do { state.apply(.room(try await client.deleteTask(groupId: room.id, threadId: task.threadId))); return true }
+        catch { actionError = error.localizedDescription; return false }
     }
 
     // MARK: - Agent profile
@@ -2020,9 +2031,18 @@ enum Chat: Identifiable, Hashable {
         }
     }
 
+    /// Owner identity remains available for bot APIs. Navigation and activity
+    /// lists must distinguish two conversations belonging to the same bot.
+    var conversationID: String {
+        switch self {
+        case let .bot(bot): return "bot:\(bot.id):\(bot.threadId)"
+        case let .room(room): return "room:\(room.id):\(room.threadId)"
+        }
+    }
+
     static func == (left: Chat, right: Chat) -> Bool {
         switch (left, right) {
-        case let (.bot(a), .bot(b)): return a.id == b.id
+        case let (.bot(a), .bot(b)): return a.id == b.id && a.threadId == b.threadId
         case let (.room(a), .room(b)): return a.id == b.id
         default: return false
         }
@@ -2033,6 +2053,7 @@ enum Chat: Identifiable, Hashable {
         case let .bot(bot):
             hasher.combine(0)
             hasher.combine(bot.id)
+            hasher.combine(bot.threadId)
         case let .room(room):
             hasher.combine(1)
             hasher.combine(room.id)
@@ -2050,6 +2071,13 @@ enum Chat: Identifiable, Hashable {
         switch self {
         case let .bot(bot): return bot.name
         case let .room(room): return room.name
+        }
+    }
+
+    var threadTitle: String {
+        switch self {
+        case let .bot(bot): return bot.tasks?.first { $0.threadId == bot.threadId }?.displayTitle ?? "Untitled thread"
+        case let .room(room): return room.tasks?.first { $0.threadId == room.threadId }?.displayTitle ?? "Conversation"
         }
     }
 

--- a/ios/App/TaskManagerView.swift
+++ b/ios/App/TaskManagerView.swift
@@ -1,20 +1,26 @@
 import SwiftUI
 import CompanionCore
 
-/// Separate contexts for either an agent or a channel. Keeping one sheet for
-/// both makes "task" mean the same operation everywhere in the app.
+/// Bot thread selection belongs to this phone. Group threads retain their
+/// shared, serial selection on the paired computer.
 struct TaskManagerView: View {
     let chat: Chat
     var onSelectThread: (String) -> Void = { _ in }
     @EnvironmentObject private var session: Session
     @Environment(\.dismiss) private var dismiss
-    @State private var showingNewTask = false
+    @State private var search = ""
     @State private var taskToRename: BotTask?
+    @State private var taskToDelete: BotTask?
     @State private var title = ""
+    @State private var isMutating = false
+    @State private var errorMessage: String?
+    @FocusState private var renameFocused: Bool
 
     private var current: Chat {
         switch chat {
-        case let .bot(bot): return session.state.bot(bot.id)?.projected(forThread: bot.threadId).map(Chat.bot) ?? chat
+        case let .bot(bot):
+            guard let live = session.state.bot(bot.id) else { return chat }
+            return .bot(live.projected(forThread: bot.threadId) ?? live)
         case let .room(room):
             return session.state.rooms.first(where: { $0.id == room.id }).map(Chat.room) ?? chat
         }
@@ -22,140 +28,287 @@ struct TaskManagerView: View {
 
     private var tasks: [BotTask] {
         switch current {
-        case let .bot(bot): return bot.visibleTasks
+        case let .bot(bot): return bot.threadGroups().flatMap(\.tasks)
         case let .room(room): return room.tasks ?? []
         }
+    }
+
+    private var matchingRoomTasks: [BotTask] {
+        let query = search.trimmingCharacters(in: .whitespacesAndNewlines)
+        return tasks.filter { query.isEmpty || $0.displayTitle.localizedCaseInsensitiveContains(query) }
     }
 
     var body: some View {
         NavigationStack {
             List {
-                Section {
-                    HStack(spacing: 12) {
-                        ChatAvatarView(chat: current, size: 48, state: .idle, animated: false)
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(current.name).font(.headline)
-                            Text(current.isBot ? "Agent threads" : "Group threads")
-                                .font(.subheadline).foregroundStyle(.secondary)
+                if let taskToRename {
+                    Section("Rename thread") {
+                        TextField("Thread title", text: $title)
+                            .focused($renameFocused)
+                            .submitLabel(.done)
+                            .onSubmit { saveRename(taskToRename) }
+                            .disabled(isMutating)
+                        HStack {
+                            Button("Cancel", role: .cancel) {
+                                self.taskToRename = nil
+                                renameFocused = false
+                            }
+                            Spacer()
+                            Button("Save") { saveRename(taskToRename) }
+                                .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                         }
+                        .buttonStyle(.borderless)
+                        .disabled(isMutating)
                     }
-                } footer: {
-                    Text("A thread is one conversation and result, with its own context and model.")
                 }
 
-                Section("Threads") {
-                    ForEach(tasks, id: \.threadId) { task in
-                        Button {
-                            Task {
-                                await switchTo(task)
-                                dismiss()
-                            }
-                        } label: {
-                            HStack {
-                                VStack(alignment: .leading, spacing: 3) {
-                                    task.title.isEmpty ? Text("Untitled thread") : Text(verbatim: task.title)
-                                        .foregroundStyle(Color.primary)
-                                    Text(RelativeStamp.list(task.createdAt))
-                                        .font(.caption)
-                                        .foregroundStyle(Color.secondary)
-                                    if let openedBy = task.openedByLabel {
-                                        Text(verbatim: openedBy)
-                                            .font(.caption)
-                                            .foregroundStyle(Color.secondary)
-                                    }
-                                }
-                                Spacer()
-                                if task.threadId == current.threadId {
-                                    Image(systemName: "checkmark.circle.fill").foregroundStyle(Color.accentColor)
-                                }
-                            }
-                        }
-                        .contextMenu {
-                            Button("Rename", systemImage: "pencil") {
-                                title = task.title
-                                taskToRename = task
-                            }
-                        }
-                        .swipeActions(edge: .trailing) {
-                            Button(role: .destructive) {
-                                Task { await delete(task) }
-                            } label: { Label("Delete", systemImage: "trash") }
-                            .disabled(tasks.count <= 1 || (current.isBot ? task.busy == true : current.busy))
-                        }
-                    }
+                threadSections
+            }
+            .safeAreaInset(edge: .top, spacing: 0) {
+                if let errorMessage {
+                    Label(errorMessage, systemImage: "exclamationmark.circle")
+                        .foregroundStyle(.red)
+                        .font(.subheadline)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                        .background(.regularMaterial)
+                        .accessibilityElement(children: .combine)
+                        .accessibilityIdentifier("thread-action-error")
                 }
             }
+            .searchable(text: $search, prompt: current.isBot ? "Search threads and folders" : "Search threads")
             .navigationTitle("\(current.name)’s threads")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .cancellationAction) { Button("Done") { dismiss() } }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }.disabled(isMutating)
+                }
                 ToolbarItem(placement: .primaryAction) {
                     Button("New thread", systemImage: "plus") {
-                        title = ""
-                        showingNewTask = true
+                        perform { await create() }
                     }
-                    .disabled(!current.isBot && current.busy)
+                    .disabled(isMutating || (!current.isBot && current.busy))
+                    .accessibilityIdentifier("new-thread")
+                }
+            }
+            .overlay(alignment: .bottom) {
+                if isMutating {
+                    ProgressView("Updating threads…")
+                        .padding(12)
+                        .background(.regularMaterial, in: Capsule())
+                        .padding()
                 }
             }
         }
-        .alert("New thread", isPresented: $showingNewTask) {
-            TextField("Title (optional)", text: $title)
-            Button("Cancel", role: .cancel) {}
-            Button("Create") {
-                Task {
-                    await create(title.trimmingCharacters(in: .whitespacesAndNewlines))
-                    dismiss()
+        .interactiveDismissDisabled(isMutating)
+        .confirmationDialog("Delete thread?", isPresented: Binding(
+            get: { taskToDelete != nil },
+            set: { if !$0 { taskToDelete = nil } }
+        ), titleVisibility: .visible) {
+            if let task = taskToDelete {
+                Button("Delete thread", role: .destructive) {
+                    taskToDelete = nil
+                    perform { await delete(task) }
                 }
             }
-        }
-        .alert("Rename thread", isPresented: Binding(
-            get: { taskToRename != nil },
-            set: { if !$0 { taskToRename = nil } }
-        )) {
-            TextField("Title", text: $title)
-            Button("Cancel", role: .cancel) { taskToRename = nil }
-            Button("Save") {
-                guard let task = taskToRename else { return }
-                Task { await rename(task, title: title) }
-                taskToRename = nil
+            Button("Cancel", role: .cancel) { taskToDelete = nil }
+        } message: {
+            if let task = taskToDelete {
+                Text("Delete “\(task.displayTitle)” and its conversation? This cannot be undone.")
             }
         }
     }
 
-    private func create(_ title: String) async {
+    @ViewBuilder private var threadSections: some View {
         switch current {
         case let .bot(bot):
-            if let updated = await session.createTask(for: bot, title: title) {
-                onSelectThread(updated.threadId)
-                dismiss()
+            let groups = bot.threadGroups(matching: search)
+            if groups.isEmpty {
+                emptySearch
+            } else {
+                ForEach(groups) { group in
+                    Section {
+                        ForEach(group.tasks, id: \.threadId) { task in
+                            threadButton(task)
+                        }
+                        if group.tasks.isEmpty {
+                            Text("No threads in this folder")
+                                .foregroundStyle(.secondary)
+                        }
+                    } header: {
+                        if let project = group.project {
+                            HStack(spacing: 5) {
+                                if let emoji = project.emoji, !emoji.isEmpty {
+                                    Text(verbatim: emoji)
+                                } else {
+                                    Image(systemName: "folder")
+                                }
+                                Text(verbatim: project.name)
+                            }
+                        } else {
+                            Text(bot.projects?.isEmpty == false ? "Unfiled" : "Threads")
+                        }
+                    }
+                }
             }
-        case let .room(room): await session.createTask(for: room, title: title)
+        case .room:
+            Section {
+                if matchingRoomTasks.isEmpty {
+                    emptySearch
+                } else {
+                    ForEach(matchingRoomTasks, id: \.threadId) { task in
+                        threadButton(task)
+                    }
+                }
+            } header: {
+                Text("Threads")
+            } footer: {
+                if current.busy {
+                    Text("You can switch or create a group thread when the current reply finishes.")
+                }
+            }
         }
+    }
+
+    private var emptySearch: some View {
+        ContentUnavailableView.search(text: search)
+    }
+
+    private func threadButton(_ task: BotTask) -> some View {
+        Button {
+            perform { await switchTo(task) }
+        } label: {
+            BotThreadRow(task: task, selected: task.threadId == current.threadId)
+        }
+        .disabled(isMutating || (!current.isBot && current.busy && task.threadId != current.threadId))
+        .accessibilityIdentifier("thread-\(task.threadId)")
+        .contextMenu {
+            Button("Rename", systemImage: "pencil") { beginRename(task) }
+                .disabled(isMutating)
+            Button("Delete", systemImage: "trash", role: .destructive) { taskToDelete = task }
+                .disabled(!canDelete(task))
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            Button(role: .destructive) { taskToDelete = task } label: {
+                Label("Delete", systemImage: "trash")
+            }
+            .disabled(!canDelete(task))
+            Button { beginRename(task) } label: {
+                Label("Rename", systemImage: "pencil")
+            }
+            .tint(.accentColor)
+            .disabled(isMutating)
+        }
+    }
+
+    private func canDelete(_ task: BotTask) -> Bool {
+        !isMutating && tasks.count > 1 && (current.isBot ? task.busy != true : !current.busy)
+    }
+
+    private func beginRename(_ task: BotTask) {
+        title = task.title
+        taskToRename = task
+        errorMessage = nil
+        renameFocused = true
+    }
+
+    private func saveRename(_ task: BotTask) {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        perform { await rename(task, title: trimmed) }
+    }
+
+    /// Lock before creating the Task so two rapid taps cannot send two writes.
+    private func perform(_ operation: @escaping @MainActor () async -> Void) {
+        guard !isMutating else { return }
+        isMutating = true
+        errorMessage = nil
+        session.actionError = nil
+        Task { @MainActor in
+            await operation()
+            isMutating = false
+        }
+    }
+
+    private func showError(_ fallback: String) {
+        errorMessage = session.actionError ?? fallback
+        session.actionError = nil
+    }
+
+    private func create() async {
+        switch current {
+        case let .bot(bot):
+            guard let updated = await session.createTask(for: bot, title: nil) else {
+                showError("Couldn't create the thread. Try again.")
+                return
+            }
+            onSelectThread(updated.threadId)
+        case let .room(room):
+            guard room.busyBotId == nil, await session.createTask(for: room, title: nil) else {
+                showError("Couldn't create the thread. Try again when the current reply finishes.")
+                return
+            }
+        }
+        dismiss()
     }
 
     private func switchTo(_ task: BotTask) async {
         switch current {
         case let .bot(bot):
-            if let updated = await session.switchTask(task, for: bot) { onSelectThread(updated.threadId) }
-        case let .room(room): await session.switchTask(task, for: room)
+            guard session.state.bot(bot.id)?.projected(forThread: task.threadId) != nil else {
+                showError("This thread is no longer available. Choose another thread.")
+                return
+            }
+            onSelectThread(task.threadId)
+        case let .room(room):
+            if task.threadId != room.threadId {
+                guard room.busyBotId == nil, await session.switchTask(task, for: room) else {
+                    showError("Couldn't switch threads. Try again when the current reply finishes.")
+                    return
+                }
+            }
         }
+        dismiss()
     }
 
     private func rename(_ task: BotTask, title: String) async {
+        let succeeded: Bool
         switch current {
-        case let .bot(bot): await session.renameTask(task, for: bot, title: title)
-        case let .room(room): await session.renameTask(task, for: room, title: title)
+        case let .bot(bot): succeeded = await session.renameTask(task, for: bot, title: title)
+        case let .room(room): succeeded = await session.renameTask(task, for: room, title: title)
         }
+        guard succeeded else {
+            showError("Couldn't rename the thread. Your title is kept above so you can try again.")
+            return
+        }
+        taskToRename = nil
+        renameFocused = false
     }
 
     private func delete(_ task: BotTask) async {
+        // Recheck after the confirmation; an SSE update may have made it busy.
+        guard tasks.count > 1,
+              let liveTask = tasks.first(where: { $0.threadId == task.threadId }),
+              current.isBot ? liveTask.busy != true : !current.busy else {
+            showError("This thread can't be deleted while it's working or if it's the last thread.")
+            return
+        }
         switch current {
         case let .bot(bot):
-            if let updated = await session.deleteTask(task, for: bot), task.threadId == bot.threadId {
-                onSelectThread(updated.threadId)
-                dismiss()
+            guard await session.deleteTask(liveTask, for: bot) != nil else {
+                showError("Couldn't delete the thread. Try again.")
+                return
             }
-        case let .room(room): await session.deleteTask(task, for: room)
+            if task.threadId == bot.threadId { dismiss() }
+        case let .room(room):
+            guard await session.deleteTask(liveTask, for: room) else {
+                showError("Couldn't delete the thread. Try again.")
+                return
+            }
+        }
+        if taskToRename?.threadId == task.threadId {
+            taskToRename = nil
+            renameFocused = false
         }
     }
 }

--- a/ios/App/ThreadPreview.json
+++ b/ios/App/ThreadPreview.json
@@ -1,0 +1,84 @@
+{
+  "bots": [
+    {
+      "id": "preview-pepper",
+      "threadId": "preview-gmail",
+      "name": "Pepper",
+      "title": "Personal assistant",
+      "description": "Helps with email and everyday plans.",
+      "notifications": false,
+      "color": "purple",
+      "unread": true,
+      "busy": true,
+      "modelSelection": { "instanceId": "preview", "model": "preview" },
+      "createdAt": 1789088400000,
+      "projects": [
+        { "id": "email", "name": "Email", "emoji": "✉️" }
+      ],
+      "tasks": [
+        {
+          "threadId": "preview-gmail",
+          "title": "Triage Gmail",
+          "createdAt": 1789088400000,
+          "projectId": "email",
+          "modelSelection": { "instanceId": "preview", "model": "preview" },
+          "busy": true,
+          "activity": "working",
+          "unread": false
+        },
+        {
+          "threadId": "preview-icloud",
+          "title": "Triage iCloud",
+          "createdAt": 1789088460000,
+          "projectId": "email",
+          "modelSelection": { "instanceId": "preview", "model": "preview" },
+          "busy": false,
+          "activity": "idle",
+          "unread": true
+        },
+        {
+          "threadId": "preview-weekend",
+          "title": "Plan weekend",
+          "createdAt": 1789088520000,
+          "modelSelection": { "instanceId": "preview", "model": "preview" },
+          "busy": false,
+          "activity": "queued",
+          "unread": false,
+          "openedBy": {
+            "botId": "preview-pepper",
+            "name": "Pepper",
+            "at": 1789088520000
+          }
+        },
+        {
+          "threadId": "preview-routine",
+          "title": "Internal routine execution",
+          "createdAt": 1789088580000,
+          "projectId": "email",
+          "routineRunId": "preview-routine-run",
+          "busy": false,
+          "unread": false
+        }
+      ],
+      "activeLeafId": "preview-gmail-reply",
+      "messages": [
+        {
+          "id": "preview-gmail-user",
+          "role": "user",
+          "kind": "text",
+          "at": 1789088400000,
+          "text": "Help me triage Gmail while keeping iCloud in a separate thread."
+        },
+        {
+          "id": "preview-gmail-reply",
+          "parentId": "preview-gmail-user",
+          "role": "bot",
+          "kind": "text",
+          "at": 1789088430000,
+          "text": "I’m reviewing Gmail here. Your iCloud conversation has its own context."
+        }
+      ]
+    }
+  ],
+  "groups": []
+}

--- a/ios/App/Updates.swift
+++ b/ios/App/Updates.swift
@@ -20,7 +20,7 @@ struct ChatUpdate: Identifiable, Hashable {
     /// The card to answer, when `kind == .needsYou`.
     let card: OptionCard?
 
-    var id: String { chat.id }
+    var id: String { chat.conversationID }
 }
 
 extension CompanionState {
@@ -31,30 +31,34 @@ extension CompanionState {
         // Newest approval first, one per chat: the pill headlines the most
         // recent thing that stopped, and the sheet lists the rest.
         for pending in pendingApprovals {
-            guard let chat = chat(forThread: pending.threadId), seen.insert(chat.id).inserted else { continue }
+            guard let chat = chat(forThread: pending.threadId), seen.insert(chat.conversationID).inserted else { continue }
             let card = pending.message.card
             out.append(ChatUpdate(chat: chat, kind: .needsYou, line: card?.subtitle ?? card?.title ?? "", card: card))
         }
 
         for bot in bots where bot.hidden != true {
-            let chat = Chat.bot(bot)
-            guard !seen.contains(chat.id) else { continue }
-            if bot.busy == true {
-                seen.insert(chat.id)
-                out.append(ChatUpdate(chat: chat, kind: .working, line: workingLine(threadId: bot.threadId), card: nil))
-            } else if bot.unread {
-                seen.insert(chat.id)
-                out.append(ChatUpdate(chat: chat, kind: .toReview, line: lastLine(threadId: bot.threadId), card: nil))
+            for task in bot.threadGroups().flatMap(\.tasks) {
+                guard let projected = bot.projected(forThread: task.threadId) else { continue }
+                let chat = Chat.bot(projected)
+                guard seen.insert(chat.conversationID).inserted else { continue }
+                if task.activity == "waiting-on-you" {
+                    out.append(ChatUpdate(chat: chat, kind: .needsYou, line: "Waiting on you", card: nil))
+                } else if task.activity == "queued" || projected.busy == true {
+                    out.append(ChatUpdate(chat: chat, kind: .working,
+                        line: task.activity == "queued" ? "Queued — waiting for an available slot" : workingLine(threadId: task.threadId), card: nil))
+                } else if projected.unread {
+                    out.append(ChatUpdate(chat: chat, kind: .toReview, line: lastLine(threadId: task.threadId), card: nil))
+                }
             }
         }
         for room in rooms {
             let chat = Chat.room(room)
-            guard !seen.contains(chat.id) else { continue }
+            guard !seen.contains(chat.conversationID) else { continue }
             if room.busyBotId != nil {
-                seen.insert(chat.id)
+                seen.insert(chat.conversationID)
                 out.append(ChatUpdate(chat: chat, kind: .working, line: workingLine(threadId: room.threadId), card: nil))
             } else if room.unread {
-                seen.insert(chat.id)
+                seen.insert(chat.conversationID)
                 out.append(ChatUpdate(chat: chat, kind: .toReview, line: lastLine(threadId: room.threadId), card: nil))
             }
         }

--- a/ios/App/UpdatesSheet.swift
+++ b/ios/App/UpdatesSheet.swift
@@ -85,6 +85,10 @@ private struct UpdateRow: View {
                     Text(update.chat.name)
                         .font(.system(size: 15, weight: .semibold))
                         .foregroundStyle(Color.primary)
+                    Text(update.chat.threadTitle)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(Color.secondary)
+                        .lineLimit(1)
                     Text(update.line.isEmpty ? " " : update.line)
                         .font(.system(size: 14))
                         .foregroundStyle(Color.secondary)
@@ -154,6 +158,7 @@ private struct UpdateRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityIdentifier("update-\(update.chat.threadId)")
     }
 }
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -49,6 +49,24 @@ real `URLSession` tests:
 `EventStreamTests` catches that class by driving a real `URLSession`.
 [`TESTING.md`](TESTING.md) is the end-to-end runbook.
 
+## Threads on iPhone and iPad
+
+Tap **Threads** beneath a bot on the home screen to expand its conversations.
+Desktop folders appear in the same order, with working, queued, waiting and
+unread state shown on each thread. Search matches thread and folder names.
+Internal routine runs are kept out of this list.
+
+Inside a chat, tap the bot/thread name in the header to switch conversations,
+create a thread, or rename/delete one. Tap the avatar for bot settings.
+Picking a bot thread is local to the phone; it does not move the desktop's
+selection. Draft text and attachments stay with their original thread while
+switching in that chat. Updates also lists sibling conversations separately.
+Group conversations retain their existing shared, serial switching behavior.
+
+Folder creation, moving threads between folders and folder reordering remain
+desktop actions. See the [isolated thread checks](../docs/verification/ios-threads.md)
+for simulator verification and its limits.
+
 ## Layout
 
 ```

--- a/ios/Sources/CompanionCore/Models.swift
+++ b/ios/Sources/CompanionCore/Models.swift
@@ -236,6 +236,13 @@ public struct ThreadOpener: Codable, Hashable, Sendable {
     public var at: Double
 }
 
+/// A folder within one bot, in the order saved by the desktop.
+public struct BotProject: Codable, Hashable, Identifiable, Sendable {
+    public var id: String
+    public var name: String
+    public var emoji: String?
+}
+
 public struct BotTask: Codable, Hashable, Sendable {
     public var threadId: String
     public var title: String
@@ -301,6 +308,7 @@ public struct Bot: Codable, Hashable, Identifiable, Sendable {
     /// older harness included) means the shipped `cursor` silhouette.
     public var mascotBody: String?
     public var tasks: [BotTask]?
+    public var projects: [BotProject]?
     public var messages: [Message]?
     public var activeLeafId: String?
     /// Paged responses only: there is more transcript above what you got.

--- a/ios/Sources/CompanionCore/Store.swift
+++ b/ios/Sources/CompanionCore/Store.swift
@@ -24,7 +24,8 @@ public struct CompanionState: Sendable {
     public var rooms: [Room] = []
     /// Transcripts by thread, which is the key both bots and rooms share.
     public var messages: [String: [Message]] = [:]
-    /// Whether there is more transcript above what we hold, per thread.
+    /// Whether there is more transcript above a fetched page, per thread.
+    /// An absent entry means no page has loaded; SSE tails do not set this.
     public var hasMore: [String: Bool] = [:]
     /// Branch heads belong to threads, not the bot's globally selected tab.
     public var activeLeafIds: [String: String] = [:]
@@ -56,6 +57,12 @@ public struct CompanionState: Sendable {
     /// stored property compiles but reads as if one shadows the other.
     public func transcript(forThread threadId: String) -> [Message] {
         messages[threadId] ?? []
+    }
+
+    /// Live events may create a partial transcript before a conversation is
+    /// opened. Only a fetched page establishes its scrollback boundary.
+    public func hasLoadedPage(forThread threadId: String) -> Bool {
+        hasMore[threadId] != nil
     }
 
     /// The active branch of a bot conversation. Rooms and legacy linear
@@ -175,9 +182,19 @@ public struct CompanionState: Sendable {
         return out.sorted { $0.message.at > $1.message.at }
     }
 
-    /// Chats worth a badge.
+    /// Visible conversations worth a badge. The bot-level flag is an
+    /// aggregate, so it must not add another count beside its unread tasks.
     public var unreadCount: Int {
-        bots.filter { $0.unread && $0.hidden != true }.count + rooms.filter(\.unread).count
+        let botCount = bots.filter { $0.hidden != true }.reduce(0) { count, bot in
+            if bot.tasks?.contains(where: { $0.unread != nil }) == true {
+                return count + bot.visibleTasks.filter { $0.unread == true }.count
+            }
+            // Legacy computers omit task unread flags entirely. Do not
+            // invent individual unread threads from their aggregate flag.
+            let hasConversation = bot.tasks == nil || !bot.visibleTasks.isEmpty
+            return count + (hasConversation && bot.unread ? 1 : 0)
+        }
+        return botCount + rooms.filter(\.unread).count
     }
 
     // MARK: - Hydrating
@@ -204,12 +221,12 @@ public struct CompanionState: Sendable {
         activeLeafIds.removeAll()
         for bot in fleet.bots {
             messages[bot.threadId] = bot.messages ?? []
-            hasMore[bot.threadId] = bot.hasMore ?? false
+            if bot.messages != nil { hasMore[bot.threadId] = bot.hasMore ?? false }
             activeLeafIds[bot.threadId] = bot.activeLeafId
         }
         for room in fleet.groups {
             messages[room.threadId] = room.messages ?? []
-            hasMore[room.threadId] = room.hasMore ?? false
+            if room.messages != nil { hasMore[room.threadId] = room.hasMore ?? false }
         }
         for (threadId, page) in waitingThreads where bot(forThread: threadId) != nil {
             merge(page, intoThread: threadId)
@@ -233,7 +250,9 @@ public struct CompanionState: Sendable {
         messages[threadId] = byId.values.sorted {
             $0.at == $1.at ? $0.id < $1.id : $0.at < $1.at
         }
-        if let more = page.hasMore { hasMore[threadId] = more }
+        // Legacy full pages omit hasMore. They still satisfy initial load,
+        // while a sparse landing window preserves an existing boundary.
+        hasMore[threadId] = page.hasMore ?? hasMore[threadId] ?? false
         if let leaf = page.activeLeafId { activeLeafIds[threadId] = leaf }
     }
 
@@ -317,8 +336,10 @@ public struct CompanionState: Sendable {
                 bots[index] = merged
             } else {
                 bots.append(bot)
-                if messages[bot.threadId] == nil {
-                    messages[bot.threadId] = bot.messages ?? []
+                if let page = bot.messages {
+                    merge(ThreadPage(messages: page, hasMore: bot.hasMore ?? false), intoThread: bot.threadId)
+                } else if messages[bot.threadId] == nil {
+                    messages[bot.threadId] = []
                 }
             }
 
@@ -360,8 +381,10 @@ public struct CompanionState: Sendable {
                 rooms[index] = merged
             } else {
                 rooms.append(room)
-                if messages[room.threadId] == nil {
-                    messages[room.threadId] = room.messages ?? []
+                if let page = room.messages {
+                    merge(ThreadPage(messages: page, hasMore: room.hasMore ?? false), intoThread: room.threadId)
+                } else if messages[room.threadId] == nil {
+                    messages[room.threadId] = []
                 }
             }
 

--- a/ios/Sources/CompanionCore/ThreadNavigation.swift
+++ b/ios/Sources/CompanionCore/ThreadNavigation.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// One folder's visible threads, or the unfiled threads after the folders.
+public struct BotThreadGroup: Identifiable, Hashable, Sendable {
+    public let project: BotProject?
+    public let tasks: [BotTask]
+
+    public var id: String { project.map { "project:\($0.id)" } ?? "unfiled" }
+}
+
+extension BotTask {
+    public var displayTitle: String {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "Untitled thread" : trimmed
+    }
+}
+
+extension Bot {
+    /// Saved folder order and server thread order are preserved. Missing
+    /// folders leave their threads accessible in the unfiled group.
+    /// A folder-name search keeps all of that folder's visible threads.
+    public func threadGroups(matching query: String = "") -> [BotThreadGroup] {
+        let threads: [BotTask]
+        if tasks == nil {
+            // Older computers have one conversation but no task metadata.
+            // An explicitly empty modern list must stay empty.
+            threads = [BotTask(
+                threadId: threadId, title: "", createdAt: createdAt,
+                modelSelection: modelSelection, busy: busy, unread: unread,
+                approvalMode: approvalMode, autoApprove: autoApprove, alwaysAllow: alwaysAllow
+            )]
+        } else {
+            threads = visibleTasks
+        }
+
+        var projectIDs = Set<String>()
+        var groups = (projects ?? []).compactMap { project -> BotThreadGroup? in
+            guard projectIDs.insert(project.id).inserted else { return nil }
+            let filed = threads.filter { $0.projectId == project.id }
+            return filed.isEmpty ? nil : BotThreadGroup(project: project, tasks: filed)
+        }
+        let unfiled = threads.filter { task in
+            task.projectId.map { !projectIDs.contains($0) } ?? true
+        }
+        if !unfiled.isEmpty {
+            groups.append(BotThreadGroup(project: nil, tasks: unfiled))
+        }
+
+        let search = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !search.isEmpty else { return groups }
+        return groups.compactMap { group in
+            if group.project?.name.localizedStandardContains(search) == true { return group }
+            let matches = group.tasks.filter { $0.displayTitle.localizedStandardContains(search) }
+            return matches.isEmpty ? nil : BotThreadGroup(project: group.project, tasks: matches)
+        }
+    }
+}

--- a/ios/Tests/CompanionCoreTests/StoreTests.swift
+++ b/ios/Tests/CompanionCoreTests/StoreTests.swift
@@ -38,6 +38,84 @@ final class StoreTests: XCTestCase {
         }
     }
 
+    func testBackgroundLiveTailStillNeedsItsInitialPage() throws {
+        var state = try hydrated()
+        let threadId = "background-thread"
+        state.bots[0].tasks = [BotTask(threadId: threadId, title: "Background", createdAt: 1)]
+        let latest = message("latest", at: 3)
+        state.apply(.message(threadId: threadId, message: latest))
+
+        XCTAssertEqual(state.transcript(forThread: threadId).map(\.id), ["latest"])
+        XCTAssertFalse(state.hasLoadedPage(forThread: threadId), "A live tail does not contain the initial history.")
+        state.merge(ThreadPage(messages: [message("old", at: 1), message("recent", at: 2)], hasMore: true),
+                    intoThread: threadId)
+        XCTAssertTrue(state.hasLoadedPage(forThread: threadId))
+        XCTAssertEqual(state.transcript(forThread: threadId).map(\.id), ["old", "recent", "latest"])
+        XCTAssertEqual(state.hasMore[threadId], true)
+    }
+
+    func testBackgroundPatchDoesNotCountAsAPageAndEmptyLegacyPageDoes() {
+        var state = CompanionState()
+        state.apply(.messagePatch(threadId: "thread", message: message("patched")))
+        XCTAssertFalse(state.hasLoadedPage(forThread: "thread"))
+        state.merge(ThreadPage(messages: []), intoThread: "thread")
+        XCTAssertTrue(state.hasLoadedPage(forThread: "thread"))
+        XCTAssertEqual(state.hasMore["thread"], false)
+        XCTAssertEqual(state.transcript(forThread: "thread").map(\.id), ["patched"])
+
+        state.merge(ThreadPage(messages: [], hasMore: true), intoThread: "thread")
+        state.merge(ThreadPage(messages: []), intoThread: "thread")
+        XCTAssertEqual(state.hasMore["thread"], true, "An unspecified landing-window boundary preserves known scrollback.")
+    }
+
+    func testMetadataOnlyFleetDoesNotCountAsLoadedButEmptyTranscriptsDo() throws {
+        var source = try fleet()
+        source.bots[0].messages = nil
+        source.groups[0].messages = nil
+        var state = CompanionState()
+        state.hydrate(source)
+        XCTAssertFalse(state.hasLoadedPage(forThread: source.bots[0].threadId))
+        XCTAssertFalse(state.hasLoadedPage(forThread: source.groups[0].threadId))
+
+        source.bots[0].messages = []
+        source.groups[0].messages = []
+        source.bots[0].hasMore = nil
+        source.groups[0].hasMore = nil
+        state.hydrate(source)
+        XCTAssertTrue(state.hasLoadedPage(forThread: source.bots[0].threadId))
+        XCTAssertTrue(state.hasLoadedPage(forThread: source.groups[0].threadId))
+    }
+
+    func testNewOwnerFramesOnlyCountAsLoadedWhenTheyContainAPage() throws {
+        var source = try fleet()
+        var bot = source.bots.removeFirst()
+        var room = source.groups.removeFirst()
+        bot.messages = nil
+        room.messages = nil
+        var state = CompanionState()
+        state.apply(.bot(bot))
+        state.apply(.room(room))
+        XCTAssertFalse(state.hasLoadedPage(forThread: bot.threadId))
+        XCTAssertFalse(state.hasLoadedPage(forThread: room.threadId))
+
+        bot.messages = []
+        room.messages = []
+        state.apply(.bot(bot))
+        state.apply(.room(room))
+        XCTAssertTrue(state.hasLoadedPage(forThread: bot.threadId))
+        XCTAssertTrue(state.hasLoadedPage(forThread: room.threadId))
+
+        state = CompanionState()
+        state.apply(.bot(bot))
+        state.apply(.room(room))
+        XCTAssertTrue(state.hasLoadedPage(forThread: bot.threadId))
+        XCTAssertTrue(state.hasLoadedPage(forThread: room.threadId))
+        state.apply(.botDeleted(botId: bot.id))
+        state.apply(.roomDeleted(groupId: room.id))
+        XCTAssertFalse(state.hasLoadedPage(forThread: bot.threadId))
+        XCTAssertFalse(state.hasLoadedPage(forThread: room.threadId))
+    }
+
     func testSidebarSectionsGroupBotsAndChannelsInNaturalOrder() throws {
         let source = try fleet()
         var researchBot = try XCTUnwrap(source.bots.first)

--- a/ios/Tests/CompanionCoreTests/ThreadNavigationTests.swift
+++ b/ios/Tests/CompanionCoreTests/ThreadNavigationTests.swift
@@ -1,0 +1,220 @@
+import XCTest
+@testable import CompanionCore
+
+final class ThreadNavigationTests: XCTestCase {
+    func testProjectsDecodeWithOptionalEmojiAndLegacyAbsence() throws {
+        let legacy = try JSONDecoder().decode(Bot.self, from: Data("""
+        {"id":"bot","threadId":"current","name":"Scout","title":"Researcher",
+         "description":"","notifications":true,"color":"green","unread":false,
+         "modelSelection":{"instanceId":"engine","model":"default"},"createdAt":1}
+        """.utf8))
+        XCTAssertNil(legacy.projects)
+        XCTAssertNil(legacy.tasks)
+
+        var modern = legacy
+        modern.projects = try JSONDecoder().decode([BotProject].self, from: Data("""
+        [{"id":"research","name":"Research","emoji":"🔬"},
+         {"id":"writing","name":"Writing"}]
+        """.utf8))
+        let decoded = try JSONDecoder().decode(Bot.self, from: JSONEncoder().encode(modern))
+        XCTAssertEqual(decoded.projects?.map(\.id), ["research", "writing"])
+        XCTAssertEqual(decoded.projects?.first?.emoji, "🔬")
+        XCTAssertNil(decoded.projects?.last?.emoji)
+    }
+
+    func testFoldersFollowSavedOrderAndThreadsKeepServerOrder() {
+        var bot = makeBot(tasks: [
+            task("b-2", project: "b"), task("loose"), task("a-2", project: "a"),
+            task("a-1", project: "a"), task("b-1", project: "b"),
+        ])
+        bot.projects = [project("a"), project("b")]
+
+        let groups = bot.threadGroups()
+        XCTAssertEqual(groups.map(\.id), ["project:a", "project:b", "unfiled"])
+        XCTAssertEqual(groups.map { $0.tasks.map(\.threadId) }, [["a-2", "a-1"], ["b-2", "b-1"], ["loose"]])
+        XCTAssertEqual(groups.first?.project, bot.projects?.first)
+        XCTAssertNil(groups.last?.project)
+    }
+
+    func testOrphansStayUnfiledAndEmptyOrDuplicateFoldersDoNotDuplicateRows() {
+        var bot = makeBot(tasks: [task("orphan", project: "deleted"), task("filed", project: "a"), task("loose")])
+        bot.projects = [project("empty"), project("a"), project("a")]
+
+        XCTAssertEqual(bot.threadGroups().map(\.id), ["project:a", "unfiled"])
+        XCTAssertEqual(bot.threadGroups().last?.tasks.map(\.threadId), ["orphan", "loose"])
+        bot.projects = nil
+        XCTAssertEqual(bot.threadGroups().map(\.id), ["unfiled"])
+        XCTAssertEqual(bot.threadGroups().first?.tasks.map(\.threadId), ["orphan", "filed", "loose"])
+    }
+
+    func testRoutineExecutionsNeverAppearInFoldersOrSearch() {
+        var execution = task("run", title: "Hidden result", project: "runs")
+        execution.routineRunId = "routine-run"
+        var bot = makeBot(tasks: [execution, task("result", title: "Daily result")])
+        bot.projects = [project("runs", name: "Hidden results")]
+
+        XCTAssertEqual(bot.threadGroups().flatMap(\.tasks).map(\.threadId), ["result"])
+        XCTAssertTrue(bot.threadGroups(matching: "Hidden").isEmpty)
+        bot.tasks = [execution]
+        XCTAssertTrue(bot.threadGroups().isEmpty)
+    }
+
+    func testLegacyFallbackKeepsCurrentConversationAndRuntimeSettings() throws {
+        var bot = makeBot()
+        bot.busy = true
+        bot.unread = true
+        bot.approvalMode = "custom"
+        bot.autoApprove = false
+        bot.alwaysAllow = ["Bash:git"]
+
+        let fallback = try XCTUnwrap(bot.threadGroups().first?.tasks.first)
+        XCTAssertEqual(fallback.threadId, bot.threadId)
+        XCTAssertEqual(fallback.displayTitle, "Untitled thread")
+        XCTAssertEqual(fallback.createdAt, bot.createdAt)
+        XCTAssertEqual(fallback.modelSelection, bot.modelSelection)
+        XCTAssertEqual(fallback.busy, true)
+        XCTAssertEqual(fallback.unread, true)
+        XCTAssertEqual(fallback.approvalMode, "custom")
+        XCTAssertEqual(fallback.autoApprove, false)
+        XCTAssertEqual(fallback.alwaysAllow, ["Bash:git"])
+        XCTAssertEqual(bot.threadGroups(matching: "untitled").first?.tasks.first?.threadId, bot.threadId)
+        bot.tasks = []
+        XCTAssertTrue(bot.threadGroups().isEmpty)
+    }
+
+    func testBlankTitlesHaveAnExplicitFallback() {
+        XCTAssertEqual(task("blank", title: " \n\t ").displayTitle, "Untitled thread")
+        XCTAssertEqual(task("empty", title: "").displayTitle, "Untitled thread")
+        XCTAssertEqual(task("named", title: "  Release notes\n").displayTitle, "Release notes")
+    }
+
+    func testSearchMatchesTitlesAndFolderNamesWithoutCaseOrAccentSensitivity() {
+        var bot = makeBot(tasks: [
+            task("plan", title: "Release plan", project: "research"),
+            task("budget", title: "Budget", project: "research"),
+            task("draft", title: "Release draft"), task("unrelated", title: "Shopping"),
+        ])
+        bot.projects = [project("research", name: "Café research")]
+
+        XCTAssertEqual(bot.threadGroups(matching: "  CAFE \n").flatMap(\.tasks).map(\.threadId), ["plan", "budget"])
+        XCTAssertEqual(bot.threadGroups(matching: "RELEASE").flatMap(\.tasks).map(\.threadId), ["plan", "draft"])
+        XCTAssertEqual(bot.threadGroups(matching: "budget").map(\.id), ["project:research"])
+        XCTAssertEqual(bot.threadGroups(matching: " \n"), bot.threadGroups())
+        XCTAssertTrue(bot.threadGroups(matching: "missing").isEmpty)
+    }
+
+    func testGroupingPreservesRuntimeMetadataAndDoesNotChangeSelection() {
+        var working = task("sibling", project: "work")
+        working.busy = true
+        working.activity = "waiting"
+        working.unread = true
+        working.openedBy = ThreadOpener(botId: "other", name: "Teammate", at: 9)
+        var bot = makeBot(tasks: [task("current"), working])
+        bot.projects = [project("work")]
+
+        XCTAssertEqual(bot.threadGroups().first?.tasks, [working])
+        XCTAssertEqual(bot.threadGroups(matching: "sibling").first?.tasks, [working])
+        XCTAssertEqual(bot.threadId, "current")
+        XCTAssertEqual(bot.tasks?.last, working)
+    }
+
+    func testSiblingNavigationProjectionsKeepTheirOwnThreadAndRuntime() throws {
+        var selected = task("current", title: "Current")
+        selected.unread = false
+        selected.busy = false
+        var sibling = task("sibling", title: "Sibling")
+        sibling.unread = true
+        sibling.busy = true
+        sibling.modelSelection = ModelSelection(instanceId: "other-engine", model: "other-model")
+        let bot = makeBot(tasks: [selected, sibling])
+
+        let first = try XCTUnwrap(bot.projected(forThread: selected.threadId))
+        let second = try XCTUnwrap(bot.projected(forThread: sibling.threadId))
+        XCTAssertEqual(first.id, second.id, "The profile API still addresses the bot owner.")
+        XCTAssertNotEqual(first.threadId, second.threadId)
+        XCTAssertEqual(second.currentTaskModelSelection, sibling.modelSelection)
+        XCTAssertEqual(first.unread, false)
+        XCTAssertEqual(second.unread, true)
+        XCTAssertEqual(second.currentTaskBusy, true)
+        XCTAssertEqual(bot.threadId, "current", "Navigation must not select the sibling on the shared profile.")
+        XCTAssertNil(bot.projected(forThread: "missing"))
+    }
+
+    func testUnreadBadgeCountsVisibleSiblingThreadsOnceEachAndKeepsRoomCount() {
+        var first = task("current")
+        first.unread = true
+        var second = task("second")
+        second.unread = true
+        var execution = task("run")
+        execution.unread = true
+        execution.routineRunId = "run-1"
+        var bot = makeBot(tasks: [first, second, execution])
+        bot.unread = true
+        var hidden = bot
+        hidden.id = "hidden"
+        hidden.hidden = true
+        var state = CompanionState()
+        state.bots = [bot, hidden]
+        state.rooms = [Room(
+            id: "room", threadId: "room-thread", name: "Channel", memberIds: [],
+            defaultResponder: GroupResponder(kind: "all"), bulletin: "", unread: true, createdAt: 1
+        )]
+
+        XCTAssertEqual(state.unreadCount, 3)
+        state.rooms = []
+        XCTAssertEqual(state.unreadCount, 2)
+        state.bots[0].tasks = [execution]
+        XCTAssertEqual(state.unreadCount, 0)
+    }
+
+    func testUnreadBadgeFallsBackOnceForLegacyMetadata() {
+        var bot = makeBot()
+        bot.unread = true
+        var state = CompanionState()
+        state.bots = [bot]
+        XCTAssertEqual(state.unreadCount, 1)
+        state.bots[0].tasks = [task("current"), task("older")]
+        XCTAssertEqual(state.unreadCount, 1)
+        state.bots[0].unread = false
+        XCTAssertEqual(state.unreadCount, 0)
+        state.bots[0].unread = true
+        state.bots[0].tasks = []
+        XCTAssertEqual(state.unreadCount, 0)
+        var execution = task("run")
+        execution.routineRunId = "run-1"
+        state.bots[0].tasks = [execution]
+        XCTAssertEqual(state.unreadCount, 0)
+    }
+
+    func testMixedUnreadMetadataDoesNotApplyAggregateToUnknownThreads() {
+        var known = task("current")
+        known.unread = true
+        var bot = makeBot(tasks: [known, task("unknown")])
+        bot.unread = true
+        var state = CompanionState()
+        state.bots = [bot]
+        XCTAssertEqual(state.unreadCount, 1)
+        state.bots[0].tasks?[0].unread = false
+        XCTAssertEqual(state.unreadCount, 0)
+        state.bots[0].tasks?[0].unread = true
+        state.bots[0].tasks?[0].routineRunId = "run-1"
+        XCTAssertEqual(state.unreadCount, 0, "An unread internal run cannot mark an unknown visible thread unread.")
+    }
+
+    private func makeBot(tasks: [BotTask]? = nil) -> Bot {
+        Bot(
+            id: "bot", threadId: "current", name: "Scout", title: "Researcher",
+            description: "", notifications: true, color: "green", unread: false,
+            modelSelection: ModelSelection(instanceId: "engine", model: "default"), createdAt: 1,
+            tasks: tasks
+        )
+    }
+
+    private func task(_ id: String, title: String? = nil, project: String? = nil) -> BotTask {
+        BotTask(threadId: id, title: title ?? id, createdAt: 1, projectId: project)
+    }
+
+    private func project(_ id: String, name: String? = nil) -> BotProject {
+        BotProject(id: id, name: name ?? id)
+    }
+}

--- a/ios/UITests/ThreadNavigationUITests.swift
+++ b/ios/UITests/ThreadNavigationUITests.swift
@@ -1,0 +1,191 @@
+import XCTest
+
+/// Runs exclusively against the bundled ThreadPreview fleet. No account,
+/// paired computer, message sends, or server mutations are involved.
+final class ThreadNavigationUITests: XCTestCase {
+    @MainActor
+    func testRosterShowsFolderThreadsAndSwitchesLocally() {
+        let app = launchPreview()
+        openGmail(in: app)
+        assertThread("Triage Gmail", in: app)
+
+        app.buttons["thread-switcher"].tap()
+        let iCloud = app.buttons["thread-preview-icloud"]
+        XCTAssertTrue(iCloud.waitForExistence(timeout: 5))
+        XCTAssertTrue(iCloud.label.contains("Unread"))
+        XCTAssertTrue(app.buttons["thread-preview-weekend"].label.contains("Queued"))
+        XCTAssertFalse(app.buttons["thread-preview-routine"].exists)
+        recordScreenshot("Thread picker with folder and runtime states", in: app)
+        iCloud.tap()
+        assertThread("Triage iCloud", in: app)
+
+        app.buttons["Back"].tap()
+        XCTAssertTrue(app.buttons["threads-toggle.preview-pepper"].waitForExistence(timeout: 5))
+        app.buttons["thread.preview-gmail"].tap()
+        assertThread("Triage Gmail", in: app)
+    }
+
+    @MainActor
+    func testHomeSearchFindsSiblingTitlesAndFolders() {
+        let app = launchPreview()
+        app.buttons["threads-toggle.preview-pepper"].tap()
+        app.buttons["Search"].tap()
+        let search = app.textFields["Search threads"]
+        XCTAssertTrue(search.waitForExistence(timeout: 5))
+        search.tap()
+        search.typeText("iCloud")
+        recordScreenshot("Home search for iCloud", in: app)
+
+        XCTAssertTrue(app.buttons["thread.preview-icloud"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.buttons["thread.preview-gmail"].exists)
+        XCTAssertFalse(app.buttons["thread.preview-weekend"].exists)
+
+        app.buttons["Cancel"].tap()
+        app.buttons["Search"].tap()
+        XCTAssertTrue(search.waitForExistence(timeout: 5))
+        search.tap()
+        search.typeText("Email")
+        XCTAssertTrue(app.buttons["thread.preview-gmail"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["thread.preview-icloud"].exists)
+        XCTAssertFalse(app.buttons["thread.preview-weekend"].exists)
+        XCTAssertFalse(app.buttons["thread.preview-routine"].exists)
+        recordScreenshot("Home search for Email folder", in: app)
+
+        app.buttons["thread.preview-icloud"].tap()
+        assertThread("Triage iCloud", in: app)
+        app.buttons["Back"].tap()
+        XCTAssertTrue(app.buttons["Cancel"].waitForExistence(timeout: 5))
+        app.buttons["Cancel"].tap()
+        XCTAssertTrue(app.buttons["threads-toggle.preview-pepper"].exists)
+        XCTAssertEqual(app.buttons["threads-toggle.preview-pepper"].value as? String, "Expanded, 3 threads")
+    }
+
+    @MainActor
+    func testSwitchingThreadsKeepsSeparateUnsentDrafts() {
+        let app = launchPreview()
+        openGmail(in: app)
+        let input = app.descendants(matching: .any).matching(identifier: "message-input").firstMatch
+        XCTAssertTrue(input.waitForExistence(timeout: 5))
+        input.tap()
+        input.typeText("Gmail draft only")
+
+        selectThread("preview-icloud", title: "Triage iCloud", in: app)
+        XCTAssertNotEqual(input.value as? String, "Gmail draft only")
+        input.tap()
+        input.typeText("iCloud draft only")
+
+        selectThread("preview-gmail", title: "Triage Gmail", in: app)
+        XCTAssertEqual(input.value as? String, "Gmail draft only")
+        selectThread("preview-icloud", title: "Triage iCloud", in: app)
+        XCTAssertEqual(input.value as? String, "iCloud draft only")
+        recordScreenshot("Restored iCloud draft after switching threads", in: app)
+    }
+
+    @MainActor
+    func testFailedCreationKeepsThreadPickerOpenWithError() {
+        let app = launchPreview()
+        openGmail(in: app)
+        app.buttons["thread-switcher"].tap()
+        let create = app.buttons["new-thread"]
+        XCTAssertTrue(create.waitForExistence(timeout: 5))
+        // The preview deliberately has no API client, so this cannot write
+        // anywhere and exercises the failure path deterministically.
+        create.tap()
+        let error = app.descendants(matching: .any).matching(identifier: "thread-action-error").firstMatch
+        XCTAssertTrue(error.waitForExistence(timeout: 5))
+        XCTAssertTrue(error.label.contains("Couldn't create the thread"))
+        XCTAssertTrue(create.exists)
+        XCTAssertTrue(create.isEnabled)
+        XCTAssertTrue(app.buttons["thread-preview-gmail"].exists)
+        recordScreenshot("Failed creation keeps thread picker open", in: app)
+        app.buttons["Done"].tap()
+        assertThread("Triage Gmail", in: app)
+    }
+
+    @MainActor
+    func testUpdatesKeepSiblingThreadsSeparate() {
+        let app = launchPreview()
+        app.buttons["updates-button"].tap()
+        let gmail = app.buttons["update-preview-gmail"]
+        let iCloud = app.buttons["update-preview-icloud"]
+        let weekend = app.buttons["update-preview-weekend"]
+        XCTAssertTrue(gmail.waitForExistence(timeout: 5))
+        XCTAssertTrue(iCloud.exists)
+        XCTAssertTrue(weekend.exists)
+        XCTAssertTrue(gmail.label.contains("Triage Gmail"))
+        XCTAssertTrue(iCloud.label.contains("Triage iCloud"))
+        XCTAssertTrue(weekend.label.contains("Plan weekend"))
+        XCTAssertFalse(app.buttons["update-preview-routine"].exists)
+        XCTAssertTrue(app.staticTexts["3 active"].exists)
+        if !iCloud.isHittable { app.swipeUp() }
+        recordScreenshot("Separate updates for sibling threads", in: app)
+        iCloud.tap()
+        assertThread("Triage iCloud", in: app)
+    }
+
+    @MainActor
+    private func launchPreview() -> XCUIApplication {
+        continueAfterFailure = false
+        let app = XCUIApplication()
+        // Xcode may prelaunch the app after installing an updated build.
+        // Restart it so Session initializes with the offline fixture flags.
+        app.terminate()
+        app.launchArguments = [
+            "-store-preview", "-threads-preview",
+            "-AppleLanguages", "(en)", "-AppleLocale", "en_US",
+            "-companion.prefs.islandIntro", "never",
+            "-companion.onboarding.welcomeSeen", "YES",
+            "-companion.onboarding.notificationsSeen", "YES"
+        ]
+        app.launch()
+        // Simulator installation can restore an unpaired, prewarmed scene
+        // without the preview arguments once. Restart only that wrong route;
+        // a missing thread in an already-loaded fixture must still fail.
+        if app.buttons["Connect computer"].exists {
+            app.terminate()
+            app.launch()
+        }
+        XCTAssertTrue(app.buttons["threads-toggle.preview-pepper"].waitForExistence(timeout: 10))
+        return app
+    }
+
+    @MainActor
+    private func openGmail(in app: XCUIApplication) {
+        let toggle = app.buttons["threads-toggle.preview-pepper"]
+        toggle.tap()
+        XCTAssertEqual(toggle.value as? String, "Expanded, 3 threads")
+        let gmail = app.buttons["thread.preview-gmail"]
+        XCTAssertTrue(gmail.waitForExistence(timeout: 5))
+        XCTAssertTrue(gmail.label.contains("Working"))
+        XCTAssertTrue(app.buttons["thread.preview-icloud"].label.contains("Unread"))
+        XCTAssertTrue(app.buttons["thread.preview-weekend"].label.contains("Queued"))
+        XCTAssertFalse(app.buttons["thread.preview-routine"].exists)
+        recordScreenshot("Expanded home threads with Email folder", in: app)
+        gmail.tap()
+    }
+
+    @MainActor
+    private func selectThread(_ id: String, title: String, in app: XCUIApplication) {
+        app.buttons["thread-switcher"].tap()
+        let row = app.buttons["thread-\(id)"]
+        XCTAssertTrue(row.waitForExistence(timeout: 5))
+        row.tap()
+        assertThread(title, in: app)
+    }
+
+    @MainActor
+    private func assertThread(_ title: String, in app: XCUIApplication) {
+        let header = app.buttons["thread-switcher"]
+        let expected = NSPredicate(format: "label == %@", "Switch thread: \(title)")
+        let appeared = XCTNSPredicateExpectation(predicate: expected, object: header)
+        XCTAssertEqual(XCTWaiter.wait(for: [appeared], timeout: 5), .completed)
+    }
+
+    @MainActor
+    private func recordScreenshot(_ name: String, in app: XCUIApplication) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -18,6 +18,17 @@ packages:
   CompanionCore:
     path: .
 
+schemes:
+  OpenMausCompanion:
+    build:
+      targets:
+        OpenMausCompanion: all
+        OpenMausCompanionUITests: [test]
+    test:
+      config: Debug
+      targets:
+        - OpenMausCompanionUITests
+
 targets:
   OpenMausCompanion:
     type: application
@@ -119,6 +130,22 @@ targets:
             ts.net:
               NSIncludesSubdomains: true
               NSExceptionAllowsInsecureHTTPLoads: true
+
+  # Native navigation coverage uses bundled synthetic data and no pairing.
+  OpenMausCompanionUITests:
+    type: bundle.ui-testing
+    platform: iOS
+    sources:
+      - path: UITests
+    dependencies:
+      - target: OpenMausCompanion
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.openmausbot.app.uitests
+        SWIFT_VERSION: "5.9"
+        TARGETED_DEVICE_FAMILY: "1,2"
+        GENERATE_INFOPLIST_FILE: YES
+        TEST_TARGET_NAME: OpenMausCompanion
 
   # The system share sheet can send a link, text, image, or document straight
   # to a paired bot without first opening the containing app. Connection


### PR DESCRIPTION
## Summary
- Show expandable threads and desktop folders beneath each bot on iPhone and iPad.
- Add a chat-header thread switcher, title/folder search, per-thread activity and unread indicators, and distinct sibling entries in Updates.
- Keep draft text and attachments with their original thread; load complete history when a background thread has only received live events.
- Improve thread creation, rename and deletion feedback, retain failed edits, and prevent duplicate creation while searching.
- Add an offline native UI fixture, regression tests and verification instructions.

## Verification
- Debug iOS Simulator build succeeded with Xcode 26.6.
- 383 CompanionCore tests passed.
- 17 isolated server integration tests passed.
- All five native UI scenarios passed on both iPhone 17 Pro and iPad Pro 13-inch (M5), using disposable iOS 26.5 simulators.
- No verification mutations against the user's live app or conversations.

## Scope
Folder management remains on desktop. Group threads retain their existing shared, serial switching behavior. No new server routes, pairing changes, version bump or release. Physical-device pairing and attachment uploads were not re-tested in this pass.

See docs/verification/ios-threads.md for the reproducible checks and limitations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added iPhone and iPad support for browsing bot threads grouped by folders.
  - Search now finds folders and thread titles.
  - Added thread creation, switching, renaming, and deletion from the chat interface.
  - Draft text, attachments, and errors are preserved separately for each thread.
  - Updates now show individual entries for sibling threads, including “waiting on you” statuses.

- **Bug Fixes**
  - Improved thread loading and unread-count handling.
  - Prevented failed thread actions from closing navigation or losing user input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->