### PR TITLE
fix(updater): show actionable failure reasons

### DIFF
--- a/electron/mac-updater.node-test.mjs
+++ b/electron/mac-updater.node-test.mjs
@@ -177,7 +177,7 @@ test("native validation errors after ZIP transfer remain visible and clean up st
   await download;
   assert.equal(h.state().status, "error");
   assert.equal(h.state().retryable, false);
-  assert.match(h.state().message, /signature validation failed.*Quit and reopen/);
+  assert.match(h.state().message, /failed verification.*Quit and reopen/);
   assert.equal(h.states.filter((s) => s.status === "error").length, 1);
   assert.equal(h.native.listenerCount("error"), 1);
   assert.equal(h.native.listenerCount("update-downloaded"), 1);

--- a/electron/update-errors.mjs
+++ b/electron/update-errors.mjs
@@ -3,12 +3,15 @@
 export function updateErrorMessage(error) {
   const message = String(error?.message ?? error ?? "Update failed");
   const detail = `${error?.code ?? ""} ${message}`;
-  // A TLS leaf signature is a connection failure, not an installer signature.
-  if (/CERT_|UNABLE_TO_VERIFY_LEAF_SIGNATURE|certificate|SSL_ERROR/i.test(detail)) {
+  // Installer errors may include SignerCertificate details. Those must not
+  // become network advice just because their diagnostic mentions certificates.
+  const integrity = /ERR_UPDATER_(?:INVALID_SIGNATURE|CHECKSUM_MISMATCH)/i.test(detail);
+  const tls = /CERT_|ERR_TLS_|UNABLE_TO_VERIFY_LEAF_SIGNATURE|SSL_ERROR|SELF_SIGNED_CERT_IN_CHAIN/i.test(detail);
+  if (!integrity && tls) {
     return "The update connection could not be verified. Check your clock, VPN or proxy; do not disable certificate checks.";
   }
   // Integrity failures must never be explained away as a network/disk issue.
-  if (/checksum|signature|codesign/i.test(detail)) {
+  if (integrity || /checksum|signature|codesign/i.test(detail)) {
     return "The update failed verification. Download a fresh installer from the official release page.";
   }
   if (/\bENOSPC\b|no space left|disk (?:is )?full/i.test(detail)) {
@@ -19,6 +22,9 @@ export function updateErrorMessage(error) {
   }
   if (/\bEBUSY\b|being used by another process/i.test(detail)) {
     return "An update file is in use. Close other copies of OpenMausBot, then try again.";
+  }
+  if (/certificate/i.test(detail)) {
+    return "The update connection could not be verified. Check your clock, VPN or proxy; do not disable certificate checks.";
   }
   if (/\b404\b|cannot find .*\.yml|cannot parse update info|no files provided|ERR_UPDATER_INVALID_RELEASE_FEED/i.test(detail)) {
     return "The update files are missing or invalid. Check the official release page, or try again later.";

--- a/electron/update-errors.mjs
+++ b/electron/update-errors.mjs
@@ -3,6 +3,10 @@
 export function updateErrorMessage(error) {
   const message = String(error?.message ?? error ?? "Update failed");
   const detail = `${error?.code ?? ""} ${message}`;
+  // A TLS leaf signature is a connection failure, not an installer signature.
+  if (/CERT_|UNABLE_TO_VERIFY_LEAF_SIGNATURE|certificate|SSL_ERROR/i.test(detail)) {
+    return "The update connection could not be verified. Check your clock, VPN or proxy; do not disable certificate checks.";
+  }
   // Integrity failures must never be explained away as a network/disk issue.
   if (/checksum|signature|codesign/i.test(detail)) {
     return "The update failed verification. Download a fresh installer from the official release page.";
@@ -15,9 +19,6 @@ export function updateErrorMessage(error) {
   }
   if (/\bEBUSY\b|being used by another process/i.test(detail)) {
     return "An update file is in use. Close other copies of OpenMausBot, then try again.";
-  }
-  if (/CERT_|CERTIFICATE|certificate|SSL_ERROR/i.test(detail)) {
-    return "The update connection could not be verified. Check your clock, VPN or proxy; do not disable certificate checks.";
   }
   if (/\b404\b|cannot find .*\.yml|cannot parse update info|no files provided|ERR_UPDATER_INVALID_RELEASE_FEED/i.test(detail)) {
     return "The update files are missing or invalid. Check the official release page, or try again later.";

--- a/electron/update-errors.mjs
+++ b/electron/update-errors.mjs
@@ -1,0 +1,29 @@
+// Keep platform error details in the updater log; show the same recovery
+// guidance in Settings and the update card. This never relaxes install locks.
+export function updateErrorMessage(error) {
+  const message = String(error?.message ?? error ?? "Update failed");
+  const detail = `${error?.code ?? ""} ${message}`;
+  // Integrity failures must never be explained away as a network/disk issue.
+  if (/checksum|signature|codesign/i.test(detail)) {
+    return "The update failed verification. Download a fresh installer from the official release page.";
+  }
+  if (/\bENOSPC\b|no space left|disk (?:is )?full/i.test(detail)) {
+    return "Not enough disk space to prepare the update. Free some space, then try again.";
+  }
+  if (/\b(?:EACCES|EPERM)\b|read.only (?:volume|file system)|permission denied|access is denied/i.test(detail)) {
+    return "The update could not write to the app or its cache. Check folder permissions, or use the official installer.";
+  }
+  if (/\bEBUSY\b|being used by another process/i.test(detail)) {
+    return "An update file is in use. Close other copies of OpenMausBot, then try again.";
+  }
+  if (/CERT_|CERTIFICATE|certificate|SSL_ERROR/i.test(detail)) {
+    return "The update connection could not be verified. Check your clock, VPN or proxy; do not disable certificate checks.";
+  }
+  if (/\b404\b|cannot find .*\.yml|cannot parse update info|no files provided|ERR_UPDATER_INVALID_RELEASE_FEED/i.test(detail)) {
+    return "The update files are missing or invalid. Check the official release page, or try again later.";
+  }
+  if (/\b(?:ENOTFOUND|ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN)\b|net::ERR_|\bHTTP[^\n]*\b5\d\d\b|status(?: code)?[: ]+5\d\d\b/i.test(detail)) {
+    return "The update download was interrupted or the server is unavailable. Check your connection and try again.";
+  }
+  return message;
+}

--- a/electron/update-errors.node-test.mjs
+++ b/electron/update-errors.node-test.mjs
@@ -19,6 +19,8 @@ test("update failures keep integrity and certificate errors distinct from recove
   ]) assert.match(updateErrorMessage(new Error(message)), expected);
   assert.match(updateErrorMessage(Object.assign(new Error("écriture impossible"), { code: "ENOSPC" })), /Free some space/);
   assert.match(updateErrorMessage(Object.assign(new Error("connection failed"), { code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE" })), /do not disable certificate checks/);
+  assert.match(updateErrorMessage(Object.assign(new Error('publisherNames differ. SignerCertificate: {"Subject":"CN=Unexpected"}'), { code: "ERR_UPDATER_INVALID_SIGNATURE" })), /failed verification/);
+  assert.match(updateErrorMessage(new Error('ERR_UPDATER_INVALID_SIGNATURE: SignerCertificate mismatch')), /failed verification/);
   assert.equal(updateErrorMessage(new Error("unknown failure")), "unknown failure");
 });
 

--- a/electron/update-errors.node-test.mjs
+++ b/electron/update-errors.node-test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+import { updateErrorMessage } from "./update-errors.mjs";
+import { createUpdaterCoordinator } from "./updater-coordinator.mjs";
+
+test("update failures keep integrity and certificate errors distinct from recoverable environment errors", () => {
+  for (const [message, expected] of [
+    ["sha512 checksum mismatch; ENOSPC", /failed verification/],
+    ["code signature is invalid", /failed verification/],
+    ["ENOSPC: write failed", /Free some space/],
+    ["EPERM: unlink C:\\Users\\test\\cache.zip", /permissions/],
+    ["Read-only file system", /permissions/],
+    ["EBUSY: rename", /file is in use/],
+    ["net::ERR_CERT_AUTHORITY_INVALID", /do not disable certificate checks/],
+    ["Cannot find latest-mac.yml: 404", /missing or invalid/],
+    ["HTTP 503 Service Unavailable", /connection and try again/],
+    ["ETIMEDOUT", /connection and try again/],
+  ]) assert.match(updateErrorMessage(new Error(message)), expected);
+  assert.match(updateErrorMessage(Object.assign(new Error("écriture impossible"), { code: "ENOSPC" })), /Free some space/);
+  assert.equal(updateErrorMessage(new Error("unknown failure")), "unknown failure");
+});
+
+test("actionable messages do not permit retrying failed native staging", async () => {
+  const updater = new EventEmitter();
+  let state = {};
+  let downloads = 0;
+  let installs = 0;
+  const coordinator = createUpdaterCoordinator(updater, (patch) => { state = { ...state, ...patch }; }, { nativeStaging: true });
+  updater.downloadUpdate = async () => {
+    downloads++;
+    updater.emit("update-downloaded", { version: "2.0.0" });
+    const error = Object.assign(new Error("write failed"), { code: "ENOSPC" });
+    updater.emit("error", error);
+    throw error;
+  };
+  updater.quitAndInstall = () => { installs++; };
+  await coordinator.download();
+  assert.equal(state.retryable, false);
+  assert.match(state.message, /Free some space.*Quit and reopen/);
+  await coordinator.download();
+  coordinator.install();
+  assert.equal(downloads, 1);
+  assert.equal(installs, 0);
+});

--- a/electron/update-errors.node-test.mjs
+++ b/electron/update-errors.node-test.mjs
@@ -18,6 +18,7 @@ test("update failures keep integrity and certificate errors distinct from recove
     ["ETIMEDOUT", /connection and try again/],
   ]) assert.match(updateErrorMessage(new Error(message)), expected);
   assert.match(updateErrorMessage(Object.assign(new Error("écriture impossible"), { code: "ENOSPC" })), /Free some space/);
+  assert.match(updateErrorMessage(Object.assign(new Error("connection failed"), { code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE" })), /do not disable certificate checks/);
   assert.equal(updateErrorMessage(new Error("unknown failure")), "unknown failure");
 });
 

--- a/electron/updater-coordinator.mjs
+++ b/electron/updater-coordinator.mjs
@@ -4,6 +4,8 @@
 // chat app must not run dpkg itself. Everything before the install is shared.
 // It receives the staged paths and resolves with an optional state patch
 // describing what is left to do, which the card renders.
+import { updateErrorMessage } from "./update-errors.mjs";
+
 export function createUpdaterCoordinator(updater, setState, { handOffInstall = null, nativeStaging = false } = {}) {
   let checkOperation = null;
   // Set from downloadUpdate's resolution: the paths electron-updater staged.
@@ -41,7 +43,7 @@ export function createUpdaterCoordinator(updater, setState, { handOffInstall = n
       setState({
         status: "error",
         retryable: false,
-        message: `${String(error?.message ?? error)} Quit and reopen OpenMausBot before trying the update again.`,
+        message: `${updateErrorMessage(error)} Quit and reopen OpenMausBot before trying the update again.`,
       });
       return;
     }
@@ -49,7 +51,7 @@ export function createUpdaterCoordinator(updater, setState, { handOffInstall = n
       setState({ status: "idle" });
       return;
     }
-    setState({ status: "error", message: String(error?.message ?? error) });
+    setState({ status: "error", message: updateErrorMessage(error) });
   };
 
   function handleRejectedOperation(manual, error) {

--- a/src/components/UpdateBanner.test.ts
+++ b/src/components/UpdateBanner.test.ts
@@ -58,4 +58,13 @@ describe("UpdateBanner", () => {
     expect(html).toContain("Copy the install command and open a terminal.");
     expect(html).not.toContain("Restart to update");
   });
+
+  it("shows the failure cause as well as the required restart without offering a retry", () => {
+    const html = render({ status: "error", retryable: false,
+      message: "Not enough disk space to prepare the update. Free some space, then try again. Quit and reopen OpenMausBot before trying the update again.",
+    });
+    expect(html).toContain("Free some space");
+    expect(html).toContain("Quit and reopen OpenMausBot");
+    expect(html).not.toContain("Try again</button>");
+  });
 });

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -92,7 +92,7 @@ export function UpdateBanner() {
                   ? "Command copied — paste it in the terminal that opened."
                   : "Command copied — paste it in a terminal to finish."
                 : s.retryable === false
-                  ? `Quit and reopen ${brand().name} before trying the update again.`
+                  ? `${friendlyError(s.message?.split(" Quit and reopen ")[0])} Quit and reopen ${brand().name} before trying the update again.`
                   : friendlyError(s.message);
 
   return (


### PR DESCRIPTION
## Summary
- Explain disk-space, permissions, file-in-use, certificate, invalid release, and network failures consistently.
- Keep verification failures distinct and retain the existing native staging/restart locks.
- Show the underlying failure alongside the required quit-and-reopen instruction.

## Verification
- 32 coordinator/native updater Node tests passed.
- 9 updater/renderer tests passed; Linux-only hand-off fixture skipped locally and covered in CI.
- Renderer typecheck, focused lint and diff checks passed.
- No updater feed, release format, download or install policy changes. No new dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved update error messages with clearer guidance for verification, disk space, permissions, file locks, certificates, invalid update sources, and connection issues.
  - Certificate and installer verification failures are now classified correctly and provide appropriate recovery guidance.
  - Update failures that cannot be retried now display the specific failure reason and instruct users to quit and reopen before trying again.
  - Prevented repeated downloads and installation attempts after certain non-retryable staging failures.
  - Retry controls are hidden when retrying cannot resolve the update issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->