### PR TITLE
fix(pnpm): move supportedArchitectures where pnpm 10 reads it

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,13 +117,5 @@
     "vite": "^7.1.0",
     "vitest": "^4.1.10",
     "wrangler": "4.123.0"
-  },
-  "pnpm": {
-    "supportedArchitectures": {
-      "cpu": [
-        "arm64",
-        "x64"
-      ]
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,13 @@ packages:
   - "."
   - "apps/docs"
   - "cloudflare/control-plane"
+# Packaging fetches optional binaries for both desktop CPU targets. This lived
+# in package.json's "pnpm" field, which pnpm 10.33 ignores — it printed a
+# warning on every command and, more to the point, silently was not applied.
+supportedArchitectures:
+  cpu:
+    - arm64
+    - x64
 allowBuilds:
   electron: true # postinstall downloads the Electron dist
   esbuild: true # postinstall validates the platform binary


### PR DESCRIPTION
pnpm 10.33 no longer reads the `pnpm` field in `package.json`. With `supportedArchitectures` declared there, every command printed:

```
The "pnpm" field in package.json is no longer read by pnpm. The following
keys were ignored: "pnpm.supportedArchitectures".
```

That warning was the visible half of the problem. The real half is that this project fetches optional binaries for both `arm64` and `x64` desktop targets, and that setting had been silently inert since upgrading to pnpm 10 — not just misplaced.

This moves `supportedArchitectures` into `pnpm-workspace.yaml`, which is where pnpm 10 actually reads it. `pnpm install` now runs without the warning, and the lockfile is untouched (nothing resolves differently, it's purely a config relocation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDxACCHTR4dJELExVRvEMo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected package configuration so optional binaries are fetched for both ARM64 and x64 desktop systems.
  - Prevented the supported CPU architecture setting from being ignored by the package manager.
  - Removed the related configuration warning during dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->