### PR TITLE
Approve for me answers itself when Claude's reviewer never starts

### DIFF
--- a/docs/approval-levels.md
+++ b/docs/approval-levels.md
@@ -6,7 +6,7 @@ when that provider resumes an existing native thread.
 | Level | Behavior |
 | --- | --- |
 | **Ask for approval** | The provider asks before actions outside its normal workspace or network permissions. |
-| **Approve for me** | Uses native automatic review on Codex, Claude, Cursor, and Grok. Other providers fall back to Ask. Requests the native reviewer leaves for you are not overridden by OpenMausBot. Unattended Auto runs use Ask. |
+| **Approve for me** | Uses native automatic review on Codex, Claude, Cursor, and Grok. Other providers fall back to Ask. Requests a running native reviewer leaves for you are not overridden by OpenMausBot, except by an **Always allow** answer you recorded for that exact command or tool. When Claude reports that its reviewer never started (see below), OpenMausBot approves routine actions itself and still asks about destructive or sensitive ones. Unattended Auto runs use Ask. |
 | **Full access** | Enables the provider's permissive mode for commands, edits, and selected-computer actions, including potentially destructive or sensitive work. Applies to this bot's direct, scheduled, and delegated work (ask_bot, delegate_bot); delegation uses the receiving bot's setting, never the sender's. Some providers still ask for approval. Questions and separate OpenMausBot confirmations still wait for you. |
 | **Custom (`config.toml`)** | Codex only. OpenMausBot reads and reapplies the effective approval and sandbox settings from your Codex configuration. |
 
@@ -52,7 +52,7 @@ Cursor, Claude, or other engine's legacy full-auto mode.
 | Provider | Auto | Full access |
 | --- | --- | --- |
 | Codex | Native automatic reviewer; workspace sandbox | No native approval prompts; unrestricted native sandbox |
-| Claude | Native `auto` mode | Native `bypassPermissions` |
+| Claude | Native `auto` mode; safe Auto when the CLI starts in Manual instead | Native `bypassPermissions` |
 | Cursor | Native `--auto-review` | Native `--force` |
 | Antigravity | Legacy `auto` behaves as Ask; UI Auto selects Full access | Native `yolo` plus automatic approval of remaining tool-permission requests; shown as Auto |
 | Grok Build | Native `--permission-mode auto`; availability of Grok's reviewer depends on its feature rollout | Native `bypassPermissions`; remaining native requests still appear |
@@ -64,6 +64,33 @@ to a different provider while elevated requires leaving Full/Custom first;
 choose Ask. Switching models within Antigravity keeps the selected level.
 Native modes require a CLI version that supports them; OpenMausBot does not
 silently substitute unrestricted access when a mode is rejected.
+
+### When the native reviewer never starts
+
+Claude Code accepts `--permission-mode auto` for every model and, when auto
+mode is unavailable to the session, starts in Manual without an error. On
+Claude Code 2.1.266 that is the case for Claude Haiku 4.5 and Sonnet 4.5,
+and for any organization that set `disableAutoMode`. In that session every
+tool call reaches OpenMausBot as a permission request, and until now each one
+became a card: a bot on **Approve for me** asked before `wc -l` in its own
+workspace.
+
+The Claude driver reads the mode the session actually runs in from the CLI's
+`init` frame and marks each request accordingly. When Auto was requested and
+the session runs Manual, **Approve for me** answers the way it did before native
+review existed: routine commands, edits, and tool calls are approved by
+OpenMausBot, the destructive and sensitive guards still card, unattended turns
+still ask, and the chat shows one notice per session naming the model the
+reviewer is unavailable for. Each approval is written to the decision log with
+the rule `native-review-inactive`. A request from a reviewer that is known to be
+running is still never answered by the app.
+
+Grok and Codex do not report whether their reviewer ran, so their requests
+still reach you. For those, **Always allow** on a card now records an answer
+that stands in next time the same command or tool is asked about, unless a
+guard applies. This mirrors the remembered-approval behavior other harnesses
+offer for Grok. It is never offered for computer control or a sandbox change,
+and never over a reviewer Claude reports as running.
 
 ### Read-only integration tools
 

--- a/server/auto-approve.test.ts
+++ b/server/auto-approve.test.ts
@@ -21,9 +21,62 @@ import {
 } from "./auto-approve.ts";
 
 describe("native permission decisions", () => {
-  it.each(["auto", "full"] as const)("does not override a native %s approval request, even with a remembered grant", (approvalMode) => {
-    expect(autoVerdict({ approvalMode, alwaysAllow: ["Read"] }, "Read", "README.md", { nativeApproval: true }))
+  it("does not override a native Full access request, even with a remembered grant", () => {
+    expect(autoVerdict({ approvalMode: "full", alwaysAllow: ["Read"] }, "Read", "README.md", { nativeApproval: true }))
       .toEqual({ approve: null, source: "native-approval" });
+  });
+
+  it("leaves a running reviewer's verdict alone, remembered grant or not", () => {
+    const bot = { approvalMode: "auto" as const, alwaysAllow: ["Read"] };
+    expect(autoVerdict(bot, "Read", "README.md", { nativeApproval: true, nativeReview: "active" }))
+      .toEqual({ approve: null, source: "native-approval" });
+    expect(autoVerdict(bot, "Bash", "wc -l notes.md", { nativeApproval: true, nativeReview: "active" }))
+      .toEqual({ approve: null, source: "native-approval" });
+    // and no "Always allow" is offered over it: the answer would not be
+    // honored next time either
+    expect(rememberableApprovalKey(bot, "Bash", "wc -l notes.md", { source: "native-approval", nativeReview: "active" }))
+      .toBeUndefined();
+  });
+
+  it("falls back to safe Auto when the provider says its reviewer never started", () => {
+    // Claude on Haiku 4.5: `--permission-mode auto` accepted, session runs
+    // Manual, every tool call arrives here. Auto answers as it always did.
+    const bot = { approvalMode: "auto" as const };
+    expect(autoVerdict(bot, "Bash", "wc -l notes.md", { nativeApproval: true, nativeReview: "inactive" }))
+      .toEqual({ approve: "auto-approved Bash", source: "auto-mode", rule: "native-review-inactive" });
+    expect(autoVerdict(bot, "Write", "memory/topic.md", { nativeApproval: true, nativeReview: "inactive" }))
+      .toEqual({ approve: "auto-approved Write", source: "auto-mode", rule: "native-review-inactive" });
+    // the guards still outrank the fallback
+    expect(autoVerdict(bot, "Bash", "rm -rf build", { nativeApproval: true, nativeReview: "inactive" }))
+      .toMatchObject({ approve: null, source: "destructive-guard" });
+    expect(autoVerdict(bot, "Bash", "cat ~/.ssh/id_rsa", { nativeApproval: true, nativeReview: "inactive" }))
+      .toMatchObject({ approve: null, source: "sensitive-guard" });
+    // and so does an unattended turn — the row names the grant it stopped
+    expect(autoVerdict(bot, "Bash", "wc -l notes.md", { nativeApproval: true, nativeReview: "inactive", unattended: true }))
+      .toEqual({ approve: null, source: "unattended-block", rule: "native-review-inactive" });
+    // a plain-Auto verdict carries no rule; only the fallback names itself
+    expect(autoVerdict(bot, "Bash", "wc -l notes.md", {}))
+      .toEqual({ approve: "auto-approved Bash", source: "auto-mode", rule: undefined });
+  });
+
+  it("lets a remembered grant answer a punt from a reviewer nobody can see", () => {
+    // Grok's classifier is feature-gated and its ACP never says whether it
+    // ran; Codex's asks are its own. The person's standing answer for this
+    // exact key stands in — Auto's blanket approval does not.
+    const bot = { approvalMode: "auto" as const, alwaysAllow: ["Bash:git"] };
+    expect(autoVerdict(bot, "Bash", "git status", { nativeApproval: true }))
+      .toEqual({ approve: "auto-approved Bash:git (always allowed)", source: "always-allow", rule: "Bash:git" });
+    expect(autoVerdict(bot, "Bash", "npm test", { nativeApproval: true }))
+      .toEqual({ approve: null, source: "native-approval" });
+    // guards outrank the grant here too
+    expect(autoVerdict(bot, "Bash", "git push --force origin main", { nativeApproval: true }))
+      .toEqual({ approve: null, source: "native-approval" });
+    // so the card may offer to remember the answer
+    expect(rememberableApprovalKey(bot, "Bash", "npm test", { source: "native-approval" })).toBe("Bash:npm");
+    expect(rememberableApprovalKey(bot, "Bash", "npm test", { source: "native-approval", nativeReview: "inactive" })).toBe("Bash:npm");
+    // but never for host control or a sandbox change
+    expect(rememberableApprovalKey(bot, "Bash", "npm test", { source: "native-approval", scope: "local-computer" })).toBeUndefined();
+    expect(rememberableApprovalKey(bot, "Bash", "npm test", { source: "native-approval", requiresExplicitApproval: true })).toBeUndefined();
   });
 });
 

--- a/server/auto-approve.ts
+++ b/server/auto-approve.ts
@@ -116,18 +116,26 @@ export function rememberableApprovalKey(
     source: AutoVerdictSource | undefined;
     scope?: "local-computer";
     requiresExplicitApproval?: boolean;
+    nativeReview?: "active" | "inactive";
   },
 ): string | undefined {
   if (
     !bot ||
     approvalModeFor(bot) === "custom" ||
-    context.source !== "no-grant" ||
     context.scope ||
     context.requiresExplicitApproval
   ) {
     return undefined;
   }
-  return approvalKey(tool, summary, context.scope);
+  // A native reviewer that is known to be running and still asked has
+  // reached a verdict of its own; remembering an answer over it would be
+  // the app second-guessing the classifier. A punt from a reviewer nobody
+  // can see (Grok's is feature-gated, Codex's has no fallback) is the
+  // person's to answer, and their standing answer counts next time.
+  const answerable =
+    context.source === "no-grant" ||
+    (context.source === "native-approval" && context.nativeReview !== "active");
+  return answerable ? approvalKey(tool, summary, context.scope) : undefined;
 }
 
 export interface AutoVerdict {
@@ -155,6 +163,11 @@ export function autoVerdict(
     unattended?: boolean;
     /** Respect the native reviewer (including a provider with no Auto mode). */
     nativeApproval?: boolean;
+    /** What the provider said about its reviewer on this request (see
+     * RuntimeEvent request.opened). "inactive" cancels nativeApproval: the
+     * provider asked for Auto and started without a reviewer, so the ask is
+     * not a verdict. "active" also fences remembered grants out. */
+    nativeReview?: "active" | "inactive";
     /** the request controls the user's active desktop */
     scope?: "local-computer";
     /** The provider is asking to widen its configured sandbox rather than
@@ -163,7 +176,17 @@ export function autoVerdict(
   },
 ): AutoVerdict {
   const mode = approvalModeFor(bot);
-  if (context?.nativeApproval) return { approve: null, source: "native-approval" };
+  // Claude with Haiku 4.5 (or any model its classifier does not cover) takes
+  // `--permission-mode auto` and starts in Manual without an error, so every
+  // ask would land here as a "reviewer's verdict" and card the person for
+  // `wc -l` in the bot's own workspace. The driver reads the effective mode
+  // from init and says so; when it does, Auto falls back to the app's own
+  // safe rules below, exactly what Auto meant before native review existed.
+  const reviewerOff = context?.nativeReview === "inactive";
+  const nativeApproval = Boolean(context?.nativeApproval) && !reviewerOff;
+  if (nativeApproval && (mode !== "auto" || context?.nativeReview === "active")) {
+    return { approve: null, source: "native-approval" };
+  }
   // This branch intentionally precedes every guard. Entering Full access is
   // separately consent-gated by the bot PATCH endpoint, and its promise is
   // literal: even destructive, sensitive, unattended, and host-computer
@@ -192,9 +215,22 @@ export function autoVerdict(
       ? null
       : mode !== "custom" && bot.alwaysAllow?.includes(key)
         ? { approve: `auto-approved ${key} (always allowed)`, source: "always-allow" as const, rule: key }
-        : mode === "auto"
-          ? { approve: `auto-approved ${tool}`, source: "auto-mode" as const, rule: undefined }
+        : mode === "auto" && !nativeApproval
+          ? {
+              approve: `auto-approved ${tool}`,
+              source: "auto-mode" as const,
+              // the log's "which rule": Auto itself, or Auto standing in for
+              // a reviewer that never started
+              rule: reviewerOff ? "native-review-inactive" : undefined,
+            }
           : null;
+  // A reviewer nobody can observe punted (Grok's classifier is feature-gated,
+  // Codex's asks are its own). Only a grant the person recorded for this
+  // exact key answers it; Auto's blanket approval does not, so a reviewer
+  // that DID block something is never overruled by a regex.
+  if (nativeApproval && grant?.source !== "always-allow") {
+    return { approve: null, source: "native-approval" };
+  }
   if (context?.unattended) {
     // Auto mode is something a person switched on for turns they are present
     // for. A webhook turn begins with nobody watching, on a payload someone

--- a/server/contracts.ts
+++ b/server/contracts.ts
@@ -145,6 +145,13 @@ export type RuntimeEvent = RuntimeEventBase &
         /** Provider asks to widen its configured sandbox. Only explicit Full
          * access may answer this automatically; Auto/remembered grants may not. */
         requiresExplicitApproval?: boolean;
+        /** Whether the provider's own automatic reviewer was running when it
+         * raised this request. Only providers that can tell set it: Claude
+         * reports the effective permission mode in its init frame, and starts
+         * in Manual without a word when Auto is unavailable for the model.
+         * "inactive" means this ask is not a reviewer's verdict, so the app's
+         * own safe-Auto rules may answer it; unset means nobody knows. */
+        nativeReview?: "active" | "inactive";
       }
     | {
         type: "request.resolved";

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -319,6 +319,7 @@ describe("ClaudeDriver turns (fake CLI)", () => {
 
   afterEach(async () => {
     delete process.env.FAKE_CLAUDE_MODE;
+    delete process.env.FAKE_CLAUDE_AUTO_UNAVAILABLE_MODELS;
     delete process.env.FAKE_CLAUDE_DUMP;
     delete process.env.FAKE_CLAUDE_PROMPTS;
     delete process.env.FAKE_CLAUDE_TRANSIENTS;
@@ -1525,6 +1526,42 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     expect(done).toMatchObject({ ok: false, stopReason: "spawn_error" });
 
     expect(await instance.snapshot()).toMatchObject({ state: "unavailable" });
+  });
+
+  it("tags each ask with whether the CLI's own reviewer is running, read from init", async () => {
+    // The real CLI accepts `--permission-mode auto` for every model and, when
+    // auto is unavailable (Haiku 4.5, Sonnet 4.5 on 2.1.266), starts in
+    // Manual without an error. Only init's permissionMode tells the truth,
+    // and the harness needs it to tell a verdict from a Manual session
+    // asking about everything.
+    process.env.FAKE_CLAUDE_AUTO_UNAVAILABLE_MODELS = "claude-haiku-4-5";
+    await create("hang", {}, { permissionMode: "bypassPermissions" });
+    const raise = async (threadId: string, id: string) => {
+      const conn = connect(permissionSocketPath(threadId));
+      await new Promise<void>((resolve, reject) => {
+        conn.on("connect", resolve);
+        conn.on("error", reject);
+      });
+      conn.write(JSON.stringify({ t: "ask", id, tool: "Bash", input: { command: "wc -l notes.md" } }) + "\n");
+      const opened = await recorder.until((e) => e.type === "request.opened" && e.requestId === id);
+      conn.destroy();
+      return opened;
+    };
+
+    // Auto on a model the classifier does not cover: the session runs Manual
+    await instance.adapter.sendTurn({ threadId: "t-review-off", text: "go", approvalMode: "auto", model: "claude-haiku-4-5" });
+    await recorder.until((e) => e.type === "session.started" && e.threadId === "t-review-off");
+    expect(await raise("t-review-off", "ask-off")).toMatchObject({ nativeReview: "inactive" });
+
+    // Auto on a covered model: the reviewer is running, its ask is a verdict
+    await instance.adapter.sendTurn({ threadId: "t-review-on", text: "go", approvalMode: "auto", model: "claude-sonnet-5" });
+    await recorder.until((e) => e.type === "session.started" && e.threadId === "t-review-on");
+    expect(await raise("t-review-on", "ask-on")).toMatchObject({ nativeReview: "active" });
+
+    // Ask mode never claims anything about a reviewer
+    await instance.adapter.sendTurn({ threadId: "t-review-ask", text: "go", approvalMode: "ask", model: "claude-haiku-4-5" });
+    await recorder.until((e) => e.type === "session.started" && e.threadId === "t-review-ask");
+    expect(await raise("t-review-ask", "ask-ask")).toHaveProperty("nativeReview", undefined);
   });
 
   it("brokers a permission ask into request.opened and answers over the socket", async () => {

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -863,6 +863,12 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
        * began the turn. The acceptance boundary for --resume: before it,
        * nothing was submitted and the turn has caused nothing. */
       sawInit: boolean;
+      /** the permission mode `init` says the session actually runs in. The
+       * CLI takes `--permission-mode auto` for any model and starts in
+       * "default" without a word when auto mode is unavailable (Haiku 4.5,
+       * Sonnet 4.5, an org that disabled it), so the flag we passed is not
+       * the truth — this is. null until init, or on a CLI that omits it. */
+      nativePermissionMode: string | null;
       /** the running turn, or null between turns */
       turn: { turnId: string; settled: boolean; sawStreamDelta: boolean; authFailed?: boolean } | null;
       idleTimer: ReturnType<typeof setTimeout> | null;
@@ -1228,6 +1234,14 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
             onAsk: (ask) => {
               const eventTurnId = sessions.get(threadId)?.turn?.turnId ?? turnId;
               askTools.set(ask.id, typeof ask.tool === "string" ? ask.tool : undefined);
+              // Auto was requested: say whether the CLI's reviewer is actually
+              // running, from init, so the harness can tell a classifier's
+              // verdict from a Manual session asking about everything.
+              const nativeMode = sessions.get(threadId)?.nativePermissionMode ?? null;
+              const nativeReview =
+                permissionMode === "auto" && nativeMode !== null
+                  ? nativeMode === "auto" ? "active" : "inactive"
+                  : undefined;
               emit({
                 ...base(threadId, eventTurnId),
                 type: "request.opened",
@@ -1235,6 +1249,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
                 requestType: ask.kind,
                 tool: ask.tool,
                 summary: askSummary(ask),
+                nativeReview,
                 approvalScope:
                   typeof ask.tool === "string" && controlsHost && ask.tool.startsWith("mcp__computer")
                     ? "local-computer"
@@ -1297,6 +1312,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         volatile: turn.systemVolatile ?? "",
         sessionId: sessionId ?? newSessionId,
         sawInit: false,
+        nativePermissionMode: null,
         turn: { turnId, settled: false, sawStreamDelta: false },
         idleTimer: null,
         closing: false,
@@ -1352,6 +1368,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
           case "system":
             if (o.subtype === "init") {
               session.sawInit = true;
+              session.nativePermissionMode = typeof o.permissionMode === "string" ? o.permissionMode : null;
               if (typeof o.session_id === "string") session.sessionId = o.session_id;
               emit({ ...base(threadId, currentTurnId()), type: "session.started", sessionId: o.session_id, model: o.model });
             } else if (o.subtype === "thinking_tokens") {

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -7,6 +7,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
 import { once } from "node:events";
 import { createServer, request, type Server } from "node:http";
+import { connect, type Socket } from "node:net";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -860,6 +861,8 @@ beforeAll(async () => {
       OMB_SSE_HEARTBEAT_MS: "50",
       FAKE_CLAUDE_MODE: "hang",
       FAKE_CLAUDE_DUMP: fakeClaudeDump,
+      // the real CLI runs Manual for these even when asked for auto
+      FAKE_CLAUDE_AUTO_UNAVAILABLE_MODELS: "claude-haiku-4-5",
       OMB_TEST_INTERNAL_CAPABILITY_KEY: TEST_CAPABILITY_KEY,
     },
     stdio: ["ignore", "pipe", "pipe"],
@@ -5387,6 +5390,69 @@ describe("harness HTTP API", () => {
     expect(disk.rooms).toEqual({ turnTimeoutMinutes: 20 });
 
     await api("PUT", "/api/config", { rooms: { turnTimeoutMinutes: 5 } });
+  });
+
+  it("answers as safe Auto when Claude's reviewer never started, and says so once", async () => {
+    // A bot on Approve for me with Haiku 4.5: the CLI takes `auto`, runs
+    // Manual, and would otherwise card the person for every tool call.
+    const bot = (await api("POST", "/api/bots", { name: "Quill" })).body.bot;
+    const conns: Socket[] = [];
+    try {
+      expect((await api("PATCH", `/api/bots/${bot.id}`, {
+        modelSelection: { instanceId: "claude", model: "claude-haiku-4-5" },
+        approvalMode: "auto",
+      })).status).toBe(200);
+      rmSync(fakeClaudeDump, { force: true });
+      expect((await api("POST", `/api/bots/${bot.id}/messages`, { text: "count my notes" })).status).toBe(202);
+      // the permission socket the driver handed its proxy, from the MCP
+      // config the fake read back
+      const dump = z.object({
+        mcpConfig: z.object({ mcpServers: z.object({ ogb: z.object({ args: z.array(z.string()) }) }) }),
+      }).parse(await readJsonFileWhenReady(fakeClaudeDump));
+      const socketPath = dump.mcpConfig.mcpServers.ogb.args[1];
+      const raise = async (id: string, command: string) => {
+        const conn = connect(socketPath);
+        conns.push(conn);
+        const answered = new Promise<{ behavior: string }>((resolve) => {
+          let buf = "";
+          conn.on("data", (chunk) => {
+            buf += chunk;
+            const nl = buf.indexOf("\n");
+            if (nl !== -1) resolve(JSON.parse(buf.slice(0, nl)));
+          });
+        });
+        await new Promise<void>((resolve, reject) => {
+          conn.on("connect", resolve);
+          conn.on("error", reject);
+        });
+        conn.write(JSON.stringify({ t: "ask", id, tool: "Bash", input: { command } }) + "\n");
+        return answered;
+      };
+      const messages = async () =>
+        (await api("GET", "/api/bots?messages=40")).body.bots.find((candidate: { id: string }) => candidate.id === bot.id)
+          .messages as Array<{ kind: string; tool?: { name: string }; card?: { title: string; subtitle: string; allowKey?: string } }>;
+
+      // routine work is approved by the app, not carded
+      await expect(raise("ask-wc", "wc -l notes.md")).resolves.toMatchObject({ behavior: "allow" });
+      await expect.poll(async () => (await messages()).some((m) => m.tool?.name.startsWith("auto-approved Bash: wc -l notes.md"))).toBe(true);
+      // and the person is told once who is approving, naming the model
+      const notices = (await messages()).filter((m) => m.tool?.name.startsWith("Approve for me: Claude's automatic reviewer is not available"));
+      expect(notices).toHaveLength(1);
+      expect(notices[0].tool!.name).toContain("claude-haiku-4-5");
+
+      await expect(raise("ask-ls", "ls memory")).resolves.toMatchObject({ behavior: "allow" });
+      await expect.poll(async () => (await messages()).some((m) => m.tool?.name.startsWith("auto-approved Bash: ls memory"))).toBe(true);
+      expect((await messages()).filter((m) => m.tool?.name.startsWith("Approve for me: Claude's automatic reviewer"))).toHaveLength(1);
+
+      // the guards still stop the fallback: a destructive command is carded
+      void raise("ask-rm", "rm -rf build");
+      await expect.poll(async () => (await messages()).find((m) => m.card?.subtitle === "rm -rf build")?.card?.title).toBe("Approval needed");
+      expect((await messages()).some((m) => m.tool?.name.startsWith("auto-approved Bash: rm -rf build"))).toBe(false);
+    } finally {
+      for (const conn of conns) conn.destroy();
+      await api("POST", `/api/bots/${bot.id}/interrupt`);
+      await api("DELETE", `/api/bots/${bot.id}`);
+    }
   });
 
   it("mounts the verification skill into a real turn when its trigger appears", async () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -2705,6 +2705,16 @@ function requestBehavior(value: unknown): "allow" | "deny" | "answer" | null {
 // the last settled assistant text per thread, so a "finished" notification
 // can carry what the bot actually said
 const lastReply = new Map<string, string>();
+/** the model each thread's provider session announced in session.started,
+ * so a fallback notice can name the model Auto is unavailable for */
+const sessionModelByThread = new Map<string, string>();
+/** threads already told that the provider's reviewer never started */
+const nativeReviewNoticed = new Set<string>();
+/** a driver kind as the chat should name it: "claudeAgent" → "Claude" */
+const providerLabel = (provider: string): string => {
+  const bare = provider.replace(/Agent$/, "");
+  return bare.charAt(0).toUpperCase() + bare.slice(1);
+};
 
 /** Put a notification on the wire. Clients decide what to do with it — a
  * desktop notification now, a push to a paired phone later. */
@@ -3321,6 +3331,7 @@ bus.subscribe((event: RuntimeEvent) => {
       if (bot && event.sessionId && event.providerInstanceId) {
         store.setResumeCursor(bot.id, event.providerInstanceId, event.sessionId, event.threadId);
       }
+      if (typeof event.model === "string" && event.model) sessionModelByThread.set(event.threadId, event.model);
       break;
     case "item.completed":
       if (event.itemType === "assistant_text") {
@@ -3415,8 +3426,32 @@ bus.subscribe((event: RuntimeEvent) => {
             // Match the dispatched mode for every provider, including
             // delegated Custom and unattended Auto downgrades.
             nativeApproval: requiresNativeApproval(event.provider, effectiveApprovalMode),
+            nativeReview: event.nativeReview,
           })
         : null;
+      // Auto's promise was "the bot handles routine actions". Claude on a
+      // model its classifier does not cover starts in Manual and asks about
+      // everything, which the person reads as Auto being broken. Say once
+      // per session who is actually approving, then let the verdict below
+      // answer as safe Auto always did.
+      if (
+        permission &&
+        asker &&
+        event.nativeReview === "inactive" &&
+        effectiveApprovalMode === "auto" &&
+        !nativeReviewNoticed.has(event.threadId)
+      ) {
+        nativeReviewNoticed.add(event.threadId);
+        const model = sessionModelByThread.get(event.threadId);
+        pushMessage({
+          role: "bot",
+          kind: "activity",
+          tool: {
+            name: `Approve for me: ${providerLabel(event.provider)}'s automatic reviewer is not available${model ? ` for ${model}` : ""}, so OpenMausBot is approving routine actions itself and still asks about destructive or sensitive ones.`,
+            ok: true,
+          },
+        });
+      }
       if (verdict?.approve && asker && event.requestId) {
         const settled = verdict.approve;
         const instance = event.providerInstanceId
@@ -3527,6 +3562,7 @@ bus.subscribe((event: RuntimeEvent) => {
                 source: verdict?.source,
                 scope: event.approvalScope,
                 requiresExplicitApproval: event.requiresExplicitApproval,
+                nativeReview: event.nativeReview,
               })
             : undefined,
           // The text stays for cards saved before heldCode existed, and for

--- a/server/testing/fake-claude-cli.ts
+++ b/server/testing/fake-claude-cli.ts
@@ -31,6 +31,10 @@
 //                      Unset, a turn makes the single default Bash call.
 //   FAKE_CLAUDE_AUTH   in (default) | out | unsupported | malformed |
 //                      inherited-api-key — what `auth status` reports
+//   FAKE_CLAUDE_AUTO_UNAVAILABLE_MODELS comma-separated --model values for
+//                      which `--permission-mode auto` starts in "default",
+//                      the way the real CLI (2.1.266) does for Haiku 4.5 and
+//                      Sonnet 4.5: init reports the mode it actually runs in.
 //
 // Keep this file dependency-free — it runs as a bare `node` subprocess.
 import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
@@ -154,6 +158,12 @@ if (argAfter("--output-format") === "text") {
 type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
 const sessionId = argAfter("--resume") ?? argAfter("--session-id") ?? "fake-session";
 const model = argAfter("--model") ?? "claude-fake";
+// The mode init reports: what was asked for, unless auto is unavailable for
+// this model, in which case the real CLI silently runs Manual ("default").
+const requestedPermissionMode = argAfter("--permission-mode") ?? "default";
+const autoUnavailableFor = (process.env.FAKE_CLAUDE_AUTO_UNAVAILABLE_MODELS ?? "").split(",").filter(Boolean);
+const permissionMode =
+  requestedPermissionMode === "auto" && autoUnavailableFor.includes(model) ? "default" : requestedPermissionMode;
 let dumped = false;
 let turnRunning = false;
 let steered: string[] = [];
@@ -244,7 +254,7 @@ const playTurn = (prompt: JsonValue) => {
     } catch {}
     const quota = Number(process.env.FAKE_CLAUDE_TRANSIENTS) || 0;
     writeFileSync(process.env.FAKE_CLAUDE_STATE, String(launched + 1));
-    out({ type: "system", subtype: "init", session_id: sessionId, model });
+    out({ type: "system", subtype: "init", session_id: sessionId, model, permissionMode });
     if (launched < quota) {
       if (process.env.FAKE_CLAUDE_PARTIAL_FAILS) {
         out({ type: "stream_event", event: { type: "content_block_delta", delta: { type: "text_delta", text: "half an answer" } } });
@@ -255,7 +265,7 @@ const playTurn = (prompt: JsonValue) => {
   }
 
   // the real CLI re-announces init on every turn of a live process
-  out({ type: "system", subtype: "init", session_id: sessionId, model });
+  out({ type: "system", subtype: "init", session_id: sessionId, model, permissionMode });
 
   // The CLI accepted the resumed session — it read the prompt — and then
   // died with nothing to show. The prompt may already have run tools, so


### PR DESCRIPTION
## Why

Bots on **Approve for me** were asking for every Bash, Write, Edit and MCP call, including reads inside their own workspace (reported from the phone on Sep 11, Claude and Grok alike).

Auto defers every permission to the provider's native reviewer and never second-guesses it. Claude Code accepts `--permission-mode auto` for any model and, when auto mode is unavailable, starts in Manual **without an error**. Verified on Claude Code 2.1.266 with the same flags the driver passes:

| Model | Mode the CLI actually started in |
|---|---|
| claude-sonnet-5, claude-opus-5 | auto |
| claude-haiku-4-5 | default (Manual) |
| claude-sonnet-4-5 | default (Manual) |

So a Haiku bot on Auto sent every tool call to the harness as a "reviewer's verdict", and each one became a card.

## What changes

- **Claude driver** reads the effective permission mode from the CLI's `init` frame and tags each `request.opened` with `nativeReview: "active" | "inactive"` (only when Auto was requested; unset otherwise).
- **autoVerdict** falls back to safe Auto when the reviewer is inactive: routine actions approve (decision log rule `native-review-inactive`), the destructive/sensitive guards, unattended turns and host control still card. A request from a reviewer known to be running is still never answered by the app.
- **One notice per session** in the chat: "Approve for me: Claude's automatic reviewer is not available for claude-haiku-4-5, so OpenMausBot is approving routine actions itself and still asks about destructive or sensitive ones."
- **Always allow on unseen reviewers** (Grok's is feature-gated, Codex's asks are its own): a grant the person recorded for that exact key now answers the next identical punt, and the card offers to remember it. Auto's blanket approval does not apply there. Never for computer control, sandbox changes, or over a reviewer Claude reports as running.
- Fake Claude CLI reports `permissionMode` in init, with `FAKE_CLAUDE_AUTO_UNAVAILABLE_MODELS` to mimic the real fallback.
- `docs/approval-levels.md` gains "When the native reviewer never starts".

## Tests

- `server/auto-approve.test.ts`: fallback, guards over fallback, unattended, active-reviewer fence, remembered grants on unseen punts, rememberable keys.
- `server/drivers/claude.test.ts`: asks tagged inactive / active / untagged from init.
- `server/index.test.ts`: end to end through the permission socket: routine asks auto-approved, notice once, destructive ask still carded.
- Mutation-checked: driver tagging off, fallback off, notice guard off, grant-over-punt off each fail exactly their test.

Grok gets only the Always-allow half: its ACP `session/new` advertises no modes, so there is no signal whether its reviewer ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto mode now safely handles routine requests when the provider’s native review is unavailable.
  * Destructive, sensitive, unattended, and interactive actions continue to require approval.
  * Added a one-time session notice explaining fallback behavior and identifying the active provider and model.
  * Added support for remembered “Always allow” approvals for eligible Grok and Codex commands or tools.

* **Documentation**
  * Documented native-review fallback behavior, notices, decision logging, and remembered approval rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->