### PR TITLE
fix(desktop): recover the embedded server after a crash

### DIFF
--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -64,6 +64,10 @@ entry only after the shared control surface can really drive it.
 The [desktop server connection smoke](desktop-server-connection.md) mounts the
 real Settings connection component in disposable Electron windows.
 
+The [embedded server recovery smoke](desktop-server-recovery.md) crashes real
+Electron-owned fixture servers, verifies bounded recovery and private access,
+and proves quit cancels recovery without replaying an interrupted fixture turn.
+
 The [Tailscale discovery fixture](tailscale.md) checks standalone macOS CLI mode
 and HTTP tailnet endpoint refresh without touching a real Tailscale installation.
 

--- a/docs/verification/desktop-server-recovery.md
+++ b/docs/verification/desktop-server-recovery.md
@@ -1,0 +1,46 @@
+# Embedded desktop server recovery
+
+Run the focused checks and real Electron utility-process fixture:
+
+```sh
+node --test electron/server-supervisor.node-test.mjs electron/server-boot-probe.node-test.mjs
+pnpm build:server
+node scripts/verify-server-recovery.mjs
+```
+
+The fixture supports macOS and Linux (Linux needs a graphical session, or
+`xvfb-run -a node scripts/verify-server-recovery.mjs`). It creates disposable
+homes and profiles, copies the bundled server outside the repository, chooses
+fresh loopback ports, and configures only the repository's inert fake engine.
+It never launches `electron/main.mjs`, a real computer/browser driver, the
+operator's installed app, or their data directory. It accepts no server URL.
+
+Three separate Electron parents exercise the production supervisor, PID health
+probe, parent-held data-directory lease, private approval coordinator, and built
+server:
+
+- Crash after a fake engine accepts a pinned user turn. Verify immediate
+  unavailability, a different PID on the same port, the unchanged parent lease,
+  the replacement's delegated child lease, and authenticated mutations.
+  The old child's pending approval must reject; a new approval must succeed.
+  The shared control surface records `wait` and bounded `messages` results,
+  while the fake engine's prompt ledger proves the interrupted turn was not
+  resent. The intentionally hung fake engine is explicitly reaped by its exact
+  fixture-recorded PID.
+- Quit through Electron's actual `before-quit` event during the first backoff.
+  Wait beyond that retry deadline and verify no replacement was spawned.
+- Crash the initial child and every replacement. Verify exactly three retries
+  with the production 1/2/4-second delays, then a terminal exhausted state.
+
+The printed evidence directory retains each scenario's JSON receipt and log.
+Successful cleanup removes only the copied server, temporary UI, and fixture
+homes. Keep the receipts and exact command sequence when reporting a pass.
+Unit checks also cover stable-uptime budget reset, old exit/ready results,
+pending-boot shutdown, repeated quit requests, failed probes, and refusing to
+fork a sibling when a child cannot be reaped.
+
+Limits: this is an owned-child smoke, not a complete packaged desktop or
+renderer test. It does not prove native failure-dialog presentation, renderer
+draft preservation, or real provider/computer-helper cleanup after SIGKILL.
+An interrupted turn remains interrupted; recovery does not synthesize a reply.
+Existing routine scheduling and persisted delegation policies are unchanged.

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -268,8 +268,9 @@ const serverSupervisor = createServerSupervisor({
     // A window opened during the outage is still on our error page instead.
     for (const win of BrowserWindow.getAllWindows()) {
       if (!serverUnavailableWindows.has(win) || activeEnvironment(environmentsState)) continue;
-      serverUnavailableWindows.delete(win);
-      void win.loadURL(`http://127.0.0.1:${SERVER_PORT}`).catch((error) => {
+      void win.loadURL(`http://127.0.0.1:${SERVER_PORT}`).then(() => {
+        serverUnavailableWindows.delete(win);
+      }).catch((error) => {
         slog(`recovered server window failed to load: ${error?.message ?? error}`);
       });
     }

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -21,6 +21,7 @@ import {
 import { migrateWorkspaceCredentials, workspaceCredentialEnv } from "./workspace-credentials.mjs";
 import { activateExistingWindow, releaseSingleInstanceLock } from "./single-instance.mjs";
 import { pollServerIdentity } from "./server-boot-probe.mjs";
+import { createServerSupervisor } from "./server-supervisor.mjs";
 import { packageUrlFromCommandLine, packageUrlFromDeepLink } from "./package-link.mjs";
 import { windowChromeOptions } from "./window-chrome.mjs";
 import { defaultSaveName, withSavableFile } from "./save-file.mjs";
@@ -98,6 +99,7 @@ let desktopWorkspaceManager = null;
 let desktopWorkspaceOwner = null;
 let pendingPackageInstallUrl = packageUrlFromCommandLine(process.argv);
 let mainWindow = null;
+const serverUnavailableWindows = new WeakSet();
 let unreadCount = 0;
 let unreadOverlayIcon = null;
 
@@ -242,7 +244,7 @@ app.on("second-instance", (_event, commandLine) => {
 // alternate ports until one binds AND identifies as ours (the probe checks
 // our API shape, not just a 200).
 let serverProc = null;
-let serverReady = true;
+let serverReady = !app.isPackaged;
 let secureCredentials = {};
 let secureCredentialState = null;
 let desktopDataDirLease = null;
@@ -251,6 +253,41 @@ const UTILITY_SERVER_STOP_TIMEOUT_MS = 6_500;
 const trustedApprovalMode = createTrustedApprovalModeCoordinator({ randomId: randomUUID });
 const desktopMutationToken = randomBytes(32).toString("base64url");
 const companionMutationToken = randomBytes(32).toString("base64url");
+const serverSupervisor = createServerSupervisor({
+  restart: () => startServerOn(SERVER_PORT),
+  stop: stopUtilityServer,
+  onReady(proc) {
+    serverProc = proc;
+    serverReady = true;
+    serverStartConflictOnly = false;
+    slog(`server ready pid=${proc.pid} port=${SERVER_PORT}`);
+    // Re-read the latest account credentials; registration may have completed
+    // while the replacement child's health probe was pending.
+    syncManagedComposioCredentials();
+    // Existing chat windows reconnect in place, preserving unsent drafts.
+    // A window opened during the outage is still on our error page instead.
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!serverUnavailableWindows.has(win) || activeEnvironment(environmentsState)) continue;
+      serverUnavailableWindows.delete(win);
+      void win.loadURL(`http://127.0.0.1:${SERVER_PORT}`).catch((error) => {
+        slog(`recovered server window failed to load: ${error?.message ?? error}`);
+      });
+    }
+  },
+  onUnavailable() {
+    serverReady = false;
+    serverProc = null;
+  },
+  onExhausted() {
+    slog("server recovery paused after repeated failures; quit and reopen to retry");
+    dialog.showErrorBox(
+      "The bot server stopped",
+      "Automatic recovery could not restart the background server. Quit and reopen OpenMausBot to try again. Interrupted chat turns were not resent.\n\n" +
+        `Server log: ${path.join(LOG_DIR, "server.log")}`,
+    );
+  },
+  log: slog,
+});
 
 function desktopDataDir() {
   // Match the historical desktop fallback for an unset or empty override,
@@ -882,7 +919,7 @@ function installDesktopMutationHeader() {
     let ownsTarget = false;
     try {
       const target = new URL(details.url);
-      ownsTarget = target.protocol === "http:" &&
+      ownsTarget = serverReady && target.protocol === "http:" &&
         target.hostname === "127.0.0.1" &&
         Number(target.port || 80) === SERVER_PORT;
     } catch {}
@@ -917,6 +954,7 @@ function receivePhoneSecretSave(proc, rawMessage) {
 }
 
 async function startServerOn(port) {
+  if (desktopShutdownStarted) return { proc: null, abort: true };
   const entry = path.join(process.resourcesPath, "server", "index.js");
   const childEnv = managedComposioChildEnvironment(composioBrokerUrl(), secureCredentials, {
     ...process.env,
@@ -959,6 +997,7 @@ async function startServerOn(port) {
   proc.stdout?.on("data", (d) => slog(`[out] ${String(d).trimEnd()}`));
   proc.stderr?.on("data", (d) => slog(`[err] ${String(d).trimEnd()}`));
   proc.on("message", (message) => {
+    if (!serverSupervisor.isCurrent(proc)) return;
     try {
       if (trustedApprovalMode.receive(proc, message)) return;
       if (receivePhoneSecretSave(proc, message)) return;
@@ -968,6 +1007,7 @@ async function startServerOn(port) {
   });
   proc.once("spawn", () => {
     slog(`spawned pid=${proc.pid}`);
+    if (!serverSupervisor.isCurrent(proc)) return;
     syncDesktopMutationToken(proc);
     syncPhoneSecretKey(proc);
   });
@@ -976,11 +1016,9 @@ async function startServerOn(port) {
     exited = true;
     trustedApprovalMode.rejectProcess(proc);
     resolveServerExit();
-    // Capabilities belong to turns in this exact server child. A crash or
-    // restart invalidates them before any replacement child receives the
-    // browser descriptor.
     slog(`exited code=${code}`);
   });
+  serverSupervisor.watch(proc);
   // wait for the port to answer (fresh machine: first boot writes data dirs).
   // Identity check is by PID: a dev harness server has the same API shape,
   // so only the child we actually forked (matching pid + static serving)
@@ -999,9 +1037,9 @@ async function startServerOn(port) {
     // child a "foreign owner" on its first health answer.
     pid: () => proc.pid,
     bootTimeoutMs: SERVER_BOOT_TIMEOUT_MS,
-    isExited: () => exited,
+    isExited: () => exited || desktopShutdownStarted,
   });
-  if (identity.outcome === "ready") return { proc };
+  if (identity.outcome === "ready" && serverSupervisor.isCurrent(proc)) return { proc };
   if (identity.outcome === "exited") {
     slog(`child on port ${port} exited before answering /api/health`);
   } else {
@@ -1024,11 +1062,11 @@ async function startServerPackaged() {
   let everyPortForeignOwned = true;
   for (let attempt = 0; attempt < 2; attempt++) {
     for (const port of [8799, 18799, 28799]) {
+      if (desktopShutdownStarted) return false;
       const started = await startServerOn(port);
       if (started.proc) {
-        serverProc = started.proc;
         SERVER_PORT = port;
-        return true;
+        if (serverSupervisor.ready(started.proc)) return true;
       }
       if (started.abort) return false;
       // A child that exited or timed out is not evidence of a port conflict —
@@ -1706,6 +1744,7 @@ function createWindow() {
   }
 
   const remote = activeEnvironment(environmentsState);
+  if (!serverReady && (desktopRemoteAccess || (app.isPackaged && !remote))) serverUnavailableWindows.add(win);
   if (desktopRemoteAccess) {
     win.loadURL(serverReady ? `http://127.0.0.1:${SERVER_PORT}` : buildErrorPage({ allPortsOccupied: serverStartConflictOnly }));
   } else if (remote) {
@@ -2054,6 +2093,7 @@ async function saveWorkspaceCredential(name, value) {
   }
   const secret = value.trim();
   const applyToHarness = async () => {
+    if (app.isPackaged && !serverReady) throw new Error("The embedded bot server is unavailable");
     // In development the server is a separately launched process, so it
     // cannot receive credentials from Electron at boot. Keep its established
     // local config path there; production always uses the encrypted store.
@@ -2254,8 +2294,9 @@ app.whenReady().then(async () => {
       slog(`desktop companion relay failed: ${error?.message ?? error}`);
     }
   } else if (app.isPackaged) {
-    serverReady = await startServerPackaged();
+    await startServerPackaged();
   }
+  if (desktopShutdownStarted) return;
   // The companion the user left on comes back without anyone finding the
   // toggle again — one attempt, after the harness port is settled, with the
   // exact options the IPC handler uses. A failure surfaces in companionState
@@ -2342,8 +2383,9 @@ app.on("before-quit", (e) => {
   desktopShutdownStarted = true;
   if (cuaCleanedUp) return;
   e.preventDefault();
-  const stoppingServer = serverProc;
-  serverProc = null;
+  // Cancel a scheduled recovery before yielding, and stop the owned child
+  // even if it has not passed its boot probe yet.
+  const stoppingServer = serverSupervisor.shutdown();
   // Release the sleep blocker synchronously; child shutdown is awaited below.
   syncCompanionKeepAwake(false, false);
   try {
@@ -2364,7 +2406,7 @@ app.on("before-quit", (e) => {
   ]);
   const cleanup = Promise.all([
     ownedHelperCleanup,
-    stopUtilityServer(stoppingServer).then((stopped) => {
+    stoppingServer.then((stopped) => {
       if (!stopped) slog("server child did not stop before desktop exit; retaining the data-directory lease");
     }),
   ]);

--- a/electron/server-supervisor.mjs
+++ b/electron/server-supervisor.mjs
@@ -1,0 +1,87 @@
+// The desktop owns one child, including while its health probe is pending.
+// Startup port selection stays with the caller; runtime recovery retries the
+// established port so existing renderer and Companion connections can recover.
+export function createServerSupervisor({
+  restart,
+  stop,
+  onReady,
+  onUnavailable,
+  onExhausted,
+  log = () => {},
+  retryDelaysMs = [1_000, 2_000, 4_000],
+  stableUptimeMs = 60_000,
+  now = () => performance.now(),
+}) {
+  let current = null;
+  let readySince = null;
+  let stopped = false;
+  let attempts = 0;
+  let timer = null;
+  let shutdownPromise = null;
+
+  const isCurrent = (proc) => !stopped && current === proc;
+
+  function ready(proc) {
+    if (!isCurrent(proc)) return false;
+    readySince = now();
+    onReady(proc);
+    return true;
+  }
+
+  function schedule() {
+    if (stopped) return;
+    if (attempts === retryDelaysMs.length) {
+      onExhausted();
+      return;
+    }
+    const delay = retryDelaysMs[attempts++];
+    log(`server recovery attempt ${attempts}/${retryDelaysMs.length} in ${delay}ms`);
+    timer = setTimeout(async () => {
+      timer = null;
+      let result;
+      try {
+        result = await restart();
+      } catch (error) {
+        log(`server recovery failed: ${error?.message ?? error}`);
+        // A thrown start with a still-owned child is not permission to fork
+        // a sibling. The caller must reap failed probes before returning.
+        result = { abort: current !== null };
+      }
+      if (stopped) return;
+      if (result?.proc && ready(result.proc)) return;
+      if (result?.abort) onExhausted();
+      else schedule();
+    }, delay);
+    timer.unref?.();
+  }
+
+  function watch(proc) {
+    if (stopped || current) throw new Error("Cannot replace an owned server child");
+    current = proc;
+    proc.once("exit", () => {
+      // Late exits from a failed boot must not clear a replacement's state.
+      if (current !== proc) return;
+      const wasReady = readySince !== null;
+      if (wasReady && now() - readySince >= stableUptimeMs) attempts = 0;
+      current = null;
+      readySince = null;
+      onUnavailable();
+      if (wasReady) schedule();
+    });
+  }
+
+  function shutdown() {
+    if (shutdownPromise) return shutdownPromise;
+    stopped = true;
+    clearTimeout(timer);
+    timer = null;
+    const proc = current;
+    current = null;
+    readySince = null;
+    onUnavailable();
+    shutdownPromise = Promise.resolve(stop(proc));
+    return shutdownPromise;
+  }
+
+  return { watch, ready, isCurrent, shutdown };
+}

--- a/electron/server-supervisor.node-test.mjs
+++ b/electron/server-supervisor.node-test.mjs
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import { createServerSupervisor } from "./server-supervisor.mjs";
+
+test("main retires an unavailable window only after recovery navigation succeeds", () => {
+  const source = readFileSync(new URL("./main.mjs", import.meta.url), "utf8");
+  assert.match(source, /void win\.loadURL\(`http:\/\/127\.0\.0\.1:\$\{SERVER_PORT\}`\)\.then\(\(\) => \{\s*serverUnavailableWindows\.delete\(win\);/);
+  assert.doesNotMatch(source, /serverUnavailableWindows\.delete\(win\);\s*void win\.loadURL/);
+});
 
 function fixture(t, options = {}) {
   t.mock.timers.enable({ apis: ["setTimeout"] });

--- a/electron/server-supervisor.node-test.mjs
+++ b/electron/server-supervisor.node-test.mjs
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+import { createServerSupervisor } from "./server-supervisor.mjs";
+
+function fixture(t, options = {}) {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const events = [];
+  const children = [];
+  let clock = 0;
+  const spawn = () => {
+    const proc = new EventEmitter();
+    children.push(proc);
+    supervisor.watch(proc);
+    return proc;
+  };
+  const supervisor = createServerSupervisor({
+    restart: async () => ({ proc: spawn() }),
+    stop: async (proc) => { events.push(["stop", proc]); proc?.emit("exit", 0); return true; },
+    onReady: (proc) => events.push(["ready", proc]),
+    onUnavailable: () => events.push(["unavailable"]),
+    onExhausted: () => events.push(["exhausted"]),
+    retryDelaysMs: [10, 20, 40],
+    stableUptimeMs: 100,
+    now: () => clock,
+    ...options,
+  });
+  const tick = async (ms) => {
+    clock += ms;
+    t.mock.timers.tick(ms);
+    await Promise.resolve();
+  };
+  return { supervisor, spawn, children, events, tick };
+}
+
+test("crash clears readiness immediately, backs off, and exhausts a bounded budget", async (t) => {
+  const f = fixture(t);
+  const first = f.spawn();
+  f.supervisor.ready(first);
+  first.emit("exit", 1);
+  assert.equal(f.events.at(-1)[0], "unavailable");
+  assert.equal(f.supervisor.isCurrent(first), false);
+  for (const delay of [10, 20, 40]) {
+    const count = f.children.length;
+    await f.tick(delay - 1);
+    assert.equal(f.children.length, count);
+    await f.tick(1);
+    assert.equal(f.children.length, count + 1);
+    const replacement = f.children.at(-1);
+    assert.deepEqual(f.events.at(-1), ["ready", replacement]);
+    first.emit("exit", 9);
+    assert.equal(f.supervisor.isCurrent(replacement), true, "an old exit cannot invalidate a new child");
+    replacement.emit("exit", 1);
+  }
+  assert.deepEqual(f.events.at(-1), ["exhausted"]);
+  await f.tick(1000);
+  assert.equal(f.children.length, 4);
+});
+
+test("only a stable ready uptime resets the recovery budget", async (t) => {
+  const f = fixture(t);
+  f.supervisor.ready(f.spawn());
+  f.children.at(-1).emit("exit", 1);
+  await f.tick(10);
+  await f.tick(100);
+  f.children.at(-1).emit("exit", 1);
+  await f.tick(10);
+  assert.equal(f.children.length, 3, "stable child reset backoff to its first delay");
+  f.children.at(-1).emit("exit", 1);
+  await f.tick(10);
+  assert.equal(f.children.length, 3, "an unstable child must not reset backoff");
+  await f.tick(10);
+  assert.equal(f.children.length, 4);
+  await f.supervisor.shutdown();
+});
+
+test("quit cancels a queued retry and cannot be undone by a stale ready result", async (t) => {
+  const f = fixture(t);
+  const first = f.spawn();
+  f.supervisor.ready(first);
+  first.emit("exit", 1);
+  await f.supervisor.shutdown();
+  await f.tick(1000);
+  assert.equal(f.children.length, 1);
+  assert.equal(f.supervisor.ready(first), false);
+  assert.throws(() => f.supervisor.watch(new EventEmitter()), /Cannot replace/);
+});
+
+test("quit reaps a replacement whose health probe is pending", async (t) => {
+  let finishBoot;
+  let replacement;
+  const f = fixture(t, {
+    restart: () => {
+      replacement = f.spawn();
+      return new Promise((resolve) => { finishBoot = resolve; });
+    },
+  });
+  f.supervisor.ready(f.spawn());
+  f.children[0].emit("exit", 1);
+  await f.tick(10);
+  assert.equal(f.supervisor.isCurrent(replacement), true);
+  await f.supervisor.shutdown();
+  finishBoot({ proc: replacement });
+  await f.tick(1000);
+  assert.ok(f.events.some(([event, proc]) => event === "stop" && proc === replacement));
+  assert.equal(f.events.filter(([event]) => event === "ready").length, 1);
+  assert.equal(f.children.length, 2);
+});
+
+test("failed probes retry once per budget entry; an unreaped child never gets a sibling", async (t) => {
+  const f = fixture(t, {
+    restart: async () => {
+      const proc = f.spawn();
+      if (f.children.length < 3) { proc.emit("exit", 1); return { proc: null }; }
+      return { proc: null, abort: true };
+    },
+  });
+  const first = f.spawn();
+  assert.throws(() => f.spawn(), /Cannot replace/);
+  f.children.pop();
+  f.supervisor.ready(first);
+  first.emit("exit", 1);
+  await f.tick(10);
+  await f.tick(20);
+  assert.equal(f.children.length, 3);
+  assert.deepEqual(f.events.at(-1), ["exhausted"]);
+  await f.tick(1000);
+  assert.equal(f.children.length, 3);
+  await f.supervisor.shutdown();
+});
+
+test("a child that dies during initial startup is not also scheduled for runtime recovery", async (t) => {
+  const f = fixture(t);
+  const child = f.spawn();
+  child.emit("exit", 1);
+  assert.equal(f.supervisor.ready(child), false);
+  await f.tick(1000);
+  assert.equal(f.children.length, 1);
+});
+
+test("repeated quit requests join the exact same child cleanup", async (t) => {
+  let finishStop;
+  let stops = 0;
+  const f = fixture(t, { stop: () => {
+    stops += 1;
+    return new Promise((resolve) => { finishStop = resolve; });
+  } });
+  const proc = f.spawn();
+  f.supervisor.ready(proc);
+  const first = f.supervisor.shutdown();
+  assert.equal(f.supervisor.shutdown(), first);
+  assert.equal(stops, 1);
+  proc.emit("exit", 0);
+  finishStop(true);
+  assert.equal(await first, true);
+  await f.tick(1000);
+  assert.equal(f.children.length, 1);
+});

--- a/scripts/verify-server-recovery.mjs
+++ b/scripts/verify-server-recovery.mjs
@@ -1,0 +1,248 @@
+// Real Electron utilityProcess + built server, never the operator's desktop.
+// Run after pnpm build:server. Evidence remains; fixture homes are removed.
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { randomBytes, randomUUID } from "node:crypto";
+import { appendFileSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { createServerSupervisor } from "../electron/server-supervisor.mjs";
+import { pollServerIdentity } from "../electron/server-boot-probe.mjs";
+import { acquireDataDirLease } from "../electron/data-dir-lease.mjs";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const flag = "--omb-server-recovery-fixture";
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+async function until(check, label) {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (await check()) return;
+    await sleep(20);
+  }
+  throw new Error(`Timed out: ${label}`);
+}
+async function freePort() {
+  const listener = createServer();
+  await new Promise((resolve) => listener.listen(0, "127.0.0.1", resolve));
+  const port = listener.address().port;
+  await new Promise((resolve) => listener.close(resolve));
+  return port;
+}
+
+if (process.versions.electron && process.argv.includes(flag)) {
+  const { app, utilityProcess } = await import("electron");
+  const [scenario, output, runtime] = process.argv.slice(process.argv.indexOf(flag) + 1);
+  const home = join(output, scenario, "home");
+  app.setPath("home", home);
+  app.setPath("userData", join(home, "profile"));
+  app.setPath("sessionData", join(home, "profile"));
+  app.commandLine.appendSwitch("disable-background-networking");
+  process.once("SIGTERM", () => app.quit());
+  process.once("SIGINT", () => app.quit());
+  const { createTrustedApprovalModeCoordinator } = createRequire(import.meta.url)("../electron/approval-trusted-mode.cjs");
+  const { DESKTOP_MUTATION_HEADER } = createRequire(import.meta.url)("../electron/desktop-server-auth.cjs");
+  const approval = createTrustedApprovalModeCoordinator({ randomId: randomUUID });
+  const events = [];
+  const commands = [];
+  const children = [];
+  const exits = new WeakMap();
+  let lease;
+  let supervisor;
+  let active = null;
+  let exhausted = false;
+  let fakePid = null;
+  let quitting = false;
+  let finalReceipt;
+  const record = (event, fields = {}) => {
+    const row = { event, at: Date.now(), ...fields };
+    events.push(row);
+    console.log(JSON.stringify(row));
+  };
+  const stop = async (proc) => {
+    if (!proc) return true;
+    proc.kill();
+    return Promise.race([exits.get(proc).then(() => true), sleep(6500).then(() => false)]);
+  };
+  app.on("before-quit", (event) => {
+    if (quitting) return;
+    quitting = true;
+    event.preventDefault();
+    void (async () => {
+      assert.equal(await supervisor?.shutdown(), true);
+      if (fakePid) { try { process.kill(fakePid, "SIGKILL"); } catch {} fakePid = null; }
+      const count = children.length;
+      // Let the first retry deadline pass after real Electron before-quit.
+      await sleep(1200);
+      assert.equal(children.length, count, "quit must not spawn another child");
+      assert.equal(active, null);
+      lease?.release();
+      record("quit-clean", { children: count });
+      if (finalReceipt) {
+        finalReceipt.events = events;
+        writeFileSync(join(output, `${scenario}.json`), `${JSON.stringify(finalReceipt, null, 2)}\n`);
+      }
+      app.exit(finalReceipt ? 0 : 1);
+    })().catch((error) => { console.error(error); app.exit(1); });
+  });
+
+  app.whenReady().then(async () => {
+    const dataDir = join(home, "data");
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(join(dataDir, "config.json"), JSON.stringify({ instances: {
+      claude: { driver: "claudeAgent", displayName: "Isolated fake", config: { cli: join(root, "server/testing/fake-claude-cli.ts") } },
+    } }));
+    const port = await freePort();
+    let webhookPort;
+    do { webhookPort = await freePort(); } while (webhookPort === port);
+    const url = `http://127.0.0.1:${port}`;
+    const token = randomBytes(32).toString("base64url");
+    lease = acquireDataDirLease(dataDir);
+    const leaseFile = join(dataDir, "openmausbot-server.lease");
+    const parentLease = readFileSync(leaseFile, "utf8");
+    const start = async () => {
+      const proc = utilityProcess.fork(join(output, "server/index.js"), [], {
+        cwd: home, stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          PATH: dirname(runtime), HOME: home, USERPROFILE: home,
+          XDG_CONFIG_HOME: home, XDG_CACHE_HOME: home, XDG_DATA_HOME: home,
+          APPDATA: home, LOCALAPPDATA: home, TMPDIR: home, TEMP: home, TMP: home,
+          OMB_DATA_DIR: dataDir, OMB_PORT: String(port), OMB_WEBHOOK_PORT: String(webhookPort),
+          OMB_STATIC_DIR: join(output, "ui"), OMB_DESKTOP_PARENT: "1",
+          ...lease.utilityServerLeaseEnvironment(),
+          FAKE_CLAUDE_MODE: "hang", FAKE_CLAUDE_PROMPTS: join(home, "prompts.jsonl"),
+          FAKE_CLAUDE_DUMP: join(home, "fake.json"),
+        },
+      });
+      children.push(proc);
+      let exited = false;
+      exits.set(proc, new Promise((resolve) => proc.once("exit", (code) => {
+        exited = true;
+        approval.rejectProcess(proc);
+        record("exit", { code });
+        resolve();
+      })));
+      supervisor.watch(proc);
+      proc.once("spawn", () => {
+        record("spawn", { pid: proc.pid, generation: children.length });
+        proc.postMessage({ type: "openmausbot:desktop-mutation-token", token, companionToken: token });
+      });
+      proc.on("message", (message) => {
+        if (supervisor.isCurrent(proc)) approval.receive(proc, message);
+      });
+      for (const stream of [proc.stdout, proc.stderr]) stream?.on("data", (data) => process.stdout.write(data));
+      const identity = await pollServerIdentity({ port, pid: () => proc.pid, bootTimeoutMs: 20_000, isExited: () => exited || quitting });
+      if (identity.outcome === "ready" && supervisor.isCurrent(proc)) return { proc };
+      return { proc: null, abort: !(await stop(proc)) };
+    };
+    supervisor = createServerSupervisor({
+      restart: start, stop, log: (message) => record("recovery", { message }),
+      onReady(proc) {
+        active = proc;
+        record("ready", { pid: proc.pid, port });
+        assert.equal(readFileSync(leaseFile, "utf8"), parentLease, "parent lease must never be replaced");
+        if (scenario === "exhausted" && children.length > 1) setTimeout(() => process.kill(proc.pid, "SIGKILL"), 30);
+      },
+      onUnavailable() { active = null; record("unavailable"); },
+      onExhausted() { exhausted = true; record("exhausted"); },
+    });
+    const initial = await start();
+    assert.ok(initial.proc, "initial server must pass its PID identity probe");
+    assert.equal(supervisor.ready(initial.proc), true);
+    const initialPid = initial.proc.pid;
+    const fetcher = async (route, options = {}) => {
+      const response = await fetch(`${url}${route}`, {
+        ...options, headers: { "content-type": "application/json", [DESKTOP_MUTATION_HEADER]: token },
+        signal: AbortSignal.timeout(10_000),
+      });
+      assert.ok(response.ok, `${route}: ${response.status} ${await response.clone().text()}`);
+      return response.json();
+    };
+    const { handleToolCall } = await import(pathToFileURL(join(output, "server/mcp-server.js")));
+    const control = async (name, args) => {
+      const result = await handleToolCall(name, args, fetcher);
+      commands.push({ name, args, result });
+      return result;
+    };
+
+    if (scenario === "recover") {
+      const { bot } = await control("create_bot", { name: "Recovery fixture" });
+      await control("send_bot_message", { bot_id: bot.id, task_id: bot.activeTaskId, text: "Do not replay this interrupted fixture turn." });
+      await until(() => existsSync(join(home, "fake.json")), "fake engine accepted the turn");
+      fakePid = JSON.parse(readFileSync(join(home, "fake.json"), "utf8")).pid;
+      const prompts = readFileSync(join(home, "prompts.jsonl"), "utf8");
+      assert.equal(prompts.trim().split("\n").length, 1);
+      // A frozen owned child cannot race an ACK ahead of our simulated crash.
+      process.kill(initialPid, "SIGSTOP");
+      const pendingApproval = approval.request(initial.proc, bot.id, "ask").then(
+        () => "unexpected success", (error) => error.message,
+      );
+      process.kill(initialPid, "SIGKILL");
+      await exits.get(initial.proc);
+      assert.equal(active, null, "readiness cleared in the same exit dispatch");
+      assert.match(await pendingApproval, /server stopped/);
+      // This inert fake intentionally hangs even after stdin closes. Reap only
+      // the exact fixture-recorded engine, never a process-name match.
+      process.kill(fakePid, "SIGKILL");
+      fakePid = null;
+      await until(() => active && active.pid !== initialPid, "replacement PID verified");
+      const replacementPid = active.pid;
+      assert.equal(JSON.parse(readFileSync(join(dataDir, ".openmausbot-server-child/openmausbot-server.lease"), "utf8")).pid, replacementPid);
+      const wait = await control("wait_for_conversation", { target_type: "bot", target_id: bot.id, task_id: bot.activeTaskId, timeout_seconds: 2 });
+      assert.equal(wait.target.busy, false);
+      const messages = await control("get_bot_messages", { bot_id: bot.id, task_id: bot.activeTaskId, limit: 10 });
+      assert.equal(messages.messages.filter((message) => message.role === "user").length, 1);
+      await sleep(1200);
+      assert.equal(readFileSync(join(home, "prompts.jsonl"), "utf8"), prompts, "recovery must not resend the turn");
+      assert.equal((await approval.request(active, bot.id, "ask")).approvalMode, "ask");
+      await control("create_bot", { name: "Replacement accepts fresh authorized writes" });
+      const refused = await fetch(`${url}/api/bots`, { method: "POST", headers: { "content-type": "application/json" }, body: '{"name":"Must refuse"}' });
+      assert.equal(refused.status, 403, "replacement remains fail-closed without the private token");
+      finalReceipt = { passed: true, scenario, url, initialPid, replacementPid, commands,
+        checks: ["PID verified replacement", "same port", "unchanged parent lease", "replacement child lease", "immediate unavailable", "pending approval rejected", "new approval accepted", "private mutation capability restored", "unauthorized write refused", "interrupted turn retained once, not replayed"],
+        limitation: "Headless fixture uses the production supervisor, probe, lease, approval protocol and built server, not the complete desktop bootstrap or renderer. The inert hung engine is explicitly reaped by the fixture." };
+    } else {
+      process.kill(initialPid, "SIGKILL");
+      await exits.get(initial.proc);
+      assert.equal(active, null);
+      if (scenario === "exhausted") {
+        await until(() => exhausted, "bounded recovery exhausted");
+        assert.equal(children.length, 4, "initial child plus exactly three replacements");
+        await sleep(4500);
+        assert.equal(children.length, 4, "exhaustion must stop retries without needing app.quit");
+      }
+      finalReceipt = { passed: true, scenario, url, initialPid, children: children.length,
+        checks: scenario === "quit" ? ["actual before-quit cancels pending retry", "no replacement after retry deadline"] : ["three bounded recovery attempts", "no restart after exhaustion"] };
+    }
+    app.quit();
+  }).catch((error) => { console.error(error); app.quit(); });
+} else {
+  assert.notEqual(process.platform, "win32", "This crash fixture uses POSIX SIGSTOP/SIGKILL");
+  // macOS's default temp path leaves no room for the server's Unix sockets.
+  const output = mkdtempSync(join(process.platform === "darwin" ? "/tmp" : tmpdir(), "omb-server-recovery-"));
+  const electron = createRequire(import.meta.url)("electron");
+  cpSync(join(root, "dist-server"), join(output, "server"), { recursive: true });
+  mkdirSync(join(output, "ui"));
+  writeFileSync(join(output, "ui/index.html"), "<!doctype html><title>Isolated recovery fixture</title>");
+  console.log(JSON.stringify({ evidence: output }));
+  for (const scenario of ["recover", "quit", "exhausted"]) {
+    const home = join(output, scenario, "home");
+    mkdirSync(home, { recursive: true });
+    const child = spawn(electron, [fileURLToPath(import.meta.url), flag, scenario, output, process.execPath], {
+      cwd: home, env: { HOME: home, USERPROFILE: home, PATH: dirname(process.execPath), TMPDIR: home, TEMP: home, TMP: home,
+        XDG_CONFIG_HOME: home, XDG_CACHE_HOME: home, XDG_DATA_HOME: home, DISPLAY: process.env.DISPLAY },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    for (const stream of [child.stdout, child.stderr]) stream.on("data", (data) => appendFileSync(join(output, `${scenario}.log`), data));
+    const timeout = setTimeout(() => child.kill("SIGTERM"), 60_000);
+    const code = await new Promise((resolve) => child.once("exit", resolve));
+    clearTimeout(timeout);
+    assert.equal(code, 0, `${scenario} failed; see ${join(output, `${scenario}.log`)}`);
+    console.log(JSON.stringify({ scenario, receipt: join(output, `${scenario}.json`), passed: true }));
+    rmSync(home, { recursive: true, force: true });
+  }
+  rmSync(join(output, "server"), { recursive: true, force: true });
+  rmSync(join(output, "ui"), { recursive: true, force: true });
+}


### PR DESCRIPTION
## What changes

Recover the desktop's embedded bot server after an unexpected exit, using the existing startup path and data-directory lease.

- Retry the established address after 1, 2, and 4 seconds; reset the budget only after 60 seconds of healthy uptime.
- Clear readiness immediately, invalidate the old child's capabilities, and refresh credentials for the verified replacement.
- Preserve existing chat windows and reconnect in place. Never resend an interrupted chat turn.
- Cancel recovery on quit, including a replacement still booting. Stop after repeated failures with an actionable error.

No dependencies or server protocol changes.

## Verification

- 171 Electron Node tests passed; 97 Electron modules syntax-checked; server build and focused lint passed.
- Isolated real Electron owned-child smoke: crash/recover on the same port with a different PID, unchanged parent-held lease, restored authorized writes, stale approval rejection, and no duplicate interrupted user message.
- Separate smoke cases verify quit cancels backoff and repeated crashes stop after three replacements.
- Evidence workflow documented in docs/verification/desktop-server-recovery.md.

Limit: this is an owned-child Electron smoke, not a full packaged-renderer/native-dialog test or a real-provider cleanup test. No live user app or data was used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic recovery when the packaged desktop server stops unexpectedly.
  - Windows that encountered an outage can reload after the server recovers.
  - Recovery attempts use bounded retries with increasing delays and show an error when recovery is exhausted.
  - Quitting the app now cancels pending recovery attempts cleanly.

- **Documentation**
  - Added guidance for running server-recovery verification scenarios and interpreting their results.

- **Tests**
  - Added unit and end-to-end coverage for crashes, recovery, shutdown cancellation, retry limits, and interrupted operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->