### PR TITLE
fix(runtime): verify CLI shutdown before releasing turns

### DIFF
--- a/docs/verification/chat-turns.md
+++ b/docs/verification/chat-turns.md
@@ -66,3 +66,26 @@ home is removed after the test.
 
 See the [Threads renderer recipe](threads.md) for the real sidebar, composer,
 optional folders, and group-history navigation checks.
+
+## CLI Stop regression
+
+```sh
+pnpm exec vitest run server/kill-tree.test.ts server/engine-install.test.ts server/cli-stop.e2e.test.ts
+```
+
+The Stop fixture wraps only the isolated launcher's fake Claude CLI with an
+owned helper that ignores TERM. It covers both a root that exits first and a
+root that also ignores TERM: the task stays busy during the grace period,
+settles only after both PIDs are gone, and accepts a subsequent message.
+The printed `.log.json` retains exact control commands, waits, transcripts,
+and PID checks. No real engine, account, or user's app data is used.
+
+Focused process checks also cover concurrent stops, denied signals, unrelated
+process safety, and bounded npm timeout errors. Codex's driver tests retain
+task ownership after an uncertain stop until a verified retry; Antigravity's
+lifecycle tests retain the verification profile on the same failure.
+POSIX group escalation and the
+new server cases are skipped on Windows; its existing `taskkill /T /F` path
+remains covered by the cross-platform child-tree test when run on Windows.
+Processes that intentionally detach into a different group are not owned by
+this POSIX group-based cancellation.

--- a/server/cli-stop.e2e.test.ts
+++ b/server/cli-stop.e2e.test.ts
@@ -1,0 +1,85 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+import { launchVerificationServer, runControlOmb } from "../scripts/control-omb.ts";
+
+function alive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+describe.skipIf(process.platform === "win32")("Stop through the isolated server", () => {
+  it.each([false, true])("keeps the task busy until its stubborn helper stops (root ignores TERM: %s)", async (stubbornRoot) => {
+    const fixture = await launchVerificationServer();
+    const evidence: unknown[] = [{ fixture: fixture.info, stubbornRoot }];
+    const pids: number[] = [];
+    const control = async (args: string[]) => {
+      const command = [...args, "--url", fixture.info.url];
+      const result = await runControlOmb(command) as any;
+      evidence.push({ command, result });
+      return result;
+    };
+    try {
+      const wrapper = join(fixture.info.dataDir, "stubborn-claude.mjs");
+      const pidFile = join(fixture.info.dataDir, "owned-pids.json");
+      const gate = join(fixture.info.dataDir, "finish.gate");
+      const fake = pathToFileURL(join(process.cwd(), "server/testing/fake-claude-cli.ts")).href;
+      const helper = "process.on('SIGTERM', () => {}); console.log(process.pid); setInterval(() => {}, 1000);";
+      writeFileSync(wrapper, [
+        "#!/usr/bin/env node",
+        "import { spawn } from 'node:child_process';",
+        "import { once } from 'node:events';",
+        "import { writeFileSync } from 'node:fs';",
+        "if (process.argv.includes('--input-format')) {",
+        stubbornRoot ? "process.on('SIGTERM', () => {});" : "",
+        `const child = spawn(process.execPath, ['-e', ${JSON.stringify(helper)}], { stdio: ['ignore', 'pipe', 'ignore'] });`,
+        "await once(child.stdout, 'data');",
+        `writeFileSync(${JSON.stringify(pidFile)}, JSON.stringify([process.pid, child.pid]));`,
+        "}",
+        "process.env.FAKE_CLAUDE_MODE = 'slow';",
+        `process.env.FAKE_CLAUDE_SLOW_FINISH_GATE = ${JSON.stringify(gate)};`,
+        `await import(${JSON.stringify(fake)});`,
+      ].join("\n"), { mode: 0o700 });
+      const configured = await fetch(`${fixture.info.url}/api/instances/claude`, {
+        method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ cli: wrapper }),
+      });
+      evidence.push({ method: "PATCH", path: "/api/instances/claude", body: { cli: wrapper }, status: configured.status });
+      expect(configured.status).toBe(200);
+      const created = await control(["new-bot", "--name", "Stop fixture"]);
+      const botId = created.bot.id;
+      const taskId = created.bot.activeTaskId;
+      const target = ["--bot", botId, "--task", taskId];
+      await control(["send", ...target, "--text", "Keep working until Stop"]);
+      await expect.poll(() => existsSync(pidFile), { timeout: 10_000 }).toBe(true);
+      pids.push(...JSON.parse(readFileSync(pidFile, "utf8")) as number[]);
+      expect(pids.every(alive)).toBe(true);
+      expect((await control(["wait", ...target, "--timeout", "1"])).status).toBe("timed-out");
+
+      const started = Date.now();
+      await control(["interrupt", ...target]);
+      // The root can already have closed, but the helper still owns work.
+      expect((await control(["wait", ...target, "--timeout", "1"])).status).toBe("timed-out");
+      expect(alive(pids[1]!)).toBe(true);
+      expect((await control(["wait", ...target, "--timeout", "10"])).status).toBe("settled");
+      expect(Date.now() - started).toBeLessThan(10_000);
+      expect(pids.some(alive)).toBe(false);
+      evidence.push({ stoppedPids: [...pids], alive: pids.map(alive), elapsedMs: Date.now() - started });
+      await control(["messages", ...target, "--limit", "10"]);
+
+      // A new turn works after the verified stop and starts a new CLI.
+      writeFileSync(gate, "finish");
+      await control(["send", ...target, "--text", "Reply after Stop"]);
+      expect((await control(["wait", ...target, "--timeout", "10"])).status).toBe("settled");
+      pids.push(...JSON.parse(readFileSync(pidFile, "utf8")) as number[]);
+      const messages = await control(["messages", ...target, "--limit", "10"]);
+      expect(messages.messages.some((message: any) => message.role === "bot" && message.text?.includes("Reply after Stop"))).toBe(true);
+    } finally {
+      // These are only the exact PIDs recorded by this fixture's wrapper.
+      for (const pid of pids) if (alive(pid)) process.kill(pid, "SIGKILL");
+      const evidencePath = `${fixture.info.logPath}.json`;
+      writeFileSync(evidencePath, JSON.stringify(evidence, null, 2));
+      console.info(JSON.stringify({ ...fixture.info, evidencePath }));
+      await fixture.close();
+    }
+  }, 35_000);
+});

--- a/server/drivers/antigravity-acp.ts
+++ b/server/drivers/antigravity-acp.ts
@@ -331,8 +331,8 @@ export class AntigravityAcpClient {
     this.stopping = killCliTree(this.child);
   }
 
-  /** Close, then wait (bounded) for the process to be gone. */
-  async closeAndWait(timeoutMs = 5_000): Promise<boolean> {
+  /** Allow the shared 5s TERM grace and 1s force-stop verification to finish. */
+  async closeAndWait(timeoutMs = 7_000): Promise<boolean> {
     this.close();
     let timer: NodeJS.Timeout | undefined;
     const timedOut = new Promise<boolean>((resolve) => {

--- a/server/drivers/antigravity-acp.ts
+++ b/server/drivers/antigravity-acp.ts
@@ -181,6 +181,7 @@ export class AntigravityAcpClient {
   private startupDiagnosticBytes = 0;
   private nativeStartupHint?: string;
   private closed = false;
+  private stopping?: Promise<boolean>;
   private readonly onAuthorizationUrl?: (url: string) => void;
   /** Settles once the runtime process is gone. On Windows a running
    * executable pins its file and its directory, so an installer must not
@@ -327,7 +328,7 @@ export class AntigravityAcpClient {
     if (this.closed) return;
     this.closed = true;
     this.failAll(new Error("Antigravity ACP was closed."));
-    killCliTree(this.child);
+    this.stopping = killCliTree(this.child);
   }
 
   /** Close, then wait (bounded) for the process to be gone. */
@@ -339,7 +340,7 @@ export class AntigravityAcpClient {
       timer.unref?.();
     });
     try {
-      return await Promise.race([this.exited.then(() => true), timedOut]);
+      return await Promise.race([this.stopping!, timedOut]);
     } finally {
       clearTimeout(timer);
     }

--- a/server/drivers/antigravity-lifecycle.test.ts
+++ b/server/drivers/antigravity-lifecycle.test.ts
@@ -58,7 +58,9 @@ beforeEach(() => {
   vi.useFakeTimers();
   vi.spyOn(console, "warn").mockImplementation(() => {});
   vi.mocked(spawnCli).mockReset();
-  vi.mocked(killCliTree).mockReset();
+  vi.mocked(killCliTree).mockReset().mockImplementation((child) => new Promise((resolve) => {
+    child.once("close", () => resolve(true));
+  }));
   vi.mocked(rm).mockReset().mockImplementation(realRm);
 });
 
@@ -129,6 +131,14 @@ describe("Antigravity initialization diagnostics", () => {
 });
 
 describe("Antigravity validation shutdown", () => {
+  it("does not release a verification profile when root close leaves an uncertain tree", async () => {
+    const child = fakeChild();
+    vi.mocked(killCliTree).mockImplementation(async () => { child.emit("close", 0); return false; });
+    await expect(validateAntigravityRuntime(runtime, "1.1.1")).rejects.toThrow("did not shut down");
+    expect(rm).not.toHaveBeenCalled();
+    expect(existsSync(scratch[0])).toBe(true);
+  });
+
   it("contains Windows one-file extraction in the owned verification profile", async () => {
     const child = fakeChild();
     vi.mocked(killCliTree).mockImplementation(async () => { child.emit("close", 0); return true; });

--- a/server/drivers/antigravity.test.ts
+++ b/server/drivers/antigravity.test.ts
@@ -207,6 +207,22 @@ createInterface({ input: process.stdin }).on('line', line => {
 });
 
 describe("stopping the runtime before touching its files", () => {
+  it.skipIf(process.platform === "win32")("waits through forced shutdown when the verified runtime ignores TERM", async () => {
+    const fake = fakeRuntime();
+    writeFileSync(fake.executable, `#!/usr/bin/env node\nprocess.on('SIGTERM', () => {});\nawait import(${JSON.stringify(pathToFileURL(FAKE_ACP).href)});\n`);
+    const runtime = await resolveAntigravityRuntime(fake.executable);
+    vi.stubEnv("FAKE_ACP_AGENT_NAME", "Google Antigravity");
+    vi.stubEnv("FAKE_ACP_AGENT_VERSION", "1.1.1");
+    vi.stubEnv("FAKE_ACP_AUTH_METHOD", "oauth-personal");
+    const spawned = vi.spyOn(procs, "spawnCli");
+    try {
+      await expect(validateAntigravityRuntime(runtime, "agy_acp_server_1.1.1")).resolves.toBeUndefined();
+      expect(spawned.mock.results[0]!.value.signalCode).toBe("SIGKILL");
+    } finally {
+      await Promise.all(spawned.mock.results.map(({ value }) => procs.killCliTree(value, 0)));
+    }
+  }, 10_000);
+
   it("validates a real fake runtime and waits for its process to close before returning", async () => {
     const fake = fakeRuntime();
     const runtime = await resolveAntigravityRuntime(fake.executable);

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -1310,6 +1310,41 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     }));
   });
 
+  it.each([false, true])("finalizes root close after an uncertain Stop succeeds on retry (retained: %s)", async (retained) => {
+    const gate = join(scratch, "retry-stop.gate");
+    await create("slow", { FAKE_CLAUDE_SLOW_FINISH_GATE: gate });
+    const threadId = `t-retry-stop-${retained}`;
+    if (retained) {
+      writeFileSync(gate, "finish");
+      const first = await instance.adapter.sendTurn({ threadId, text: "first" });
+      await recorder.until((event) => event.type === "turn.completed" && event.turnId === first.turnId);
+      rmSync(gate);
+    }
+    const running = await instance.adapter.sendTurn({ threadId, text: "stop then retry" });
+    await recorder.until((event) => event.type === "item.completed" && event.itemType === "tool" && event.turnId === running.turnId);
+    const kill = procs.killCliTree;
+    const uncertain = vi.spyOn(procs, "killCliTree").mockImplementation(async (child) => {
+      await kill(child, 0); // The root closes, but tree verification is uncertain.
+      return false;
+    });
+    try {
+      await instance.adapter.interruptTurn(threadId);
+      await recorder.until((event) => event.type === "runtime.error" && event.message.includes("could not be confirmed stopped"));
+      expect(instance.adapter.hasSession(threadId)).toBe(true);
+      expect(recorder.events.some((event) => event.type === "turn.completed" && event.turnId === running.turnId)).toBe(false);
+    } finally {
+      uncertain.mockRestore();
+      await instance.adapter.interruptTurn(threadId);
+    }
+    await recorder.until((event) => event.type === "turn.completed" && event.turnId === running.turnId);
+    expect(instance.adapter.hasSession(threadId)).toBe(false);
+    expect(recorder.events.filter((event) => event.type === "turn.completed" && event.turnId === running.turnId)).toHaveLength(1);
+
+    writeFileSync(gate, "finish");
+    const replacement = await instance.adapter.sendTurn({ threadId, text: "replacement" });
+    await recorder.until((event) => event.type === "turn.completed" && event.turnId === replacement.turnId);
+  });
+
   it("a message sent mid-turn is steered into the running turn", async () => {
     await create("slow");
     const { turnId } = await instance.adapter.sendTurn({ threadId: "t-steer", text: "first" });

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -874,6 +874,8 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       idleTimer: ReturnType<typeof setTimeout> | null;
       closing: boolean;
       stderr: string;
+      /** Root close can precede a failed group stop; retry its finalization. */
+      finishClose?: () => Promise<void>;
     }
     const sessions = new Map<string, Session>();
     const configuredIdleMinimum = Number(process.env.OMB_CLAUDE_SESSION_IDLE_MIN_MS);
@@ -882,6 +884,11 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       : 10_000;
     const SESSION_IDLE_MS = Math.max(sessionIdleMinimum, Number(process.env.OMB_CLAUDE_SESSION_IDLE_MS) || 10 * 60_000);
 
+    const stopSession = (session: Session) => {
+      void killCliTree(session.child).then((stopped) => {
+        if (stopped) void session.finishClose?.();
+      });
+    };
     const closeSession = (threadId: string, why: string) => {
       const s = sessions.get(threadId);
       if (!s || s.closing) return;
@@ -899,7 +906,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         s.child.stdin.end();
       } catch {}
       const kill = setTimeout(() => {
-        void killCliTree(s.child);
+        stopSession(s);
       }, 5_000);
       kill.unref?.();
     };
@@ -1164,7 +1171,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         live.turn = { turnId, settled: false, sawStreamDelta: false };
         active.set(threadId, { stop: () => {
           closeSession(threadId, "interrupted");
-          killCliTree(live.child);
+          stopSession(live);
         }, turnId, broker: live.broker });
         emit({ ...base(threadId, turnId), type: "turn.started" });
         const volatile = turn.systemVolatile ?? "";
@@ -1496,7 +1503,9 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         settle(false, "spawn_error");
       });
 
-      child.on("close", async (code) => {
+      let closeFinalized = false;
+      const finalizeClose = async (code: number | null) => {
+        if (closeFinalized) return;
         // The root can close while its MCP helpers are still running. Join
         // an in-flight stop (or reap its remaining group) before releasing
         // the turn so a replacement cannot overlap the old helpers.
@@ -1506,6 +1515,8 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
           emit({ ...base(threadId, currentTurnId()), type: "runtime.error", message: "Claude could not be confirmed stopped; its helper processes may still be running." });
           return;
         }
+        if (closeFinalized) return;
+        closeFinalized = true;
         // a turn still running when the process died is a failed turn; a
         // process that exited between turns (idle close, contract change)
         // is just a session ending
@@ -1665,6 +1676,10 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         }
         removePrivateTempDir(session.systemPromptPath);
         if (sessions.get(threadId) === session) sessions.delete(threadId);
+      };
+      child.on("close", (code) => {
+        session.finishClose = () => finalizeClose(code);
+        void session.finishClose();
       });
 
       const stop = () => {
@@ -1673,7 +1688,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         closeSession(threadId, "interrupted");
         retry.cancelled = true;
         retryAbort.abort();
-        killCliTree(child);
+        stopSession(session);
       };
       active.set(threadId, { stop, turnId, broker });
       emit({ ...base(threadId, turnId), type: "turn.started" });

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -899,7 +899,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         s.child.stdin.end();
       } catch {}
       const kill = setTimeout(() => {
-        if (s.child.exitCode === null) killCliTree(s.child);
+        void killCliTree(s.child);
       }, 5_000);
       kill.unref?.();
     };
@@ -1357,6 +1357,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       const currentTurnId = () => session.turn?.turnId ?? turnId;
 
       const handleLine = (line: string) => {
+        if (session.closing) return;
         let o: any;
         try {
           o = JSON.parse(line);
@@ -1495,7 +1496,16 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         settle(false, "spawn_error");
       });
 
-      child.on("close", (code) => {
+      child.on("close", async (code) => {
+        // The root can close while its MCP helpers are still running. Join
+        // an in-flight stop (or reap its remaining group) before releasing
+        // the turn so a replacement cannot overlap the old helpers.
+        if (!(await killCliTree(child, 0))) {
+          session.broker?.close();
+          session.broker = undefined;
+          emit({ ...base(threadId, currentTurnId()), type: "runtime.error", message: "Claude could not be confirmed stopped; its helper processes may still be running." });
+          return;
+        }
         // a turn still running when the process died is a failed turn; a
         // process that exited between turns (idle close, contract change)
         // is just a session ending

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -6,10 +6,11 @@
 // The fake is a shebang script — the same constraint codex.cmd itself
 // hits on Windows. resolveCliSpawn covers both, so these run everywhere.
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { once } from "node:events";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ProviderInstance } from "../contracts.ts";
 import { NATIVE_DIR } from "../config.ts";
@@ -21,6 +22,7 @@ import {
   codexUpdateCommand,
 } from "./codex.ts";
 import { removeTempDir } from "../testing/cleanup.ts";
+import * as procs from "../procs.ts";
 
 const FAKE_CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "testing", "fake-codex-app-server.ts");
 
@@ -1069,6 +1071,37 @@ describe("CodexDriver turns (fake app-server)", () => {
     await expect(instance.adapter.sendTurn({ threadId: "t-busy", text: "two" })).rejects.toThrow(/already running/);
     await instance.adapter.interruptTurn("t-busy");
     await recorder.until((e) => e.type === "turn.completed");
+  });
+
+  it.each([false, true])("keeps ownership after an uncertain stop even when root close arrives (before failure: %s)", async (closeFirst) => {
+    await create();
+    const stopping = vi.spyOn(procs, "killCliTree").mockImplementation(async (child) => {
+      if (closeFirst && child.exitCode === null && child.signalCode === null) {
+        const closed = once(child, "close");
+        child.kill("SIGKILL");
+        await closed;
+      }
+      return false;
+    });
+    try {
+      await instance.adapter.sendTurn({ threadId: "t-uncertain-stop", text: "one" });
+      await recorder.until((event) => event.type === "runtime.error" && event.message.includes("did not shut down"));
+      const child = stopping.mock.calls[0]![0];
+      if (!closeFirst) {
+        const closed = once(child, "close");
+        child.kill("SIGKILL");
+        await closed;
+        await expect.poll(() => stopping.mock.calls.length).toBeGreaterThan(1);
+      }
+      expect(recorder.events.some((event) => event.type === "turn.completed")).toBe(false);
+      expect(instance.adapter.hasSession("t-uncertain-stop")).toBe(true);
+      await expect(instance.adapter.sendTurn({ threadId: "t-uncertain-stop", text: "two" })).rejects.toThrow(/already running/);
+    } finally {
+      stopping.mockRestore();
+      await instance.adapter.interruptTurn("t-uncertain-stop");
+    }
+    await recorder.until((event) => event.type === "turn.completed");
+    expect(instance.adapter.hasSession("t-uncertain-stop")).toBe(false);
   });
 
   it("a missing binary surfaces as a failed turn, and snapshot says unavailable", async () => {

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -660,10 +660,16 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
         });
 
       let stopping: Promise<boolean> | undefined;
-      const terminate = () => stopping ??= killCliTree(child);
-      const stop = () => {
+      const terminate = () => stopping ??= killCliTree(child).then((stopped) => {
+        if (!stopped) stopping = undefined;
+        return stopped;
+      });
+      let completeStoppedTurn: (() => void) | undefined;
+      const stop = async () => {
         stopRequested = true;
-        return terminate();
+        const stopped = await terminate();
+        if (stopped) completeStoppedTurn?.();
+        return stopped;
       };
 
       const settle = async (ok: boolean, stopReason: string | null) => {
@@ -677,12 +683,9 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
           active.delete(threadId);
           emit({ ...base(threadId, turnId), type: "turn.completed", ok, stopReason, cost: null, ...(state.usage ? { usage: state.usage } : {}) });
         };
-        if (await stop()) {
-          complete();
-        } else {
+        completeStoppedTurn = complete;
+        if (!(await stop())) {
           emit({ ...base(threadId, turnId), type: "runtime.error", message: "codex did not shut down after termination was requested" });
-          if (child.exitCode !== null || child.signalCode !== null) complete();
-          else child.once("close", complete);
         }
       };
 
@@ -1006,6 +1009,12 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       });
       child.on("close", (code) => {
         if (abandoned) return;
+        if (state.settled) {
+          // Root exit alone cannot release a turn after an uncertain stop.
+          // Recheck its group; an explicit later Stop can also retry this.
+          void stop();
+          return;
+        }
         if (!state.settled) {
           emit({
             ...base(threadId, turnId),

--- a/server/engine-install.test.ts
+++ b/server/engine-install.test.ts
@@ -1,10 +1,11 @@
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { enginesBinDir, enginesPrefix, installNpmEngine, npmPackageOf, serverInstallFor } from "./engine-install.ts";
 import { augmentedPath, findCliCandidates, registerPathDir, resetPathCacheForTests } from "./env-path.ts";
 import { removeTempDir } from "./testing/cleanup.ts";
+import * as procs from "./procs.ts";
 
 // A stand-in npm: records its arguments, honours --prefix, and behaves per
 // FAKE_NPM_MODE. Nothing reaches a registry or the network.
@@ -15,7 +16,8 @@ const args = process.argv.slice(2);
 const mode = process.env.FAKE_NPM_MODE || 'ok';
 appendFileSync(process.env.FAKE_NPM_LOG, JSON.stringify({ args, cwd: process.cwd(), secret: process.env.XAI_API_KEY ?? null }) + '\\n');
 if (mode === 'fail') { console.error('npm ERR! code E404\\nnpm ERR! 404 Not Found - registry-token-fixture'); process.exit(1); }
-if (mode === 'hang') { setInterval(() => {}, 1000); }
+if (mode === 'stubborn') process.on('SIGTERM', () => {});
+if (mode === 'hang' || mode === 'stubborn') { setInterval(() => {}, 1000); }
 else {
   const prefix = args[args.indexOf('--prefix') + 1];
   if (mode !== 'no-bin') {
@@ -103,6 +105,32 @@ describe.skipIf(process.platform === "win32")("installing with npm", () => {
   it("stops an install that hangs", async () => {
     process.env.FAKE_NPM_MODE = "hang";
     await expect(installNpmEngine("fake-engine", { baseDir: base, timeoutMs: 300 })).rejects.toThrow("took too long");
+  });
+
+  it("force-stops an install that ignores TERM", async () => {
+    process.env.FAKE_NPM_MODE = "stubborn";
+    const stopped = vi.spyOn(procs, "killCliTree");
+    try {
+      await expect(installNpmEngine("fake-engine", { baseDir: base, timeoutMs: 300 })).rejects.toThrow("took too long and was stopped");
+      expect(stopped.mock.calls[0]![0].signalCode).toBe("SIGKILL");
+    } finally {
+      stopped.mockRestore();
+    }
+  }, 10_000);
+
+  it("reports an uncertain stop without waiting forever for npm close", async () => {
+    process.env.FAKE_NPM_MODE = "hang";
+    const kill = procs.killCliTree;
+    const stopped = vi.spyOn(procs, "killCliTree").mockResolvedValue(false);
+    try {
+      await expect(installNpmEngine("fake-engine", { baseDir: base, timeoutMs: 300 })).rejects.toThrow("could not be confirmed stopped");
+      expect(stopped.mock.calls[0]![0].exitCode).toBeNull();
+      expect(stopped.mock.calls[0]![0].signalCode).toBeNull();
+    } finally {
+      const children = stopped.mock.calls.map(([child]) => child);
+      stopped.mockRestore();
+      await Promise.all(children.map((child) => kill(child, 0)));
+    }
   });
 
   it("says plainly when npm is missing", async () => {

--- a/server/engine-install.ts
+++ b/server/engine-install.ts
@@ -130,10 +130,15 @@ function runNpm(args: string[], env: NodeJS.ProcessEnv, cwd: string, timeoutMs: 
     let timedOut = false;
     const timer = setTimeout(() => {
       timedOut = true;
-      void killCliTree(child);
+      void killCliTree(child).then((stopped) => {
+        rejectRun(new Error(stopped
+          ? "The install took too long and was stopped. Check the server's network connection and try again."
+          : "The install took too long, but npm could not be confirmed stopped. Ask the server administrator to stop the install process before trying again."));
+      });
     }, timeoutMs);
     timer.unref();
     child.once("error", (error: NodeJS.ErrnoException) => {
+      if (timedOut) return; // A failed kill is not a failed npm launch.
       clearTimeout(timer);
       rejectRun(new Error(error.code === "ENOENT"
         ? "npm is not installed on this server. Install Node.js with npm for the user running OpenMausBot, then try again."
@@ -141,10 +146,7 @@ function runNpm(args: string[], env: NodeJS.ProcessEnv, cwd: string, timeoutMs: 
     });
     child.once("close", (code) => {
       clearTimeout(timer);
-      if (timedOut) {
-        rejectRun(new Error("The install took too long and was stopped. Check the server's network connection and try again."));
-        return;
-      }
+      if (timedOut) return; // The whole group must stop, not just npm's root.
       resolveRun({ code, output });
     });
   });

--- a/server/kill-tree.test.ts
+++ b/server/kill-tree.test.ts
@@ -3,11 +3,24 @@
 // contract of killCliTree, so it is what gets tested: a grandchild must not
 // survive the kill on either platform.
 import { spawn } from "node:child_process";
-import { describe, expect, it } from "vitest";
+import { once } from "node:events";
+import type { Readable } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
 
 import { killCliTree, spawnCli } from "./procs.ts";
 
 const IDLE = "setInterval(() => {}, 1000)";
+const STUBBORN = `process.on('SIGTERM', () => {}); console.log(process.pid); ${IDLE}`;
+
+function reportedPid(stdout: Readable): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("process did not report its pid")), 5_000);
+    stdout.once("data", (chunk) => {
+      clearTimeout(timer);
+      resolve(Number(String(chunk).trim()));
+    });
+  });
+}
 
 function alive(pid: number): boolean {
   try {
@@ -30,14 +43,14 @@ describe("killCliTree", () => {
 
   it("reaps a grandchild, not just the process it was handed", async () => {
     // a stand-in CLI: spawns one helper, reports its pid, then idles
-    const parent = spawn(
+    const parent = spawnCli(
       process.execPath,
       [
         "-e",
         `const c = require("node:child_process").spawn(process.execPath, ["-e", ${JSON.stringify(IDLE)}], { stdio: "ignore" });` +
           `console.log(c.pid); ${IDLE}`,
       ],
-      { stdio: ["ignore", "pipe", "ignore"], detached: true },
+      { stdio: ["pipe", "pipe", "pipe"] },
     );
     let grandchild = 0;
     try {
@@ -74,4 +87,81 @@ describe("killCliTree", () => {
       }
     }
   }, 20_000);
+
+  it.skipIf(process.platform === "win32")("escalates ignored TERM and shares concurrent stop attempts", async () => {
+    const child = spawnCli(process.execPath, ["-e", STUBBORN], { stdio: ["pipe", "pipe", "pipe"] });
+    try {
+      await reportedPid(child.stdout);
+      const started = Date.now();
+      const stopped = killCliTree(child, 80);
+      expect(killCliTree(child, 80)).toBe(stopped);
+      await expect(stopped).resolves.toBe(true);
+      expect(Date.now() - started).toBeGreaterThanOrEqual(75);
+      expect(Date.now() - started).toBeLessThan(1_500);
+      expect(child.signalCode).toBe("SIGKILL");
+      expect(alive(child.pid!)).toBe(false);
+      expect(killCliTree(child)).toBe(stopped);
+    } finally {
+      await killCliTree(child, 0);
+    }
+  });
+
+  it.skipIf(process.platform === "win32").each([false, true])("waits for stubborn same-group helpers when the root exits first (already exited: %s)", async (exitFirst) => {
+    const parent = spawnCli(process.execPath, ["-e", `
+      const c = require('node:child_process').spawn(process.execPath, ['-e', ${JSON.stringify(STUBBORN)}], { stdio: ['ignore', 'pipe', 'ignore'] });
+      c.stdout.once('data', (pid) => { process.stdout.write(pid); ${exitFirst ? "process.exit(0);" : ""} });
+      ${IDLE};
+    `], { stdio: ["pipe", "pipe", "pipe"] });
+    const rootClosed = once(parent, "close");
+    let helper = 0;
+    try {
+      helper = await reportedPid(parent.stdout);
+      if (exitFirst) await rootClosed;
+      expect(alive(helper)).toBe(true);
+      await expect(killCliTree(parent, 80)).resolves.toBe(true);
+      expect(alive(helper)).toBe(false);
+      expect(parent.exitCode !== null || parent.signalCode !== null).toBe(true);
+    } finally {
+      await killCliTree(parent, 0);
+      if (helper && alive(helper)) process.kill(helper, "SIGKILL");
+    }
+  });
+
+  it.skipIf(process.platform === "win32")("does not signal an unowned process group or an unrelated child", async () => {
+    const child = spawn(process.execPath, ["-e", STUBBORN], { stdio: ["ignore", "pipe", "ignore"] });
+    const unrelated = spawnCli(process.execPath, ["-e", STUBBORN], { stdio: ["pipe", "pipe", "pipe"] });
+    const signals = vi.spyOn(process, "kill");
+    try {
+      await Promise.all([reportedPid(child.stdout!), reportedPid(unrelated.stdout)]);
+      await expect(killCliTree(child, 80)).resolves.toBe(true);
+      expect(signals.mock.calls.some(([pid]) => Number(pid) < 0)).toBe(false);
+      expect(alive(unrelated.pid!)).toBe(true);
+      expect(alive(process.pid)).toBe(true);
+    } finally {
+      signals.mockRestore();
+      await Promise.all([killCliTree(child, 0), killCliTree(unrelated, 0)]);
+    }
+  });
+
+  it.skipIf(process.platform === "win32")("returns false after bounded failed signaling and permits a retry", async () => {
+    const child = spawnCli(process.execPath, ["-e", STUBBORN], { stdio: ["pipe", "pipe", "pipe"] });
+    await reportedPid(child.stdout);
+    const kill = process.kill.bind(process);
+    const signals = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+      if (pid === -child.pid! && signal !== 0) throw Object.assign(new Error("denied"), { code: "EPERM" });
+      return kill(pid, signal);
+    });
+    const direct = vi.spyOn(child, "kill").mockReturnValue(false);
+    try {
+      const started = Date.now();
+      await expect(killCliTree(child, 30)).resolves.toBe(false);
+      expect(Date.now() - started).toBeLessThan(1_500);
+      expect(alive(child.pid!)).toBe(true);
+      expect(direct.mock.calls).toEqual([["SIGTERM"], ["SIGKILL"]]);
+    } finally {
+      signals.mockRestore();
+      direct.mockRestore();
+      await expect(killCliTree(child, 0)).resolves.toBe(true);
+    }
+  });
 });

--- a/server/procs.ts
+++ b/server/procs.ts
@@ -53,6 +53,11 @@ export function assertSafeCliArgv(
   throw error;
 }
 
+// Only spawnCli establishes a private POSIX group. A plain spawned child
+// (for example inside an MCP gate) may share our own group: never signal it.
+const cliGroups = new WeakSet<ChildProcess>();
+const stopping = new WeakMap<ChildProcess, Promise<boolean>>();
+
 export function spawnCli(
   cli: string,
   args: string[],
@@ -66,6 +71,7 @@ export function spawnCli(
     // win32: taskkill /T does the reaping instead (see killCliTree)
     ...(process.platform === "win32" ? { windowsHide: true } : { detached: true }),
   }) as ChildProcessByStdio<Writable, Readable, Readable>; // callers always pipe all three
+  if (process.platform !== "win32") cliGroups.add(child);
 
   // A write to a dying child's stdin fails differently per platform, and one
   // of the ways is fatal. On POSIX the kill is synchronous, the stream is
@@ -122,10 +128,64 @@ export function describeSpawnFailure(err: NodeJS.ErrnoException, cli: string): S
   return { message: `spawn failed: ${err.message}`, setup: false };
 }
 
-/** Stop a CLI and every process it spawned (MCP proxies included). */
+/** Stop an owned CLI group, including helpers after its root exits. timeoutMs
+ * is the TERM grace period; SIGKILL gets one further second to settle. Helpers
+ * that deliberately detach into another group are outside this ownership. */
 export function killCliTree(child: ChildProcess, timeoutMs = 5_000): Promise<boolean> {
+  const existing = stopping.get(child);
+  if (existing) return existing;
   const pid = child.pid;
-  if (!pid || child.exitCode !== null || child.signalCode !== null) return Promise.resolve(true);
+  if (!pid) return Promise.resolve(true);
+  if (!Number.isInteger(pid) || pid <= 1 || pid === process.pid) return Promise.resolve(false);
+
+  const run = stopCliTree(child, pid, Number.isFinite(timeoutMs) ? Math.max(0, timeoutMs) : 5_000);
+  stopping.set(child, run);
+  // A failed attempt may be retried. Remember success so a delayed caller
+  // cannot signal a reused PID/group after this child's group disappeared.
+  void run.then((stopped) => { if (!stopped) stopping.delete(child); });
+  return run;
+}
+
+async function stopCliTree(child: ChildProcess, pid: number, timeoutMs: number): Promise<boolean> {
+  const exited = () => child.exitCode !== null || child.signalCode !== null;
+  if (process.platform !== "win32") {
+    const group = cliGroups.has(child);
+    const settled = () => {
+      if (!exited()) return false;
+      if (!group) return true;
+      try {
+        process.kill(-pid, 0);
+        return false;
+      } catch (error) {
+        // EPERM and other failures do not prove that the group is gone.
+        return (error as NodeJS.ErrnoException).code === "ESRCH";
+      }
+    };
+    const signal = (value: NodeJS.Signals) => {
+      try {
+        if (group) process.kill(-pid, value);
+        else child.kill(value);
+      } catch {
+        try { child.kill(value); } catch { /* report uncertainty below */ }
+      }
+    };
+    const wait = async (ms: number) => {
+      const deadline = Date.now() + ms;
+      while (!settled()) {
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) return false;
+        await new Promise((resolve) => setTimeout(resolve, Math.min(25, remaining)));
+      }
+      return true;
+    };
+    if (settled()) return true;
+    signal("SIGTERM");
+    if (await wait(timeoutMs)) return true;
+    signal("SIGKILL");
+    return wait(1_000);
+  }
+
+  if (exited()) return true;
 
   return new Promise((resolve) => {
     let timer: NodeJS.Timeout;
@@ -139,29 +199,16 @@ export function killCliTree(child: ChildProcess, timeoutMs = 5_000): Promise<boo
     timer = setTimeout(() => done(false), timeoutMs);
     timer.unref?.();
 
-    if (process.platform === "win32") {
-      execFile("taskkill", ["/PID", String(pid), "/T", "/F"], { windowsHide: true }, (err) => {
-        if (!err) return;
-        try {
-          // taskkill is unavailable or the tree lookup failed. At least stop
-          // the process we own instead of leaving the entire turn running.
-          child.kill();
-        } catch {
-          /* already gone */
-        }
-      });
-      return;
-    }
-
-    try {
-      process.kill(-pid, "SIGTERM");
-    } catch {
+    execFile("taskkill", ["/PID", String(pid), "/T", "/F"], { windowsHide: true }, (err) => {
+      if (!err) return;
       try {
-        child.kill("SIGTERM");
+        // taskkill is unavailable or the tree lookup failed. At least stop
+        // the process we own instead of leaving the entire turn running.
+        child.kill();
       } catch {
         /* already gone */
       }
-    }
+    });
   });
 }
 


### PR DESCRIPTION
## What changes

Make Stop finish reliably when a provider or its helper processes do not exit promptly.

- Track only process groups created by our CLI launcher; never group-signal an unrelated child.
- Send graceful termination, then bounded force-stop, and confirm that the owned group is gone before reporting success.
- Deduplicate concurrent stops and allow retry after an uncertain result.
- Make Claude and Codex preserve turn ownership until shutdown is confirmed; a later successful Stop can finish cleanup without leaving the thread permanently busy.
- Make npm install timeouts settle visibly and let Antigravity verification wait for the complete shutdown budget before removing its files.

No new dependencies. Windows taskkill behavior is preserved. Deliberately detached descendants outside the owned POSIX group are not covered.

## Verification

- Initial compatibility run: 398 tests passed, 1 Windows-specific skip across 14 files.
- Review corrections: 105 Claude/isolated Stop tests passed (1 Windows-specific skip), and 63 Antigravity tests passed.
- Real isolated server Stop workflows: root exits before helper; root and helper ignore TERM. Both retain busy state during shutdown, confirm the recorded PIDs are gone, and accept a subsequent message.
- Real TERM-ignoring Antigravity fixture validates successfully after forced shutdown.
- False-then-true stop regressions cover fresh and retained Claude sessions, exactly one completion, and a working replacement turn.
- Server typecheck, focused lint, and whitespace checks passed. No live user app or data used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task interruption so stubborn processes are fully stopped before a task is marked complete.
  - Preserved session and task ownership when shutdown cannot be confirmed, allowing safe retries.
  - Prevented premature completion events and ensured subsequent turns work after successful interruption.
  - Improved timeout handling for engine installation, including clearer errors when termination cannot be confirmed.
  - Reduced the risk of accidentally terminating unrelated processes during shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->