### PR TITLE
fix(desktop): avoid blocking driver startup and stalled stream buffers

### DIFF
--- a/docs/verification/chat-ui.md
+++ b/docs/verification/chat-ui.md
@@ -132,6 +132,30 @@ reason otherwise; `OMB_UI_E2E=1` forces the verified download. The `ui-smoke`
 job in `.github/workflows/ci.yml` runs it on Ubuntu 24.04 and uploads the
 screenshot; it is not one of the required checks.
 
+## Paused-frame stream buffering
+
+`scripts/testing/stream-buffer.e2e.test.ts` launches the same isolated server,
+Vite and disposable browser session, mounting the real `StoreProvider` with a
+fixture-only text/reasoning probe. It pauses `requestAnimationFrame`, sends
+through the shared control surface, and holds the fake CLI's final frames
+until both intermediate channels reach the renderer. After settlement it
+asserts exactly one complete reply and empty stream channels, including after
+the fallback timer could fire. This probes state; the current app's active-turn
+tail displays presence rather than partial text/reasoning.
+
+```sh
+OMB_UI_E2E=1 pnpm exec vitest run scripts/testing/stream-buffer.e2e.test.ts
+pnpm exec vitest run src/state/store.test.ts
+```
+
+Only the **pending buffer** is drained: once per frame, after 100ms when timers
+run, or at 64 × 1024 UTF-16 characters (not bytes). The size test also pauses
+timers and proves an oversized chunk is flushed intact. Total accumulated
+output is intentionally unbounded; no output is truncated and this is not a
+hard memory cap. Fully suspended browser execution cannot run either callback.
+The fixture prints a persistent `.stream.json` evidence path after closing its
+browser and server and removing its temporary data.
+
 ## Bot setup and MCP access recipe
 
 `scripts/testing/bot-tools-ui.e2e.test.ts` uses the same full-app launcher and

--- a/docs/verification/local-computer-launch.md
+++ b/docs/verification/local-computer-launch.md
@@ -27,6 +27,21 @@ by this fix. The prompt prefers background window-targeted actions and asks
 before escalating to foreground control; that is guidance, not an OS-level
 background-input guarantee.
 
+## Responsive desktop startup
+
+`pnpm exec vitest run electron/cua-launch.test.mjs` checks the desktop CUA
+startup boundary without native permissions or controlling a real app. Electron
+and the CUA SDK are mocked; every subprocess is redirected to an inert Node
+child in a disposable home. The checks cover responsive asynchronous launch,
+the actual eight-second TERM-ignoring timeout, Stop cancellation, original
+failure details, bounded permission-status output, and cancellation of stalled
+or late embedded startup without publishing over or stopping a replacement.
+The installed SDK receives the startup AbortSignal directly.
+
+The Electron subprocess ratchet permits only the pre-existing cached boot-ID
+read and Linux private-group lookup. Those synchronous ownership checks remain
+outside this narrow change; the active macOS launch/status calls are asynchronous.
+
 Reference: OpenClaw's [macOS host coordinator](https://github.com/openclaw/openclaw/blob/7e1b9a63cf64fa5e77b92a7f77e8fccba7b61812/apps/macos/Sources/OpenClaw/CuaDriverHostCoordinator.swift)
 keeps the daemon owned by the desktop host, and its
 [window action adapter](https://github.com/openclaw/openclaw/blob/7e1b9a63cf64fa5e77b92a7f77e8fccba7b61812/extensions/cua-computer/src/window-actions.ts)

--- a/docs/verification/local-computer-launch.md
+++ b/docs/verification/local-computer-launch.md
@@ -36,7 +36,9 @@ child in a disposable home. The checks cover responsive asynchronous launch,
 the actual eight-second TERM-ignoring timeout, Stop cancellation, original
 failure details, bounded permission-status output, and cancellation of stalled
 or late embedded startup without publishing over or stopping a replacement.
-The installed SDK receives the startup AbortSignal directly.
+The installed SDK receives the startup AbortSignal directly. Registered IPC
+retry checks also prove concurrent requests share one stop/start sequence and
+an explicit Stop/quit during cleanup prevents its delayed restart.
 
 The Electron subprocess ratchet permits only the pre-existing cached boot-ID
 read and Linux private-group lookup. Those synchronous ownership checks remain

--- a/electron/cua-launch.test.mjs
+++ b/electron/cua-launch.test.mjs
@@ -5,8 +5,8 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const fixture = vi.hoisted(() => ({ home: "", script: "", socketReady: false, children: [], calls: [], embeddedDelays: [], hosts: [] }));
-vi.mock("electron", () => ({ app: { isPackaged: false, getPath: () => fixture.home }, ipcMain: { handle: vi.fn() } }));
+const fixture = vi.hoisted(() => ({ home: "", script: "", socketReady: false, children: [], calls: [], embeddedDelays: [], hosts: [], handlers: new Map() }));
+vi.mock("electron", () => ({ app: { isPackaged: false, getPath: () => fixture.home }, ipcMain: { handle: (name, handler) => fixture.handlers.set(name, handler) } }));
 vi.mock("@trycua/cua-driver/embedded", () => ({
   EmbeddedCuaDriverHost: class {
     constructor() { this.delay = fixture.embeddedDelays.shift(); fixture.hosts.push(this); }
@@ -69,6 +69,7 @@ vi.mock("node:child_process", async (original) => {
 });
 
 let cua;
+let localOriginModule;
 beforeEach(async () => {
   fixture.home = mkdtempSync(join(tmpdir(), "omb-cua-async-"));
   fixture.script = "setTimeout(() => process.exit(0), 120)";
@@ -77,10 +78,13 @@ beforeEach(async () => {
   fixture.calls = [];
   fixture.embeddedDelays = [];
   fixture.hosts = [];
+  fixture.handlers.clear();
   vi.stubEnv("OPENMAUSBOT_CUA_EMBEDDED", "1");
   vi.stubEnv("CUA_DRIVER_PATH", "/fixture/cua-driver");
   vi.resetModules();
   cua = await import("./cua.mjs");
+  localOriginModule = (await import("./local-origin.cjs")).default;
+  localOriginModule.setLocalOrigin("http://127.0.0.1:19777");
 });
 afterEach(async () => {
   await cua?.stopCua();
@@ -91,6 +95,7 @@ afterEach(async () => {
     await closed;
   }
   vi.unstubAllEnvs();
+  localOriginModule.setLocalOrigin(null);
   rmSync(fixture.home, { recursive: true, force: true });
 });
 
@@ -169,6 +174,59 @@ describe.skipIf(process.platform !== "darwin")("async standalone CUA launch (iso
     expect(JSON.parse(readFileSync(join(fixture.home, "cua-connection.json"), "utf8")).socketPath).toBe("/fixture/10.sock");
     await cua.stopCua();
     expect(fixture.hosts[1].stop).toHaveBeenCalledOnce();
+  });
+
+  it.each([false, true])("coalesces concurrent IPC retries and respects explicit Stop during cleanup: %s", async (cancel) => {
+    fixture.embeddedDelays = [1, 10, 20];
+    await cua.startCua();
+    let releaseStop;
+    fixture.hosts[0].stop.mockImplementation(() => new Promise((resolve) => { releaseStop = resolve; }));
+    cua.registerCuaIpc();
+    const retry = fixture.handlers.get("cua:linux-retry");
+    const event = { senderFrame: { url: "http://127.0.0.1:19777/" } };
+    let attempts;
+    try {
+      attempts = [retry(event), retry(event)];
+      // Both complete IPC flows must wait for the same old host to stop.
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      expect(fixture.hosts).toHaveLength(1);
+      expect(fixture.hosts[0].stop).toHaveBeenCalledOnce();
+      if (cancel) await cua.stopCua(); // the same boundary quit calls
+    } finally {
+      releaseStop?.();
+      fixture.hosts[0].stop.mockResolvedValue();
+    }
+    const results = await Promise.all(attempts);
+    expect(results[0]).toEqual(results[1]);
+    expect(results[0]).toMatchObject(cancel
+      ? { enabled: false, status: "error", message: "Computer use restart cancelled" }
+      : { enabled: true, status: "ready" });
+    expect(fixture.hosts).toHaveLength(cancel ? 1 : 2);
+    await cua.stopCua();
+    for (const host of fixture.hosts) {
+      expect(host.stop).toHaveBeenCalledOnce();
+      expect(host.uniffiDestroy).toHaveBeenCalledOnce();
+    }
+    expect(JSON.parse(readFileSync(join(fixture.home, "cua-connection.json"), "utf8")).mode).toBe("unavailable");
+  });
+
+  it("cancels concurrent IPC retries during replacement startup", async () => {
+    fixture.embeddedDelays = [1, "until-abort"];
+    await cua.startCua();
+    cua.registerCuaIpc();
+    const retry = fixture.handlers.get("cua:linux-retry");
+    const event = { senderFrame: { url: "http://127.0.0.1:19777/" } };
+    const attempts = [retry(event), retry(event)];
+    await expect.poll(() => fixture.hosts.length).toBe(2);
+    await cua.stopCua();
+    const results = await Promise.all(attempts);
+    expect(results[0]).toEqual(results[1]);
+    expect(results[0]).toMatchObject({ enabled: false, status: "error" });
+    for (const host of fixture.hosts) {
+      expect(host.stop).toHaveBeenCalledOnce();
+      expect(host.uniffiDestroy).toHaveBeenCalledOnce();
+    }
+    expect(JSON.parse(readFileSync(join(fixture.home, "cua-connection.json"), "utf8")).mode).toBe("unavailable");
   });
 
   it("reads permission status asynchronously with bounded output", async () => {

--- a/electron/cua-launch.test.mjs
+++ b/electron/cua-launch.test.mjs
@@ -1,0 +1,192 @@
+import { once } from "node:events";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fixture = vi.hoisted(() => ({ home: "", script: "", socketReady: false, children: [], calls: [], embeddedDelays: [], hosts: [] }));
+vi.mock("electron", () => ({ app: { isPackaged: false, getPath: () => fixture.home }, ipcMain: { handle: vi.fn() } }));
+vi.mock("@trycua/cua-driver/embedded", () => ({
+  EmbeddedCuaDriverHost: class {
+    constructor() { this.delay = fixture.embeddedDelays.shift(); fixture.hosts.push(this); }
+    async start({ signal }) {
+      if (this.delay === "until-abort") {
+        await new Promise((_, reject) => signal.addEventListener("abort", () => reject(signal.reason), { once: true }));
+      } else {
+        await new Promise((resolve) => setTimeout(resolve, this.delay));
+      }
+      return { socketPath: `/fixture/${this.delay}.sock` };
+    }
+    stop = vi.fn(async () => {});
+    uniffiDestroy = vi.fn();
+  },
+}));
+vi.mock("@trycua/cua-driver/electron", () => ({
+  requestMacOSPermissions: () => ({ accessibility: false, screenRecording: false }),
+  hasRequiredMacOSPermissions: () => fixture.embeddedDelays.length > 0,
+}));
+vi.mock("node:fs", async (original) => {
+  const fs = await original();
+  return { ...fs, default: { ...fs.default, existsSync: (file) => {
+    if (file === "/Applications/CuaDriver.app/Contents/MacOS/cua-driver") return true;
+    if (String(file).endsWith("cua-driver.sock")) return fixture.socketReady;
+    return fs.existsSync(file);
+  } } };
+});
+vi.mock("node:net", async (original) => {
+  const net = await original();
+  const { EventEmitter } = await import("node:events");
+  return { ...net, default: { ...net.default, createConnection: () => {
+    const socket = Object.assign(new EventEmitter(), { destroy: vi.fn() });
+    queueMicrotask(() => socket.emit("connect"));
+    return socket;
+  } } };
+});
+vi.mock("node:child_process", async (original) => {
+  const process = await original();
+  const { promisify } = await import("node:util");
+  const execFile = (command, args, options, callback) => {
+    fixture.calls.push({ command, args, options });
+    // Always run this inert Node child, never open the operator's native app.
+    const child = process.execFile(globalThis.process.execPath, ["-e", fixture.script], options, (error, stdout, stderr) => {
+      if (!error && command === "/usr/bin/open") fixture.socketReady = true;
+      callback(error, stdout, stderr);
+    });
+    fixture.children.push(child);
+    return child;
+  };
+  execFile[promisify.custom] = (...args) => {
+    let child;
+    const promise = new Promise((resolve, reject) => {
+      child = execFile(...args, (error, stdout, stderr) => error
+        ? reject(Object.assign(error, { stdout, stderr })) : resolve({ stdout, stderr }));
+    });
+    promise.child = child;
+    return promise;
+  };
+  return { ...process, execFile };
+});
+
+let cua;
+beforeEach(async () => {
+  fixture.home = mkdtempSync(join(tmpdir(), "omb-cua-async-"));
+  fixture.script = "setTimeout(() => process.exit(0), 120)";
+  fixture.socketReady = false;
+  fixture.children = [];
+  fixture.calls = [];
+  fixture.embeddedDelays = [];
+  fixture.hosts = [];
+  vi.stubEnv("OPENMAUSBOT_CUA_EMBEDDED", "1");
+  vi.stubEnv("CUA_DRIVER_PATH", "/fixture/cua-driver");
+  vi.resetModules();
+  cua = await import("./cua.mjs");
+});
+afterEach(async () => {
+  await cua?.stopCua();
+  for (const child of fixture.children) {
+    if (child.exitCode !== null || child.signalCode !== null) continue;
+    const closed = once(child, "close");
+    child.kill("SIGKILL");
+    await closed;
+  }
+  vi.unstubAllEnvs();
+  rmSync(fixture.home, { recursive: true, force: true });
+});
+
+describe.skipIf(process.platform !== "darwin")("async standalone CUA launch (isolated commands)", () => {
+  it("keeps the event loop responsive and publishes the existing descriptor shape", async () => {
+    let ticks = 0;
+    const timer = setInterval(() => ticks++, 10);
+    try {
+      await expect(cua.startCua()).resolves.toMatchObject({ mode: "standalone", mcpArgs: ["mcp"] });
+      expect(ticks).toBeGreaterThan(2);
+      expect(fixture.calls[0]).toMatchObject({ command: "/usr/bin/open", args: ["-a", "CuaDriver"], options: { timeout: 8_000, killSignal: "SIGKILL" } });
+    } finally { clearInterval(timer); }
+  });
+
+  it("keeps the embedded and fallback launch failures visible", async () => {
+    fixture.script = "process.stderr.write('fixture launch failure'); process.exit(4)";
+    const result = await cua.startCua();
+    expect(result.mode).toBe("unavailable");
+    expect(result.reason).toContain("embedded host failed");
+    expect(result.reason).toContain("standalone launch failed");
+    expect(result.reason).toContain("fixture launch failure");
+  });
+
+  it("cancels a pending launch without publishing a stale ready connection", async () => {
+    fixture.script = "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)";
+    const started = cua.startCua();
+    const aborted = expect(started).rejects.toMatchObject({ name: "AbortError" });
+    await expect.poll(() => fixture.children.length).toBe(1);
+    await cua.stopCua();
+    await aborted;
+    await expect.poll(() => fixture.children[0].signalCode).toBe("SIGKILL");
+    expect(fixture.socketReady).toBe(false);
+  });
+
+  it("bounds a TERM-ignoring launch with forceful timeout", async () => {
+    fixture.script = "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)";
+    await expect(cua.startCua()).resolves.toMatchObject({ mode: "unavailable", reason: expect.stringContaining("standalone launch failed") });
+    expect(fixture.children[0].signalCode).toBe("SIGKILL");
+  }, 12_000);
+
+  it("does not let an aborted embedded start publish over or stop its replacement", async () => {
+    fixture.embeddedDelays = [150, 10];
+    const first = cua.startCua();
+    const aborted = expect(first).rejects.toMatchObject({ name: "AbortError" });
+    await expect.poll(() => fixture.hosts.length).toBe(1);
+    await cua.stopCua();
+    await expect(cua.startCua()).resolves.toMatchObject({ mode: "embedded", socketPath: "/fixture/10.sock" });
+    await aborted;
+    expect(fixture.hosts[0].stop).toHaveBeenCalledOnce();
+    expect(fixture.hosts[1].stop).not.toHaveBeenCalled();
+    expect(JSON.parse(readFileSync(join(fixture.home, "cua-connection.json"), "utf8")).socketPath).toBe("/fixture/10.sock");
+  });
+
+  it("passes cancellation to an embedded startup stalled until abort", async () => {
+    fixture.embeddedDelays = ["until-abort"];
+    const started = cua.startCua();
+    const aborted = expect(started).rejects.toMatchObject({ name: "AbortError" });
+    await expect.poll(() => fixture.hosts.length).toBe(1);
+    await cua.stopCua();
+    await aborted;
+    expect(fixture.hosts[0].stop).toHaveBeenCalledOnce();
+    expect(fixture.hosts[0].uniffiDestroy).toHaveBeenCalledOnce();
+    expect(fixture.calls).toHaveLength(0);
+  });
+
+  it("keeps a replacement host when the previous host's Stop finishes late", async () => {
+    fixture.embeddedDelays = [1, 10];
+    await cua.startCua();
+    fixture.hosts[0].stop.mockImplementation(() => new Promise((resolve) => setTimeout(resolve, 150)));
+    const stopping = cua.stopCua();
+    await expect(cua.startCua()).resolves.toMatchObject({ socketPath: "/fixture/10.sock" });
+    await stopping;
+    expect(fixture.hosts[0].uniffiDestroy).toHaveBeenCalledOnce();
+    expect(fixture.hosts[1].stop).not.toHaveBeenCalled();
+    expect(fixture.hosts[1].uniffiDestroy).not.toHaveBeenCalled();
+    expect(JSON.parse(readFileSync(join(fixture.home, "cua-connection.json"), "utf8")).socketPath).toBe("/fixture/10.sock");
+    await cua.stopCua();
+    expect(fixture.hosts[1].stop).toHaveBeenCalledOnce();
+  });
+
+  it("reads permission status asynchronously with bounded output", async () => {
+    fixture.script = "setTimeout(() => console.log(JSON.stringify({ accessibility: true })), 120)";
+    await expect(cua.cuaPermissionsStatus()).resolves.toEqual({ available: true, accessibility: true });
+    expect(fixture.calls[0]).toMatchObject({ args: ["permissions", "status", "--json"], options: { timeout: 5_000, maxBuffer: 65_536, killSignal: "SIGKILL" } });
+  });
+});
+
+it("does not add blocking subprocess calls to Electron runtime modules", () => {
+  const root = dirname(fileURLToPath(import.meta.url));
+  // These existing synchronous ownership checks need separate lifecycle work:
+  // one cached boot ID read, and Linux's driver/private-group validation.
+  const allowed = { "data-dir-lease.mjs": 2, "cua-linux.cjs": 2 };
+  for (const entry of readdirSync(root, { recursive: true })) {
+    const name = String(entry).replaceAll("\\", "/");
+    if (!/\.(?:mjs|cjs)$/.test(name) || /(?:\.test\.|\.node-test\.|^vendor\/|^build-)/.test(name)) continue;
+    const matches = readFileSync(join(root, name), "utf8").match(/\b(?:spawnSync|execFileSync|execSync)\b/g) ?? [];
+    expect(matches.length, name).toBeLessThanOrEqual(allowed[name] ?? 0);
+  }
+});

--- a/electron/cua.mjs
+++ b/electron/cua.mjs
@@ -54,6 +54,8 @@ process.env.CUA_DRIVER_RS_TELEMETRY_ENABLED ??= "0";
 
 let embeddedHost = null; // EmbeddedCuaDriverHost | null
 let startupAbort = null;
+let lifecycleGeneration = 0;
+let macRetry = null;
 let linuxRuntime = null;
 let linuxBundleStage = null;
 let stateListener = () => {};
@@ -237,6 +239,7 @@ async function startEmbedded(binary, signal) {
 
 export async function startCua() {
   if (process.platform === "linux") return ensureLinuxRuntime().initialize();
+  lifecycleGeneration++;
   startupAbort?.abort();
   startupAbort = new AbortController();
   const { signal } = startupAbort;
@@ -312,6 +315,7 @@ export async function cuaPermissionsStatus() {
 }
 
 export async function stopCua() {
+  lifecycleGeneration++;
   startupAbort?.abort();
   startupAbort = null;
   if (linuxRuntime) {
@@ -369,25 +373,33 @@ export function registerCuaIpc() {
   }));
   ipcMain.handle("cua:linux-retry", localOnly("cua:linux-retry", async () => {
     if (process.platform === "darwin") {
-      try {
-        await stopCua();
-        const connection = await startCua();
-        const ready = connection?.mode === "embedded" || connection?.mode === "standalone";
-        return {
-          enabled: ready,
-          status: ready ? "ready" : "error",
-          reasonCode: ready ? undefined : "permissions-required",
-          message: connection?.reason,
-        };
-      } catch (error) {
-        console.error("[cua] macOS retry failed:", error);
-        return {
-          enabled: false,
-          status: "error",
-          reasonCode: "permissions-required",
-          message: error instanceof Error ? error.message : String(error),
-        };
-      }
+      // Concurrent IPC requests share the whole stop/start sequence. A later
+      // explicit Stop (including quit) or startup cancels its delayed restart.
+      macRetry ??= (async () => {
+        try {
+          const stopping = stopCua();
+          const generation = lifecycleGeneration;
+          await stopping;
+          if (generation !== lifecycleGeneration) throw new Error("Computer use restart cancelled");
+          const connection = await startCua();
+          const ready = connection?.mode === "embedded" || connection?.mode === "standalone";
+          return {
+            enabled: ready,
+            status: ready ? "ready" : "error",
+            reasonCode: ready ? undefined : "permissions-required",
+            message: connection?.reason,
+          };
+        } catch (error) {
+          console.error("[cua] macOS retry failed:", error);
+          return {
+            enabled: false,
+            status: "error",
+            reasonCode: "permissions-required",
+            message: error instanceof Error ? error.message : String(error),
+          };
+        }
+      })().finally(() => { macRetry = null; });
+      return macRetry;
     }
     if (process.platform !== "linux") {
       return { enabled: false, status: "unavailable", reasonCode: "unsupported-platform" };

--- a/electron/cua.mjs
+++ b/electron/cua.mjs
@@ -15,8 +15,10 @@
 // <userData>/cua-connection.json for the harness server to hand to drivers.
 
 import { app, ipcMain } from "electron";
-import { spawnSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { createRequire } from "node:module";
+import { promisify } from "node:util";
+import { setTimeout as delay } from "node:timers/promises";
 import fs from "node:fs";
 import net from "node:net";
 import path from "node:path";
@@ -47,9 +49,11 @@ const STANDALONE_SOCKET = path.join(
 );
 const HOST_BUNDLE_ID = "com.openmausbot.app";
 const CUA_ENV = { CUA_DRIVER_RS_TELEMETRY_ENABLED: "0" };
+const execFileAsync = promisify(execFile);
 process.env.CUA_DRIVER_RS_TELEMETRY_ENABLED ??= "0";
 
 let embeddedHost = null; // EmbeddedCuaDriverHost | null
+let startupAbort = null;
 let linuxRuntime = null;
 let linuxBundleStage = null;
 let stateListener = () => {};
@@ -128,13 +132,16 @@ function socketAlive(sockPath) {
   return new Promise((resolve) => {
     if (!fs.existsSync(sockPath)) return resolve(false);
     const s = net.createConnection(sockPath);
+    let timer;
     const done = (ok) => {
+      clearTimeout(timer);
       s.destroy();
       resolve(ok);
     };
     s.once("connect", () => done(true));
     s.once("error", () => done(false));
-    setTimeout(() => done(false), 1500).unref();
+    timer = setTimeout(() => done(false), 1500);
+    timer.unref();
   });
 }
 
@@ -155,17 +162,28 @@ async function loadEmbeddedSdk() {
   return import(pathToFileURL(path.join(process.resourcesPath, "cua-sdk", "cua-sdk.mjs")).href);
 }
 
-async function attachStandalone() {
+async function attachStandalone(signal) {
   const driver = fs.existsSync(INSTALLED_DRIVER) ? INSTALLED_DRIVER : null;
   if (!driver) return null;
   if (!(await socketAlive(STANDALONE_SOCKET))) {
+    signal.throwIfAborted();
     // Launch CuaDriver.app through LaunchServices so Accessibility /
     // Screen Recording stay on com.trycua.driver — the identity this
     // machine already granted — instead of the freshly signed OpenMausBot.
-    spawnSync("open", ["-a", "CuaDriver"], { timeout: 8000 });
+    const launch = execFileAsync("/usr/bin/open", ["-a", "CuaDriver"], {
+      timeout: 8_000, killSignal: "SIGKILL", maxBuffer: 8_192,
+    });
+    // execFile's AbortSignal path can send TERM independently of its timeout
+    // killSignal. Stop must also bound a launcher that ignores TERM.
+    const abort = () => launch.child.kill("SIGKILL");
+    signal.addEventListener("abort", abort, { once: true });
+    if (signal.aborted) abort();
+    try { await launch; }
+    finally { signal.removeEventListener("abort", abort); }
     for (let i = 0; i < 25; i++) {
+      signal.throwIfAborted();
       if (await socketAlive(STANDALONE_SOCKET)) break;
-      await new Promise((resolve) => setTimeout(resolve, 200));
+      await delay(200, undefined, { signal });
     }
   }
   if (!(await socketAlive(STANDALONE_SOCKET))) return null;
@@ -178,10 +196,11 @@ async function attachStandalone() {
   };
 }
 
-async function startEmbedded(binary) {
+async function startEmbedded(binary, signal) {
   // Import from the staged Resources tree in production. The app intentionally
   // excludes general node_modules, so a bare package import only works in dev.
   const sdk = await loadEmbeddedSdk();
+  signal.throwIfAborted();
   // CUA's embedding contract requires grants before the child daemon starts;
   // these SDK calls execute in Electron main so macOS attributes them to
   // OpenMausBot rather than to a terminal or helper process.
@@ -195,7 +214,8 @@ async function startEmbedded(binary) {
   }
   const host = new sdk.EmbeddedCuaDriverHost(binary, HOST_BUNDLE_ID);
   try {
-    const conn = await host.start();
+    const conn = await host.start({ signal });
+    signal.throwIfAborted();
     embeddedHost = host;
     return {
       mode: "embedded",
@@ -217,6 +237,9 @@ async function startEmbedded(binary) {
 
 export async function startCua() {
   if (process.platform === "linux") return ensureLinuxRuntime().initialize();
+  startupAbort?.abort();
+  startupAbort = new AbortController();
+  const { signal } = startupAbort;
   const binary = resolveDriverBinary();
   if (!binary) {
     return persistAndNotify({
@@ -231,9 +254,18 @@ export async function startCua() {
 
   if (wantEmbedded) {
     try {
-      nextConnection = await startEmbedded(binary);
+      nextConnection = await startEmbedded(binary, signal);
     } catch (err) {
-      nextConnection = await attachStandalone();
+      signal.throwIfAborted();
+      try {
+        nextConnection = await attachStandalone(signal);
+      } catch (standaloneError) {
+        signal.throwIfAborted();
+        nextConnection = {
+          mode: "unavailable",
+          reason: `embedded host failed: ${err?.message ?? err}; standalone launch failed: ${standaloneError?.message ?? standaloneError}`,
+        };
+      }
       if (!nextConnection) {
         nextConnection = {
           mode: "unavailable",
@@ -258,17 +290,20 @@ export async function startCua() {
     };
   }
 
+  signal.throwIfAborted();
   return persistAndNotify(nextConnection);
 }
 
-export function cuaPermissionsStatus() {
+export async function cuaPermissionsStatus() {
   const binary = resolveDriverBinary();
   if (!binary) return { available: false };
-  const out = spawnSync(binary, ["permissions", "status", "--json"], {
+  const out = await execFileAsync(binary, ["permissions", "status", "--json"], {
     encoding: "utf8",
     timeout: 5000,
+    killSignal: "SIGKILL",
+    maxBuffer: 65_536,
     env: { ...process.env, ...CUA_ENV },
-  });
+  }).catch((error) => ({ stdout: error.stdout }));
   try {
     return { available: true, ...JSON.parse(out.stdout) };
   } catch {
@@ -277,6 +312,8 @@ export function cuaPermissionsStatus() {
 }
 
 export async function stopCua() {
+  startupAbort?.abort();
+  startupAbort = null;
   if (linuxRuntime) {
     await linuxRuntime.shutdown();
     if (linuxBundleStage) {
@@ -285,16 +322,17 @@ export async function stopCua() {
     }
     return;
   }
-  if (embeddedHost) {
+  const host = embeddedHost;
+  embeddedHost = null;
+  if (host) {
     try {
-      await embeddedHost.stop();
-      embeddedHost.uniffiDestroy?.();
+      await host.stop();
+      host.uniffiDestroy?.();
     } catch {
       // daemon holds a parent-liveness pipe; host death closes it anyway
     }
-    embeddedHost = null;
   }
-  if (connectionStore.get()) {
+  if (!startupAbort && connectionStore.get()) {
     persistAndNotify({ mode: "unavailable", reason: "desktop-host-stopped" });
   }
 }

--- a/scripts/testing/stream-buffer-preview.tsx
+++ b/scripts/testing/stream-buffer-preview.tsx
@@ -1,0 +1,19 @@
+// Fixture-only probe of the real renderer store. The app's active-turn UI
+// shows presence rather than partial text; these outputs make both stream
+// channels observable without changing that product behavior.
+import { createRoot } from "react-dom/client";
+import { StoreProvider, useStore, useStreaming } from "../../src/state/store";
+
+function Probe() {
+  const { state } = useStore();
+  const stream = useStreaming();
+  const bot = state.bots[0];
+  return <>
+    <output id="ready">{String(state.connected && !!bot)}</output>
+    <output id="text">{bot && stream.streaming[bot.threadId]}</output>
+    <output id="reasoning">{bot && stream.reasoning[bot.threadId]}</output>
+    <output id="messages">{JSON.stringify(bot?.messages.filter((message) => message.role === "bot").map((message) => message.text) ?? [])}</output>
+  </>;
+}
+
+createRoot(document.getElementById("root")!).render(<StoreProvider><Probe /></StoreProvider>);

--- a/scripts/testing/stream-buffer.e2e.test.ts
+++ b/scripts/testing/stream-buffer.e2e.test.ts
@@ -1,0 +1,94 @@
+import { execFile } from "node:child_process";
+import { existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+import { expect, it } from "vitest";
+import { closeBrowserSession, resolveAgentBrowserBinary } from "../../server/browser-engine.ts";
+import { launchVerificationServer, runControlOmb } from "../control-omb.ts";
+import { ensureUiBrowser, sessionEnv, UI_TOOLS_DIR } from "./control-omb-ui.ts";
+import { fixtureApi, mountPreview, type MountedPreview } from "./preview-fixture.ts";
+
+const enabled = process.env.OMB_UI_E2E === "1" || !!resolveAgentBrowserBinary({ dataDir: UI_TOOLS_DIR, env: process.env });
+if (!enabled) console.info("skipping stream-buffer e2e: no agent-browser resolves; set OMB_UI_E2E=1 to install the pinned tools");
+const execFileAsync = promisify(execFile);
+
+it.skipIf(!enabled)("drains pending text and reasoning with rAF paused, then settles without duplicated output", async () => {
+  const { binary, chrome } = await ensureUiBrowser();
+  const fixture = await launchVerificationServer(process.env, undefined, undefined, { binaryPath: binary, executablePath: chrome ?? "" });
+  const env = sessionEnv({ home: fixture.info.dataDir, session: `omb-stream-${new URL(fixture.info.url).port}`, chrome });
+  const browser = async (...args: string[]) => {
+    const { stdout } = await execFileAsync(binary, [...args, "--json"], { env, timeout: 30_000, killSignal: "SIGKILL", maxBuffer: 1_048_576 });
+    const result = JSON.parse(stdout);
+    expect(result.success).toBe(true);
+    return result.data;
+  };
+  const control = (...args: string[]) => runControlOmb([...args, "--url", fixture.info.url]) as Promise<any>;
+  const evidence: unknown[] = [{ fixture: fixture.info }];
+  let preview: MountedPreview | undefined;
+  try {
+    const wrapper = join(fixture.info.dataDir, "gated-stream.mjs");
+    const gate = join(fixture.info.dataDir, "settle.gate");
+    // The existing fake CLI emits both delta channels. Hold only its final
+    // frames until the browser has observed the intermediate renderer state.
+    writeFileSync(wrapper, [
+      "#!/usr/bin/env node",
+      "import { existsSync } from 'node:fs';",
+      "if (process.argv.includes('--input-format')) {",
+      "process.env.FAKE_CLAUDE_MODE = 'stream';",
+      "process.env.FAKE_CLAUDE_TOOL_CALLS = '[]';",
+      "const write = process.stdout.write.bind(process.stdout);",
+      "const pending = []; let held = false;",
+      "process.stdout.write = (chunk) => {",
+      "const frame = JSON.parse(String(chunk));",
+      "if (held || frame.type === 'assistant') { held = true; pending.push(chunk); return true; }",
+      "return write(chunk); };",
+      `const timer = setInterval(() => { if (!existsSync(${JSON.stringify(gate)})) return;`,
+      "clearInterval(timer); process.stdout.write = write; for (const chunk of pending) write(chunk); }, 10);",
+      "}",
+      `await import(${JSON.stringify(pathToFileURL(join(process.cwd(), "server/testing/fake-claude-cli.ts")).href)});`,
+    ].join("\n"), { mode: 0o700 });
+    const api = fixtureApi(fixture.info.url);
+    await api("PATCH", "/api/instances/claude", { cli: wrapper });
+    const created = await control("new-bot", "--name", "Stream fixture");
+    const target = ["--bot", created.bot.id, "--task", created.bot.activeTaskId];
+    preview = await mountPreview(fixture, {
+      entry: "/scripts/testing/stream-buffer-preview.tsx", route: "/__stream-buffer.html",
+      title: "Isolated stream buffer", logLevel: "warn",
+    });
+    await browser("open", preview.previewUrl);
+    await browser("wait", "--fn", "document.querySelector('#ready')?.textContent === 'true'");
+    const before = await browser("eval", "JSON.parse(document.querySelector('#messages').textContent)");
+    const finalMessages = [...before.result, "hello from fake claude"];
+    await browser("eval", "window.requestAnimationFrame = () => 1; window.cancelAnimationFrame = () => {};");
+    await control("send", ...target, "--text", "Show the whole reply");
+    await browser("wait", "--fn", "document.querySelector('#text').textContent === 'hello from fake claude' && document.querySelector('#reasoning').textContent === 'hmm'");
+    const read = () => browser("eval", "({text: document.querySelector('#text').textContent, reasoning: document.querySelector('#reasoning').textContent, messages: JSON.parse(document.querySelector('#messages').textContent)})");
+    const intermediate = await read();
+    evidence.push({ intermediate });
+    expect(intermediate.result).toEqual({ text: "hello from fake claude", reasoning: "hmm", messages: before.result });
+    writeFileSync(gate, "settle");
+    const settled = await control("wait", ...target, "--timeout", "15");
+    expect(settled.status).toBe("settled");
+    await browser("wait", "--fn", `document.querySelector('#messages').textContent === ${JSON.stringify(JSON.stringify(finalMessages))} && document.querySelector('#text').textContent === '' && document.querySelector('#reasoning').textContent === ''`);
+    // Wait past the fallback timer: no cleared delta may reappear afterward.
+    await browser("eval", "new Promise(resolve => setTimeout(resolve, 250))");
+    const final = await read();
+    evidence.push({ settled, final, messages: await control("messages", ...target, "--limit", "10") });
+    expect(final.result).toEqual({ text: "", reasoning: "", messages: finalMessages });
+    const logs = await browser("console");
+    expect(logs.messages.filter((message: { type: string }) => message.type === "error")).toEqual([]);
+  } finally {
+    let browserClosed = false;
+    try { browserClosed = await closeBrowserSession(binary, env); }
+    finally {
+      try { await preview?.close(); }
+      finally { await fixture.close(); }
+    }
+    expect(browserClosed).toBe(true);
+    expect(existsSync(fixture.info.dataDir)).toBe(false);
+    const evidencePath = `${fixture.info.logPath}.stream.json`;
+    writeFileSync(evidencePath, JSON.stringify(evidence, null, 2));
+    console.info(JSON.stringify({ evidencePath, serverPid: fixture.info.pid, dataRemoved: true }));
+  }
+}, 120_000);

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   configStatusFromFrame,
+  createStreamDeltaBuffer,
   currentTaskBot,
   initialState,
   loadSnapshotBoundary,
@@ -20,6 +21,57 @@ import {
 } from "./store";
 import { openLiveEvents, type LiveEventSourceLike, type LiveEventsPlatform } from "../lib/live-events";
 import type { RoutineRun } from "../lib/routines";
+
+describe("stream delta flushing", () => {
+  afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); });
+  const prepare = () => {
+    vi.useFakeTimers();
+    const frames = new Map<number, FrameRequestCallback>();
+    let next = 0;
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => { frames.set(++next, callback); return next; });
+    vi.stubGlobal("cancelAnimationFrame", (id: number) => frames.delete(id));
+    const flushed = vi.fn();
+    return { buffer: createStreamDeltaBuffer(flushed), frames, flushed };
+  };
+
+  it("drains a paused animation frame on the timer without duplication", () => {
+    const { buffer, frames, flushed } = prepare();
+    buffer.push("a", "assistant_text", "hello");
+    buffer.push("a", "assistant_text", " world");
+    buffer.push("b", "reasoning_text", "thinking");
+    expect(flushed).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(100);
+    expect(flushed).toHaveBeenCalledExactlyOnceWith([
+      ["a", { text: "hello world", reasoning: "" }], ["b", { text: "", reasoning: "thinking" }],
+    ]);
+    expect(frames.size).toBe(0);
+    vi.advanceTimersByTime(1_000);
+    expect(flushed).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushes oversized chunks in full even when timers and frames are paused", () => {
+    const { buffer, flushed } = prepare();
+    const text = "🙂".repeat(40_000);
+    buffer.push("a", "assistant_text", text);
+    expect(flushed).toHaveBeenCalledExactlyOnceWith([["a", { text, reasoning: "" }]]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("clears only the settled task and cancels pending work on disposal", () => {
+    const { buffer, frames, flushed } = prepare();
+    buffer.push("a", "assistant_text", "already in transcript");
+    buffer.push("b", "assistant_text", "still streaming");
+    buffer.clear("a");
+    frames.values().next().value!(0);
+    expect(flushed).toHaveBeenCalledExactlyOnceWith([["b", { text: "still streaming", reasoning: "" }]]);
+    buffer.push("b", "reasoning_text", "unmounted");
+    buffer.dispose();
+    expect(frames.size).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+    vi.advanceTimersByTime(1_000);
+    expect(flushed).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("independent bot threads", () => {
   const bot: Bot = {

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -2039,6 +2039,59 @@ interface StreamState {
 const EMPTY_STREAM: StreamState = { streaming: {}, reasoning: {} };
 const StreamContext = createContext<StreamState>(EMPTY_STREAM);
 
+type PendingDelta = { text: string; reasoning: string };
+
+/** Paint once per frame, but keep draining when a hidden tab pauses rAF.
+ * Flush pending chunks at 64 Ki UTF-16 characters or a 100ms fallback timer.
+ * Accumulated output remains intact and unbounded; this is not a memory cap. */
+export function createStreamDeltaBuffer(onFlush: (entries: Array<[string, PendingDelta]>) => void) {
+  const buffer = new Map<string, PendingDelta>();
+  let frame: number | null = null;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let characters = 0;
+  const cancel = () => {
+    if (frame !== null) cancelAnimationFrame(frame);
+    frame = null;
+    clearTimeout(timer);
+    timer = undefined;
+  };
+  const flush = () => {
+    cancel();
+    if (!buffer.size) return;
+    const entries = [...buffer];
+    buffer.clear();
+    characters = 0;
+    onFlush(entries);
+  };
+  return {
+    push(threadId: string, kind: string, delta: string) {
+      if (kind !== "assistant_text" && kind !== "reasoning_text") return;
+      const entry = buffer.get(threadId) ?? { text: "", reasoning: "" };
+      if (kind === "assistant_text") entry.text += delta;
+      else entry.reasoning += delta;
+      buffer.set(threadId, entry);
+      characters += delta.length;
+      if (characters >= 64 * 1024) flush();
+      else if (frame === null) {
+        frame = requestAnimationFrame(flush);
+        timer = setTimeout(flush, 100);
+      }
+    },
+    clear(threadId: string) {
+      const entry = buffer.get(threadId);
+      if (entry) characters -= entry.text.length + entry.reasoning.length;
+      buffer.delete(threadId);
+      if (!buffer.size) cancel();
+    },
+    flush,
+    dispose() {
+      cancel();
+      buffer.clear();
+      characters = 0;
+    },
+  };
+}
+
 export function useStreaming() {
   return useContext(StreamContext);
 }
@@ -2067,8 +2120,18 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   // state is intentionally OUTSIDE the reducer so token frames re-render
   // only StreamContext consumers
   const [stream, setStream] = useState<StreamState>(EMPTY_STREAM);
-  const deltaBuffer = useRef(new Map<string, { text: string; reasoning: string }>());
-  const deltaFlush = useRef<number | null>(null);
+  const deltaBuffer = useMemo(() => createStreamDeltaBuffer((entries) => {
+    setStream((prev) => {
+      const streaming = { ...prev.streaming };
+      const reasoning = { ...prev.reasoning };
+      for (const [threadId, d] of entries) {
+        if (d.text) streaming[threadId] = (streaming[threadId] ?? "") + d.text;
+        if (d.reasoning) reasoning[threadId] = (reasoning[threadId] ?? "") + d.reasoning;
+      }
+      return { streaming, reasoning };
+    });
+  }), []);
+  const flushDeltas = deltaBuffer.flush;
   const clearStream = (threadId: string) => {
     // Drop the thread's un-flushed deltas too: the settled message that
     // triggered this clear already contains them. Without this, the pending
@@ -2077,30 +2140,11 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     // card looks glued to the top), keeps the caret blinking while the bot
     // is actually waiting, and the next block's deltas append onto the
     // duplicated tail instead of starting a fresh bubble.
-    deltaBuffer.current.delete(threadId);
+    deltaBuffer.clear(threadId);
     setStream((prev) => {
       if (!(threadId in prev.streaming) && !(threadId in prev.reasoning)) return prev;
       const { [threadId]: _s, ...streaming } = prev.streaming;
       const { [threadId]: _r, ...reasoning } = prev.reasoning;
-      return { streaming, reasoning };
-    });
-  };
-  const flushDeltas = () => {
-    if (deltaFlush.current !== null) {
-      cancelAnimationFrame(deltaFlush.current);
-      deltaFlush.current = null;
-    }
-    const buf = deltaBuffer.current;
-    if (buf.size === 0) return;
-    const entries = [...buf];
-    buf.clear();
-    setStream((prev) => {
-      const streaming = { ...prev.streaming };
-      const reasoning = { ...prev.reasoning };
-      for (const [threadId, d] of entries) {
-        if (d.text) streaming[threadId] = (streaming[threadId] ?? "") + d.text;
-        if (d.reasoning) reasoning[threadId] = (reasoning[threadId] ?? "") + d.reasoning;
-      }
       return { streaming, reasoning };
     });
   };
@@ -3037,20 +3081,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         case "runtime": {
           const event = frame.event;
           if (event.type === "content.delta") {
-            // Batch token deltas per animation frame (t3code-style): a fast
-            // stream dispatches once per frame instead of once per token, so
-            // the app tree re-renders at most ~60x/s while streaming.
-            const buf = deltaBuffer.current;
-            const entry = buf.get(event.threadId) ?? { text: "", reasoning: "" };
-            if (event.streamKind === "assistant_text") entry.text += event.delta;
-            else if (event.streamKind === "reasoning_text") entry.reasoning += event.delta;
-            buf.set(event.threadId, entry);
-            if (deltaFlush.current === null) {
-              deltaFlush.current = requestAnimationFrame(() => {
-                deltaFlush.current = null;
-                flushDeltas();
-              });
-            }
+            deltaBuffer.push(event.threadId, event.streamKind, event.delta);
           } else if (event.type === "turn.completed") {
             // flush any buffered tail before clearing so no tokens are lost
             flushDeltas();
@@ -3111,6 +3142,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     });
     return () => {
       alive = false;
+      deltaBuffer.dispose();
       clearTimeout(hydrationFallback);
       for (const refresh of peripheralRefresh.values()) {
         if (refresh.timer) clearTimeout(refresh.timer);


### PR DESCRIPTION
## What changes

Keep the desktop responsive during computer-driver startup and chat stream bursts.

- Replace blocking CUA launch/permission subprocess calls with bounded asynchronous execution.
- Cancel stalled native/standalone startup and prevent late cleanup from stopping or overwriting a replacement connection.
- Coalesce concurrent computer retries and cancel delayed restarts after Stop or quit.
- Drain pending text/reasoning deltas on an animation frame, a 100ms fallback, or a 65,536-character threshold. Hidden tabs no longer depend solely on animation frames to drain.
- Keep all output; the threshold bounds pending accumulation only, not the final response length.

No dependencies, draft eviction, UI redesign or output truncation. Cached startup/Linux ownership checks are covered by a blocking-call ratchet, not rewritten.

## Verification

- 138 targeted tests passed, 3 platform skips; typecheck and scoped lint passed.
- Real bounded timeout test confirms a stalled CUA launch command is killed without blocking the event loop.
- Startup/stop tests cover an SDK start pending until abort and late old-host cleanup after replacement.
- Final 39-test CUA/Electron rerun passed, including registered IPC handler regressions for concurrent retries, Stop during cleanup and Stop during stalled replacement startup.
- Isolated real StoreProvider/server-SSE fixture with animation frames paused observes intermediate text/reasoning, exactly one completed reply, and no duplicated tail.
- Real Electron MCP proxy checks passed. Recipes/evidence limits documented under docs/verification.

No live app, user data, or native permission prompts used. Draft retention/eviction is deliberately unchanged.
