### PR TITLE
fix(chat): retain accepted follow-ups across restarts

### DIFF
--- a/docs/verification/chat-turns.md
+++ b/docs/verification/chat-turns.md
@@ -40,6 +40,27 @@ command without starting a turn.
 - A bot working inside a channel must be awaited through that channel.
 - `needs-user`, `failed`, and `stalled` are results, not successful settlement.
 
+## Queued follow-up recovery
+
+Accepted bot and channel follow-ups are committed to the transcript database
+before acknowledgement. A normal restart restores only work whose dispatch has
+not begun. A claimed dispatch has an uncertain outcome: retain the user's words
+and a visible review notice instead of automatically repeating the action.
+Cancellation receipts survive restart. Importing a workspace backup pauses all
+of its queued work for review, even when restoring to the original directory.
+
+```sh
+pnpm exec vitest run server/chat-followups.test.ts server/chat-followups-restart.test.ts server/workspace-backup.test.ts
+```
+
+The restart test launches an isolated real server with the fake engine, accepts
+queued bot/channel sends, kills only that fixture server, and starts a replacement
+against the same disposable home. It checks original receipts, native image
+content, reply targets, cancellation conflicts, one uncertain-dispatch notice,
+and a second restart without replay. It records the fixture log and a retained
+`.log.chat-followups-restart.json` receipt before removing the temporary home.
+This does not prove resumption or cleanup of real provider sessions after a crash.
+
 ## Concurrent-task regression
 
 ```sh

--- a/server/channel-queue.ts
+++ b/server/channel-queue.ts
@@ -7,6 +7,7 @@
 // never saw.
 
 import { newId } from "./contracts.ts";
+import { chatFollowups, saveChatFollowup, settleChatFollowups } from "./message-db.ts";
 
 interface ChannelQueueItem {
   id: string;
@@ -24,6 +25,17 @@ interface ChannelQueueEntry {
 }
 
 const queues = new Map<string, ChannelQueueEntry>(); // threadId -> waiting sends
+
+export function restoreChannelMessages(): void {
+  queues.clear();
+  for (const row of chatFollowups("channel")) {
+    if (row.status !== "pending") continue;
+    const entry = queues.get(row.threadId) ?? { groupId: row.ownerId, items: [] };
+    if (entry.groupId !== row.ownerId) throw new Error("queued task belongs to another channel");
+    entry.items.push({ ...row.payload, id: row.id, mode: row.payload.mode ?? "chat" });
+    queues.set(row.threadId, entry);
+  }
+}
 
 export interface QueuedChannelMessage {
   id: string;
@@ -50,6 +62,7 @@ export function queueChannelMessage(
     mode: options.mode ?? "chat",
     via: options.via,
   };
+  saveChatFollowup({ id: item.id, kind: "channel", ownerId: groupId, threadId, payload: item });
   entry.items.push(item);
   queues.set(threadId, entry);
   return { id: item.id };
@@ -72,6 +85,7 @@ export function cancelChannelMessage(groupId: string, queueId: string): boolean 
     if (entry.groupId !== groupId) continue;
     const items = entry.items.filter((item) => item.id !== queueId);
     if (items.length === entry.items.length) continue;
+    settleChatFollowups([queueId], "cancelled");
     if (items.length === 0) queues.delete(threadId);
     else queues.set(threadId, { groupId, items });
     return true;
@@ -86,17 +100,23 @@ export function cancelChannelMessage(groupId: string, queueId: string): boolean 
  */
 export function drainChannelMessages(
   isWorking: (groupId: string) => boolean,
-  run: (input: ChannelQueueItem & { groupId: string; threadId: string }) => void,
+  run: (input: ChannelQueueItem & { groupId: string; threadId: string }) => void | Promise<void>,
 ): void {
   for (const [threadId, entry] of queues) {
     if (isWorking(entry.groupId)) continue;
-    const item = entry.items.shift();
+    const item = entry.items[0];
     if (!item) {
       queues.delete(threadId);
       continue;
     }
+    settleChatFollowups([item.id], "dispatching");
+    entry.items.shift();
     if (entry.items.length === 0) queues.delete(threadId);
-    run({ ...item, groupId: entry.groupId, threadId });
+    const running = run({ ...item, groupId: entry.groupId, threadId });
+    void Promise.resolve(running).then(
+      () => settleChatFollowups([item.id], null),
+      () => settleChatFollowups([item.id], "interrupted"),
+    ).catch((error) => console.warn("channel-queue: could not settle durable follow-up", error));
   }
 }
 

--- a/server/chat-followups-restart.test.ts
+++ b/server/chat-followups-restart.test.ts
@@ -109,6 +109,21 @@ it("survives a real server crash: queued sends keep receipts, cancellation and u
     writeFileSync(join(dataDir, `${uncertain.threadId}.gate`), "finish first task only");
     await expect.poll(() => prompts(later.threadId).length, { timeout: 15_000 }).toBe(1);
 
+    // Stop revokes provider credentials before the provider reports completion;
+    // it must still retire the already-dispatched queue receipt exactly once.
+    const stopped = (await api("POST", "/api/bots", { name: "Stopped follow-up" }, 201)).bot;
+    const stoppedTask = (await api("POST", `/api/bots/${stopped.id}/tasks`, { title: "Stop this follow-up" }, 201)).task;
+    await api("POST", `/api/bots/${stopped.id}/messages`, { threadId: stopped.threadId, text: "Hold capacity before Stop" }, 202);
+    const stoppedBody = { threadId: stoppedTask.threadId, text: "Stop this dispatched follow-up", sendId: "stopped_bot_send_123456" };
+    const stoppedReceipt = await api("POST", `/api/bots/${stopped.id}/messages`, stoppedBody, 202);
+    expect(stoppedReceipt).toMatchObject({ queued: true, reason: "capacity" });
+    writeFileSync(join(dataDir, `${stopped.threadId}.gate`), "release capacity for the stopped follow-up");
+    await expect.poll(() => prompts(stoppedTask.threadId).length, { timeout: 15_000 }).toBe(1);
+    expect(journal()).toContainEqual({ id: stoppedReceipt.queueId, status: "dispatching" });
+    await api("POST", `/api/bots/${stopped.id}/interrupt`, { threadId: stoppedTask.threadId });
+    await expect.poll(() => journal().some((row) => row.id === stoppedReceipt.queueId), { timeout: 5_000 }).toBe(false);
+    expect((await api("POST", `/api/bots/${stopped.id}/messages`, stoppedBody, 202)).message.queueId).toBe(stoppedReceipt.queueId);
+
     const initial = await api("POST", `/api/groups/${channel.id}/messages`, { text: "Working channel" }, 202);
     const channelBody = { text: "Channel follow-up after restart", threadId: channel.threadId,
       replyToId: initial.message.id, sendId: "durable_channel_send_123456", mode: "chat" };
@@ -125,6 +140,8 @@ it("survives a real server crash: queued sends keep receipts, cancellation and u
     await waitForExit(fixture.child, { signal: "SIGKILL" });
     writeFileSync(join(dataDir, "restarted"), "allow restored fake turns to finish");
     await restart();
+    expect((await messages(stoppedTask.threadId)).some((message) => message.queueId === stoppedReceipt.queueId && message.kind === "activity")).toBe(false);
+    expect(prompts(stoppedTask.threadId)).toHaveLength(1);
     await expect.poll(async () => (await messages(bot.threadId)).filter((message) => message.sendId === body.sendId).length, { timeout: 15_000 }).toBe(1);
     const settled = await runControlOmb(["wait", "--bot", bot.id, "--task", bot.threadId, "--url", url]);
     expect(settled).toMatchObject({ status: "settled" });

--- a/server/chat-followups-restart.test.ts
+++ b/server/chat-followups-restart.test.ts
@@ -1,0 +1,166 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { closeSync, mkdirSync, openSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { expect, it } from "vitest";
+
+import { launchVerificationServer, runControlOmb } from "../scripts/control-omb.ts";
+import { waitForExit } from "./testing/cleanup.ts";
+
+it("survives a real server crash: queued sends keep receipts, cancellation and uncertain dispatch never replay", async () => {
+  const fixture = await launchVerificationServer();
+  const { url, dataDir, logPath } = fixture.info;
+  let restarted: ChildProcess | undefined;
+  const evidence: unknown[] = [];
+  const api = async (method: string, path: string, body?: unknown, status = 200) => {
+    const response = await fetch(`${url}${path}`, {
+      method, headers: { "content-type": "application/json" },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }), signal: AbortSignal.timeout(5_000),
+    });
+    const result = await response.json() as any;
+    if (method !== "GET") evidence.push({ method, path, body, status: response.status, result });
+    expect(response.status, JSON.stringify(result)).toBe(status);
+    return result;
+  };
+  const messages = async (thread: string) => (await api("GET", `/api/threads/${thread}/messages?limit=100`)).messages as any[];
+  const prompts = (thread: string): any[] => {
+    try { return readFileSync(join(dataDir, `${thread}.prompts`), "utf8").trim().split("\n").map((line) => JSON.parse(line)); }
+    catch (error) {
+      if (error instanceof SyntaxError || (error as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw error;
+    }
+  };
+  const journal = () => {
+    const db = new DatabaseSync(join(dataDir, "messages.db"), { readOnly: true });
+    try { return db.prepare("SELECT id, status FROM chat_followups ORDER BY rowid").all(); }
+    finally { db.close(); }
+  };
+  const restart = async () => {
+    const env: NodeJS.ProcessEnv = {};
+    for (const [key, value] of Object.entries(process.env)) {
+      if (["SYSTEMROOT", "WINDIR", "COMSPEC", "PATHEXT", "LANG", "LC_ALL", "TZ"].includes(key.toUpperCase()) && value) env[key.toUpperCase()] = value;
+    }
+    Object.assign(env, {
+      HOME: dataDir, USERPROFILE: dataDir, OMB_DATA_DIR: dataDir,
+      APPDATA: join(dataDir, "AppData", "Roaming"), LOCALAPPDATA: join(dataDir, "AppData", "Local"),
+      XDG_CONFIG_HOME: join(dataDir, ".config"), XDG_CACHE_HOME: join(dataDir, ".cache"),
+      XDG_DATA_HOME: join(dataDir, ".local", "share"), HERMES_HOME: join(dataDir, ".hermes"),
+      TEMP: join(dataDir, "tmp"), TMP: join(dataDir, "tmp"), TMPDIR: join(dataDir, "tmp"),
+      OMB_PORT: new URL(url).port, OMB_WEBHOOK_PORT: String(Number(new URL(url).port) + 1), PATH: dirname(process.execPath),
+    });
+    const log = openSync(logPath, "a", 0o600);
+    restarted = spawn(process.execPath, ["--experimental-strip-types", fileURLToPath(new URL("./index.ts", import.meta.url))], {
+      cwd: fileURLToPath(new URL("..", import.meta.url)), env, stdio: ["ignore", log, log],
+    });
+    closeSync(log);
+    await expect.poll(async () => {
+      expect(restarted?.exitCode, `see ${logPath}`).toBeNull();
+      try { return (await fetch(`${url}/api/health`, { signal: AbortSignal.timeout(1_000) })).ok; }
+      catch { return false; }
+    }, { timeout: 20_000 }).toBe(true);
+  };
+  try {
+    const wrapper = join(dataDir, "queued-claude.mjs");
+    writeFileSync(wrapper, [
+      "#!/usr/bin/env node",
+      'import { existsSync } from "node:fs";',
+      'import { basename, join } from "node:path";',
+      'const thread = basename(process.cwd());',
+      `const home = ${JSON.stringify(dataDir)};`,
+      'process.env.FAKE_CLAUDE_MODE = existsSync(join(home, "restarted")) ? "happy" : "slow";',
+      'process.env.FAKE_CLAUDE_SLOW_FINISH_GATE = join(home, thread + ".gate");',
+      'process.env.FAKE_CLAUDE_PROMPTS = join(home, thread + ".prompts");',
+      // Crash the server, not unrelated processes: a fixture provider exits
+      // when its parent's pipe closes, even if its fake finish gate is shut.
+      'process.stdin.on("end", () => process.exit(0));',
+      `await import(${JSON.stringify(pathToFileURL(fileURLToPath(new URL("./testing/fake-claude-cli.ts", import.meta.url))).href)});`,
+    ].join("\n"), { mode: 0o700 });
+    await api("PATCH", "/api/instances/claude", { cli: wrapper });
+    await api("PATCH", "/api/config", { threads: { maxConcurrentPerBot: 1 } });
+    const bot = (await api("POST", "/api/bots", { name: "Durable follow-ups" }, 201)).bot;
+    const uncertain = (await api("POST", "/api/bots", { name: "Uncertain follow-up" }, 201)).bot;
+    const later = (await api("POST", `/api/bots/${uncertain.id}/tasks`, { title: "In-flight receipt" }, 201)).task;
+    const worker = (await api("POST", "/api/bots", { name: "Channel worker" }, 201)).bot;
+    const channel = (await api("POST", "/api/groups", {
+      name: "Durable channel", memberIds: [worker.id],
+      setup: { bulletin: "", defaultResponder: { kind: "member", botId: worker.id } },
+    }, 201)).group;
+
+    await api("POST", `/api/bots/${bot.id}/messages`, { text: "Working before restart", threadId: bot.threadId }, 202);
+    await expect.poll(() => prompts(bot.threadId).length, { timeout: 15_000 }).toBe(1);
+    const replyToId = (await messages(bot.threadId)).find((message) => message.role === "user").id;
+    const attachments = join(dataDir, "attachments");
+    mkdirSync(attachments, { recursive: true });
+    const image = join(attachments, "123e4567-e89b-42d3-a456-426614174000.png");
+    writeFileSync(image, Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+j7f8AAAAASUVORK5CYII=", "base64"));
+    const text = `Inspect screenshot after the first task\n\n<attached-image path="${image}" name="fixture.png" />`;
+    const body = { text, threadId: bot.threadId, replyToId, sendId: "durable_bot_send_123456" };
+    const queued = await api("POST", `/api/bots/${bot.id}/messages`, body, 202);
+    expect(queued).toMatchObject({ queued: true, queueId: expect.any(String) });
+    const cancelledBody = { ...body, text: `${text}\n\nCancelled task`, sendId: "cancelled_bot_send_123456" };
+    const cancelled = await api("POST", `/api/bots/${bot.id}/messages`, cancelledBody, 202);
+    await api("DELETE", `/api/bots/${bot.id}/queue/${cancelled.queueId}`, { threadId: bot.threadId });
+
+    await api("POST", `/api/bots/${uncertain.id}/messages`, { threadId: uncertain.threadId, text: "Hold capacity" }, 202);
+    const uncertainBody = { threadId: later.threadId, text: "A possibly executed action", sendId: "uncertain_bot_send_123456" };
+    const claimed = await api("POST", `/api/bots/${uncertain.id}/messages`, uncertainBody, 202);
+    expect(claimed).toMatchObject({ queued: true, reason: "capacity" });
+    writeFileSync(join(dataDir, `${uncertain.threadId}.gate`), "finish first task only");
+    await expect.poll(() => prompts(later.threadId).length, { timeout: 15_000 }).toBe(1);
+
+    const initial = await api("POST", `/api/groups/${channel.id}/messages`, { text: "Working channel" }, 202);
+    const channelBody = { text: "Channel follow-up after restart", threadId: channel.threadId,
+      replyToId: initial.message.id, sendId: "durable_channel_send_123456", mode: "chat" };
+    const channelQueued = await api("POST", `/api/groups/${channel.id}/messages`, channelBody, 202);
+    expect(channelQueued).toMatchObject({ queued: true, queueId: expect.any(String) });
+    const channelCancelledBody = { ...channelBody, text: "Never run cancelled channel task", sendId: "cancelled_channel_send_123456" };
+    const channelCancelled = await api("POST", `/api/groups/${channel.id}/messages`, channelCancelledBody, 202);
+    await api("DELETE", `/api/groups/${channel.id}/queue/${channelCancelled.queueId}`);
+    expect(journal()).toEqual(expect.arrayContaining([
+      { id: queued.queueId, status: "pending" }, { id: cancelled.queueId, status: "cancelled" },
+      { id: claimed.queueId, status: "dispatching" }, { id: channelQueued.queueId, status: "pending" },
+    ]));
+
+    await waitForExit(fixture.child, { signal: "SIGKILL" });
+    writeFileSync(join(dataDir, "restarted"), "allow restored fake turns to finish");
+    await restart();
+    await expect.poll(async () => (await messages(bot.threadId)).filter((message) => message.sendId === body.sendId).length, { timeout: 15_000 }).toBe(1);
+    const settled = await runControlOmb(["wait", "--bot", bot.id, "--task", bot.threadId, "--url", url]);
+    expect(settled).toMatchObject({ status: "settled" });
+    expect((await api("POST", `/api/bots/${bot.id}/messages`, body, 202)).message).toMatchObject({
+      sendId: body.sendId, queueId: queued.queueId, replyToId, text,
+    });
+    expect((await api("POST", `/api/bots/${bot.id}/messages`, cancelledBody, 409)).error).toContain("cancelled");
+    expect(prompts(bot.threadId)).toHaveLength(2);
+    expect(prompts(bot.threadId)[1].message.content).toEqual(expect.arrayContaining([expect.objectContaining({ type: "image" })]));
+
+    await expect.poll(async () => (await messages(channel.threadId)).filter((message) => message.sendId === channelBody.sendId).length, { timeout: 15_000 }).toBe(1);
+    expect((await api("POST", `/api/groups/${channel.id}/messages`, channelBody, 202)).message).toMatchObject({
+      text: channelBody.text, queueId: channelQueued.queueId, replyToId: initial.message.id, channelMode: "chat", via: "api",
+    });
+    expect((await api("POST", `/api/groups/${channel.id}/messages`, channelCancelledBody, 409)).error).toContain("cancelled");
+    const channelSettled = await runControlOmb(["wait", "--channel", channel.id, "--url", url]);
+    expect(channelSettled).toMatchObject({ status: "settled" });
+    await expect.poll(() => journal().some((row) => row.id === queued.queueId || row.id === channelQueued.queueId)).toBe(false);
+    const interrupted = await messages(later.threadId);
+    expect(interrupted.filter((message) => message.queueId === claimed.queueId)).toEqual([
+      expect.objectContaining({ role: "user", text: uncertainBody.text, sendId: uncertainBody.sendId }),
+      expect.objectContaining({ kind: "activity", tool: { name: expect.stringContaining("Review the result"), ok: false } }),
+    ]);
+    expect((await api("POST", `/api/bots/${uncertain.id}/messages`, uncertainBody, 202)).message.queueId).toBe(claimed.queueId);
+    expect(prompts(later.threadId)).toHaveLength(1);
+    // A second boot must not duplicate recovery notices or replay a claim.
+    await waitForExit(restarted, { signal: "SIGTERM" });
+    await restart();
+    expect((await messages(later.threadId)).filter((message) => message.queueId === claimed.queueId)).toEqual(interrupted.filter((message) => message.queueId === claimed.queueId));
+    expect(prompts(later.threadId)).toHaveLength(1);
+    evidence.push({ settled, channelSettled, journal: journal(), recoveredBot: await messages(bot.threadId), recoveredChannel: await messages(channel.threadId), interrupted });
+  } finally {
+    await waitForExit(restarted, { signal: "SIGTERM" });
+    const evidencePath = `${logPath}.chat-followups-restart.json`;
+    writeFileSync(evidencePath, JSON.stringify({ fixture: fixture.info, evidence }, null, 2));
+    console.log(JSON.stringify({ logPath, evidencePath }));
+    await fixture.close();
+  }
+}, 90_000);

--- a/server/chat-followups.test.ts
+++ b/server/chat-followups.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import * as journal from "./message-db.ts";
+import { cancelChannelMessage, drainChannelMessages, queuedChannelMessage, queueChannelMessage, restoreChannelMessages } from "./channel-queue.ts";
+import { cancelSteeredMessage, drainSteeredMessages, queuedSteerSnapshot, queueSteeredMessage, restoreSteeredMessages, type SteerStore } from "./steer-queue.ts";
+import type { BotRecord, Message } from "./store.ts";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  journal.settleChatFollowups(journal.chatFollowups().map((row) => row.id), null);
+  restoreSteeredMessages();
+  restoreChannelMessages();
+});
+
+function storeFor(botId: string, threadId: string): SteerStore & { messages: Message[] } {
+  const messages: Message[] = [];
+  return {
+    messages,
+    bot: (id) => id === botId ? { id, threadId, busy: false } as BotRecord : null,
+    appendMessage: (_thread, message) => {
+      const saved = { ...message, id: `message-${messages.length}`, at: Date.now() };
+      messages.push(saved);
+      return saved;
+    },
+    patchMessage: () => null,
+  };
+}
+
+describe("durable accepted follow-ups", () => {
+  it("restores bot order, receipt, attachments, reply context and unattended provenance", async () => {
+    const text = 'inspect this\n\n<attached-image path="/fixture/picture.png" name="picture.png" />';
+    const first = queueSteeredMessage("bot", "thread", text, {
+      prompt: `Reply context\n${text}`, replyToId: "reply", sendId: "first", reason: "capacity", unattended: true,
+    });
+    const second = queueSteeredMessage("bot", "thread", "then summarize", { sendId: "second" });
+    const cancelled = queueSteeredMessage("bot", "thread", "never run", { sendId: "cancelled" });
+    expect(cancelSteeredMessage("bot", cancelled.id)).toBe(true);
+    journal.closeMessageDb();
+    restoreSteeredMessages();
+    expect(queuedSteerSnapshot(() => true)).toEqual({ thread: [
+      { queueId: first.id, text, reason: "capacity" },
+      { queueId: second.id, text: "then summarize" },
+    ] });
+    const store = storeFor("bot", "thread");
+    const run = vi.fn(() => {
+      expect(journal.chatFollowups().filter((row) => row.status === "dispatching").map((row) => row.id))
+        .toEqual([first.id, second.id]);
+    });
+    drainSteeredMessages(store, run);
+    expect(run.mock.calls[0]).toEqual([
+      "bot", "thread", `Reply context\n${text}\n\nthen summarize`, store.messages[1],
+      ["message-0", "message-1"], true,
+    ]);
+    expect(store.messages).toEqual([
+      expect.objectContaining({ text, replyToId: "reply", sendId: "first", queueId: first.id }),
+      expect.objectContaining({ text: "then summarize", sendId: "second", queueId: second.id }),
+    ]);
+    await Promise.resolve();
+    expect(journal.chatFollowups().map((row) => row.id)).toEqual([cancelled.id]);
+    expect(journal.cancelledChatFollowup("bot", "bot", "thread", "cancelled")).toBe(true);
+    expect(journal.cancelledChatFollowup("bot", "other", "thread", "cancelled")).toBe(false);
+    expect(journal.chatFollowups()[0].payload).toEqual({ text: "" });
+  });
+
+  it("restores channel target, mode and API provenance without reviving cancelled messages", async () => {
+    const first = queueChannelMessage("group", "old-thread", "continue goal", {
+      mode: "goal", via: "api", replyToId: "reply", sendId: "first",
+    });
+    const second = queueChannelMessage("group", "old-thread", "next", { sendId: "second" });
+    const cancelled = queueChannelMessage("group", "old-thread", "drop", { sendId: "cancelled" });
+    expect(cancelChannelMessage("group", cancelled.id)).toBe(true);
+    journal.closeMessageDb();
+    restoreChannelMessages();
+    const run = vi.fn();
+    drainChannelMessages(() => false, run);
+    expect(run).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+      groupId: "group", threadId: "old-thread", id: first.id, text: "continue goal",
+      mode: "goal", via: "api", replyToId: "reply", sendId: "first",
+    }));
+    expect(journal.chatFollowups().find((row) => row.id === first.id)?.status).toBe("dispatching");
+    drainChannelMessages(() => false, run);
+    expect(run.mock.calls[1][0]).toMatchObject({ id: second.id, mode: "chat", text: "next" });
+    await Promise.resolve();
+    expect(journal.cancelledChatFollowup("channel", "group", "old-thread", "cancelled")).toBe(true);
+  });
+
+  it("does not publish or cancel in memory when its durable write fails", () => {
+    const saved = queueSteeredMessage("bot", "thread", "keep");
+    const save = vi.spyOn(journal, "saveChatFollowup").mockImplementation(() => { throw new Error("disk full"); });
+    expect(() => queueSteeredMessage("bot", "thread", "not accepted")).toThrow("disk full");
+    expect(() => queueChannelMessage("group", "channel", "not accepted")).toThrow("disk full");
+    save.mockRestore();
+    const channel = queueChannelMessage("group", "channel", "keep channel", { sendId: "channel-send" });
+    const settle = vi.spyOn(journal, "settleChatFollowups").mockImplementation(() => { throw new Error("disk full"); });
+    expect(() => cancelSteeredMessage("bot", saved.id)).toThrow("disk full");
+    expect(() => cancelChannelMessage("group", channel.id)).toThrow("disk full");
+    expect(queuedSteerSnapshot(() => true)).toEqual({ thread: [{ queueId: saved.id, text: "keep" }] });
+    const store = storeFor("bot", "thread");
+    const run = vi.fn();
+    expect(() => drainSteeredMessages(store, run)).toThrow("disk full");
+    expect(() => drainChannelMessages(() => false, run)).toThrow("disk full");
+    expect(queuedChannelMessage("group", "channel", "channel-send")?.id).toBe(channel.id);
+    expect(store.messages).toEqual([]);
+    expect(run).not.toHaveBeenCalled();
+    settle.mockRestore();
+  });
+
+  it("never restores a claim whose dispatch may have started", async () => {
+    const bot = queueSteeredMessage("bot", "thread", "possibly executed");
+    const channel = queueChannelMessage("group", "channel", "possibly executed");
+    expect(() => drainSteeredMessages(storeFor("bot", "thread"), () => { throw new Error("lost dispatch"); })).toThrow();
+    drainChannelMessages(() => false, () => Promise.reject(new Error("lost channel dispatch")));
+    await Promise.resolve();
+    journal.closeMessageDb();
+    restoreSteeredMessages();
+    restoreChannelMessages();
+    const run = vi.fn();
+    drainSteeredMessages(storeFor("bot", "thread"), run);
+    drainChannelMessages(() => false, run);
+    expect(run).not.toHaveBeenCalled();
+    expect(journal.chatFollowups()).toEqual([
+      expect.objectContaining({ id: bot.id, status: "dispatching" }),
+      expect.objectContaining({ id: channel.id, status: "interrupted" }),
+    ]);
+  });
+
+  it("deleting a thread deletes pending work and cancellation tombstones", () => {
+    queueSteeredMessage("bot", "thread", "pending");
+    const cancelled = queueChannelMessage("group", "thread", "cancelled", { sendId: "old-id" });
+    cancelChannelMessage("group", cancelled.id);
+    journal.deleteThread("thread");
+    journal.closeMessageDb();
+    restoreSteeredMessages();
+    restoreChannelMessages();
+    expect(journal.chatFollowups()).toEqual([]);
+    expect(queuedSteerSnapshot(() => true)).toEqual({});
+    const run = vi.fn();
+    drainChannelMessages(() => false, run);
+    expect(run).not.toHaveBeenCalled();
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -697,8 +697,6 @@ function revokeAllInternalCapabilities(): void {
 function bindInternalCapabilityToProviderTurn(threadId: string, generation: string, turnId?: string): void {
   if (turnId && !internalGenerationByProviderTurn.bind(threadId, generation, turnId)) {
     revokeInternalCapabilityGeneration(threadId, generation);
-    // This exact provider turn completed before its dispatch ACK arrived.
-    settleDirectFollowup(generation);
   }
 }
 
@@ -707,7 +705,6 @@ function revokeInternalCapabilityForProviderEvent(event: RuntimeEvent): void {
   const owner = internalGenerationByProviderTurn.complete(event.threadId, event.turnId);
   if (!owner) return;
   revokeInternalCapabilityGeneration(owner.threadId, owner.generation);
-  settleDirectFollowup(owner.generation);
 }
 
 /** Resolve a high-entropy bearer to its immutable server-side claims.
@@ -807,12 +804,17 @@ type DirectTurnDispatchClaim = {
 class DirectTurnSetupCancelled extends Error {}
 const directTurnDispatchClaims = new Map<string, DirectTurnDispatchClaim>();
 const directTurnGenerationByThread = new Map<string, string>();
-const directFollowupSettlers = new Map<string, () => void>();
+// Stop revokes credentials before completion, but the receipt must retain its
+// exact provider-turn owner until that completion or explicit failure cleanup.
+const directFollowupTurns = new ProviderTurnGenerationRegistry();
+const directFollowupSettlers = new Map<string, { threadId: string; settle: () => void }>();
 function settleDirectFollowup(generation: string | undefined): void {
   if (!generation) return;
-  const settle = directFollowupSettlers.get(generation);
+  const pending = directFollowupSettlers.get(generation);
+  if (!pending) return;
   directFollowupSettlers.delete(generation);
-  settle?.();
+  directFollowupTurns.deleteGeneration(pending.threadId, generation);
+  pending.settle();
 }
 // Keep the exact provider/profile settings that own a running conversation.
 // Selecting another thread or changing a default must not retarget its tools.
@@ -2931,6 +2933,10 @@ bus.subscribe((event: RuntimeEvent) => {
   else if (event.type === "turn.completed") {
     watchdog.settle(event.threadId);
     revokeInternalCapabilityForProviderEvent(event);
+    if (event.turnId) {
+      const owner = directFollowupTurns.complete(event.threadId, event.turnId);
+      if (owner) settleDirectFollowup(owner.generation);
+    }
   } else if (event.type !== "session.exited") watchdog.touch(event.threadId);
 });
 
@@ -4814,7 +4820,7 @@ async function startTurn(
   const resourceOwner = { threadId, generation: dispatchClaimId };
   turnResourceOwners.set(threadId, resourceOwner);
   directTurnGenerationByThread.set(threadId, dispatchClaimId);
-  if (opts?.onTurnSettled) directFollowupSettlers.set(dispatchClaimId, opts.onTurnSettled);
+  if (opts?.onTurnSettled) directFollowupSettlers.set(dispatchClaimId, { threadId, settle: opts.onTurnSettled });
   directTurnDispatchClaims.set(threadId, { id: dispatchClaimId, botId, threadId, phase: "setup" });
   directTurnBots.set(threadId, bot);
   beginInternalCapabilityGeneration(threadId, dispatchClaimId);
@@ -5273,6 +5279,11 @@ async function startTurn(
         throw new DirectTurnSetupCancelled("turn stopped during provider setup");
       }
       bindInternalCapabilityToProviderTurn(threadId, dispatchClaimId, dispatch.value.turnId);
+      if (directFollowupSettlers.has(dispatchClaimId) && dispatch.value.turnId &&
+        !directFollowupTurns.bind(threadId, dispatchClaimId, dispatch.value.turnId)) {
+        // This exact queued turn completed before its dispatch ACK arrived.
+        settleDirectFollowup(dispatchClaimId);
+      }
       clearDirectTurnDispatch(threadId, dispatchClaimId);
       // dispatched: the rewind is spent, and the old cursors are dead
       if (rewound) store.patchTask(bot.id, threadId, { rewound: false, resumeCursors: {} });

--- a/server/index.ts
+++ b/server/index.ts
@@ -697,6 +697,8 @@ function revokeAllInternalCapabilities(): void {
 function bindInternalCapabilityToProviderTurn(threadId: string, generation: string, turnId?: string): void {
   if (turnId && !internalGenerationByProviderTurn.bind(threadId, generation, turnId)) {
     revokeInternalCapabilityGeneration(threadId, generation);
+    // This exact provider turn completed before its dispatch ACK arrived.
+    settleDirectFollowup(generation);
   }
 }
 
@@ -705,6 +707,7 @@ function revokeInternalCapabilityForProviderEvent(event: RuntimeEvent): void {
   const owner = internalGenerationByProviderTurn.complete(event.threadId, event.turnId);
   if (!owner) return;
   revokeInternalCapabilityGeneration(owner.threadId, owner.generation);
+  settleDirectFollowup(owner.generation);
 }
 
 /** Resolve a high-entropy bearer to its immutable server-side claims.
@@ -3755,7 +3758,6 @@ bus.subscribe((event: RuntimeEvent) => {
       if (bot) {
         const resourceOwner = turnResourceOwners.get(event.threadId);
         const generation = directTurnGenerationByThread.get(event.threadId);
-        settleDirectFollowup(generation);
         const isCurrent = () => directTurnGenerationByThread.get(event.threadId) === generation &&
           Boolean(store.taskByThread(bot.id, event.threadId));
         const settleDirectTurn = (resumeQueued = false) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -173,7 +173,7 @@ import type { GroupGoalRunCardData, GroupGoalRunStatus } from "../shared/group-g
 
 import { BUILT_IN_DRIVERS } from "./drivers/builtIn.ts";
 import { getOrCreateChannel, mirrorActivity, mirrorExchange, mirrorReply, type CommsBus } from "./comms-visibility.ts";
-import { readMessageText, recallMessages, searchMessages, closeMessageDb } from "./message-db.ts";
+import { readMessageText, recallMessages, searchMessages, closeMessageDb, chatFollowups, cancelledChatFollowup, settleChatFollowups } from "./message-db.ts";
 import { claimRecallCrossings, recallCrossingLabel } from "./recall-disclosure.ts";
 
 /** A session_read answer competes with the transcript for the context
@@ -189,12 +189,14 @@ import {
   queuedSteeredMessage,
   queuedThreadPosition,
   queueSteeredMessage,
+  restoreSteeredMessages,
 } from "./steer-queue.ts";
 import {
   cancelChannelMessage,
   drainChannelMessages,
   queuedChannelMessage,
   queueChannelMessage,
+  restoreChannelMessages,
 } from "./channel-queue.ts";
 import {
   acceptedSendMatch,
@@ -802,6 +804,13 @@ type DirectTurnDispatchClaim = {
 class DirectTurnSetupCancelled extends Error {}
 const directTurnDispatchClaims = new Map<string, DirectTurnDispatchClaim>();
 const directTurnGenerationByThread = new Map<string, string>();
+const directFollowupSettlers = new Map<string, () => void>();
+function settleDirectFollowup(generation: string | undefined): void {
+  if (!generation) return;
+  const settle = directFollowupSettlers.get(generation);
+  directFollowupSettlers.delete(generation);
+  settle?.();
+}
 // Keep the exact provider/profile settings that own a running conversation.
 // Selecting another thread or changing a default must not retarget its tools.
 const directTurnBots = new Map<string, BotRecord>();
@@ -1348,6 +1357,7 @@ function checkedMemberIds(value: unknown): { ok: true; memberIds: string[] } | {
 }
 let bootSelection = { instanceId: "", model: "" };
 const store = new Store(() => bootSelection);
+let followupsReady = false;
 const sendSequencer = new SendSequencer();
 bootSelection = await defaultSelection();
 store.seedIfEmpty();
@@ -2786,6 +2796,7 @@ const watchdog = new TurnWatchdog({
       kind: "activity",
       tool: { name: `error: no activity for ${minutes} minutes — the turn was stopped`, ok: false },
     });
+    settleDirectFollowup(stalledGeneration);
     finalizeDelegationWatch(turn.threadId, false, "", "Delegated turn stalled and was stopped");
     turnUsage.delete(turn.threadId);
     roomStallCompletions.stall(turn.threadId);
@@ -3744,6 +3755,7 @@ bus.subscribe((event: RuntimeEvent) => {
       if (bot) {
         const resourceOwner = turnResourceOwners.get(event.threadId);
         const generation = directTurnGenerationByThread.get(event.threadId);
+        settleDirectFollowup(generation);
         const isCurrent = () => directTurnGenerationByThread.get(event.threadId) === generation &&
           Boolean(store.taskByThread(bot.id, event.threadId));
         const settleDirectTurn = (resumeQueued = false) => {
@@ -4302,6 +4314,7 @@ bus.subscribe((event: RuntimeEvent) => {
 });
 
 function drainQueuedSends() {
+  if (!followupsReady) return;
   drainSteeredMessages(store, (botId, threadId, prompt, userMessage, excludeIds, unattended) =>
     // A plain attended turn — no automationSource, no comms depth: exactly
     // what typing the same words into an idle bot would run. The one
@@ -4310,15 +4323,19 @@ function drainQueuedSends() {
     // Drain just appended the held lines; userMessage keeps startTurn
     // from duplicating the last one, and excludeIds drops every drained
     // line from the transcript-replay so they are not also in `prompt`.
-    startTurn(botId, prompt, { threadId, userMessage, excludeMessageIds: excludeIds, unattended }).then(() => undefined).catch((err) => {
-      store.appendMessage(threadId, {
-        role: "bot",
-        kind: "activity",
-        tool: {
-          name: `error: queued message could not start — ${(err instanceof Error ? err.message : String(err)).slice(0, 120)}`,
-          ok: false,
-        },
-      });
+    new Promise<void>((resolve, reject) => {
+      void startTurn(botId, prompt, {
+        threadId, userMessage, excludeMessageIds: excludeIds, unattended, onTurnSettled: resolve,
+      }).catch((err) => {
+        store.appendMessage(threadId, {
+          role: "bot", kind: "activity",
+          tool: {
+            name: `error: queued message could not start — ${(err instanceof Error ? err.message : String(err)).slice(0, 120)}`,
+            ok: false,
+          },
+        });
+        resolve();
+      }).catch(reject);
     }),
     // Provider completion can precede its dispatch promise: keep the queue
     // intact until that exact handshake releases its runtime-only claim.
@@ -4561,6 +4578,8 @@ async function startTurn(
      * dispatch the same user action twice. */
     sendId?: string;
     onDispatchError?: (message: string) => void;
+    /** Queue receipts outlive the dispatch acknowledgment until this exact turn settles. */
+    onTurnSettled?: () => void;
   },
 ) {
   workspaceMaintenance.assertAvailable();
@@ -4793,6 +4812,7 @@ async function startTurn(
   const resourceOwner = { threadId, generation: dispatchClaimId };
   turnResourceOwners.set(threadId, resourceOwner);
   directTurnGenerationByThread.set(threadId, dispatchClaimId);
+  if (opts?.onTurnSettled) directFollowupSettlers.set(dispatchClaimId, opts.onTurnSettled);
   directTurnDispatchClaims.set(threadId, { id: dispatchClaimId, botId, threadId, phase: "setup" });
   directTurnBots.set(threadId, bot);
   beginInternalCapabilityGeneration(threadId, dispatchClaimId);
@@ -5286,6 +5306,7 @@ async function startTurn(
         drainDelegationWakes();
       }
     } catch (e) {
+      settleDirectFollowup(dispatchClaimId);
       clearCancelledProviderHandshake(threadId, `direct:${dispatchClaimId}`);
       clearDirectTurnDispatch(threadId, dispatchClaimId);
       revokeInternalCapabilityGeneration(threadId, dispatchClaimId);
@@ -7239,6 +7260,7 @@ function startGroupTurn(
 }
 
 function drainQueuedChannelSends(): void {
+  if (!followupsReady) return;
   drainChannelMessages(
     (groupId) => {
       const group = store.group(groupId);
@@ -7251,8 +7273,11 @@ function drainQueuedChannelSends(): void {
         : Boolean(group && store.groupTaskByThread(group.id, threadId));
       if (!group || !ownsThread) return;
       try {
-        startGroupTurn(groupId, text, resolveReplyTarget(threadId, replyToId), sendId, mode, id, { via });
+        startGroupTurn(groupId, text, resolveReplyTarget(threadId, replyToId), sendId, mode, id, { via, threadId });
       } catch (error) {
+        if (!store.messagesFor(threadId).some((message) => message.queueId === id && message.role === "user")) {
+          store.appendMessage(threadId, { role: "user", kind: "text", text, replyToId, sendId, channelMode: mode, queueId: id, via });
+        }
         store.appendMessage(threadId, {
           role: "bot",
           kind: "activity",
@@ -7265,6 +7290,7 @@ function drainQueuedChannelSends(): void {
       // A message with no eligible responder creates no operation. Continue
       // draining instead of leaving later user messages behind it forever.
       queueMicrotask(drainQueuedChannelSends);
+      return groupQueues.get(groupId);
     },
   );
 }
@@ -8409,6 +8435,7 @@ async function reloadProviders() {
         });
         store.setTaskActivity(botId, threadId, "idle");
       }
+      settleDirectFollowup(owner?.generation);
       retryDelegationsWaitingOn(botId);
     }
     for (const [threadId, speaker] of rooms) {
@@ -11377,6 +11404,9 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
         sendFingerprint(text, replyTo?.id, channelMode),
         async () => {
           if (sendId) {
+            if (cancelledChatFollowup("channel", group.id, threadId, sendId)) {
+              throw Object.assign(new Error("this queued sendId was cancelled; send a new message to try again"), { status: 409 });
+            }
             const accepted = acceptedSendMatch(store.messagesFor(threadId), sendId, text, replyTo?.id, channelMode);
             if (accepted.kind === "conflict") {
               throw Object.assign(new Error("sendId already belongs to another message"), { status: 409 });
@@ -12300,6 +12330,7 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
           // staged provider images into a message, so dispose them here.
           for (const task of store.tasks(bot.id)) {
             purgeGeneratedImagesForThread(task.threadId);
+            settleDirectFollowup(directTurnGenerationByThread.get(task.threadId));
             directTurnGenerationByThread.delete(task.threadId);
             directTurnBots.delete(task.threadId);
           }
@@ -12792,6 +12823,9 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
         sendFingerprint(text, replyTo?.id),
         async () => {
           if (sendId) {
+            if (cancelledChatFollowup("bot", bot.id, threadId, sendId)) {
+              throw Object.assign(new Error("this queued sendId was cancelled; send a new message to try again"), { status: 409 });
+            }
             const accepted = acceptedSendMatch(store.messagesFor(threadId), sendId, text, replyTo?.id);
             if (accepted.kind === "conflict") {
               throw Object.assign(new Error("sendId already belongs to another message"), { status: 409 });
@@ -13301,6 +13335,7 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
       const stagedSkillCleanups = stagedSkillCleanupsForThread(m[2]);
       const updated = store.deleteTask(m[1], m[2]);
       if (!updated) return json(res, 400, { error: "a bot keeps at least one task" });
+      settleDirectFollowup(directTurnGenerationByThread.get(m[2]));
       rejectDeletedThreadSkillStages(stagedSkillCleanups);
       const fresh = botWithThread(updated);
       broadcast({ kind: "bot", bot: fresh });
@@ -14833,8 +14868,42 @@ try {
   console.warn(`attachments: startup partial cleanup failed: ${error instanceof Error ? error.message : String(error)}`);
 }
 
+// A dispatch claim is deliberately committed before transcript/provider work.
+// If we died after that point, its outcome is unknown: recover the user's words
+// and a review notice, never hand them to a model for a second execution.
+for (const row of chatFollowups()) {
+  if (row.status !== "dispatching" && row.status !== "interrupted") continue;
+  const owned = row.kind === "bot"
+    ? Boolean(store.taskByThread(row.ownerId, row.threadId))
+    : Boolean(store.groupByThread(row.threadId)?.id === row.ownerId);
+  if (!owned) { settleChatFollowups([row.id], "cancelled"); continue; }
+  settleChatFollowups([row.id], "interrupted");
+  const messages = store.messagesFor(row.threadId);
+  if (!messages.some((message) => message.queueId === row.id && message.role === "user")) {
+    store.appendMessage(row.threadId, {
+      role: "user", kind: "text", text: row.payload.text, replyToId: row.payload.replyToId,
+      sendId: row.payload.sendId, queueId: row.id,
+      ...(row.kind === "channel" ? { channelMode: row.payload.mode, via: row.payload.via } : {}),
+    });
+  }
+  if (!messages.some((message) => message.queueId === row.id && message.kind === "activity")) {
+    store.appendMessage(row.threadId, {
+      role: "bot", kind: "activity", queueId: row.id,
+      tool: { name: "Queued follow-up interrupted by restart or restore — it may have already run. Review the result before sending it again.", ok: false },
+    });
+  }
+  // The FULL-sync retirement also flushes both transcript writes. Retrying
+  // this sendId now finds the canonical message, without a permanent journal scan.
+  settleChatFollowups([row.id], null);
+}
+restoreSteeredMessages();
+restoreChannelMessages();
+
 server.listen(PORT, "127.0.0.1", () => {
   console.log(`openmausbot server on http://127.0.0.1:${PORT}`);
+  followupsReady = true;
+  drainQueuedSends();
+  drainQueuedChannelSends();
   // Startup work uses the same turn dispatcher and local tool endpoint as
   // ordinary chat. Start only once every registry is initialized and the
   // endpoint is listening; earlier dispatch can hit uninitialized bindings.
@@ -14870,6 +14939,7 @@ if (TUNNEL_SOCKET) {
 const gracefulShutdown = createGracefulShutdown({
   cleanup: [
     () => {
+      followupsReady = false;
       // Child MCP processes and the HTTP listener can remain alive while the
       // asynchronous shutdown jobs drain. Invalidate their turn bearers before
       // any cleanup function reaches an await.

--- a/server/message-db.ts
+++ b/server/message-db.ts
@@ -10,7 +10,7 @@
 // Legacy JSON thread files import lazily: the first read of a thread with
 // no rows pulls the old file in, after which the DB is the source of
 // truth (the JSON file is left behind as a one-time backup).
-import { chmodSync, closeSync, existsSync, openSync, readFileSync, renameSync } from "node:fs";
+import { chmodSync, closeSync, existsSync, mkdirSync, openSync, readFileSync, renameSync } from "node:fs";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
@@ -24,6 +24,7 @@ let handle: DatabaseSync | null = null;
 let handlePath: string | null = null;
 
 function open(): DatabaseSync {
+  mkdirSync(DATA_DIR, { recursive: true, mode: 0o700 });
   const file = DB_FILE();
   // Transcripts can contain private conversations and tool output. Create
   // the database with owner-only permissions and also repair an existing
@@ -51,6 +52,16 @@ function open(): DatabaseSync {
       thread_id TEXT PRIMARY KEY,
       active_leaf_id TEXT
     );
+    CREATE TABLE IF NOT EXISTS chat_followups (
+      id TEXT PRIMARY KEY,
+      kind TEXT NOT NULL,
+      owner_id TEXT NOT NULL,
+      thread_id TEXT NOT NULL,
+      send_id TEXT,
+      status TEXT NOT NULL,
+      payload TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS chat_followups_receipt ON chat_followups(kind, owner_id, thread_id, send_id);
   `);
   ensureRecallIndex(db);
   ensureMemoryIndex(db);
@@ -159,6 +170,78 @@ function db(): DatabaseSync {
   handle = open();
   handlePath = DB_FILE();
   return handle;
+}
+
+export interface FollowupPayload {
+  text: string;
+  prompt?: string;
+  replyToId?: string;
+  sendId?: string;
+  reason?: "capacity";
+  unattended?: boolean;
+  mode?: "chat" | "goal";
+  via?: "api";
+}
+export type FollowupStatus = "pending" | "dispatching" | "interrupted" | "cancelled";
+export interface ChatFollowup {
+  id: string;
+  kind: "bot" | "channel";
+  ownerId: string;
+  threadId: string;
+  status: FollowupStatus;
+  payload: FollowupPayload;
+}
+
+/** A 202/cancel/dispatch claim must reach disk before publishing its result.
+ * Use the existing transcript DB (and backup path), with FULL sync for these
+ * small transactions only; ordinary transcript writes keep their policy. */
+function writeFollowups(write: (connection: DatabaseSync) => void): void {
+  const connection = db();
+  connection.exec("PRAGMA synchronous = FULL");
+  try {
+    connection.exec("BEGIN IMMEDIATE");
+    try { write(connection); connection.exec("COMMIT"); }
+    catch (error) { connection.exec("ROLLBACK"); throw error; }
+  } finally { connection.exec("PRAGMA synchronous = NORMAL"); }
+}
+
+export function saveChatFollowup(followup: Omit<ChatFollowup, "status">): void {
+  writeFollowups((connection) => connection.prepare(
+    "INSERT INTO chat_followups(id, kind, owner_id, thread_id, send_id, status, payload) VALUES (?, ?, ?, ?, ?, 'pending', ?)",
+  ).run(followup.id, followup.kind, followup.ownerId, followup.threadId, followup.payload.sendId ?? null, JSON.stringify(followup.payload)));
+}
+
+/** Null retires a dispatch whose canonical transcript is already durable.
+ * Cancellation tombstones remain so a retried sendId cannot resurrect it. */
+export function settleChatFollowups(ids: string[], status: FollowupStatus | null): void {
+  if (!ids.length) return;
+  writeFollowups((connection) => {
+    const statement = connection.prepare(status === null
+      ? "DELETE FROM chat_followups WHERE id = ?"
+      : status === "cancelled"
+        ? "UPDATE chat_followups SET status = ?, payload = '{\"text\":\"\"}' WHERE id = ?"
+        : "UPDATE chat_followups SET status = ? WHERE id = ?");
+    for (const id of ids) {
+      if (status === null) statement.run(id);
+      else statement.run(status, id);
+    }
+  });
+}
+
+export function chatFollowups(kind?: ChatFollowup["kind"]): ChatFollowup[] {
+  const rows = (kind
+    ? db().prepare("SELECT * FROM chat_followups WHERE kind = ? ORDER BY rowid").all(kind)
+    : db().prepare("SELECT * FROM chat_followups ORDER BY rowid").all()) as Array<{
+      id: string; kind: ChatFollowup["kind"]; owner_id: string; thread_id: string; status: FollowupStatus; payload: string;
+    }>;
+  return rows.map((row) => ({ id: row.id, kind: row.kind, ownerId: row.owner_id, threadId: row.thread_id,
+    status: row.status, payload: JSON.parse(row.payload) as FollowupPayload }));
+}
+
+export function cancelledChatFollowup(kind: ChatFollowup["kind"], ownerId: string, threadId: string, sendId: string): boolean {
+  return Boolean(db().prepare(
+    "SELECT 1 FROM chat_followups WHERE kind = ? AND owner_id = ? AND thread_id = ? AND send_id = ? AND status = 'cancelled'",
+  ).get(kind, ownerId, threadId, sendId));
 }
 
 const rowToMessage = (row: { json: string }): Message => JSON.parse(row.json) as Message;
@@ -286,8 +369,11 @@ export function setActiveLeaf(threadId: string, leafId: string | null): void {
 }
 
 export function deleteThread(threadId: string): void {
-  db().prepare("DELETE FROM messages WHERE thread_id = ?").run(threadId);
-  db().prepare("DELETE FROM thread_state WHERE thread_id = ?").run(threadId);
+  writeFollowups((connection) => {
+    connection.prepare("DELETE FROM chat_followups WHERE thread_id = ?").run(threadId);
+    connection.prepare("DELETE FROM messages WHERE thread_id = ?").run(threadId);
+    connection.prepare("DELETE FROM thread_state WHERE thread_id = ?").run(threadId);
+  });
 }
 
 export interface SearchHit {

--- a/server/steer-queue.test.ts
+++ b/server/steer-queue.test.ts
@@ -13,6 +13,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -353,6 +354,7 @@ describe("steer-queue e2e (fake ACP fleet)", () => {
   let stopGate: string;
   let stopRpcDump: string;
   let earlyGate: string;
+  let receiptGate: string;
   let dispatchGate: string;
   const evidence: unknown[] = [];
   let evidencePath: string;
@@ -399,6 +401,7 @@ describe("steer-queue e2e (fake ACP fleet)", () => {
     stopGate = join(home, "gates", "stop.gate");
     stopRpcDump = join(home, "gates", "stop.rpc");
     earlyGate = join(home, "gates", "early-provider.gate");
+    receiptGate = join(home, "gates", "receipt-provider.gate");
     dispatchGate = join(home, "gates", "early-dispatch.gate");
     evidencePath = join(tmpdir(), `omb-steer-evidence-${Date.now()}-${process.pid}.json`);
     // The CLI and harness remain real. Delay only the adapter's returned
@@ -406,7 +409,15 @@ describe("steer-queue e2e (fake ACP fleet)", () => {
     const prelude = join(home, "delayed-dispatch.mjs");
     writeFileSync(prelude, [
       `import { ProviderRegistry } from ${JSON.stringify(pathToFileURL(join(SERVER_DIR, "harness/registry.ts")).href)};`,
+      `import { EventBus } from ${JSON.stringify(pathToFileURL(join(SERVER_DIR, "harness/bus.ts")).href)};`,
       'import { existsSync, writeFileSync } from "node:fs";',
+      'import { randomUUID } from "node:crypto";',
+      'let oldCompletion, receiptBus;',
+      'const publish = EventBus.prototype.publish;',
+      'EventBus.prototype.publish = function(event) {',
+      '  if (event.providerInstanceId === "steerReceipt" && event.type === "turn.completed" && !oldCompletion) { oldCompletion = event; receiptBus = this; }',
+      '  return publish.call(this, event);',
+      '};',
       'const load = ProviderRegistry.prototype.load;',
       'ProviderRegistry.prototype.load = async function(configs) {',
       '  await load.call(this, configs);',
@@ -417,6 +428,23 @@ describe("steer-queue e2e (fake ACP fleet)", () => {
       '    const result = await send(turn);',
       `    writeFileSync(${JSON.stringify(`${dispatchGate}.entered`)}, "entered");`,
       `    while (!existsSync(${JSON.stringify(dispatchGate)})) await new Promise(resolve => setTimeout(resolve, 20));`,
+      '    return result;',
+      '  };',
+      '  const receipt = this.get("steerReceipt");',
+      '  if (!receipt) return;',
+      '  const sendReceipt = receipt.adapter.sendTurn;',
+      '  let calls = 0;',
+      '  receipt.adapter.sendTurn = async (turn) => {',
+      '    const replacement = ++calls === 2;',
+      '    if (replacement) {',
+      // Replay only a completion from this fixture's old real provider turn,
+      // after the replacement has installed its generation but before its ACK.
+      '      publish.call(receiptBus, { ...oldCompletion, eventId: randomUUID(), createdAt: new Date().toISOString() });',
+      `      writeFileSync(${JSON.stringify(`${receiptGate}.late`)}, "old completion delivered");`,
+      `      while (!existsSync(${JSON.stringify(`${receiptGate}.dispatch`)})) await new Promise(resolve => setTimeout(resolve, 20));`,
+      '    }',
+      '    const result = await sendReceipt(turn);',
+      `    while (replacement && !existsSync(${JSON.stringify(`${receiptGate}.ack`)})) await new Promise(resolve => setTimeout(resolve, 20));`,
       '    return result;',
       '  };',
       '};',
@@ -433,6 +461,11 @@ describe("steer-queue e2e (fake ACP fleet)", () => {
           steerEarly: {
             driver: "grokAgent",
             environment: { FAKE_ACP_MODE: "echo-gated", FAKE_ACP_GATE_FILE: earlyGate },
+            config: { cli: FAKE_CLI, fullAuto: true },
+          },
+          steerReceipt: {
+            driver: "grokAgent",
+            environment: { FAKE_ACP_MODE: "echo-gated", FAKE_ACP_GATE_FILE: receiptGate },
             config: { cli: FAKE_CLI, fullAuto: true },
           },
           // the RPC dump lets the interrupt test wait for session/prompt to
@@ -511,6 +544,31 @@ describe("steer-queue e2e (fake ACP fleet)", () => {
     expect(echoes(final)[1].text).toContain("queued after acknowledgment");
     expect(final.messages.some((message: any) => message.tool?.name?.includes("queued message could not start"))).toBe(false);
     evidence.push({ earlyCompletionQueue: { pending, final } });
+  }, 30_000);
+
+  it("retains a replacement receipt through stale completion and settles its own completion before ACK", async () => {
+    const bot = await newBot("steerReceipt", "Receipt generation");
+    expect((await api("POST", `/api/bots/${bot.id}/messages`, { text: "first receipt turn" })).status).toBe(202);
+    const body = { threadId: bot.threadId, text: "queued replacement", sendId: "replacement_receipt_123456" };
+    const queued = await api("POST", `/api/bots/${bot.id}/messages`, body);
+    expect(queued.body).toMatchObject({ queued: true, queueId: expect.any(String) });
+    const receipt = () => {
+      const database = new DatabaseSync(join(home, ".openmausbot", "messages.db"), { readOnly: true });
+      try { return database.prepare("SELECT status FROM chat_followups WHERE id = ?").get(queued.body.queueId); }
+      finally { database.close(); }
+    };
+    writeFileSync(receiptGate, "finish the old turn");
+    await until(async () => existsSync(`${receiptGate}.late`), "old completion during replacement setup");
+    expect(receipt()).toEqual({ status: "dispatching" });
+    writeFileSync(`${receiptGate}.dispatch`, "start replacement provider");
+    await until(async () => echoes(await botById(bot.id)).length === 2, "replacement completion before its ACK");
+    expect(receipt()).toEqual({ status: "dispatching" });
+    writeFileSync(`${receiptGate}.ack`, "acknowledge replacement");
+    await until(async () => receipt() === undefined, "receipt settlement by the replacement's exact provider turn");
+    const retried = await api("POST", `/api/bots/${bot.id}/messages`, body);
+    expect(retried.body.message).toMatchObject({ queueId: queued.body.queueId, sendId: body.sendId });
+    expect(echoes(await botById(bot.id))).toHaveLength(2);
+    evidence.push({ receiptGeneration: { queued, retried, final: await botById(bot.id) } });
   }, 30_000);
 
   it(

--- a/server/steer-queue.ts
+++ b/server/steer-queue.ts
@@ -4,11 +4,11 @@
 // here until the bot settles, then lands in the thread and runs as ONE
 // follow-up turn whose prompt is the queued texts separated by a blank line.
 //
-// The queue is memory-only and is NOT in `messages[]` while the current
+// The durable queue is NOT in `messages[]` while the current
 // turn is running: appending immediately would make the queued line the
 // active leaf, so remaining tool/assistant events of *this* turn would
-// hang off a user line the model has not seen. Restart loses the queue
-// (same as delegations / approvals). The composer shows a pending chip
+// hang off a user line the model has not seen. Restart restores only sends
+// whose dispatch has not begun. The composer shows a pending chip
 // until drain appends the words.
 //
 // Unlike the delegation drain, an interrupted or failed turn does NOT
@@ -18,6 +18,7 @@
 // the feature.
 
 import { newId } from "./contracts.ts";
+import { chatFollowups, saveChatFollowup, settleChatFollowups } from "./message-db.ts";
 import type { BotRecord, Message } from "./store.ts";
 
 /** The slice of Store this module needs — narrow so tests can fake it. */
@@ -46,6 +47,17 @@ interface QueueEntry {
 }
 
 const queues = new Map<string, QueueEntry>(); // threadId → waiting sends
+
+export function restoreSteeredMessages(): void {
+  queues.clear();
+  for (const row of chatFollowups("bot")) {
+    if (row.status !== "pending") continue;
+    const entry = queues.get(row.threadId) ?? { botId: row.ownerId, items: [] };
+    if (entry.botId !== row.ownerId) throw new Error("queued task belongs to another bot");
+    entry.items.push({ ...row.payload, messageId: row.id, prompt: row.payload.prompt ?? row.payload.text });
+    queues.set(row.threadId, entry);
+  }
+}
 const listeners = new Set<() => void>();
 const changed = () => {
   for (const listener of listeners) {
@@ -86,7 +98,7 @@ export function queueSteeredMessage(
   // A thread cannot legitimately change owners. Refuse to merge unrelated
   // queues even if a corrupt caller reuses a thread id.
   if (entry.botId !== botId) throw new Error("queued task belongs to another bot");
-  entry.items.push({
+  const item = {
     messageId: id,
     text,
     prompt: options.prompt ?? text,
@@ -94,7 +106,9 @@ export function queueSteeredMessage(
     sendId: options.sendId,
     reason: options.reason,
     unattended: options.unattended,
-  });
+  };
+  saveChatFollowup({ id, kind: "bot", ownerId: botId, threadId, payload: item });
+  entry.items.push(item);
   queues.set(threadId, entry);
   changed();
   return { id };
@@ -140,6 +154,7 @@ export function drainSteeredMessages(
       : store.bot(entry.botId);
     if (!bot) {
       // the bot or task was deleted while messages waited
+      settleChatFollowups(entry.items.map((item) => item.messageId), "cancelled");
       queues.delete(threadId);
       changed();
       continue;
@@ -147,6 +162,8 @@ export function drainSteeredMessages(
     if (bot.busy || isBlocked?.(entry.botId, threadId)) continue;
     // committed to draining: the entry leaves the map before anything runs,
     // so a settle racing another settle can never fire the same queue twice
+    const ids = entry.items.map((item) => item.messageId);
+    settleChatFollowups(ids, "dispatching");
     queues.delete(threadId);
     changed();
     const appended: Message[] = [];
@@ -171,7 +188,7 @@ export function drainSteeredMessages(
     // message into one HTML block, which makes that attachment stop being a
     // native image when the combined follow-up is dispatched.
     const prompt = entry.items.map((item) => item.prompt).join("\n\n");
-    void run(
+    const running = run(
       entry.botId,
       threadId,
       prompt,
@@ -181,6 +198,10 @@ export function drainSteeredMessages(
       // person's words in the same queue cannot re-attend a bot's own
       entry.items.some((item) => item.unattended === true),
     );
+    void Promise.resolve(running).then(
+      () => settleChatFollowups(ids, null),
+      () => settleChatFollowups(ids, "interrupted"),
+    ).catch((error) => console.warn("steer-queue: could not settle durable follow-up", error));
   }
 }
 
@@ -199,12 +220,13 @@ export function queuedSteeredMessage(
 /** Drop one waiting send owned by this bot so it never drains. The queue id
  * is stable even if the bot switches away from the task while the request is
  * in flight. Returns false when it was already drained, belongs to another
- * bot, or a restart lost the in-memory auto-run intent. */
+ * bot, or dispatch has already started. */
 export function cancelSteeredMessage(botId: string, messageId: string, expectedThreadId?: string): boolean {
   for (const [threadId, entry] of queues) {
     if (entry.botId !== botId || (expectedThreadId !== undefined && threadId !== expectedThreadId)) continue;
     const items = entry.items.filter((item) => item.messageId !== messageId);
     if (items.length === entry.items.length) continue;
+    settleChatFollowups([messageId], "cancelled");
     if (items.length === 0) queues.delete(threadId);
     else queues.set(threadId, { botId: entry.botId, items });
     changed();

--- a/server/workspace-backup.test.ts
+++ b/server/workspace-backup.test.ts
@@ -47,6 +47,11 @@ function fixture(root: string): DatabaseSync {
   };
   db.prepare("INSERT INTO messages VALUES (?, ?, ?, ?)").run("thread", message.id, message.text, JSON.stringify(message));
   db.prepare("INSERT INTO thread_state VALUES (?, ?)").run("thread", "message");
+  db.exec("CREATE TABLE chat_followups(id TEXT PRIMARY KEY, kind TEXT, owner_id TEXT, thread_id TEXT, send_id TEXT, status TEXT, payload TEXT)");
+  for (const status of ["pending", "dispatching", "cancelled"]) {
+    db.prepare("INSERT INTO chat_followups VALUES (?, 'bot', 'bot', 'thread', ?, ?, ?)").run(status, `send-${status}`, status,
+      JSON.stringify({ text: message.text, replyToId: "message", prompt: "Source-only reply context" }));
+  }
   return db;
 }
 function encryptedPayload(root: string, plaintext: Buffer): string {
@@ -128,6 +133,12 @@ describe("encrypted full workspace backups", () => {
         expect(message.text).toContain(`<attached-image path="${join(target, "attachments", "image.png")}" name="image.png" />`);
         expect(message.text).toContain(`\`\`\`\n<attached-image path="${join(source, "attachments", "image.png")}" />\n\`\`\``);
         expect(restoredDb.prepare("SELECT active_leaf_id FROM thread_state").get()?.active_leaf_id).toBe("message");
+        expect(restoredDb.prepare("SELECT id, status FROM chat_followups ORDER BY rowid").all()).toEqual([
+          { id: "pending", status: "interrupted" }, { id: "dispatching", status: "interrupted" }, { id: "cancelled", status: "cancelled" },
+        ]);
+        const followup = JSON.parse(String(restoredDb.prepare("SELECT payload FROM chat_followups WHERE id = 'pending'").get()!.payload));
+        expect(followup).toMatchObject({ replyToId: "message", text: expect.stringContaining(join(target, "attachments", "image.png")) });
+        expect(followup).not.toHaveProperty("prompt");
       } finally { restoredDb.close(); }
       expect(readJson(join(target, "routines.json"))).toMatchObject({ routines: [{ enabled: false }], runs: [{ status: "failed" }, { status: "completed" }] });
       expect(readJson(join(target, "webhooks.json"))).toMatchObject({ webhooks: [{ enabled: false }], deliveries: [{ id: "delivery" }] });
@@ -146,6 +157,21 @@ describe("encrypted full workspace backups", () => {
         expect(statSync(join(target, "attachments", "image.png")).mode & 0o777).toBe(0o600);
       }
     } finally { if (db.isOpen) db.close(); }
+  });
+
+  it("also pauses pending chat follow-ups when restoring into the original home", async () => {
+    const source = directory();
+    fixture(source).close();
+    const exported = await createWorkspaceBackup(source, { password: PASSWORD });
+    const staged = await stageWorkspaceBackup(source, exported.path, { password: PASSWORD });
+    commitPendingWorkspaceRestore(source, staged.id);
+    applyPendingWorkspaceRestore(source);
+    const db = new DatabaseSync(join(source, "messages.db"), { readOnly: true });
+    try {
+      expect(db.prepare("SELECT id, status FROM chat_followups ORDER BY rowid").all()).toEqual([
+        { id: "pending", status: "interrupted" }, { id: "dispatching", status: "interrupted" }, { id: "cancelled", status: "cancelled" },
+      ]);
+    } finally { db.close(); }
   });
 
   it("authenticates before extraction and leaves the existing workspace unchanged for wrong passwords or damaged ciphertext", async () => {

--- a/server/workspace-backup.ts
+++ b/server/workspace-backup.ts
@@ -39,7 +39,7 @@ const EXCLUSION_NOTES = [
   "External project folders, CLI login homes, browser session homes, OS keychains, companion devices and other servers.",
   "VM/container disk layers and remote cloud data; durable files inside this workspace are included.",
 ];
-const RESTORE_WARNING = "Restoring pauses routines, webhooks and calendar calls, and does not resume pending delegations or queued runs. Definitions and historical receipts are retained; review before enabling them again.";
+const RESTORE_WARNING = "Restoring pauses routines, webhooks and calendar calls, and does not resume pending delegations, queued chat messages or queued runs. Definitions and historical receipts are retained; review before enabling them again.";
 
 type Entry = { path: string; type: "file" | "directory"; size: number; mode: number; sha256?: string };
 interface Manifest extends WorkspaceBackupPrivateMetadata {
@@ -743,16 +743,30 @@ function prepareRestore(dataDir: string, id: string, manifest: Manifest): string
     });
   }
   const dbPath = join(prepared, "messages.db");
-  if (existsSync(dbPath) && manifest.sourceDataDir !== resolve(dataDir)) {
+  if (existsSync(dbPath)) {
     const db = new DatabaseSync(dbPath);
     try {
-      const update = db.prepare("UPDATE messages SET json = ?, text = ? WHERE thread_id = ? AND id = ?");
       db.exec("BEGIN");
-      for (const row of db.prepare("SELECT thread_id, id, json FROM messages").iterate()) {
-        const message: unknown = JSON.parse(String(row.json));
-        rebaseMessage(message, manifest.sourceDataDir, resolve(dataDir));
-        const json = JSON.stringify(message);
-        if (json !== row.json) update.run(json, record(message) && typeof message.text === "string" ? message.text : null, row.thread_id, row.id);
+      if (manifest.sourceDataDir !== resolve(dataDir)) {
+        const update = db.prepare("UPDATE messages SET json = ?, text = ? WHERE thread_id = ? AND id = ?");
+        for (const row of db.prepare("SELECT thread_id, id, json FROM messages").iterate()) {
+          const message: unknown = JSON.parse(String(row.json));
+          rebaseMessage(message, manifest.sourceDataDir, resolve(dataDir));
+          const json = JSON.stringify(message);
+          if (json !== row.json) update.run(json, record(message) && typeof message.text === "string" ? message.text : null, row.thread_id, row.id);
+        }
+      }
+      // Import is not a server restart: the source may still be running.
+      // Keep accepted words/receipts for review, but never execute a copy of
+      // its pending work (including when restoring to the original home).
+      if (db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'chat_followups'").get()) {
+        const pause = db.prepare("UPDATE chat_followups SET status = 'interrupted', payload = ? WHERE id = ?");
+        for (const row of db.prepare("SELECT id, payload FROM chat_followups WHERE status IN ('pending', 'dispatching', 'interrupted')").iterate()) {
+          const payload: unknown = JSON.parse(String(row.payload));
+          rebaseMessage(payload, manifest.sourceDataDir, resolve(dataDir));
+          if (record(payload)) delete payload.prompt;
+          pause.run(JSON.stringify(payload), row.id);
+        }
       }
       db.exec("COMMIT");
     } finally { db.close(); }


### PR DESCRIPTION
## What changes

Keep accepted queued messages across server restarts using the existing transcript SQLite database.

- Persist before acknowledging, cancelling, or claiming dispatch.
- Restore only unstarted bot/channel follow-ups, preserving order, receipt IDs, attachments, reply context, target thread and unattended/API provenance.
- Never automatically replay a possibly executed turn: retain the user's words and show a review notice.
- Keep cancellation receipts across restarts; scrub cancelled payloads and remove receipts when their thread is deleted.
- Pause queued work on backup import, including same-directory restore.
- Bind journal completion to the exact provider turn, not the current thread generation or initial dispatch acknowledgement. Keep receipt ownership independent of credential revocation so explicit Stop still retires its receipt.
- Fix queued channel sends targeting the selected thread instead of their original thread.

No new dependencies or parallel storage mechanism. This does not resume interrupted provider sessions.

## Verification

- 154 broader queue, store, capacity, channel-goal and backup tests passed.
- Final 41-test restart/concurrency/backup/lifecycle rerun passed; server typecheck and focused lint passed.
- Reproduced and fixed stale completion settling a newer queued turn, completion before dispatch acknowledgement, and explicit Stop leaving a dispatched receipt behind.
- Real isolated server crash/restart covers accepted202 receipts, bot+channel queues, image/reply preservation, cancelled-send409, an actually dispatched turn not replaying, and a second restart without duplicate notices.
- Documented in docs/verification/chat-turns.md. No live user app, credentials or data used.
