### PR TITLE
fix(atomic): retry a rename Windows refuses for a moment

### DIFF
--- a/server/atomic.test.ts
+++ b/server/atomic.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { writeFileAtomic } from "./atomic.ts";
+import { renameWithRetry, writeFileAtomic } from "./atomic.ts";
 
 describe("writeFileAtomic", () => {
   let dir: string;
@@ -58,5 +58,54 @@ describe("writeFileAtomic", () => {
     mkdirSync(p);
     expect(() => writeFileAtomic(p, "cannot replace a directory")).toThrow();
     expect(readdirSync(dir)).toEqual(["target"]);
+  });
+});
+
+// Windows refuses a rename onto an existing path while anything else holds a
+// handle to either file, and a virus scanner or the search indexer opening a
+// just-closed file for a few milliseconds is enough. Callers treat a throw here
+// as a failed save, so a transient error used to lose the write.
+describe("renameWithRetry", () => {
+  function failing(times: number, code: string) {
+    let calls = 0;
+    return {
+      get calls() {
+        return calls;
+      },
+      rename: () => {
+        calls += 1;
+        if (calls <= times) throw Object.assign(new Error(`${code}: simulated`), { code });
+      },
+    };
+  }
+
+  it("survives a transient EPERM instead of losing the write", () => {
+    const stub = failing(3, "EPERM");
+    expect(() => renameWithRetry("a.tmp", "a", stub.rename)).not.toThrow();
+    expect(stub.calls).toBe(4);
+  });
+
+  it("retries EACCES and EBUSY the same way", () => {
+    for (const code of ["EACCES", "EBUSY"]) {
+      const stub = failing(1, code);
+      expect(() => renameWithRetry("a.tmp", "a", stub.rename)).not.toThrow();
+      expect(stub.calls).toBe(2);
+    }
+  });
+
+  it("gives up rather than retrying forever", () => {
+    const stub = failing(Number.MAX_SAFE_INTEGER, "EPERM");
+    expect(() => renameWithRetry("a.tmp", "a", stub.rename)).toThrow(/EPERM/);
+    expect(stub.calls).toBe(6); // first attempt plus five backoffs
+  });
+
+  it("does not retry an error that will never clear", () => {
+    // Busy-waiting on a missing directory or a cross-device rename would hide
+    // a real bug behind a delay and still fail.
+    for (const code of ["ENOENT", "EXDEV", "EISDIR"]) {
+      const stub = failing(Number.MAX_SAFE_INTEGER, code);
+      expect(() => renameWithRetry("a.tmp", "a", stub.rename)).toThrow(new RegExp(code));
+      expect(stub.calls).toBe(1);
+    }
   });
 });

--- a/server/atomic.ts
+++ b/server/atomic.ts
@@ -7,6 +7,47 @@
 import { randomUUID } from "node:crypto";
 import { closeSync, fsyncSync, openSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 
+/** Windows refuses a rename onto an existing path while anything else holds a
+ * handle to either file, and a virus scanner or the search indexer opening a
+ * just-closed file for a few milliseconds is enough. It surfaces as EPERM or
+ * EACCES from an operation that is correct and would succeed a moment later —
+ * so it is retried rather than reported. Everything else throws immediately;
+ * a real permission problem must not be papered over by a busy-wait.
+ *
+ * Total worst case is ~155 ms across 6 attempts. Kept synchronous because
+ * every caller is a synchronous save path, and making one of them async is a
+ * much larger change than this bug warrants.
+ *
+ * ponytail: fixed backoff, no jitter. If contention turns out to be heavy
+ * enough that these collide, jitter it then. */
+const RENAME_RETRY_DELAYS_MS = [5, 10, 20, 40, 80];
+const RETRYABLE_RENAME_CODES = new Set(["EPERM", "EACCES", "EBUSY"]);
+
+function sleepSync(ms: number): void {
+  // No synchronous sleep in Node without a syscall: a zero-length read on a
+  // shared array with a timeout is the standard trick and does not spin the CPU.
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/** `rename` is injectable for tests only — there is no portable way to make a
+ * real filesystem produce a transient EPERM on demand. */
+export function renameWithRetry(
+  tmp: string,
+  path: string,
+  rename: (from: string, to: string) => void = renameSync,
+): void {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      rename(tmp, path);
+      return;
+    } catch (e) {
+      const code = (e as { code?: string }).code;
+      if (!code || !RETRYABLE_RENAME_CODES.has(code) || attempt >= RENAME_RETRY_DELAYS_MS.length) throw e;
+      sleepSync(RENAME_RETRY_DELAYS_MS[attempt]!);
+    }
+  }
+}
+
 export function writeFileAtomic(path: string, data: string, options: { mode?: number } = {}): void {
   const tmp = `${path}.${process.pid}.${randomUUID()}.tmp`;
   let fd: number | null = null;
@@ -19,7 +60,7 @@ export function writeFileAtomic(path: string, data: string, options: { mode?: nu
     fsyncSync(fd);
     closeSync(fd);
     fd = null;
-    renameSync(tmp, path);
+    renameWithRetry(tmp, path);
   } catch (e) {
     if (fd !== null) {
       try {


### PR DESCRIPTION
On Windows, `renameSync` in `writeFileAtomic` can throw `EPERM` (or `EACCES`/`EBUSY`) even though the rename is otherwise correct. Windows refuses a rename onto an existing path while anything else still holds a handle to either file, and a virus scanner or the search indexer briefly opening a just-closed file is enough to trigger it. Every caller treats a throw here as a failed save, so a purely transient lock could lose a write — and through an HTTP handler it didn't even look like a filesystem issue (e.g. an import endpoint would just return a 500).

This adds `renameWithRetry`, which retries `EPERM`/`EACCES`/`EBUSY` with a short fixed backoff (5, 10, 20, 40, 80 ms — six attempts, ~155 ms worst case) before giving up. Every other error code still throws immediately: retrying a missing directory or a cross-device rename would just hide a real bug behind a delay and fail anyway.

Kept synchronous, since every caller here is a synchronous save path — making one of them async would be a much bigger change than this warrants. `rename` is injectable so tests can simulate a transient `EPERM` without needing a real filesystem race.

Tests added in `server/atomic.test.ts` cover: a transient `EPERM` succeeding after retries, `EACCES`/`EBUSY` handled the same way, giving up after six attempts, and `ENOENT`/`EXDEV`/`EISDIR` not being retried at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDxACCHTR4dJELExVRvEMo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of atomic file updates on Windows when temporary file locks briefly prevent renaming.
  - Transient permission and file-in-use errors are now retried automatically, while permanent errors continue to fail immediately.
  - Operations now stop retrying after the configured limit and report the underlying error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->