### PR TITLE
fix(computer): close panel before opening bot settings

### DIFF
--- a/scripts/testing/cloud-preview.tsx
+++ b/scripts/testing/cloud-preview.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { ComputerPanel } from "../../src/components/ComputerPanel";
+import { BotSettingsDialog } from "../../src/components/BotSettingsDialog";
 import { RemoteDesktopPanel } from "../../src/components/remote-desktop-panel";
 import { StoreProvider, useStore } from "../../src/state/store";
 import { applySkin, readSkin } from "../../src/lib/skins";
@@ -117,6 +118,7 @@ function Fixture() {
     if (bot) {
       dispatch({ type: "screenFrame", botId: bot.id, png: blank, mime: "image/png" });
       dispatch({ type: "updateBot", botId: bot.id, patch: { computer: "cloud", cloudBackend: "box" } });
+      dispatch({ type: "toggleComputer", open: true });
     }
   }, [bot?.id, dispatch]);
   return <div className="flex h-screen justify-center">
@@ -133,10 +135,11 @@ function Fixture() {
       <button onClick={() => transport.releaseJoin()}>Release desktop join</button>
       <button disabled={!bot} onClick={() => dispatch({ type: "screenFrame", botId: bot.id, png: frame("New live frame", "#312e81"), mime: "image/png" })}>Publish live frame</button>
     </div>
-    {bot ? panel === "computer"
+    {state.settingsOpen && bot && <BotSettingsDialog key={bot.id} bot={bot} />}
+    {state.computerOpen && bot ? panel === "computer"
       ? <ComputerPanel key={generation} bot={{ ...bot, busy }} />
       : <RemoteDesktopPanel key={generation} bot={{ ...bot, busy }} />
-      : "Loading fixture…"}
+      : !state.settingsOpen && <button onClick={() => dispatch({ type: "toggleComputer", open: true })}>Open computer panel</button>}
   </div>;
 }
 applySkin(readSkin());

--- a/src/components/ComputerPanel.tsx
+++ b/src/components/ComputerPanel.tsx
@@ -1021,7 +1021,14 @@ export function ComputerPanel({
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3">
         <button
-          onClick={() => dispatch({ type: "toggleSettings", open: true, section: "access" })}
+          onClick={() => {
+            // Keep the panel/modal states exclusive at this entry point. That
+            // removes the still-mounted Computer panel from the settings
+            // dialog's focus path, and dismissing Settings returns directly
+            // to the conversation that opened it.
+            dispatch({ type: "toggleComputer", open: false });
+            dispatch({ type: "toggleSettings", open: true, section: "access" });
+          }}
           className="rounded-md p-1 text-ink-secondary hover:bg-control hover:text-ink"
           title={t("computer.botSettings")}
         >


### PR DESCRIPTION
## What changed

- Close the Computer panel before opening Bot Settings from its gear button.
- Extend the cloud preview fixture so the Computer → Bot Settings → conversation transition remains reproducible.

## Why

Opening Bot Settings while the Computer panel stayed mounted left two overlapping modal/panel focus paths. From that entry point, the close button, backdrop, and Escape key could focus the dialog without dismissing it, forcing users to restart the desktop app.

Keeping these surfaces mutually exclusive at the Computer-panel entry point makes dismissing Bot Settings return directly to the conversation that opened it.

## How it was verified

- Focused Oxlint on the two changed files: passed.
- Focused Vitest: 3 files, 90 tests passed.
- Frontend and server TypeScript checks: passed.
- The cloud preview fixture now exercises opening Settings from an already-open Computer panel and reopening the panel after dismissal.

## Screenshots (UI changes)

No visual styling change; this fixes the panel transition and dismissal behavior.

## Checklist

- [ ] Full `pnpm test` suite run locally (focused tests and both TypeScript checks passed)
- [x] Server behavior changes come with tests (not applicable; frontend-only change)
- [x] No `dist-server/` edits
- [x] macOS-only code is platform-gated; no `shell: true` / cmd.exe string-building
- [x] No secrets in logs, responses, events, or argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Opening Access settings from the Computer panel now closes the panel first, preventing overlapping views.
  * Closing settings returns you to the conversation you started from.
  * Cloud preview now displays the appropriate computer panel, settings view, or open-panel option based on the current state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->