### PR TITLE
fix(pi): update provider catalog on explicit refresh

### DIFF
--- a/server/drivers/pi.test.ts
+++ b/server/drivers/pi.test.ts
@@ -24,6 +24,7 @@ import {
   PiDriver,
   preferPiInjectRows,
   splitPiModel,
+  updatePiModelCatalog,
 } from "./pi.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-pi-cli.ts");
@@ -187,6 +188,45 @@ describe("PiDriver catalog (fake CLI)", () => {
       FAKE_PI_MODE: "no-models",
     });
     expect(catalog.options).toEqual([]);
+  });
+
+  it("updates pi's catalog only on explicit refresh, then probes it again", async () => {
+    const home = mkdtempSync(join(tmpdir(), "omb-pi-update-"));
+    const dump = join(home, "launches.jsonl");
+    const instance = await PiDriver.create({
+      instanceId: "pi-refresh",
+      displayName: undefined,
+      environment: { HOME: home, FAKE_PI_DUMP: dump },
+      enabled: true,
+      config: { cli: FAKE_CLI, fullAuto: false },
+    });
+    try {
+      const startup = readFileSync(dump, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+      expect(startup.some((entry) => entry.argv?.[0] === "update")).toBe(false);
+
+      writeFileSync(dump, "");
+      await instance.refreshModels?.();
+      const refresh = readFileSync(dump, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+      expect(refresh.map((entry) => entry.argv)).toEqual([
+        ["update", "--models", "--no-approve"],
+        ["--mode", "rpc", "--no-session"],
+      ]);
+    } finally {
+      await instance.dispose();
+    }
+  });
+
+  it("reports update failure without preventing a cached catalog probe", async () => {
+    expect(await updatePiModelCatalog(FAKE_CLI, {
+      PATH: process.env.PATH ?? "",
+      FAKE_PI_MODE: "update-error",
+    })).toBe(false);
+    const catalog = await fetchPiModels(FAKE_CLI, {
+      PATH: process.env.PATH ?? "",
+      HOME: join(tmpdir(), "omb-pi-update-error"),
+      FAKE_PI_MODE: "update-error",
+    });
+    expect(catalog.options).toHaveLength(2);
   });
 });
 

--- a/server/drivers/pi.ts
+++ b/server/drivers/pi.ts
@@ -27,7 +27,7 @@ import { join } from "node:path";
 import { PROVIDER_CREDENTIAL_ENV, stripWorkspaceCredentialEnv } from "../config.ts";
 import { computerProxyEnv } from "../container-computer.ts";
 import { augmentedPath } from "../env-path.ts";
-import { describeSpawnFailure, killCliTree, spawnCli } from "../procs.ts";
+import { describeSpawnFailure, execCli, killCliTree, spawnCli } from "../procs.ts";
 import { SPAWNED_PROXIES } from "../proxy-paths.ts";
 
 import type {
@@ -54,6 +54,7 @@ import { appendNative } from "./native.ts";
 
 const DRIVER_KIND = "piAgent";
 const PI_ARGS = ["--mode", "rpc", "--no-session"];
+const PI_MODEL_UPDATE_ARGS = ["update", "--models", "--no-approve"];
 const NODE_ENV_FLAG = { ELECTRON_RUN_AS_NODE: "1" };
 
 type PiPromptImage = {
@@ -363,6 +364,23 @@ export async function fetchPiModels(
   });
 }
 
+/** Refresh pi's provider-owned catalog cache. This is deliberately called
+ * only by the explicit model-picker refresh action, never during app startup.
+ * Failure is non-fatal: the caller still probes the last usable cache. */
+export async function updatePiModelCatalog(
+  cli: string,
+  env: Record<string, string | undefined>,
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    execCli(
+      cli,
+      PI_MODEL_UPDATE_ARGS,
+      { env, timeout: 60_000, maxBuffer: 1024 * 1024 },
+      (error) => resolve(!error),
+    );
+  });
+}
+
 export interface PiConfig {
   cli: string;
   /** Full-auto: never ask before an action. Host control is unavailable in
@@ -440,7 +458,7 @@ export const PiDriver: ProviderDriver<PiConfig> = {
     const { instanceId, config } = input;
     const catalogEnv = piEnvironment({ ...process.env, ...input.environment });
     let models = EMPTY;
-    const refreshModels = async () => {
+    const readModels = async () => {
       let base = models;
       try {
         const resolved = await fetchPiModels(config.cli, catalogEnv);
@@ -455,7 +473,13 @@ export const PiDriver: ProviderDriver<PiConfig> = {
         if (base.options.length) models = base;
       }
     };
-    await refreshModels();
+    const refreshModels = async () => {
+      await updatePiModelCatalog(config.cli, catalogEnv);
+      await readModels();
+    };
+    // Startup stays local and fast. Only the explicit Refresh button crosses
+    // pi's model-catalog network boundary.
+    await readModels();
 
     const listeners = new Set<RuntimeEventListener>();
     // one active turn per thread

--- a/server/testing/fake-pi-cli.ts
+++ b/server/testing/fake-pi-cli.ts
@@ -58,6 +58,11 @@ if (process.env.FAKE_PI_DUMP) {
   }
 }
 
+// Explicit model refresh is a short-lived command, separate from RPC mode.
+if (argv[0] === "update" && argv.includes("--models")) {
+  process.exit(mode === "update-error" ? 1 : 0);
+}
+
 // exit-early: die before saying anything — a failed spawn surfaces as a
 // runtime.error + failed turn, never a hang.
 if (mode === "exit-early") {


### PR DESCRIPTION
## What changed

- Run `pi update --models --no-approve` when the model picker explicitly requests a refresh.
- Probe the refreshed RPC catalog immediately afterward.
- Keep startup local and fast: app launch still reads the existing pi catalog without running an update.
- Treat update failures as non-fatal and fall back to the last usable catalog/local models.
- Add fake-CLI contract coverage for the refresh command, startup behavior, and failure fallback.

## Why

Pi can learn about newly published provider models only after its catalog cache is updated. OpenMausBot's Refresh button previously re-read the existing cache, so a model visible after manually running `pi update --models` did not appear through the app's own refresh action.

## How it was verified

- `tsc -b && tsc -p tsconfig.server.json`
- focused `oxlint` on the three changed files
- `vitest run server/drivers/pi.test.ts` (47 tests passed)
- verified startup does not invoke `pi update`
- verified explicit refresh invokes the update once, then probes RPC models
- verified an update error still allows probing the cached catalog

Comparison base: `4feae359`
Head: `9f9bd022`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model catalogs are no longer refreshed over the network during application startup.
  * Startup now uses the locally cached catalog when available.
  * Explicit catalog refreshes report failures while preserving access to cached models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->