### PR TITLE
fix(webhooks): prevent duplicate jobs across restarts

### DIFF
--- a/docs/verification/routines.md
+++ b/docs/verification/routines.md
@@ -131,6 +131,20 @@ JSON evidence paths. These complement the scheduler, proposal and renderer
 tests; they do not prove real-provider tool selection, actual desktop work, or
 packaged Electron behavior.
 
+Webhook delivery IDs are committed atomically with their execution receipt.
+Retries keep the same run ID for seven days, independently of run-log pruning;
+unfinished work remains deduplicated beyond that window. A full retry ledger
+rejects new work rather than discarding identities that senders may still retry.
+
+```sh
+pnpm exec vitest run server/webhook-idempotency.test.ts server/webhook-restart.e2e.test.ts
+```
+
+The restart test launches a disposable fake-engine server, creates a webhook,
+then exits an owned worker between the execution and ingress commits. It restarts
+that same isolated server and checks that redelivery returns the original run ID
+with one execution. Its retained JSON evidence includes the receipt and transcript.
+
 The results integration fixture additionally proves fresh provider contexts,
 saved destination snapshots, dated result cards, approval links, deleted-thread
 fallback, and continued user conversations staying visible. Native decoding and

--- a/server/index.ts
+++ b/server/index.ts
@@ -5904,6 +5904,7 @@ const webhooks = new WebhookManager({
     return !bot ? "missing" : bot.busy ? "busy" : "ready";
   },
   enqueue: (input) => routines!.enqueueWebhook(input),
+  findRun: (webhookId, deliveryId) => routines!.webhookRunReceipt(webhookId, deliveryId),
   cancelQueued: (webhookId, message) => routines!.cancelQueuedWebhook(webhookId, message),
   pendingRuns: (webhookId) => routines!.activeWebhookRunCount(webhookId),
 });

--- a/server/routines.ts
+++ b/server/routines.ts
@@ -1370,9 +1370,11 @@ export class RoutineManager {
 
       // Oldest queued requests have priority. New manual/webhook arrivals
       // must not continually overtake work that has already waited. Snapshot
-      // the queue because each dispatch can asynchronously add/cancel work.
-      for (const run of this.runs.slice()) {
-        if (run.status !== "queued") continue;
+      // IDs retain order across awaits without holding stale objects after
+      // another request rolls back a failed routine-definition write.
+      for (const id of this.runs.map((run) => run.id)) {
+        const run = this.runs.find((candidate) => candidate.id === id);
+        if (!run || run.status !== "queued") continue;
         // A queued interval represents the latest useful check, not a backlog
         // item. If the bot stayed busy across later occurrences, align this
         // scheduled receipt to the newest due point immediately before it can

--- a/server/routines.ts
+++ b/server/routines.ts
@@ -1180,13 +1180,14 @@ export class RoutineManager {
       throw Object.assign(new Error("Webhook retry history is full; try again later"), { status: 429 });
     }
     receipts.push({ webhookId: input.webhookId, deliveryId: input.deliveryId, runId: run.id, acceptedAt: this.now() });
+    const previousRuns = this.runs.slice();
     this.runs.push(run);
     this.webhookRunReceipts = receipts;
     try { this.save(); }
     catch (error) {
-      // tick() may be awaiting a provider with references to other runs. Undo
-      // only this synchronous append, not those live objects or their array.
-      this.runs.splice(this.runs.indexOf(run), 1);
+      // Restore pruned history too, retaining the live run objects that tick()
+      // may be awaiting rather than replacing them with cloned snapshots.
+      this.runs = previousRuns;
       this.webhookRunReceipts = previousReceipts;
       throw error;
     }

--- a/server/routines.ts
+++ b/server/routines.ts
@@ -1128,10 +1128,7 @@ export class RoutineManager {
     return cloneRun(run);
   }
 
-  /** Queue an event-driven job without inventing a calendar schedule. Webhook
-   * definitions live in their own store; the execution receipt deliberately
-   * reuses this manager so busy-bot ordering, task creation and VM routing stay
-   * identical for every unattended job. */
+  /** Look up an accepted delivery independently of run-log retention. */
   webhookRunReceipt(webhookId: string, deliveryId: string): { id: string } | null {
     const receipt = this.webhookRunReceipts.find((candidate) =>
       candidate.webhookId === webhookId && candidate.deliveryId === deliveryId &&
@@ -1143,6 +1140,7 @@ export class RoutineManager {
     return active ? { id: active.id } : null;
   }
 
+  /** Queue webhook work through the same dispatcher as scheduled routines. */
   enqueueWebhook(input: {
     webhookId: string;
     webhookName: string;
@@ -1174,18 +1172,24 @@ export class RoutineManager {
       attachments: [],
       createdAt: this.now(),
     };
-    this.commitMutation(() => {
-      this.webhookRunReceipts = this.webhookRunReceipts.filter((receipt) =>
-        receipt.acceptedAt >= this.now() - WEBHOOK_RETRY_WINDOW_MS);
-      // Never evict a promised retry identity to admit fresh work.
-      if (this.webhookRunReceipts.length >= MAX_WEBHOOK_RECEIPTS) {
-        throw Object.assign(new Error("Webhook retry history is full; try again later"), { status: 429 });
-      }
-      this.runs.push(run);
-      this.webhookRunReceipts.push({
-        webhookId: input.webhookId, deliveryId: input.deliveryId, runId: run.id, acceptedAt: this.now(),
-      });
-    });
+    const previousReceipts = this.webhookRunReceipts;
+    const receipts = previousReceipts.filter((receipt) =>
+      receipt.acceptedAt >= this.now() - WEBHOOK_RETRY_WINDOW_MS);
+    // Never evict a promised retry identity to admit fresh work.
+    if (receipts.length >= MAX_WEBHOOK_RECEIPTS) {
+      throw Object.assign(new Error("Webhook retry history is full; try again later"), { status: 429 });
+    }
+    receipts.push({ webhookId: input.webhookId, deliveryId: input.deliveryId, runId: run.id, acceptedAt: this.now() });
+    this.runs.push(run);
+    this.webhookRunReceipts = receipts;
+    try { this.save(); }
+    catch (error) {
+      // tick() may be awaiting a provider with references to other runs. Undo
+      // only this synchronous append, not those live objects or their array.
+      this.runs.splice(this.runs.indexOf(run), 1);
+      this.webhookRunReceipts = previousReceipts;
+      throw error;
+    }
     this.emitRun(run);
     queueMicrotask(() => void this.tick());
     return cloneRun(run);
@@ -1733,7 +1737,6 @@ export class RoutineManager {
       routines: this.routines.map(cloneRoutine),
       runs: this.runs.map(cloneRun),
       receipts: this.routineRequestReceipts.map((receipt) => ({ ...receipt })),
-      webhookReceipts: this.webhookRunReceipts.map((receipt) => ({ ...receipt })),
     };
     try {
       mutate();
@@ -1742,7 +1745,6 @@ export class RoutineManager {
       this.routines = before.routines;
       this.runs = before.runs;
       this.routineRequestReceipts = before.receipts;
-      this.webhookRunReceipts = before.webhookReceipts;
       try {
         rollback?.();
       } catch (cleanupError) {

--- a/server/routines.ts
+++ b/server/routines.ts
@@ -207,7 +207,19 @@ interface RoutineFile {
   runs: RoutineRun[];
   /** Durable commit receipts for cross-file confirmation recovery. */
   routineRequestReceipts?: RoutineRequestReceipt[];
+  /** Compact delivery identities outlive the independently trimmed run log. */
+  webhookRunReceipts?: WebhookRunReceipt[];
 }
+
+const webhookRunReceiptSchema = z.object({
+  webhookId: z.string().min(1).max(200),
+  deliveryId: z.string().min(1).max(200),
+  runId: z.string().min(1),
+  acceptedAt: z.number().finite().nonnegative(),
+});
+type WebhookRunReceipt = z.infer<typeof webhookRunReceiptSchema>;
+const WEBHOOK_RETRY_WINDOW_MS = 7 * 24 * 60 * 60_000;
+const MAX_WEBHOOK_RECEIPTS = 20_000;
 
 export type RoutineRequestOwner = Pick<RoutineRequestReceipt, "requestId" | "messageId" | "botId" | "threadId">;
 
@@ -698,6 +710,7 @@ export class RoutineManager {
   private routines: Routine[] = [];
   private runs: RoutineRun[] = [];
   private routineRequestReceipts: RoutineRequestReceipt[] = [];
+  private webhookRunReceipts: WebhookRunReceipt[] = [];
   private timer: ReturnType<typeof setInterval> | null = null;
   private ticking = false;
 
@@ -758,10 +771,26 @@ export class RoutineManager {
             Number.isFinite(receipt?.appliedAt)
           )
         : [];
+      this.webhookRunReceipts = Array.isArray(disk.webhookRunReceipts)
+        ? disk.webhookRunReceipts.flatMap((receipt) => {
+            const parsed = webhookRunReceiptSchema.safeParse(receipt);
+            return parsed.success ? [parsed.data] : [];
+          })
+        : [];
+      // Upgrade old run logs before history pruning can discard their IDs.
+      const known = new Set(this.webhookRunReceipts.map((r) => JSON.stringify([r.webhookId, r.deliveryId])));
+      for (const run of this.runs) {
+        if (!run.webhookId || !run.deliveryId || run.createdAt < this.now() - WEBHOOK_RETRY_WINDOW_MS) continue;
+        const key = JSON.stringify([run.webhookId, run.deliveryId]);
+        if (known.has(key)) continue;
+        this.webhookRunReceipts.push({ webhookId: run.webhookId, deliveryId: run.deliveryId, runId: run.id, acceptedAt: run.createdAt });
+        known.add(key);
+      }
     } catch {
       this.routines = [];
       this.runs = [];
       this.routineRequestReceipts = [];
+      this.webhookRunReceipts = [];
     }
     // A local process cannot still own these turns after a full restart.
     const recovered: RoutineRun[] = [];
@@ -1103,6 +1132,17 @@ export class RoutineManager {
    * definitions live in their own store; the execution receipt deliberately
    * reuses this manager so busy-bot ordering, task creation and VM routing stay
    * identical for every unattended job. */
+  webhookRunReceipt(webhookId: string, deliveryId: string): { id: string } | null {
+    const receipt = this.webhookRunReceipts.find((candidate) =>
+      candidate.webhookId === webhookId && candidate.deliveryId === deliveryId &&
+      candidate.acceptedAt >= this.now() - WEBHOOK_RETRY_WINDOW_MS);
+    if (receipt) return { id: receipt.runId };
+    // Never duplicate work that is still pending, even beyond the retry window.
+    const active = this.runs.find((run) => run.webhookId === webhookId && run.deliveryId === deliveryId &&
+      ["queued", "running", "waiting"].includes(run.status));
+    return active ? { id: active.id } : null;
+  }
+
   enqueueWebhook(input: {
     webhookId: string;
     webhookName: string;
@@ -1111,7 +1151,9 @@ export class RoutineManager {
     runOn: RoutineRunOn;
     deliveryId: string;
     receivedAt: number;
-  }): RoutineRun {
+  }): { id: string } {
+    const existing = this.webhookRunReceipt(input.webhookId, input.deliveryId);
+    if (existing) return existing;
     if (this.options.botState(input.botId) === "missing") {
       throw Object.assign(new Error("The assigned MAUS no longer exists"), { status: 410 });
     }
@@ -1132,8 +1174,18 @@ export class RoutineManager {
       attachments: [],
       createdAt: this.now(),
     };
-    this.runs.push(run);
-    this.save();
+    this.commitMutation(() => {
+      this.webhookRunReceipts = this.webhookRunReceipts.filter((receipt) =>
+        receipt.acceptedAt >= this.now() - WEBHOOK_RETRY_WINDOW_MS);
+      // Never evict a promised retry identity to admit fresh work.
+      if (this.webhookRunReceipts.length >= MAX_WEBHOOK_RECEIPTS) {
+        throw Object.assign(new Error("Webhook retry history is full; try again later"), { status: 429 });
+      }
+      this.runs.push(run);
+      this.webhookRunReceipts.push({
+        webhookId: input.webhookId, deliveryId: input.deliveryId, runId: run.id, acceptedAt: this.now(),
+      });
+    });
     this.emitRun(run);
     queueMicrotask(() => void this.tick());
     return cloneRun(run);
@@ -1681,6 +1733,7 @@ export class RoutineManager {
       routines: this.routines.map(cloneRoutine),
       runs: this.runs.map(cloneRun),
       receipts: this.routineRequestReceipts.map((receipt) => ({ ...receipt })),
+      webhookReceipts: this.webhookRunReceipts.map((receipt) => ({ ...receipt })),
     };
     try {
       mutate();
@@ -1689,6 +1742,7 @@ export class RoutineManager {
       this.routines = before.routines;
       this.runs = before.runs;
       this.routineRequestReceipts = before.receipts;
+      this.webhookRunReceipts = before.webhookReceipts;
       try {
         rollback?.();
       } catch (cleanupError) {
@@ -1718,6 +1772,7 @@ export class RoutineManager {
       routines: this.routines,
       runs: this.runs,
       routineRequestReceipts: this.routineRequestReceipts,
+      webhookRunReceipts: this.webhookRunReceipts,
     } satisfies RoutineFile, null, 2), { mode: 0o600 });
   }
 }

--- a/server/webhook-idempotency.test.ts
+++ b/server/webhook-idempotency.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, expect, it } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
 import { RoutineManager } from "./routines.ts";
 import { WebhookManager } from "./webhooks.ts";
 
@@ -21,7 +21,7 @@ function harness() {
   };
   return { dir, options, manager: new RoutineManager(options), advance: (ms: number) => { now += ms; } };
 }
-afterEach(() => { for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true }); });
+afterEach(() => { vi.restoreAllMocks(); for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true }); });
 
 it("recovers the canonical job when saving the ingress receipt failed, even with a full queue", () => {
   const h = harness();
@@ -100,4 +100,37 @@ it("refuses fresh work instead of evicting unexpired retry identities at capacit
   expect(reloaded.enqueueWebhook({ ...input, deliveryId: "event-0" })).toEqual({ id: "run-0" });
   expect(() => reloaded.enqueueWebhook(input)).toThrow("retry history is full");
   expect(reloaded.listRuns()).toEqual([]);
+});
+
+it.each(["capacity", "disk"] as const)("a rejected %s admission does not detach the scheduler's live runs", async (failure) => {
+  const h = harness();
+  let release!: () => void;
+  const held = new Promise<void>((resolve) => { release = resolve; });
+  const starts: string[] = [];
+  const manager = new RoutineManager({
+    ...h.options, botState: () => "ready", createTask: (botId) => ({ threadId: `thread-${botId}` }),
+    startTurn: async (botId) => { starts.push(botId); if (botId === "A") await held; },
+  });
+  manager.enqueueWebhook({ ...input, botId: "A", deliveryId: "A" });
+  const second = manager.enqueueWebhook({ ...input, botId: "B", deliveryId: "B" });
+  await Promise.resolve();
+  expect(starts).toEqual(["A"]);
+  const internals = manager as unknown as {
+    webhookRunReceipts: Array<{ webhookId: string; deliveryId: string; runId: string; acceptedAt: number }>;
+    save(): void;
+  };
+  if (failure === "capacity") {
+    internals.webhookRunReceipts = Array.from({ length: 20_000 }, (_, index) => ({
+      webhookId: "hook", deliveryId: `filler-${index}`, runId: `run-${index}`, acceptedAt: Date.now(),
+    }));
+  } else {
+    vi.spyOn(internals, "save").mockImplementationOnce(() => { throw new Error("disk full"); });
+  }
+  expect(() => manager.enqueueWebhook({ ...input, botId: "C", deliveryId: "C" })).toThrow();
+  release();
+  await vi.waitFor(() => expect(starts).toEqual(["A", "B"]));
+  expect(manager.listRuns().find((run) => run.id === second.id)).toMatchObject({ status: "running", threadId: "thread-B" });
+  await manager.tick();
+  expect(starts).toEqual(["A", "B"]);
+  expect(manager.listRuns()).toHaveLength(2);
 });

--- a/server/webhook-idempotency.test.ts
+++ b/server/webhook-idempotency.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
@@ -100,6 +100,35 @@ it("refuses fresh work instead of evicting unexpired retry identities at capacit
   expect(reloaded.enqueueWebhook({ ...input, deliveryId: "event-0" })).toEqual({ id: "run-0" });
   expect(() => reloaded.enqueueWebhook(input)).toThrow("retry history is full");
   expect(reloaded.listRuns()).toEqual([]);
+});
+
+it("restores pruned run history when the webhook disk commit fails at the retention limit", () => {
+  const h = harness();
+  h.manager.enqueueWebhook(input);
+  const disk = JSON.parse(readFileSync(h.options.file, "utf8"));
+  disk.runs = Array.from({ length: 2_000 }, (_, index) => ({
+    ...disk.runs[0], id: `history-${index}`, deliveryId: `history-${index}`, status: "completed",
+  }));
+  writeFileSync(h.options.file, JSON.stringify(disk));
+  const manager = new RoutineManager(h.options);
+  const before = manager.listRuns();
+  const saved = join(h.dir, "saved-routines.json");
+  renameSync(h.options.file, saved);
+  mkdirSync(h.options.file); // Fail the real atomic rename, after save() prunes.
+  expect(() => manager.enqueueWebhook({ ...input, deliveryId: "next" })).toThrow();
+  expect(manager.listRuns()).toEqual(before);
+  expect(manager.webhookRunReceipt(input.webhookId, "next")).toBeNull();
+  rmSync(h.options.file, { recursive: true });
+  renameSync(saved, h.options.file);
+
+  manager.create({ name: "Unrelated save", prompt: "No work", botId: "bot", enabled: false,
+    schedule: { type: "interval", everyMinutes: 60, anchorAt: Date.now() },
+  });
+  expect(new RoutineManager(h.options).listRuns()).toEqual(before);
+  const accepted = manager.enqueueWebhook({ ...input, deliveryId: "next" });
+  expect(manager.listRuns()).toHaveLength(2_000);
+  expect(manager.listRuns().some((run) => run.id === "history-0")).toBe(false);
+  expect(new RoutineManager(h.options).webhookRunReceipt(input.webhookId, "next")).toEqual({ id: accepted.id });
 });
 
 it.each(["capacity", "disk", "routine-write"] as const)("a rejected %s admission does not detach the scheduler's live runs", async (failure) => {

--- a/server/webhook-idempotency.test.ts
+++ b/server/webhook-idempotency.test.ts
@@ -1,0 +1,103 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, it } from "vitest";
+import { RoutineManager } from "./routines.ts";
+import { WebhookManager } from "./webhooks.ts";
+
+const dirs: string[] = [];
+const week = 7 * 24 * 60 * 60_000;
+const input = {
+  webhookId: "hook", webhookName: "Incoming", prompt: "Handle once", botId: "bot",
+  runOn: "maus" as const, deliveryId: "delivery", receivedAt: Date.now(),
+};
+function harness() {
+  const dir = mkdtempSync(join(tmpdir(), "omb-webhook-commit-"));
+  dirs.push(dir);
+  let now = Date.now();
+  const options = {
+    file: join(dir, "routines.json"), now: () => now,
+    botState: () => "busy" as const, createTask: () => null, startTurn: async () => {},
+  };
+  return { dir, options, manager: new RoutineManager(options), advance: (ms: number) => { now += ms; } };
+}
+afterEach(() => { for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true }); });
+
+it("recovers the canonical job when saving the ingress receipt failed, even with a full queue", () => {
+  const h = harness();
+  const options = {
+    file: join(h.dir, "webhooks.json"), botState: () => "busy" as const,
+    enqueue: (event: Parameters<RoutineManager["enqueueWebhook"]>[0]) => {
+      h.manager.enqueueWebhook(event);
+      throw new Error("lost response after durable enqueue");
+    },
+  };
+  const webhook = new WebhookManager(options);
+  const { webhook: hook, secret } = webhook.create({ name: "Incoming", prompt: "Handle once", botId: "bot" });
+  const event = { deliveryId: "retry", payload: { item: 1 } };
+  expect(() => webhook.receive(hook.endpointId, secret, event)).toThrow("lost response");
+  const first = h.manager.listRuns()[0]!;
+  expect(JSON.parse(readFileSync(options.file, "utf8")).deliveries).toEqual([]);
+
+  const recovered = new RoutineManager(h.options);
+  const retried = new WebhookManager({
+    ...options, enqueue: (event) => recovered.enqueueWebhook(event),
+    findRun: (hookId, deliveryId) => recovered.webhookRunReceipt(hookId, deliveryId), pendingRuns: () => 3,
+  });
+  expect(retried.receive(hook.endpointId, secret, event)).toEqual({
+    runId: first.id, deliveryId: "retry", duplicate: true,
+  });
+  expect(recovered.listRuns()).toHaveLength(1);
+  expect(recovered.enqueueWebhook({ ...input, webhookId: hook.id, deliveryId: "retry" })).toEqual({ id: first.id });
+});
+
+it("retains delivery identities after run-history pruning, with a seven-day retry window", () => {
+  const h = harness();
+  const first = h.manager.enqueueWebhook(input);
+  const disk = JSON.parse(readFileSync(h.options.file, "utf8"));
+  disk.runs = []; // Run-log retention is independent of the retry guarantee.
+  writeFileSync(h.options.file, JSON.stringify(disk));
+  let reloaded = new RoutineManager(h.options);
+  expect(reloaded.enqueueWebhook(input)).toEqual({ id: first.id });
+  expect(reloaded.listRuns()).toEqual([]);
+  expect(reloaded.enqueueWebhook({ ...input, webhookId: "another-hook" }).id).not.toBe(first.id);
+  h.advance(week + 1);
+  reloaded = new RoutineManager(h.options);
+  expect(reloaded.enqueueWebhook(input).id).not.toBe(first.id);
+});
+
+it("never duplicates unfinished work after the retry window expires", () => {
+  const h = harness();
+  const first = h.manager.enqueueWebhook(input);
+  h.advance(week + 1);
+  expect(new RoutineManager(h.options).enqueueWebhook(input)).toEqual({ id: first.id });
+});
+
+it("upgrades legacy run identities and does not acknowledge a failed disk commit", () => {
+  const h = harness();
+  mkdirSync(h.options.file);
+  expect(() => h.manager.enqueueWebhook(input)).toThrow();
+  expect(h.manager.listRuns()).toEqual([]);
+  expect(h.manager.webhookRunReceipt(input.webhookId, input.deliveryId)).toBeNull();
+  rmSync(h.options.file, { recursive: true });
+  const first = h.manager.enqueueWebhook(input);
+  const disk = JSON.parse(readFileSync(h.options.file, "utf8"));
+  delete disk.webhookRunReceipts;
+  writeFileSync(h.options.file, JSON.stringify(disk));
+  expect(new RoutineManager(h.options).enqueueWebhook(input)).toEqual({ id: first.id });
+});
+
+it("refuses fresh work instead of evicting unexpired retry identities at capacity", () => {
+  const h = harness();
+  h.manager.enqueueWebhook(input);
+  const disk = JSON.parse(readFileSync(h.options.file, "utf8"));
+  disk.webhookRunReceipts = Array.from({ length: 20_000 }, (_, index) => ({
+    webhookId: "hook", deliveryId: `event-${index}`, runId: `run-${index}`, acceptedAt: Date.now(),
+  }));
+  disk.runs = [];
+  writeFileSync(h.options.file, JSON.stringify(disk));
+  const reloaded = new RoutineManager(h.options);
+  expect(reloaded.enqueueWebhook({ ...input, deliveryId: "event-0" })).toEqual({ id: "run-0" });
+  expect(() => reloaded.enqueueWebhook(input)).toThrow("retry history is full");
+  expect(reloaded.listRuns()).toEqual([]);
+});

--- a/server/webhook-idempotency.test.ts
+++ b/server/webhook-idempotency.test.ts
@@ -102,7 +102,7 @@ it("refuses fresh work instead of evicting unexpired retry identities at capacit
   expect(reloaded.listRuns()).toEqual([]);
 });
 
-it.each(["capacity", "disk"] as const)("a rejected %s admission does not detach the scheduler's live runs", async (failure) => {
+it.each(["capacity", "disk", "routine-write"] as const)("a rejected %s admission does not detach the scheduler's live runs", async (failure) => {
   const h = harness();
   let release!: () => void;
   const held = new Promise<void>((resolve) => { release = resolve; });
@@ -126,7 +126,13 @@ it.each(["capacity", "disk"] as const)("a rejected %s admission does not detach 
   } else {
     vi.spyOn(internals, "save").mockImplementationOnce(() => { throw new Error("disk full"); });
   }
-  expect(() => manager.enqueueWebhook({ ...input, botId: "C", deliveryId: "C" })).toThrow();
+  if (failure === "routine-write") {
+    expect(() => manager.create({ name: "Unrelated routine", prompt: "Never saved", botId: "C", enabled: false,
+      schedule: { type: "interval", everyMinutes: 60, anchorAt: Date.now() },
+    })).toThrow("disk full");
+  } else {
+    expect(() => manager.enqueueWebhook({ ...input, botId: "C", deliveryId: "C" })).toThrow();
+  }
   release();
   await vi.waitFor(() => expect(starts).toEqual(["A", "B"]));
   expect(manager.listRuns().find((run) => run.id === second.id)).toMatchObject({ status: "running", threadId: "thread-B" });

--- a/server/webhook-restart.e2e.test.ts
+++ b/server/webhook-restart.e2e.test.ts
@@ -1,0 +1,92 @@
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { closeSync, openSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, it } from "vitest";
+import { launchVerificationServer, runControlOmb } from "../scripts/control-omb.ts";
+import type { RoutineRun } from "./routines.ts";
+import { waitForExit } from "./testing/cleanup.ts";
+
+it("does not run a delivery twice after a process dies between the queue and ingress commits", async () => {
+  const fixture = await launchVerificationServer();
+  const { url, dataDir, logPath } = fixture.info;
+  let restarted: ChildProcess | undefined;
+  const api = async (path: string, body?: unknown) => {
+    const response = await fetch(`${url}${path}`, {
+      method: body === undefined ? "GET" : "POST",
+      headers: { "content-type": "application/json" },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      signal: AbortSignal.timeout(2_000),
+    });
+    if (!response.ok) throw new Error(`${path}: ${response.status}`);
+    return await response.json() as any;
+  };
+  try {
+    const bot = (await api("/api/bots", { name: "Delivery restart probe" })).bot;
+    const created = await api("/api/webhooks", { name: "Only once", prompt: "Handle this event once", botId: bot.id });
+    await waitForExit(fixture.child, { signal: "SIGTERM" });
+
+    const env: NodeJS.ProcessEnv = {};
+    for (const key of ["SYSTEMROOT", "WINDIR", "COMSPEC", "PATHEXT", "LANG", "LC_ALL", "TZ"]) {
+      if (process.env[key]) env[key] = process.env[key];
+    }
+    Object.assign(env, {
+      HOME: dataDir, USERPROFILE: dataDir, OMB_DATA_DIR: dataDir,
+      APPDATA: join(dataDir, "AppData", "Roaming"), LOCALAPPDATA: join(dataDir, "AppData", "Local"),
+      XDG_CONFIG_HOME: join(dataDir, ".config"), XDG_CACHE_HOME: join(dataDir, ".cache"),
+      XDG_DATA_HOME: join(dataDir, ".local", "share"), HERMES_HOME: join(dataDir, ".hermes"),
+      TEMP: join(dataDir, "tmp"), TMP: join(dataDir, "tmp"), TMPDIR: join(dataDir, "tmp"),
+      OMB_PORT: new URL(url).port, OMB_WEBHOOK_PORT: String(Number(new URL(url).port) + 1),
+      PATH: dirname(process.execPath), FAKE_CLAUDE_MODE: "happy",
+    });
+    // This disposable child executes the real enqueue then exits before the
+    // WebhookManager can record acceptance. No production crash switch needed.
+    const crash = spawnSync(process.execPath, ["--input-type=module", "-e", `
+      import { readFileSync } from 'node:fs';
+      import { RoutineManager } from ${JSON.stringify(new URL("./routines.ts", import.meta.url).href)};
+      import { WebhookManager } from ${JSON.stringify(new URL("./webhooks.ts", import.meta.url).href)};
+      const input = JSON.parse(readFileSync(0, 'utf8'));
+      const routines = new RoutineManager({ botState: () => 'busy', createTask: () => null, startTurn: async () => {} });
+      const hooks = new WebhookManager({ botState: () => 'busy', enqueue: event => {
+        routines.enqueueWebhook(event);
+        process.exit(86);
+      }});
+      hooks.receive(input.endpointId, input.secret, { deliveryId: 'restart-event', payload: { item: 1 } });
+    `], {
+      env, timeout: 10_000, encoding: "utf8",
+      input: JSON.stringify({ endpointId: created.webhook.endpointId, secret: created.credential.secret }),
+    });
+    expect(crash.status, crash.stderr).toBe(86);
+    const committed = JSON.parse(readFileSync(join(dataDir, "routines.json"), "utf8")).runs[0] as RoutineRun;
+    expect(JSON.parse(readFileSync(join(dataDir, "webhooks.json"), "utf8")).deliveries).toEqual([]);
+    const log = openSync(logPath, "a", 0o600);
+    restarted = spawn(process.execPath, ["--experimental-strip-types", fileURLToPath(new URL("./index.ts", import.meta.url))], {
+      cwd: fileURLToPath(new URL("..", import.meta.url)), env, stdio: ["ignore", log, log],
+    });
+    closeSync(log);
+    await expect.poll(async () => {
+      const runs: RoutineRun[] = (await api("/api/routines")).runs;
+      return runs.find((run) => run.id === committed.id)?.status;
+    }, { timeout: 20_000, interval: 150 }).toBe("completed");
+
+    const response = await fetch(created.credential.url, {
+      method: "POST", headers: { "content-type": "application/json", "idempotency-key": "restart-event" },
+      body: JSON.stringify({ item: 1 }), signal: AbortSignal.timeout(2_000),
+    });
+    expect(response.status).toBe(202);
+    const receipt = await response.json();
+    expect(receipt).toMatchObject({ duplicate: true, runId: committed.id });
+    const runs: RoutineRun[] = (await api("/api/routines")).runs;
+    expect(runs.filter((run) => run.webhookId === created.webhook.id)).toHaveLength(1);
+    const run = runs.find((run) => run.id === committed.id)!;
+    const wait = await runControlOmb(["wait", "--bot", bot.id, "--task", run.threadId!, "--url", url]);
+    const messages = await runControlOmb(["messages", "--bot", bot.id, "--task", run.threadId!, "--url", url]);
+    expect(wait).toMatchObject({ status: "settled" });
+    const evidencePath = `${logPath}.webhook-restart.json`;
+    writeFileSync(evidencePath, JSON.stringify({ fixture: fixture.info, crashExit: crash.status, receipt, runs, wait, messages }, null, 2));
+    console.log(JSON.stringify({ logPath, evidencePath }));
+  } finally {
+    await waitForExit(restarted, { signal: "SIGTERM" });
+    await fixture.close();
+  }
+}, 45_000);

--- a/server/webhooks.ts
+++ b/server/webhooks.ts
@@ -67,6 +67,8 @@ export interface WebhookManagerOptions {
   }) => { id: string };
   cancelQueued?: (webhookId: string, message: string) => void;
   pendingRuns?: (webhookId: string) => number;
+  /** The execution store commits this identity together with the queued run. */
+  findRun?: (webhookId: string, deliveryId: string) => { id: string } | null;
 }
 
 export type WebhookManagerEvent =
@@ -444,7 +446,10 @@ export class WebhookManager {
     const requestedDeliveryId = String(event.deliveryId ?? "").trim().slice(0, 200);
     if (requestedDeliveryId) {
       const key = `${trigger.endpointId}:${requestedDeliveryId}`;
-      const duplicate = this.deliveries.find((delivery) => delivery.key === key);
+      const committed = this.options.findRun?.(trigger.id, requestedDeliveryId);
+      const duplicate = committed
+        ? { runId: committed.id }
+        : this.deliveries.find((delivery) => delivery.key === key);
       if (duplicate) {
         this.appendAttempt(trigger, event, {
           outcome: "duplicate",


### PR DESCRIPTION
## What changes

Prevent duplicate webhook jobs when the server stops between saving an execution and saving the ingress receipt.

- Commit the delivery identity atomically with the queued run, using the existing routines store.
- Check that canonical receipt before queue/rate backpressure, so retries still return the original job.
- Retain compact receipts independently of trimmed run history for seven days; never duplicate still-active work after that window.
- At receipt capacity, reject new work instead of silently evicting promised retry identities.
- Roll back failed enqueue writes without replacing other live run objects. Re-resolve scheduler IDs after asynchronous dispatch, so an unrelated failed routine write cannot make another queued job execute twice.

No new dependencies or database. Existing webhook secrets and URLs are unchanged.

## Verification

- 123 tests passed across routines, webhooks, receipt regressions, startup and the real restart fixture; server typecheck, focused lint and whitespace checks passed.
- A real disk-write failure at the 2,000-run pruning boundary preserves terminal history and live scheduler object identities before a successful retry.
- Actual isolated server workflow: a delivery worker exits after committing the run but before the ingress receipt. Restarting and redelivering returns the same run ID and executes it only once.
- Regression cases cover history pruning, legacy upgrade, disk-write failure, receipt capacity, and a rejected admission/routine write while another dispatch is awaiting its provider.
- The unrelated-routine-write regression failed against the old scheduler snapshot and passes with ID re-resolution.
- Documented verification in docs/verification/routines.md. No live app, user data or external provider used.

Scope: deduplicating accepted jobs, not exactly-once guarantees for external side effects.
