### PR TITLE
fix: Grok images, Claude authentication and thread approvals

### DIFF
--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -116,6 +116,10 @@ responsive layouts, theme contrast, and status refreshes without losing drafts.
 The [Claude account recipe](claude-account.md) checks sign-out, cancellation and
 retry against an offline Claude CLI confined to a disposable home.
 
+The [provider recovery recipe](provider-recovery.md) verifies real Grok image
+transport and Claude authentication against loopback APIs, plus scoped thread
+approvals and provider safety errors in an isolated desktop UI.
+
 The [Codex account recipe](codex-account.md) checks account switching against an
 offline Codex CLI whose identity is synthetic and whose credential directory is empty.
 

--- a/docs/verification/provider-recovery.md
+++ b/docs/verification/provider-recovery.md
@@ -1,0 +1,80 @@
+# Provider images, authentication and thread approvals
+
+Every command below uses a disposable home. No real account, API key,
+provider charge, deployment, or running OpenMausBot workspace is involved.
+
+## Real CLI transport checks
+
+Pass the path to an already installed CLI. These checks never update it.
+
+```sh
+node --experimental-strip-types scripts/verify-grok-images.ts /absolute/path/to/grok
+node --experimental-strip-types scripts/verify-claude-auth-settings.ts /absolute/path/to/claude
+node --experimental-strip-types scripts/verify-claude-auth-settings.ts /absolute/path/to/claude --api-key
+```
+
+- Grok must deliver the **exact** synthetic PNG bytes to a loopback model.
+  Grok 1.0.25 advertises `image:false` despite accepting native ACP image
+  blocks. OMB enables that verified compatibility path only for official
+  1.0.x runtimes from 1.0.25 onward; other runtimes must negotiate image
+  input normally. The fixture uses a valid 32×32 PNG because Grok rejects
+  images below 8 pixels per axis or 512 total pixels.
+- Claude must complete **two** turns using the selected account's personal
+  `apiKeyHelper`, and again with `settings.json`'s API key. All authenticated
+  model requests go to the fake local Anthropic endpoint. An unrelated
+  personal SessionStart hook must not run. OMB retains project settings but
+  projects only account authentication from personal settings. Explicit OMB
+  credentials/endpoints take precedence as a pair.
+
+These prove transport/auth integration, not hosted image interpretation,
+subscription entitlement, Console-profile availability, or production API
+uptime. If Claude still reports signed out, compare its `/status` Profile
+and the account selected in OMB; never request the user's keys or tokens.
+
+## Isolated server and real UI
+
+```sh
+pnpm exec electron scripts/smoke-approval-modes.cjs --ui
+```
+
+The real server runs under Electron's private utility-process channel with
+fake Claude, Codex, Grok and Antigravity providers. Assertions cover:
+
+- Changing a bot's default to Full leaves existing Ask threads unchanged.
+- Explicitly applying that approved default changes only the selected thread.
+- Direct HTTP elevation, unknown threads, unapproved defaults and threads
+  using a different provider are rejected.
+- The updated conversation uses the provider's native Full mode; unrelated
+  conversations remain Ask. Delegation never borrows the sender's authority.
+- Auto-accept edits works only for providers that implement that mode.
+- The real composer opens a scoped warning with Cancel focused. Cancel does
+  not send a grant; confirmation changes server state through the private
+  channel and updates the composer through SSE. A subsequent message completes.
+- At 390px the new control and confirmation remain usable. The provider
+  safety error explains the restriction and does not offer Retry.
+
+For a UI-only rerun use `--ui-only` instead of `--ui`. Screenshots are written
+to `.omb-scratch/verify-evidence/provider-fixes/`. The fixture exits and removes
+its own disposable server/browser data; the screenshots remain.
+
+## Regression checks
+
+```sh
+pnpm exec vitest run server/drivers/acp/acp.test.ts server/drivers/claude.test.ts server/drivers/claude-auth.test.ts server/drivers/codex.test.ts server/drivers/retry.test.ts server/store.test.ts src/components/ChatView.controls.test.ts
+node --test electron/approval-trusted-mode.node-test.mjs
+pnpm typecheck
+pnpm lint
+```
+
+The tests also cover image-byte redaction, unknown ACP runtimes, private
+authentication-file permissions and cleanup, explicit credential precedence,
+authentication rotation on retained sessions, crash recovery at every grant
+phase, and safety failures delivered as RPC errors or completion events.
+
+Codex safety monitoring is independent of tool approval settings. This change
+preserves the actual provider error, prevents automatic replay, and explains
+the distinction; it does **not** bypass provider safety or claim to fix an
+unseen deployment refusal. See the [official Codex safety guidance](https://learn.chatgpt.com/docs/agent-approvals-security#safety-monitoring-and-paused-tasks).
+
+Grok's upstream image ingestion is in [its ACP prompt builder](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-shell/src/session/acp_session_impl/prompt_build.rs).
+Claude's account settings are documented in [Claude Code settings](https://code.claude.com/docs/en/settings).

--- a/electron/approval-trusted-mode.cjs
+++ b/electron/approval-trusted-mode.cjs
@@ -8,7 +8,7 @@ function plainObject(value) {
   return value && typeof value === "object" && !Array.isArray(value);
 }
 
-function trustedApprovalModeRequest(requestId, botId, mode, acknowledgeLocalAuto = false) {
+function trustedApprovalModeRequest(requestId, botId, mode, acknowledgeLocalAuto = false, threadId) {
   if (typeof requestId !== "string" || !REQUEST_ID.test(requestId)) {
     throw new Error("invalid trusted approval-mode request id");
   }
@@ -19,12 +19,16 @@ function trustedApprovalModeRequest(requestId, botId, mode, acknowledgeLocalAuto
   if (typeof acknowledgeLocalAuto !== "boolean") {
     throw new Error("invalid local Auto acknowledgement");
   }
+  if (threadId !== undefined && (typeof threadId !== "string" || !BOT_ID.test(threadId) || (mode !== "full" && mode !== "custom"))) {
+    throw new Error("invalid thread for trusted approval mode");
+  }
   return {
     type: "approval-trusted-mode-set",
     requestId,
     botId,
     mode,
     ...(acknowledgeLocalAuto ? { acknowledgeLocalAuto: true } : {}),
+    ...(threadId !== undefined ? { threadId } : {}),
   };
 }
 
@@ -104,8 +108,8 @@ function createTrustedApprovalModeCoordinator({ randomId, timeoutMs = 10_000 } =
   const usedRequestIds = new Set();
   const latestRequestByBot = new Map();
 
-  function nextMessage(botId, mode, acknowledgeLocalAuto = false) {
-    const message = trustedApprovalModeRequest(randomId(), botId, mode, acknowledgeLocalAuto);
+  function nextMessage(botId, mode, acknowledgeLocalAuto = false, threadId) {
+    const message = trustedApprovalModeRequest(randomId(), botId, mode, acknowledgeLocalAuto, threadId);
     if (usedRequestIds.has(message.requestId)) {
       throw new Error("Trusted approval-mode request id was reused");
     }
@@ -128,7 +132,7 @@ function createTrustedApprovalModeCoordinator({ randomId, timeoutMs = 10_000 } =
     }
     let message;
     try {
-      message = nextMessage(botId, mode, options.acknowledgeLocalAuto ?? false);
+      message = nextMessage(botId, mode, options.acknowledgeLocalAuto ?? false, options.threadId);
     } catch (error) {
       return Promise.reject(error);
     }

--- a/electron/approval-trusted-mode.node-test.mjs
+++ b/electron/approval-trusted-mode.node-test.mjs
@@ -26,6 +26,11 @@ function fakeProcess() {
 }
 
 test("builds only bounded bot-scoped approval-mode requests", () => {
+  assert.equal(trustedApprovalModeRequest(REQUEST_ID, "bot-1", "full", false, "thread-1").threadId, "thread-1");
+  for (const threadId of ["", "../another-thread", null, 42]) {
+    assert.throws(() => trustedApprovalModeRequest(REQUEST_ID, "bot-1", "full", false, threadId), /invalid thread/);
+  }
+  assert.throws(() => trustedApprovalModeRequest(REQUEST_ID, "bot-1", "ask", false, "thread-1"), /invalid thread/);
   assert.deepEqual(trustedApprovalModeRequest(REQUEST_ID, "bot-1", "full"), {
     type: "approval-trusted-mode-set",
     requestId: REQUEST_ID,

--- a/scripts/smoke-approval-modes.cjs
+++ b/scripts/smoke-approval-modes.cjs
@@ -106,6 +106,10 @@ app.whenReady().then(async () => {
     return { status: response.status, body: await response.json() };
   };
   await until(() => api("/api/health").catch(() => null));
+  const verifyUi = () => require("./testing/approval-ui-smoke.cjs")({ root, url: `http://127.0.0.1:${port}`, api, until,
+    grant: (botId, mode, options) => coordinator.request(child, botId, mode, options),
+  });
+  if (process.argv.includes("--ui-only")) { await verifyUi(); return; }
   const created = await api("/api/bots", "POST", { modelSelection: { instanceId: "claude", model: "claude-sonnet-5" } });
   assert.equal(created.status, 201);
   const id = created.body.bot.id;
@@ -121,6 +125,40 @@ app.whenReady().then(async () => {
     console.log(JSON.stringify({ mode, native, privateGrant: true, turnSettled: true }));
   }
   await assert.rejects(coordinator.request(child, id, "custom"), /only for Codex/);
+  // Existing conversations retain their snapshot when the bot default
+  // changes. Only an explicit private desktop grant may upgrade one thread.
+  for (const [instanceId, model] of [["claude", "claude-sonnet-5"], ["codex", "gpt-6-astra"], ["grok-reads", "grok-4.6"], ["agy", "gemini-3.8-flash-high"]]) {
+    const scoped = (await api("/api/bots", "POST", { name: "Existing thread", modelSelection: { instanceId, model } })).body.bot;
+    await coordinator.request(child, scoped.id, "ask");
+    const old = (await api(`/api/bots/${scoped.id}/tasks`, "POST", { title: "Existing Ask thread" })).body.task;
+    const other = (await api(`/api/bots/${scoped.id}/tasks`, "POST", { title: "Leave this thread alone" })).body.task;
+    assert.ok(old?.threadId && other?.threadId);
+    await assert.rejects(coordinator.request(child, scoped.id, "full", { threadId: old.threadId }), /bot settings/);
+    await coordinator.request(child, scoped.id, "full");
+    const readScoped = async () => (await api("/api/bots?messages=0")).body.bots.find((bot) => bot.id === scoped.id);
+    await until(async () => (await readScoped()).approvalMode === "full");
+    if (instanceId === "claude") {
+      assert.equal((await api(`/api/bots/${scoped.id}/tasks/${other.threadId}`, "PATCH", { approvalMode: "edits" })).status, 200);
+      await api(`/api/bots/${scoped.id}/tasks/${other.threadId}`, "PATCH", { approvalMode: "ask", modelSelection: { instanceId: "codex", model: "gpt-6-astra" } });
+      await assert.rejects(coordinator.request(child, scoped.id, "full", { threadId: other.threadId }), /bot's provider/);
+      assert.equal((await api(`/api/bots/${scoped.id}/tasks/${other.threadId}`, "PATCH", { approvalMode: "edits" })).status, 400);
+    }
+    assert.equal((await readScoped()).tasks.find((task) => task.threadId === old.threadId).approvalMode, "ask");
+    assert.equal((await api(`/api/bots/${scoped.id}/tasks/${old.threadId}`, "PATCH", { approvalMode: "full" })).status, 403);
+    await coordinator.request(child, scoped.id, "full", { threadId: old.threadId });
+    await until(async () => (await readScoped()).tasks.find((task) => task.threadId === old.threadId).approvalMode === "full");
+    assert.equal((await readScoped()).tasks.find((task) => task.threadId === other.threadId).approvalMode, "ask");
+    await assert.rejects(coordinator.request(child, scoped.id, "full", { threadId: "missing-thread" }), /bot settings/);
+    const sent = await api(`/api/bots/${scoped.id}/messages`, "POST", { text: "Verify existing thread Full", threadId: old.threadId });
+    assert.equal(sent.status, 202);
+    await until(async () => !(await readScoped()).tasks.find((task) => task.threadId === old.threadId).busy);
+    const source = instanceId === "claude" ? dump : instanceId === "codex" ? codexDump : instanceId === "agy" ? agyDump : grokDump;
+    const seen = JSON.parse(readFileSync(source, "utf8"));
+    if (instanceId === "claude") assert.equal(seen.argv[seen.argv.indexOf("--permission-mode") + 1], "bypassPermissions");
+    if (instanceId === "grok-reads") assert.equal(seen.argv[seen.argv.indexOf("--permission-mode") + 1], "bypassPermissions");
+    if (instanceId === "codex") assert.equal(seen.calls.find((call) => call.method === "turn/start").params.approvalPolicy, "never");
+    console.log(JSON.stringify({ provider: instanceId, existingThread: "full", otherThread: "ask", privateGrant: true, turnSettled: true }));
+  }
   const pendingCard = (bot) => bot.messages.find((message) => message.card?.requestId && !message.card.answered && !message.card.dismissed)?.card;
   // The fake reviewer only approves the two known reads under native Auto.
   // Their actual MCP calls reach this real isolated server. This verifies the
@@ -208,7 +246,10 @@ app.whenReady().then(async () => {
   // The test-only capability drives the real peer dispatch route without
   // introducing another fake-agent workflow or weakening production auth.
   const peerTarget = (await api("/api/bots", "POST", { modelSelection: { instanceId: "agy", model: "gemini-3.8-flash-high" } })).body.bot;
+  await coordinator.request(child, peerTarget.id, "ask");
+  const peerThread = (await api(`/api/bots/${peerTarget.id}/tasks`, "POST", { title: "Existing delegated conversation" })).body.task;
   await coordinator.request(child, peerTarget.id, "full");
+  await coordinator.request(child, peerTarget.id, "full", { threadId: peerThread.threadId });
   assert.equal((await api(`/api/bots/${id}`, "PATCH", { approvePeerComms: false })).status, 200);
   const capability = await api("/api/testing/internal-capability", "POST", { botId: id, threadId: created.body.bot.threadId }, { "x-openmausbot-test-capability": testCapabilityKey });
   assert.equal(capability.status, 201);
@@ -226,10 +267,11 @@ app.whenReady().then(async () => {
   assert.equal(peerCalls.find((call) => call.params.configId === "mode")?.params.value, "yolo");
   console.log(JSON.stringify({ provider: "antigravity", mode: "full", peerInitiated: true, native: "yolo", autoApproved: true, humanApproved: false }));
 
-  // Revoking the receiving bot's grant must restore prompts on the resumed
+  // Revoking the receiving thread's grant must restore prompts on the resumed
   // delegated session, even when the sender itself has Full access.
   await coordinator.request(child, id, "full");
   await coordinator.request(child, peerTarget.id, "ask");
+  assert.equal((await api(`/api/bots/${peerTarget.id}/tasks/${peerThread.threadId}`, "PATCH", { approvalMode: "ask" })).status, 200);
   const askPeerRequest = api("/api/internal/ask-bot", "POST", { toBotId: peerTarget.id, message: "Ask target must not inherit sender Full" }, { authorization: `Bearer ${capability.body.token}` });
   void askPeerRequest.catch(() => {});
   const peerCard = await until(async () => pendingCard((await api("/api/bots")).body.bots.find((bot) => bot.id === peerTarget.id)));
@@ -252,6 +294,9 @@ app.whenReady().then(async () => {
   const customCalls = JSON.parse(readFileSync(codexDump, "utf8")).calls;
   assert.equal(customCalls.find((call) => call.method === "turn/start")?.params.approvalsReviewer, "auto_review");
   console.log(JSON.stringify({ provider: "codex", mode: "custom", peerInitiated: true, effectiveMode: "auto", nativeApprovalShown: true }));
+  if (process.argv.includes("--ui")) {
+    await verifyUi();
+  }
   console.log("Approval smoke passed; HTTP elevation rejected, private grant and resumed mode transitions verified.");
 }).catch((error) => {
   console.error(error);

--- a/scripts/testing/approval-preview-preload.cjs
+++ b/scripts/testing/approval-preview-preload.cjs
@@ -1,0 +1,13 @@
+const { contextBridge, ipcRenderer } = require("electron");
+// Only used by the disposable smoke window, never by the packaged app.
+contextBridge.exposeInMainWorld("ogb", {
+  platform: process.platform,
+  getCapabilities: async () => ({
+    host: { platform: process.platform, label: "Fixture", session: "unknown", packaged: true },
+    windowChrome: "native",
+    screenPreview: { available: false, interaction: "none" },
+    dictation: { available: false, engine: "none", onDevice: false },
+    localComputer: { available: false, support: "unsupported", enabled: false, status: "unavailable" },
+  }),
+  approvals: { setMode: (botId, mode, options) => ipcRenderer.invoke("fixture:thread-approval", botId, mode, options) },
+});

--- a/scripts/testing/approval-ui-smoke.cjs
+++ b/scripts/testing/approval-ui-smoke.cjs
@@ -1,0 +1,65 @@
+const { BrowserWindow, ipcMain } = require("electron");
+const assert = require("node:assert/strict");
+const { mkdirSync, writeFileSync } = require("node:fs");
+const { join } = require("node:path");
+const { pathToFileURL } = require("node:url");
+
+module.exports = async function verifyApprovalUi({ root, url, api, until, grant }) {
+  const { mountPreview } = await import(pathToFileURL(join(root, "scripts/testing/preview-fixture.ts")).href);
+  const bot = (await api("/api/bots", "POST", { name: "Thread permission fixture", modelSelection: { instanceId: "claude", model: "claude-sonnet-5" } })).body.bot;
+  await grant(bot.id, "ask");
+  const old = (await api(`/api/bots/${bot.id}/tasks`, "POST", { title: "Existing conversation" })).body.task;
+  await grant(bot.id, "full");
+  const readMode = async () => (await api("/api/bots?messages=0")).body.bots.find(candidate => candidate.id === bot.id).tasks.find(task => task.threadId === old.threadId).approvalMode;
+  const preview = await mountPreview({ info: { url } }, { entry: "/src/testing/thread-approvals.tsx", route: "/__thread-approvals.html", title: "Isolated thread approvals", logLevel: "silent" });
+  const window = new BrowserWindow({ show: false, width: 1100, height: 800, webPreferences: { preload: join(root, "scripts/testing/approval-preview-preload.cjs"), contextIsolation: true, sandbox: true } });
+  let calls = 0;
+  ipcMain.handle("fixture:thread-approval", (event, botId, mode, options) => {
+    assert.equal(event.sender, window.webContents);
+    assert.equal(botId, bot.id);
+    assert.equal(mode, "full");
+    assert.deepEqual(options, { threadId: old.threadId });
+    calls++;
+    return grant(botId, mode, options);
+  });
+  const evaluate = js => window.webContents.executeJavaScript(js);
+  const text = () => evaluate("document.body.innerText");
+  const click = name => evaluate(`(() => { const button = [...document.querySelectorAll('button')].find(b => b.textContent.trim() === ${JSON.stringify(name)}); if (!button || button.disabled) throw new Error('Missing enabled button'); button.click(); return true; })()`);
+  const evidence = join(root, ".omb-scratch/verify-evidence/provider-fixes");
+  mkdirSync(evidence, { recursive: true });
+  try {
+    await window.loadURL(`${preview.previewUrl}?bot=${bot.id}`);
+    await until(async () => (await text()).includes("Use bot’s Full access for this thread"));
+    assert.ok((await text()).includes("Full access controls tool approvals, not provider safety checks"));
+    assert.equal(await evaluate("[...document.querySelectorAll('button')].some(b => b.textContent.trim() === 'Retry')"), false);
+    await click("Use bot’s Full access for this thread");
+    await until(async () => (await text()).includes("Other existing threads keep their approval levels"));
+    assert.equal(await evaluate("document.activeElement.textContent.trim()"), "Cancel");
+    await click("Cancel");
+    assert.equal(calls, 0);
+    assert.equal(await readMode(), "ask");
+    window.setSize(390, 844);
+    await until(async () => await evaluate("innerWidth") === 390);
+    writeFileSync(join(evidence, "narrow.png"), (await window.webContents.capturePage()).toPNG());
+    await until(() => evaluate("document.documentElement.scrollWidth <= innerWidth"));
+    await click("Use bot’s Full access for this thread");
+    await until(async () => (await text()).includes("Enable Full access?"));
+    writeFileSync(join(evidence, "confirmation.png"), (await window.webContents.capturePage()).toPNG());
+    await click("Enable full access");
+    await until(async () => await readMode() === "full");
+    await until(async () => !(await text()).includes("Use bot’s Full access for this thread"));
+    assert.equal(calls, 1);
+    await evaluate("document.querySelector('textarea').focus(); true");
+    window.webContents.insertText("Run the safe fixture");
+    window.webContents.sendInputEvent({ type: "keyDown", keyCode: "Return" });
+    window.webContents.sendInputEvent({ type: "keyUp", keyCode: "Return" });
+    await until(async () => (await text()).includes("hello from fake claude"));
+    window.setSize(1100, 800);
+    writeFileSync(join(evidence, "applied.png"), (await window.webContents.capturePage()).toPNG());
+    console.log(JSON.stringify({ ui: true, cancelPreservedAsk: true, confirmedThreadFull: true, sentAfterGrant: true, narrowLayout: true, safetyGuidance: true, evidence }));
+  } finally {
+    ipcMain.removeHandler("fixture:thread-approval");
+    window.destroy();
+    await preview.close();
+  }
+};

--- a/scripts/verify-claude-auth-settings.ts
+++ b/scripts/verify-claude-auth-settings.ts
@@ -1,0 +1,76 @@
+// Real Claude CLI through the OMB driver, synthetic account and loopback API.
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const cli = resolve(process.argv[2] ?? "");
+const apiKey = process.argv.includes("--api-key");
+assert.ok(process.argv[2], "Pass the absolute Claude CLI path");
+const home = mkdtempSync(join(tmpdir(), "omb-claude-auth-fixture-"));
+const account = join(home, ".claude");
+const workspace = join(home, "workspace");
+mkdirSync(account);
+mkdirSync(workspace);
+process.env = {
+  HOME: home, USERPROFILE: home, XDG_CONFIG_HOME: join(home, ".config"),
+  PATH: process.env.PATH, OMB_DATA_DIR: join(home, "omb"),
+  CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+  DISABLE_TELEMETRY: "1", DISABLE_ERROR_REPORTING: "1",
+  ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
+};
+const requests: { authenticated: boolean; model: string }[] = [];
+const server = createServer(async (req, res) => {
+  let body = "";
+  for await (const chunk of req) body += chunk;
+  if (req.url?.includes("count_tokens")) {
+    res.writeHead(200, { "Content-Type": "application/json" }).end('{"input_tokens":10}');
+    return;
+  }
+  if (req.method !== "POST" || !req.url?.startsWith("/v1/messages")) { res.writeHead(404).end(); return; }
+  const payload = JSON.parse(body);
+  requests.push({ authenticated: req.headers["x-api-key"] === "fixture-only-key" || req.headers.authorization === "Bearer fixture-only-key", model: payload.model });
+  const response = { id: "msg_fixture", type: "message", role: "assistant", model: payload.model, content: [{ type: "text", text: "Offline authentication works." }], stop_reason: "end_turn", stop_sequence: null, usage: { input_tokens: 10, output_tokens: 5 } };
+  if (!payload.stream) { res.writeHead(200, { "Content-Type": "application/json" }).end(JSON.stringify(response)); return; }
+  const events = [
+    { type: "message_start", message: { ...response, content: [], stop_reason: null } },
+    { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+    { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Offline authentication works." } },
+    { type: "content_block_stop", index: 0 },
+    { type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 5 } },
+    { type: "message_stop" },
+  ];
+  res.writeHead(200, { "Content-Type": "text/event-stream" });
+  res.end(events.map(event => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join(""));
+});
+await new Promise<void>(done => server.listen(0, "127.0.0.1", done));
+const port = (server.address() as { port: number }).port;
+writeFileSync(join(account, "settings.json"), JSON.stringify({
+  ...(!apiKey ? { apiKeyHelper: "echo fixture-only-key" } : {}),
+  env: { ANTHROPIC_BASE_URL: `http://127.0.0.1:${port}`, ...(apiKey ? { ANTHROPIC_API_KEY: "fixture-only-key" } : {}) },
+  hooks: { SessionStart: [{ hooks: [{ type: "command", command: `${JSON.stringify(process.execPath)} -e "require('fs').writeFileSync('hook-ran', 'unexpected')"` }] }] },
+}), { mode: 0o600 });
+const { ensureDirs } = await import("../server/config.ts");
+ensureDirs();
+const { ClaudeDriver } = await import("../server/drivers/claude.ts");
+const { recordEvents } = await import("../server/testing/events.ts");
+const provider = await ClaudeDriver.create({ instanceId: "fixture", displayName: "Offline Claude", enabled: true, environment: {}, config: { cli, configDir: account, permissionMode: "acceptEdits", tools: [] } });
+const recorder = recordEvents(provider.adapter);
+try {
+  for (let i = 0; i < 2; i++) {
+    const { turnId } = await provider.adapter.sendTurn({ threadId: "fixture-thread", text: "Reply briefly. No tools.", cwd: workspace, model: "claude-sonnet-4-6", approvalMode: "ask" });
+    const done = await recorder.until(event => event.type === "turn.completed" && event.turnId === turnId, 40_000);
+    assert.equal((done as { ok: boolean }).ok, true, JSON.stringify(recorder.events.filter(event => event.type === "runtime.error")));
+  }
+  assert.ok(requests.length >= 2);
+  assert.ok(requests.every(request => request.authenticated));
+  assert.equal(existsSync(join(workspace, "hook-ran")), false, "Personal hooks must stay isolated");
+  console.log(JSON.stringify({ ok: true, turns: 2, authentication: apiKey ? "settings env key" : "apiKeyHelper", authenticated: true, settingsIsolated: true, endpoint: "loopback only" }));
+} finally {
+  recorder.stop();
+  await provider.dispose();
+  server.closeAllConnections();
+  await new Promise<void>(done => server.close(() => done()));
+  rmSync(home, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+}

--- a/scripts/verify-grok-images.ts
+++ b/scripts/verify-grok-images.ts
@@ -1,0 +1,66 @@
+// Real Grok CLI, disposable HOME, synthetic pixels and a loopback model only.
+// No subscription login, real provider request, or live OMB data is involved.
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { createInterface } from "node:readline";
+
+const cli = resolve(process.argv[2] ?? "/opt/homebrew/bin/grok");
+const home = mkdtempSync(join(tmpdir(), "omb-grok-images-"));
+// Valid 32×32 PNG: Grok requires >=8 pixels per axis and >=512 pixels total.
+const pixels = "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKklEQVR4nGP4YKNBU8QwasGoBaMWjFowasGoBaMWjFowasGoBaMWDBULAA+GUEwTofF+AAAAAElFTkSuQmCC";
+let sawImage = false;
+const server = createServer(async (req, res) => {
+  let body = "";
+  for await (const chunk of req) body += chunk;
+  if (req.method !== "POST" || !req.url?.endsWith("/chat/completions")) { res.writeHead(404).end(); return; }
+  const payload = JSON.parse(body);
+  sawImage ||= payload.messages?.some((m: { content?: unknown }) => Array.isArray(m.content) && m.content.some((c: {type?: string; image_url?: {url?: string}}) => c.type === "image_url" && c.image_url?.url === `data:image/png;base64,${pixels}`)) === true;
+  const response = { id: "fixture", created: 0, object: "chat.completion", model: "fixture", choices: [{index:0, message:{role:"assistant", content:"fixture image received"}, finish_reason:"stop"}], usage:{prompt_tokens:1,completion_tokens:1,total_tokens:2} };
+  if (!payload.stream) { res.writeHead(200, {"Content-Type":"application/json"}).end(JSON.stringify(response)); return; }
+  res.writeHead(200, {"Content-Type":"text/event-stream"});
+  res.end(`data: ${JSON.stringify({...response, object:"chat.completion.chunk", choices:[{index:0,delta:{role:"assistant",content:"fixture image received"},finish_reason:null}]})}\n\ndata: ${JSON.stringify({...response,object:"chat.completion.chunk",choices:[{index:0,delta:{},finish_reason:"stop"}]})}\n\ndata: [DONE]\n\n`);
+});
+await new Promise<void>(done => server.listen(0, "127.0.0.1", done));
+const port = (server.address() as {port:number}).port;
+mkdirSync(join(home, ".grok"));
+writeFileSync(join(home, ".grok", "config.toml"), `[cli]\nauto_update = false\n[models]\ndefault = "fixture"\n[model.fixture]\nmodel = "fixture"\nname = "Offline fixture"\nbase_url = "http://127.0.0.1:${port}/v1"\napi_backend = "chat_completions"\napi_key = "fixture-not-a-secret"\n`);
+const child = spawn(cli, ["--no-auto-update", "-m", "fixture", "agent", "stdio"], { cwd:home, env:{HOME:home, USERPROFILE:home, PATH:process.env.PATH, GROK_HOME:join(home,".grok")}, stdio:["pipe","pipe","pipe"] });
+child.stderr.resume();
+const lines = createInterface({input:child.stdout});
+let id = 0;
+const pending = new Map<number, {resolve:(result:any)=>void; reject:(error:Error)=>void}>();
+lines.on("line", line => {
+  try {
+    const message = JSON.parse(line);
+    const request = pending.get(message.id);
+    if (!request) return;
+    pending.delete(message.id);
+    if (message.error) request.reject(new Error(JSON.stringify(message.error))); else request.resolve(message.result);
+  } catch { /* startup notices are not protocol replies */ }
+});
+const request = (method:string, params:unknown) => new Promise<any>((resolve, reject) => {
+  const requestId = ++id;
+  const timer = setTimeout(() => { pending.delete(requestId); reject(new Error(`${method} timed out`)); }, 20_000);
+  pending.set(requestId,{resolve:(result)=>{clearTimeout(timer);resolve(result);},reject:(error)=>{clearTimeout(timer);reject(error);}});
+  child.stdin.write(JSON.stringify({jsonrpc:"2.0", id:requestId,method,params})+"\n");
+});
+try {
+  const init = await request("initialize",{protocolVersion:1,clientCapabilities:{}});
+  assert.equal(init._meta?.grokShell, true, "Compatibility exception is specific to the official Grok runtime");
+  const session = await request("session/new",{cwd:home,mcpServers:[]});
+  await request("session/set_config_option",{sessionId:session.sessionId,configId:"model",value:"fixture"});
+  await request("session/prompt",{sessionId:session.sessionId,prompt:[{type:"text",text:"Describe this image. Do not use tools."},{type:"image",data:pixels,mimeType:"image/png"}]});
+  assert.equal(sawImage,true,"Grok must deliver exact image pixels to the model endpoint");
+  console.log(JSON.stringify({ok:true,version:init._meta?.agentVersion,advertisedImages:init.agentCapabilities?.promptCapabilities?.image,pixelsDelivered:true}));
+} finally {
+  lines.close();
+  child.kill();
+  await new Promise<void>(done => { if(child.exitCode!==null || child.signalCode!==null) done(); else child.once("close",()=>done()); });
+  server.closeAllConnections();
+  await new Promise<void>(done=>server.close(()=>done()));
+  rmSync(home,{recursive:true,force:true});
+}

--- a/server/drivers/acp/acp.test.ts
+++ b/server/drivers/acp/acp.test.ts
@@ -16,7 +16,7 @@ import { ensureDirs, NATIVE_DIR } from "../../config.ts";
 import type { ProviderInstance } from "../../contracts.ts";
 import { recordEvents, type EventRecorder } from "../../testing/events.ts";
 import { createAcpDriver, skipSubscriptionAuthForLocalInject, type AcpSupport } from "./core.ts";
-import { GrokAgentDriver } from "./grok.ts";
+import { GrokAgentDriver, grokAcceptsUnadvertisedImages } from "./grok.ts";
 import { GeminiAgentDriver } from "./gemini.ts";
 import { KimiAgentDriver } from "./kimi.ts";
 import { DroidAgentDriver } from "./droid.ts";
@@ -232,6 +232,7 @@ describe("ACP turns (fake CLI)", () => {
     delete process.env.FAKE_ACP_USAGE_ROOT;
     delete process.env.FAKE_ACP_LOAD_NULL;
     delete process.env.FAKE_ACP_IMAGE_CAPABILITY;
+    delete process.env.FAKE_ACP_GROK_VERSION;
     delete process.env.FAKE_ACP_DUMP_PROMPT;
     recorder?.stop();
     await instance?.dispose();
@@ -336,7 +337,7 @@ describe("ACP turns (fake CLI)", () => {
     const dump = join(scratch, "text-fallback.json");
     process.env.FAKE_ACP_DUMP = dump;
     process.env.FAKE_ACP_DUMP_PROMPT = "1";
-    await create(GrokAgentDriver);
+    await create(SelectModelDriver);
 
     const text = '<attached-image path="/private/image.png" name="image.png" />';
     const { turnId } = await instance.adapter.sendTurn({
@@ -348,6 +349,31 @@ describe("ACP turns (fake CLI)", () => {
     await recorder.until((event) => event.type === "turn.completed" && event.turnId === turnId);
 
     expect(JSON.parse(readFileSync(`${dump}.prompt.json`, "utf8"))).toEqual([{ type: "text", text }]);
+  });
+
+  it("sends native images on Grok's verified runtime even with the false capability", async () => {
+    const dump = join(scratch, "grok-image.json");
+    const imagePath = join(scratch, "grok.png");
+    const bytes = Buffer.from("synthetic-private-image");
+    writeFileSync(imagePath, bytes);
+    process.env.FAKE_ACP_DUMP = dump;
+    process.env.FAKE_ACP_DUMP_PROMPT = "1";
+    process.env.FAKE_ACP_GROK_VERSION = "1.0.25";
+    await create(GrokAgentDriver);
+    expect(instance.adapter.capabilities.images).toBe(true);
+    const { turnId } = await instance.adapter.sendTurn({
+      threadId: "t-grok-image", text: "Inspect", images: [{ path: imagePath, mime: "image/png", bytes: bytes.length }],
+    });
+    const done = await recorder.until((event) => event.type === "turn.completed" && event.turnId === turnId);
+    expect(done).toMatchObject({ ok: true });
+    expect(JSON.parse(readFileSync(`${dump}.prompt.json`, "utf8"))).toContainEqual({ type: "image", data: bytes.toString("base64"), mimeType: "image/png" });
+    expect(readFileSync(join(NATIVE_DIR, "t-grok-image.ndjson"), "utf8")).not.toContain(bytes.toString("base64"));
+  });
+
+  it.each([null, {}, { _meta: { grokShell: true, agentVersion: "1.0.24" } },
+    { _meta: { grokShell: true, agentVersion: "1.0.25-preview" } },
+    { _meta: { grokShell: false, agentVersion: "1.0.25" } }])("does not assume image support for unknown Grok runtime %j", (init) => {
+    expect(grokAcceptsUnadvertisedImages(init)).toBe(false);
   });
 
   it("emits each assistant text block before the tool that follows it", async () => {

--- a/server/drivers/acp/core.ts
+++ b/server/drivers/acp/core.ts
@@ -94,6 +94,9 @@ export interface AcpSupport {
   /** Whether models behind this ACP harness can consume a referenced image.
    * Most coding agents can open local files; opt out for text-only agents. */
   images?: boolean;
+  /** Narrow compatibility exception for a CLI with verified native image
+   * transport but a defective initialize capability (never a path fallback). */
+  acceptsUnadvertisedImages?(initializeResult: unknown): boolean;
   /** Message shown when the CLI is present but not signed in. */
   loginNote: string;
   /** How a user installs this harness's CLI; surfaced by the setup UI. */
@@ -901,7 +904,8 @@ export function createAcpDriver(support: AcpSupport): ProviderDriver<AcpConfig> 
             }
 
             const images = turn.images ?? [];
-            const runtimeAcceptsImages = init?.agentCapabilities?.promptCapabilities?.image === true;
+            const runtimeAcceptsImages = init?.agentCapabilities?.promptCapabilities?.image === true ||
+              support.acceptsUnadvertisedImages?.(init) === true;
             if (images.length && support.images === true && !runtimeAcceptsImages) {
               throw new Error(
                 `${support.displayName} is configured for image attachments, but this installed runtime does not advertise ACP image input. Update the ${support.displayName} CLI or send the message without an image.`,

--- a/server/drivers/acp/grok.ts
+++ b/server/drivers/acp/grok.ts
@@ -180,10 +180,21 @@ export function ensureGrokInjectSlug(
   return slug;
 }
 
+/** Grok 1.0.25 consumes native image blocks but advertises image:false.
+ * Verified with the real CLI and a loopback model: scripts/verify-grok-images.ts.
+ * Keep unknown/older runtimes on the normal capability negotiation path. */
+export function grokAcceptsUnadvertisedImages(init: unknown): boolean {
+  const meta = (init as { _meta?: { grokShell?: unknown; agentVersion?: unknown } } | null)?._meta;
+  if (meta?.grokShell !== true || typeof meta.agentVersion !== "string") return false;
+  const version = /^1\.0\.(\d+)$/.exec(meta.agentVersion);
+  return Boolean(version && Number(version[1]) >= 25);
+}
+
 const support: AcpSupport = {
   driverKind: "grokAgent",
   displayName: "Grok",
-  images: false,
+  images: true,
+  acceptsUnadvertisedImages: grokAcceptsUnadvertisedImages,
   models: STATIC_GROK_MODELS,
   resolveModels: (env) => mergeLocalInject(readGrokModelCatalog(env), env),
   // Grok's accepted levels vary by model and the CLI validates lazily — a

--- a/server/drivers/claude.test.ts
+++ b/server/drivers/claude.test.ts
@@ -25,6 +25,7 @@ import {
   createPermissionBroker,
   parseClaudeCliVersion,
   permissionSocketPath,
+  readClaudeAuthSettings,
   type ClaudeConfig,
 } from "./claude.ts";
 import { removeTempDir } from "../testing/cleanup.ts";
@@ -796,6 +797,63 @@ describe("ClaudeDriver turns (fake CLI)", () => {
     const seen = JSON.parse(readFileSync(dump, "utf8"));
     expect(seen.argv).not.toContain("--strict-mcp-config");
     expect(seen.argv).not.toContain("--setting-sources");
+  });
+
+  it("preserves only the selected account's auth settings in a private file", async () => {
+    const account = join(scratch, "account");
+    mkdirSync(account);
+    const settings = { apiKeyHelper: "echo synthetic-helper-key", env: { ANTHROPIC_BASE_URL: "http://127.0.0.1:9", ANTHROPIC_AUTH_TOKEN: "synthetic-token", OMB_TTS_KEY: "must-not-leak" }, hooks: { SessionStart: [{ command: "must-not-run" }] }, permissions: { defaultMode: "bypassPermissions" } };
+    writeFileSync(join(account, "settings.json"), JSON.stringify(settings));
+    const dump = join(scratch, "account.json");
+    await create(undefined, { FAKE_CLAUDE_DUMP: dump }, { configDir: account });
+    await instance.adapter.sendTurn({ threadId: "t-auth-settings", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed");
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.settings).toEqual({ apiKeyHelper: settings.apiKeyHelper, env: { ANTHROPIC_BASE_URL: settings.env.ANTHROPIC_BASE_URL, ANTHROPIC_AUTH_TOKEN: "synthetic-token" } });
+    expect(seen.argv[seen.argv.indexOf("--setting-sources") + 1]).toBe("project");
+    expect(JSON.stringify(seen.argv)).not.toContain("synthetic");
+    const settingsPath = seen.argv[seen.argv.indexOf("--settings") + 1];
+    if (process.platform !== "win32") expect(seen.settingsMode).toBe(0o600);
+    const log = readFileSync(join(NATIVE_DIR, "t-auth-settings.ndjson"), "utf8");
+    expect(log).not.toContain("synthetic-token");
+    expect(log).not.toContain(settings.apiKeyHelper);
+    await instance.dispose();
+    expect(existsSync(settingsPath)).toBe(false);
+  });
+
+  it("restarts a retained session when the selected account's auth changes", async () => {
+    const account = join(scratch, "account");
+    mkdirSync(account);
+    const path = join(account, "settings.json");
+    writeFileSync(path, JSON.stringify({ env: { ANTHROPIC_API_KEY: "synthetic-old" } }));
+    const dump = join(scratch, "rotate.json");
+    await create(undefined, { FAKE_CLAUDE_DUMP: dump }, { configDir: account });
+    const first = await instance.adapter.sendTurn({ threadId: "t-auth-rotate", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed" && e.turnId === first.turnId);
+    const before = JSON.parse(readFileSync(dump, "utf8"));
+    writeFileSync(path, JSON.stringify({ env: { ANTHROPIC_API_KEY: "synthetic-new" } }));
+    const second = await instance.adapter.sendTurn({ threadId: "t-auth-rotate", text: "again" });
+    await recorder.until((e) => e.type === "turn.completed" && e.turnId === second.turnId);
+    const after = JSON.parse(readFileSync(dump, "utf8"));
+    expect(after.pid).not.toBe(before.pid);
+    expect(after.settings.env.ANTHROPIC_API_KEY).toBe("synthetic-new");
+  });
+
+  it("does not mix a personal helper/endpoint with an explicitly configured OMB connection", async () => {
+    const account = join(scratch, "account");
+    mkdirSync(account);
+    writeFileSync(join(account, "settings.json"), JSON.stringify({ apiKeyHelper: "do-not-run", env: { ANTHROPIC_API_KEY: "personal", ANTHROPIC_BASE_URL: "https://personal.invalid" } }));
+    const dump = join(scratch, "explicit.json");
+    await create(undefined, { FAKE_CLAUDE_DUMP: dump, ANTHROPIC_API_KEY: "workspace-key" }, { configDir: account });
+    await instance.adapter.sendTurn({ threadId: "t-auth-explicit", text: "hi" });
+    await recorder.until((e) => e.type === "turn.completed");
+    const seen = JSON.parse(readFileSync(dump, "utf8"));
+    expect(seen.settings).toBe(null);
+    expect(seen.env.ANTHROPIC_API_KEY).toBe("workspace-key");
+    expect(seen.env.ANTHROPIC_BASE_URL).toBeUndefined();
+    expect(readClaudeAuthSettings({ HOME: scratch, CLAUDE_CONFIG_DIR: join(scratch, "other-account") })).toEqual({});
+    writeFileSync(join(account, "settings.json"), "malformed");
+    expect(readClaudeAuthSettings({ CLAUDE_CONFIG_DIR: account })).toEqual({});
   });
 
   it("withholds a flag from a CLI that predates it, instead of failing every turn", async () => {

--- a/server/drivers/claude.ts
+++ b/server/drivers/claude.ts
@@ -189,6 +189,32 @@ function inheritsUserConfig(env: NodeJS.ProcessEnv): boolean {
   return env.OMB_CLAUDE_INHERIT_USER_CONFIG === "1";
 }
 
+/** Retain the selected CLI account's authentication without importing its
+ * hooks, permissions, MCP servers or personal instructions. Explicit OMB
+ * connections/local endpoints own their entire routing + credential pair. */
+export function readClaudeAuthSettings(
+  env: NodeJS.ProcessEnv,
+  instanceEnvironment: NodeJS.ProcessEnv = {},
+): { env?: Record<string, string>; apiKeyHelper?: string } {
+  if (CLAUDE_ACCOUNT_ENV_KEYS.some((key) => instanceEnvironment[key])) return {};
+  try {
+    const settings = JSON.parse(readFileSync(join(resolveClaudeConfigDir(undefined, env), "settings.json"), "utf8"));
+    const authEnv: Record<string, string> = {};
+    for (const key of CLAUDE_ACCOUNT_ENV_KEYS) {
+      if (!key.endsWith("_FILE_DESCRIPTOR") && typeof settings?.env?.[key] === "string") {
+        authEnv[key] = settings.env[key];
+      }
+    }
+    return {
+      ...(Object.keys(authEnv).length ? { env: authEnv } : {}),
+      ...(typeof settings?.apiKeyHelper === "string" && settings.apiKeyHelper.trim()
+        ? { apiKeyHelper: settings.apiKeyHelper } : {}),
+    };
+  } catch {
+    return {};
+  }
+}
+
 /** MCP servers the bot's own project declares in `<cwd>/.mcp.json`.
  *
  * The CLI would find this file itself, but the harness launches it with
@@ -1145,6 +1171,11 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       }
 
       const env = environment(turnModel);
+      const authSettings = isolated && !injected.injected
+        ? readClaudeAuthSettings(env, input.environment) : {};
+      const authSettingsPath = mcpConfigPath && Object.keys(authSettings).length
+        ? join(dirname(mcpConfigPath), "auth-settings.json") : null;
+      if (authSettingsPath) args.push("--settings", authSettingsPath);
       // Our approvals and browser credentials expire at the user-turn
       // boundary. Native background workers cannot outlive that boundary;
       // parallel bot work must use the harness's durable delegate_bot path.
@@ -1152,7 +1183,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
       const cwd = turn.cwd ?? homedir();
       // Everything that shapes the process, minus session/turn-specific temp
       // paths. Their contents are represented directly in the key instead.
-      const privateFileFlags = new Set(["--mcp-config"]);
+      const privateFileFlags = new Set(["--mcp-config", "--settings"]);
       const keyArgs = args.filter((a, i) => !privateFileFlags.has(a) && !privateFileFlags.has(args[i - 1] ?? ""));
       const argsKey = JSON.stringify({
         args: keyArgs,
@@ -1164,6 +1195,11 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         model: injected.model ?? null,
         base: env.ANTHROPIC_BASE_URL ?? null,
         configDir: env.CLAUDE_CONFIG_DIR ?? null,
+        // Rotating an account's key/helper must not reuse the old process.
+        auth: createHash("sha256").update(JSON.stringify({
+          settings: authSettings,
+          env: Object.fromEntries(CLAUDE_ACCOUNT_ENV_KEYS.map((key) => [key, env[key]])),
+        })).digest("hex"),
       });
 
       // Reuse the live process when it is idle, unchanged, and is the session
@@ -1298,6 +1334,9 @@ export const ClaudeDriver: ProviderDriver<ClaudeConfig> = {
         // Write once, only after the broker has selected its real endpoint.
         if (mcpConfigPath) {
           writeFileSync(mcpConfigPath, JSON.stringify({ mcpServers }), { mode: 0o600 });
+        }
+        if (authSettingsPath) {
+          writeFileSync(authSettingsPath, JSON.stringify(authSettings), { mode: 0o600 });
         }
         if (sessionId) args.push("--resume", sessionId);
         else args.push("--session-id", newSessionId!);

--- a/server/drivers/codex.test.ts
+++ b/server/drivers/codex.test.ts
@@ -1212,6 +1212,18 @@ describe("CodexDriver turns (fake app-server)", () => {
     });
   });
 
+  it.each(["safety-rpc", "safety-completion", "safety-notification"])("surfaces %s once without retrying or asking for login", async (mode) => {
+    await create({ mode });
+    const { turnId } = await instance.adapter.sendTurn({ threadId: "t-safety", text: "Deploy my site", approvalMode: "full" });
+    const done = await recorder.until((e) => e.type === "turn.completed" && e.turnId === turnId);
+    expect(done).toMatchObject({ ok: false, stopReason: "provider_safety" });
+    const errors = recorder.events.filter((e) => e.type === "runtime.error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ message: expect.stringContaining("blocked by our safety systems") });
+    expect(errors[0]).not.toHaveProperty("setup");
+    expect(recorder.events.some((e) => e.type === "turn.retrying")).toBe(false);
+  });
+
   it("auto-retries a transient turn/start failure, then completes with one final message", async () => {
     process.env.FAKE_CODEX_TRANSIENTS = "2";
     process.env.FAKE_CODEX_STATE = join(scratch, "codex-launches");

--- a/server/drivers/codex.ts
+++ b/server/drivers/codex.ts
@@ -600,6 +600,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
       const earlyNotifications: any[] = [];
       const state = {
         settled: false,
+        lastError: "",
         lastText: "",
         sawStreamDelta: false,
         // codex reports token usage as a running THREAD total; the harness
@@ -951,7 +952,15 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
           }
           case "turn/completed": {
             const t = p.turn ?? {};
-            void settle(t.status === "completed", t.status === "completed" ? null : (t.error?.message ?? t.status ?? "failed"));
+            const message = typeof t.error?.message === "string" ? t.error.message.slice(0, 400) : "";
+            if (t.status !== "completed" && message && message !== state.lastError) {
+              state.lastError = message;
+              emit({ ...base(threadId, turnId), type: "runtime.error", message,
+                ...(classifyError({ text: message }).reason === "auth" ? { setup: true } : {}),
+              });
+            }
+            void settle(t.status === "completed", t.status === "completed" ? null :
+              (classifyError({ text: message || state.lastError }).reason === "provider_safety" ? "provider_safety" : (message || t.status || "failed")));
             break;
           }
           case "error":
@@ -959,7 +968,10 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
             // {error:{message}} — surface either (agentcal armor)
             {
               const message = p.message ?? p.error?.message;
-              if (message) emit({ ...base(threadId, turnId), type: "runtime.error", message: String(message).slice(0, 400) });
+              if (message) {
+                state.lastError = String(message).slice(0, 400);
+                emit({ ...base(threadId, turnId), type: "runtime.error", message: state.lastError });
+              }
             }
             break;
         }
@@ -1199,7 +1211,7 @@ export const CodexDriver: ProviderDriver<CodexConfig> = {
             message,
             ...(needsAuth ? { setup: true } : {}),
           });
-          await settle(false, needsAuth ? "auth_required" : "rpc_error");
+          await settle(false, needsAuth ? "auth_required" : verdict.reason === "provider_safety" ? "provider_safety" : "rpc_error");
         }
       }
     };

--- a/server/drivers/retry.test.ts
+++ b/server/drivers/retry.test.ts
@@ -3,6 +3,13 @@ import { describe, expect, it } from "vitest";
 import { BACKOFF_BASE_MS, RETRY_MAX_ATTEMPTS, classifyError, computeBackoff } from "./retry.ts";
 
 describe("classifyError", () => {
+  it("does not retry a provider safety block even inside a 503 or rate-limit error", () => {
+    for (const text of ["HTTP 503: blocked by our safety systems", "429: safety monitoring paused this task"]) {
+      expect(classifyError({ text })).toEqual({ transient: false, reason: "provider_safety" });
+      expect(classifyError({ exitCode: 1, stderr: text })).toEqual({ transient: false, reason: "provider_safety" });
+    }
+    expect(classifyError({ text: "503: checking deployment safety" }).reason).toBe("server_error");
+  });
   it("calls provider rate limits transient", () => {
     expect(classifyError(new Error("xAI HTTP 429: Too Many Requests"))).toEqual({
       transient: true,

--- a/server/drivers/retry.ts
+++ b/server/drivers/retry.ts
@@ -4,6 +4,7 @@
 // (429/5xx/overloaded/reset) gets up to MAX_ATTEMPTS tries, an auth or
 // request-shape problem never does.
 import type { ProviderErrorCode } from "../contracts.ts";
+import { isProviderSafetyBlock } from "../../shared/provider-safety.ts";
 
 export const RETRY_MAX_ATTEMPTS = 3;
 
@@ -91,6 +92,8 @@ const messageOf = (err: FailureInput): string => {
  */
 export function classifyError(err: FailureInput): ErrorClassification {
   const text = messageOf(err);
+  // A surrounding HTTP 5xx/429 must not replay a provider safety block.
+  if (isProviderSafetyBlock(text)) return { transient: false, reason: "provider_safety" };
   if (err && "exitCode" in err) {
     const { exitCode: code } = err;
     if (code !== null && code < 0) return { transient: false, reason: "interrupted" };

--- a/server/index.ts
+++ b/server/index.ts
@@ -1570,6 +1570,13 @@ const approvalModeForTurn = (bot: BotRecord, peerInitiated = false): ApprovalMod
 function handleDesktopTrustedApprovalMessage(raw: unknown): boolean {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return false;
   const message = raw as Record<string, unknown>;
+  const threadCanReceiveGrant = (bot: BotRecord): boolean => {
+    const threadId = bot.approvalGrant?.threadId;
+    if (!threadId) return true;
+    const target = store.projectBotForTask(bot.id, threadId);
+    return Boolean(target && !threadBusy(bot.id, threadId) &&
+      registry.cliTarget(target.modelSelection.instanceId)?.driverKind === registry.cliTarget(bot.modelSelection.instanceId)?.driverKind);
+  };
   if (message.type === "approval-trusted-mode-commit") {
     const requestId = typeof message.requestId === "string" && /^[A-Za-z0-9_-]{1,80}$/.test(message.requestId)
       ? message.requestId
@@ -1587,8 +1594,12 @@ function handleDesktopTrustedApprovalMessage(raw: unknown): boolean {
       bot.approvalGrant.phase === "committed" &&
       bot.approvalMode === mode &&
       !bot.busy &&
+      threadCanReceiveGrant(bot) &&
       supportsApprovalMode(registry.cliTarget(bot.modelSelection.instanceId)?.driverKind, mode)
     ) {
+      if (bot.approvalGrant.threadId) {
+        store.patchTask(botId, bot.approvalGrant.threadId, { approvalMode: mode, autoApprove: false });
+      }
       store.patchBot(botId, { approvalGrant: undefined });
     } else if (bot?.approvalGrant?.requestId === requestId) {
       store.patchBot(botId, { approvalMode: "ask", autoApprove: false, approvalGrant: undefined });
@@ -1629,7 +1640,7 @@ function handleDesktopTrustedApprovalMessage(raw: unknown): boolean {
         return true;
       }
       store.patchBot(botId, {
-        approvalGrant: { requestId, mode, phase: "confirmed" },
+        approvalGrant: { ...bot.approvalGrant, requestId, mode, phase: "confirmed" },
       });
       confirm(true);
       return true;
@@ -1679,7 +1690,7 @@ function handleDesktopTrustedApprovalMessage(raw: unknown): boolean {
       }
       // Still inert: Electron must receive this acknowledgement and request
       // finalization before the durable mode can affect any turn.
-      store.patchBot(botId, { approvalGrant: { requestId, mode, phase: "activated" } });
+      store.patchBot(botId, { approvalGrant: { ...bot.approvalGrant, requestId, mode, phase: "activated" } });
       activate(true);
       return true;
     }
@@ -1717,11 +1728,12 @@ function handleDesktopTrustedApprovalMessage(raw: unknown): boolean {
       bot.approvalGrant.phase === "activated" &&
       bot.approvalMode === mode &&
       !bot.busy &&
+      threadCanReceiveGrant(bot) &&
       supportsApprovalMode(registry.cliTarget(bot.modelSelection.instanceId)?.driverKind, mode)
     ) {
       // Durable but still inert. Electron must observe this exact ACK before
       // sending the one-way commit release that clears the journal.
-      store.patchBot(botId, { approvalGrant: { requestId, mode, phase: "committed" } });
+      store.patchBot(botId, { approvalGrant: { ...bot.approvalGrant, requestId, mode, phase: "committed" } });
       finalize(true);
       return true;
     }
@@ -1763,6 +1775,20 @@ function handleDesktopTrustedApprovalMessage(raw: unknown): boolean {
     return true;
   }
   const currentMode = approvalModeFor(existing);
+  const threadId = message.threadId;
+  if (threadId !== undefined) {
+    const target = typeof threadId === "string" && /^[\w-]{1,128}$/.test(threadId)
+      ? store.projectBotForTask(botId, threadId) : null;
+    if (!target || (mode !== "full" && mode !== "custom") || currentMode !== mode || existing.approvalGrant) {
+      respond({ ok: false, error: "Choose this bot's approval level in bot settings before applying it to an existing thread" });
+      return true;
+    }
+    if (threadBusy(botId, threadId as string) ||
+      registry.cliTarget(target.modelSelection.instanceId)?.driverKind !== registry.cliTarget(existing.modelSelection.instanceId)?.driverKind) {
+      respond({ ok: false, error: "Stop this thread and use the bot's provider before applying its approval level" });
+      return true;
+    }
+  }
   const emergencyDowngrade = existing.busy && isEmergencyApprovalDowngrade(currentMode, mode);
   const clearsPendingElevation = mode === "ask" && existing.approvalGrant !== undefined;
   if (existing.busy && !emergencyDowngrade && !clearsPendingElevation) {
@@ -1791,7 +1817,7 @@ function handleDesktopTrustedApprovalMessage(raw: unknown): boolean {
     approvalMode: mode,
     autoApprove: mode === "auto",
     approvalGrant: mode === "full" || mode === "custom"
-      ? { requestId, mode, phase: "prepared" }
+      ? { requestId, mode, phase: "prepared", ...(typeof threadId === "string" ? { threadId } : {}) }
       : undefined,
   });
   if (!updated) {
@@ -13140,7 +13166,10 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
         const mode = body.approvalMode ?? (body.autoApprove ? "auto" : "ask");
         // Elevated modes still require the trusted desktop transition. A
         // thread settings PATCH cannot manufacture that grant.
-        if (mode !== "ask" && mode !== "auto") return json(res, 403, { error: "Full and Custom access require confirmation in bot settings" });
+        if (mode !== "ask" && mode !== "auto" && mode !== "edits") return json(res, 403, { error: "Full and Custom access require trusted desktop confirmation" });
+        if (!supportsApprovalMode(registry.cliTarget(current.modelSelection.instanceId)?.driverKind, mode)) {
+          return json(res, 400, { error: "This provider does not support the selected approval level" });
+        }
         if (threadBusy(current.id, current.threadId)) return json(res, 409, { error: "stop this thread before changing its approval mode" });
         if (current.approvalGrant) return json(res, 409, { error: "the bot's approval mode is still being confirmed" });
         if (mode === "auto" && approvalModeFor(current) !== "auto" && auth.kind === "loopback" && !DESKTOP_MANAGED && !req.headers.origin && store.bots.some((bot) => bot.busy)) {

--- a/server/store.test.ts
+++ b/server/store.test.ts
@@ -283,6 +283,22 @@ describe("Store", () => {
     expect(persisted.find((candidate) => candidate.id === bot.id)).not.toHaveProperty("approvalGrant");
   });
 
+  it.each(["prepared", "confirmed", "activated", "committed"] as const)("revokes a thread-scoped grant after restart in phase %s", (phase) => {
+    const store = new Store(selection);
+    const bot = store.createBot();
+    const target = store.createTask(bot.id, "Target")!;
+    store.patchBot(bot.id, { approvalMode: "full", approvalGrant: {
+      requestId: "123e4567-e89b-42d3-a456-426614174000", mode: "full", phase, threadId: target.threadId,
+    } });
+    // Even a crash between writing the thread and clearing the journal
+    // must not leave an unacknowledged elevated conversation executable.
+    store.patchTask(bot.id, target.threadId, { approvalMode: "full" });
+    const reloaded = new Store(selection);
+    expect(reloaded.bot(bot.id)?.approvalMode).toBe("ask");
+    expect(reloaded.bot(bot.id)?.approvalGrant).toBeUndefined();
+    expect(reloaded.projectBotForTask(bot.id, target.threadId)?.approvalMode).toBe("ask");
+  });
+
   it("normalizes persisted cloud backends without changing valid or absent values", () => {
     const store = new Store(selection);
     const box = store.createBot();

--- a/server/store.ts
+++ b/server/store.ts
@@ -596,6 +596,8 @@ export interface BotRecord {
     requestId: string;
     mode: "full" | "custom";
     phase: "prepared" | "confirmed" | "activated" | "committed";
+    /** Optional existing thread receiving this already-approved bot default. */
+    threadId?: string;
   };
   /** Tools this bot may always use without asking, even outside auto mode
    * (set by "Always allow" on an approval card). */

--- a/server/testing/fake-acp-cli.ts
+++ b/server/testing/fake-acp-cli.ts
@@ -350,7 +350,10 @@ function handle(msg: any) {
               ...(acceptsImages ? { promptCapabilities: { image: true } } : {}),
             }
           : undefined,
-        _meta: { modelState: { currentModelId: "fake-acp-model" } },
+        _meta: {
+          modelState: { currentModelId: "fake-acp-model" },
+          ...(process.env.FAKE_ACP_GROK_VERSION ? { grokShell: true, agentVersion: process.env.FAKE_ACP_GROK_VERSION } : {}),
+        },
       });
       break;
     }

--- a/server/testing/fake-claude-cli.ts
+++ b/server/testing/fake-claude-cli.ts
@@ -37,7 +37,7 @@
 //                      Sonnet 4.5: init reports the mode it actually runs in.
 //
 // Keep this file dependency-free — it runs as a bare `node` subprocess.
-import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
 
 const mode = process.env.FAKE_CLAUDE_MODE ?? "happy";
 const scriptedReplies = (() => {
@@ -214,6 +214,9 @@ const playTurn = (prompt: JsonValue) => {
       }
     }
     const systemPromptPath = argAfter("--append-system-prompt-file");
+    const settingsPath = argAfter("--settings");
+    const settings = settingsPath ? JSON.parse(readFileSync(settingsPath, "utf8")) : null;
+    const settingsMode = settingsPath ? statSync(settingsPath).mode & 0o777 : null;
     let systemPrompt: string | null = null;
     if (systemPromptPath) {
       try {
@@ -224,7 +227,7 @@ const playTurn = (prompt: JsonValue) => {
     }
     writeFileSync(
       process.env.FAKE_CLAUDE_DUMP,
-      JSON.stringify({ pid: process.pid, argv, env: process.env, prompt, systemPrompt, mcpConfig }, null, 2),
+      JSON.stringify({ pid: process.pid, argv, env: process.env, prompt, systemPrompt, mcpConfig, settings, settingsMode }, null, 2),
     );
   }
 

--- a/server/testing/fake-codex-app-server.ts
+++ b/server/testing/fake-codex-app-server.ts
@@ -227,6 +227,17 @@ process.stdin.on("data", (chunk) => {
         break;
       case "turn/start": {
         nativeThreadId = msg.params?.threadId ?? nativeThreadId;
+        if (mode === "safety-rpc") {
+          out({ jsonrpc: "2.0", id: msg.id, error: { code: -32603, message: "HTTP 503: This task was blocked by our safety systems." } });
+          break;
+        }
+        if (mode === "safety-completion" || mode === "safety-notification") {
+          out({ jsonrpc: "2.0", id: msg.id, result: { turn: { id: nativeTurnId } } });
+          const message = "This task was blocked by our safety systems.";
+          if (mode === "safety-notification") notify("error", { message });
+          notify("turn/completed", { turn: { status: "failed", error: { message } } });
+          break;
+        }
         if (msg.params?.permissions && (!experimentalApi || mode === "config-profile-unsupported")) {
           out({ jsonrpc: "2.0", id: msg.id, error: { code: -32602, message: "experimental API required for permissions" } });
           break;

--- a/shared/provider-safety.ts
+++ b/shared/provider-safety.ts
@@ -1,0 +1,7 @@
+/** Match provider error wording, not ordinary assistant discussions of safety. */
+export function isProviderSafetyBlock(message: string): boolean {
+  return /\bblocked by (?:our|the provider['’]s) safety systems\b|\bsafety monitoring\b.{0,100}\b(?:paused|ended|blocked)\b|\b(?:safety_check_failed|safety_policy_violation)\b/i.test(message);
+}
+
+export const PROVIDER_SAFETY_GUIDANCE = "The provider stopped this task. Full access controls tool approvals, not provider safety checks. Review the provider’s findings in Codex if available; OpenMausBot cannot override this block.";
+export const PROVIDER_SAFETY_HELP_URL = "https://learn.chatgpt.com/docs/agent-approvals-security#safety-monitoring-and-paused-tasks";

--- a/src/components/ChatView.controls.test.ts
+++ b/src/components/ChatView.controls.test.ts
@@ -19,7 +19,7 @@ vi.mock("@/state/store", async (importOriginal) => {
   }) };
 });
 vi.mock("./DesktopCapabilities", () => ({
-  useDesktopCapabilities: () => ({ capabilities: { dictation: { available: false } }, ready: true }),
+  useDesktopCapabilities: () => ({ capabilities: { dictation: { available: false }, host: { packaged: true } }, ready: true }),
 }));
 vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
 vi.mock("./ModelPicker", () => ({ ModelPicker: (props: ComponentProps<typeof ModelPicker>) => {
@@ -31,7 +31,7 @@ vi.mock("./ApprovalModeSelector", () => ({ ApprovalModeSelector: (props: Compone
   return createElement("span", { "data-test-approval-control": true });
 } }));
 
-const { ChatView } = await import("./ChatView");
+const { ChatView, ErrorRow } = await import("./ChatView");
 afterAll(() => vi.unstubAllGlobals());
 
 const bot: Bot = {
@@ -43,6 +43,21 @@ const bot: Bot = {
 };
 
 describe("thread control placement", () => {
+  it("offers scoped Full access only when the bot already has it and the local trusted bridge exists", () => {
+    const fullBot = { ...bot, busy: false, approvalMode: "full" as const };
+    expect(renderToStaticMarkup(createElement(ChatView, { bot: fullBot }))).not.toContain("Use bot’s Full access for this thread");
+    window.ogb = { approvals: { setMode: vi.fn() } } as unknown as NonNullable<Window["ogb"]>;
+    expect(renderToStaticMarkup(createElement(ChatView, { bot: fullBot }))).toContain("Use bot’s Full access for this thread");
+    expect(renderToStaticMarkup(createElement(ChatView, { bot }))).not.toContain("Use bot’s Full access for this thread");
+    delete window.ogb;
+  });
+
+  it("explains provider safety errors without offering an ineffective Retry", () => {
+    const markup = renderToStaticMarkup(createElement(ErrorRow, { message: "Blocked by our safety systems", onRetry: () => {} }));
+    expect(markup).toContain("Full access controls tool approvals, not provider safety checks");
+    expect(markup).not.toContain("<button");
+    expect(renderToStaticMarkup(createElement(ErrorRow, { message: "Network timeout", onRetry: () => {} }))).toContain("<button");
+  });
   it.each([
     "شغّل الاختبارات\nThen run typecheck\nوبعدها ارفع الفرع",
     "שלום עולם\nThen run typecheck\nתודה רבה",

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -35,6 +35,7 @@ import {
   type Message,
 } from "@/state/store";
 import { EngineSetup } from "./EngineSetup";
+import { isProviderSafetyBlock, PROVIDER_SAFETY_GUIDANCE, PROVIDER_SAFETY_HELP_URL } from "../../shared/provider-safety";
 import { BotAvatar } from "./Avatar";
 import { TurnPresence } from "./TurnPresence";
 import { showToolCallsEnabled, skillAuthoringEnabled } from "@/lib/feature-flags";
@@ -137,7 +138,7 @@ function CopyButton({ text, className }: { text: string; className?: string }) {
  * Once the engine reports itself fixed the card flips back to Retry, which
  * (with the on-focus re-probe) happens by itself when the user returns from
  * the terminal. */
-function ErrorRow({
+export function ErrorRow({
   message,
   onRetry,
   setupInstance,
@@ -153,7 +154,12 @@ function ErrorRow({
           <AlertTriangle size={15} className="mt-0.5 shrink-0" />
           <span className="min-w-0 break-words">{message}</span>
         </div>
-        {setupInstance &&
+        {isProviderSafetyBlock(message) ? (
+          <p className="mt-2 text-[12.5px] leading-relaxed text-ink-secondary">
+            {PROVIDER_SAFETY_GUIDANCE}{" "}
+            <a href={PROVIDER_SAFETY_HELP_URL} target="_blank" rel="noreferrer" className="underline">About provider safety checks</a>
+          </p>
+        ) : setupInstance &&
         !(setupInstance.snapshot.state === "available" && setupInstance.snapshot.authenticated !== false) ? (
           <EngineSetup instance={setupInstance} className="mt-2 text-ink-secondary" />
         ) : (
@@ -1402,7 +1408,7 @@ export function ChatView({ bot: profile }: { bot: Bot }) {
       )}
       <Composer
         key={bot.threadId}
-        bot={bot}
+        bot={profile}
         replyTo={replyTo}
         onClearReply={clearReply}
         onConsumeReply={consumeReply}

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -26,6 +26,7 @@ import { BotAvatar } from "./Avatar";
 import { MentionTextarea } from "./MentionTextarea";
 import { ComposerAttachments, pathForFile } from "./ComposerAttachments";
 import { LocalComputerAutoWarning } from "./LocalComputerAutoWarning";
+import { FullAccessWarning } from "./FullAccessWarning";
 import { ApprovalModeSelector } from "./ApprovalModeSelector";
 import { approvalModeFor, type ApprovalMode } from "../../shared/approval-mode";
 import {
@@ -370,16 +371,20 @@ export function Composer({
   }, [busy, pendingCount, steering]);
   const fileInput = useRef<HTMLInputElement>(null);
   const [approvalWarning, setApprovalWarning] = useState<{
-    mode: "auto";
+    mode: "auto" | "full";
     botId: string;
     threadId: string;
   } | null>(null);
+  const [applyingThreadAccess, setApplyingThreadAccess] = useState(false);
   const [attachmentNotice, setAttachmentNotice] = useState<string | null>(null);
   // Approval mode belongs to one bot; a room has several, each with its own.
   const modeBot = group ? undefined : bot;
   const approvalEngine = modeBot
     ? state.instances.find((instance) => instance.instanceId === modeBot.modelSelection.instanceId)
     : undefined;
+  const canApplyBotFullAccess = Boolean(modeBot && profile && !remoteClient && window.ogb?.approvals && capabilities.host.packaged &&
+    approvalModeFor(profile) === "full" && approvalModeFor(modeBot) !== "full" &&
+    approvalEngine?.driverKind === state.instances.find((instance) => instance.instanceId === profile.modelSelection.instanceId)?.driverKind);
   const uploadImage = useCallback(async (file: File): Promise<Attachment | null> => {
     const optimistic = optimisticImageAttachment(file);
     if (!optimistic) return null;
@@ -795,6 +800,19 @@ export function Composer({
             className="pointer-events-none absolute -left-5 -right-5 -bottom-3 top-1/2 bg-app"
           />
         <div data-tour="composer" className="relative z-[1] rounded-3xl bg-composer px-2 py-1.5 ring-1 ring-composer-ring">
+        {canApplyBotFullAccess && modeBot && !locked && (
+          <button
+            type="button"
+            disabled={Boolean(profile?.busy || modeBot.busy || applyingThreadAccess)}
+            onClick={() => setApprovalWarning({ mode: "full", botId: modeBot.id, threadId: modeBot.threadId })}
+            className="block max-w-full px-3 pb-2 pt-1 text-left text-[12px] text-ink-secondary hover:text-ink disabled:opacity-50"
+            title={profile?.busy || modeBot.busy
+              ? "Stop this bot’s current work before changing this thread’s access"
+              : "Other existing threads keep their current approval levels"}
+          >
+            Use bot’s Full access for this thread
+          </button>
+        )}
         <div className="flex items-end gap-1">
           <input
             ref={fileInput}
@@ -1024,6 +1042,22 @@ export function Composer({
         </div>
       </div>
       <div className="pointer-events-auto">
+      <FullAccessWarning
+        open={approvalWarning?.mode === "full"}
+        scope="thread"
+        onCancel={() => setApprovalWarning(null)}
+        onConfirm={() => {
+          const target = approvalWarning;
+          setApprovalWarning(null);
+          if (target?.mode !== "full" || !window.ogb?.approvals || applyingThreadAccess) return;
+          setApplyingThreadAccess(true);
+          // The private reply predates commit. SSE supplies the final task;
+          // applying that early reply here could overwrite its new mode.
+          void window.ogb.approvals.setMode(target.botId, "full", { threadId: target.threadId })
+            .catch((error) => dispatch({ type: "error", message: error instanceof Error ? error.message : String(error) }))
+            .finally(() => setApplyingThreadAccess(false));
+        }}
+      />
       <LocalComputerAutoWarning
         open={approvalWarning?.mode === "auto"}
         onCancel={() => setApprovalWarning(null)}

--- a/src/components/FullAccessWarning.tsx
+++ b/src/components/FullAccessWarning.tsx
@@ -8,10 +8,12 @@ export function FullAccessWarning({
   open,
   onCancel,
   onConfirm,
+  scope = "bot",
 }: {
   open: boolean;
   onCancel: () => void;
   onConfirm: () => void;
+  scope?: "bot" | "thread";
 }) {
   const cancelRef = useRef<HTMLButtonElement>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -67,7 +69,9 @@ export function FullAccessWarning({
               Enable Full access?
             </h2>
             <p id="full-access-warning-body" className="mt-1.5 text-[13px] leading-relaxed text-ink-secondary">
-              {FULL_ACCESS_WARNING}
+              {scope === "thread"
+                ? "Apply this bot's Full access to this thread only, including work delegated here. It can read, edit and delete files, use the internet, and control its selected computer without asking—even for destructive or sensitive actions. Other existing threads keep their approval levels. Provider safety restrictions, questions and separate OpenMausBot confirmations still apply."
+                : FULL_ACCESS_WARNING}
             </p>
           </div>
         </div>

--- a/src/components/bot-settings/PermissionsSection.tsx
+++ b/src/components/bot-settings/PermissionsSection.tsx
@@ -112,7 +112,8 @@ export function PermissionsSection({
       <div className="rounded-xl bg-card p-4">
         <div className="text-[15px] font-medium text-ink">Approval level</div>
         <div className="mt-0.5 text-[13px] text-ink-secondary">
-          Choose how much this bot can do before it stops to ask you.
+          Default for new threads, routines and delegated work. Existing threads keep their own level;
+          change it from that thread’s composer.
         </div>
         <div className="mt-3">
           <ApprovalModeSelector

--- a/src/testing/thread-approvals.tsx
+++ b/src/testing/thread-approvals.tsx
@@ -1,0 +1,21 @@
+// The real chat/composer against the disposable approval smoke server.
+import { createRoot } from "react-dom/client";
+import { ChatView, ErrorRow } from "../components/ChatView";
+import { DesktopCapabilitiesProvider } from "../components/DesktopCapabilities";
+import { StoreProvider, useStore } from "../state/store";
+import { applySkin } from "../lib/skins";
+import { setAnalyticsEnabled } from "../lib/analytics";
+import "../styles.css";
+
+function Fixture() {
+  const { state } = useStore();
+  const bot = state.bots.find(candidate => candidate.id === new URLSearchParams(location.search).get("bot"));
+  return <div className="flex h-screen flex-col bg-app text-ink">
+    {state.error && <p role="alert">{state.error}</p>}
+    <div className="p-4"><ErrorRow message="This task was blocked by our safety systems." onRetry={() => { throw new Error("Safety errors must not expose Retry"); }} /></div>
+    {bot && <div className="min-h-0 flex-1"><ChatView bot={bot} /></div>}
+  </div>;
+}
+setAnalyticsEnabled(false);
+applySkin("midnight");
+createRoot(document.getElementById("root")!).render(<DesktopCapabilitiesProvider><StoreProvider><Fixture /></StoreProvider></DesktopCapabilitiesProvider>);

--- a/src/types/ogb.d.ts
+++ b/src/types/ogb.d.ts
@@ -114,7 +114,7 @@ const __APP_VERSION__: string;
         setMode(
           botId: string,
           mode: import("../../shared/approval-mode").ApprovalMode,
-          options?: { acknowledgeLocalAuto?: boolean },
+          options?: { acknowledgeLocalAuto?: boolean; threadId?: string },
         ): Promise<import("../state/store").Bot>;
       };
       localControl: {


### PR DESCRIPTION
## Summary

Fixes the OMB-side regressions behind Grok image rejection, Claude settings-based authentication disappearing, and existing delegated threads retaining a different approval level from their bot. Also makes Codex provider safety failures understandable without retrying or bypassing them.

- **Grok image attachments:** enable native ACP image transport. A narrow compatibility exception handles official Grok 1.0.x runtimes from 1.0.25 onward, which accept image blocks but advertise `image:false`. Unknown/older runtimes still require negotiated support. Image bytes remain redacted from diagnostics.
- **Claude authentication:** preserve the selected account's authentication settings and API-key helper while keeping personal hooks, permissions, MCP servers and instructions isolated. Explicit OMB connections retain precedence. Temporary settings files are private, cleaned up, and never expose keys on process arguments. Credential changes invalidate retained processes.
- **Thread permissions:** add an explicit desktop confirmation to apply an already-approved bot Full Access default to one existing thread. Other threads remain unchanged; delegation does not inherit the sender's authority. Keep elevation on the private desktop channel, reject HTTP elevation, and cover interrupted grant recovery. Also honor supported thread-level Auto-accept edits.
- **Codex safety errors:** preserve errors delivered at turn completion, classify known safety blocks as terminal, and show provider guidance instead of a misleading Retry button. This does **not** bypass provider safety or claim to resolve an unseen deployment refusal.

## Verification

All verification used disposable homes/workspaces, fake providers or loopback APIs; no live user data, credentials, paid model calls, or deployments were used.

- 357 focused provider/store/UI tests passed; 1 existing platform guard test skipped.
- Separate server/store/approval/UI regression run: 291 tests passed (overlaps the focused suite).
- 11 trusted-desktop protocol tests passed.
- Real Grok CLI 1.0.25 delivered the exact synthetic PNG bytes to a loopback model endpoint.
- Real Claude Code 2.1.266 completed two turns with a synthetic API-key helper and two with a settings-based API key; personal hooks stayed isolated.
- Isolated Electron/server smoke passed for Claude, Codex, Grok and Antigravity, including delegation through an existing thread and explicit permission downgrade.
- Real renderer smoke verified Cancel, scoped confirmation, server/SSE updates, sending after permission change, narrow layout, and safety error presentation.
- Verification-doc and Verify-card regression tests passed.
- Typecheck, lint, frontend production build, server production build, and diff whitespace checks passed.

Reproduction steps and boundaries: `docs/verification/provider-recovery.md`.

## Remaining boundaries

- Real CLI transport checks do not establish hosted model entitlement or production API availability.
- If a Claude Console profile still reports signed out, its `/status` profile and selected OMB account need comparison; the reporter's exact profile was not supplied.
- Codex safety monitoring is controlled by the provider, independently of Full Access.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added thread-level Full access controls for eligible bot conversations, including confirmation warnings and safety validation.
  - Added support for native image delivery with compatible Grok runtimes.
  - Claude authentication settings are now recovered from supported CLI configuration when needed.
  - Provider safety errors now show guidance and support links without offering ineffective retries.

- **Documentation**
  - Added verification procedures for provider images, authentication, approvals, and safety handling using isolated test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->