### PR TITLE
fix(ui): clear stuck approvals after deleting a thread

### DIFF
--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -120,6 +120,10 @@ The [provider recovery recipe](provider-recovery.md) verifies real Grok image
 transport and Claude authentication against loopback APIs, plus scoped thread
 approvals and provider safety errors in an isolated desktop UI.
 
+The [skill approval lifecycle recipe](skill-approval-lifecycle.md) checks Deny,
+missing staged records and active-thread deletion in two isolated app windows,
+including the surviving conversation and sending again without deleting the bot.
+
 The [Codex account recipe](codex-account.md) checks account switching against an
 offline Codex CLI whose identity is synthetic and whose credential directory is empty.
 

--- a/docs/verification/skill-approval-lifecycle.md
+++ b/docs/verification/skill-approval-lifecycle.md
@@ -1,0 +1,52 @@
+# Learned-skill approval lifecycle
+
+Run the existing disposable Electron/server harness with its skill UI recipe:
+
+```sh
+pnpm exec electron scripts/smoke-approval-modes.cjs --skill-ui-only
+```
+
+The harness creates a temporary home, runs the real server with fake provider
+CLIs, and mounts the real ChatView, task picker, composer and StoreProvider in
+two hidden Electron windows. It never touches the running app or user data.
+No skill is enabled, no real provider is called, and no cleanup instruction
+from the reported screenshot is executed.
+
+The recipe asserts:
+
+1. Clicking **Deny** settles a staged skill card in both windows.
+2. Deny also works when the temporary staged record has already disappeared.
+3. A denied skill name can be proposed again; it is not silently reserved.
+4. Deleting the active thread through the real task picker removes its pending
+   card in both windows. The second window receives only server events, not
+   the delete request's response.
+5. The surviving thread retains its exact messages; the bot remains present.
+6. The staged skill is removed, and a new message sent through the composer
+   receives a fake-provider reply in both windows without reopening the app.
+
+Screenshots and assertion results are saved in
+`.omb-scratch/verify-evidence/skill-approval/`. Windows, server and temporary
+data are cleaned up after the run; the evidence remains.
+
+## Ordering regressions
+
+```sh
+pnpm exec vitest run src/state/store.test.ts src/components/ChatView.controls.test.ts src/components/ApprovalCard.test.ts server/skills.test.ts server/independent-task-store.test.ts
+pnpm exec vitest run server/index.test.ts -t 'only enables the exact learned-skill'
+pnpm typecheck
+pnpm lint
+```
+
+The original failure is a slim bot event arriving before its full replacement
+transcript. Previously this changed the thread ID but retained the deleted
+thread's messages, including its pending approval. Subsequent snapshots were
+ignored because the thread ID now matched, and Deny targeted the wrong thread.
+
+The state tests assert immediate removal of the old transcript, a disabled
+composer until its replacement arrives, full-snapshot-first ordering, replay
+of intervening events, rejection of old buffered approval patches, and no
+rollback from duplicate responses or navigation to another thread.
+
+This proves the reported lifecycle with real server/renderer state and a
+synthetic skill. It does not prove provider-specific tool behavior or recover
+a bot that the user has already deleted.

--- a/scripts/smoke-approval-modes.cjs
+++ b/scripts/smoke-approval-modes.cjs
@@ -109,6 +109,12 @@ app.whenReady().then(async () => {
   const verifyUi = () => require("./testing/approval-ui-smoke.cjs")({ root, url: `http://127.0.0.1:${port}`, api, until,
     grant: (botId, mode, options) => coordinator.request(child, botId, mode, options),
   });
+  if (process.argv.includes("--skill-ui-only")) {
+    await require("./testing/skill-approval-ui-smoke.cjs")({ root, home, url: `http://127.0.0.1:${port}`, api, until,
+      capability: (botId, threadId) => api("/api/testing/internal-capability", "POST", { botId, threadId, skillAuthoring: true }, { "x-openmausbot-test-capability": testCapabilityKey }),
+    });
+    return;
+  }
   if (process.argv.includes("--ui-only")) { await verifyUi(); return; }
   const created = await api("/api/bots", "POST", { modelSelection: { instanceId: "claude", model: "claude-sonnet-5" } });
   assert.equal(created.status, 201);

--- a/scripts/testing/skill-approval-preview.tsx
+++ b/scripts/testing/skill-approval-preview.tsx
@@ -1,0 +1,22 @@
+// Real conversation and task controls, connected only to the disposable server.
+import { createRoot } from "react-dom/client";
+import { ChatView } from "../../src/components/ChatView";
+import { DesktopCapabilitiesProvider } from "../../src/components/DesktopCapabilities";
+import { StoreProvider, useStore } from "../../src/state/store";
+import { setAnalyticsEnabled } from "../../src/lib/analytics";
+import { applySkin } from "../../src/lib/skins";
+import "../../src/styles.css";
+
+function Fixture() {
+  const { state } = useStore();
+  const bot = state.bots.find(candidate => candidate.id === new URLSearchParams(location.search).get("bot"));
+  return <main className="flex h-screen flex-col bg-app text-ink">
+    {state.error && <p role="alert">{state.error}</p>}
+    <output hidden id="fixture-state">{JSON.stringify({ threadId: bot?.threadId, pending: bot?.awaitingThreadSnapshot,
+      messageIds: bot?.messages.map(message => message.id) })}</output>
+    {bot && <div className="min-h-0 flex-1"><ChatView bot={bot} /></div>}
+  </main>;
+}
+setAnalyticsEnabled(false);
+applySkin("midnight");
+createRoot(document.getElementById("root")!).render(<DesktopCapabilitiesProvider><StoreProvider><Fixture /></StoreProvider></DesktopCapabilitiesProvider>);

--- a/scripts/testing/skill-approval-ui-smoke.cjs
+++ b/scripts/testing/skill-approval-ui-smoke.cjs
@@ -1,0 +1,102 @@
+const { BrowserWindow } = require("electron");
+const assert = require("node:assert/strict");
+const { mkdirSync, writeFileSync, readFileSync } = require("node:fs");
+const { join } = require("node:path");
+const { pathToFileURL } = require("node:url");
+
+module.exports = async function verifySkillApprovalUi({ root, home, url, api, until, capability }) {
+  const { mountPreview } = await import(pathToFileURL(join(root, "scripts/testing/preview-fixture.ts")).href);
+  const bot = (await api("/api/bots", "POST", { name: "Sprout fixture", modelSelection: { instanceId: "claude", model: "claude-sonnet-5" } })).body.bot;
+  const savedThreadId = bot.threadId;
+  const readBot = async () => (await api("/api/bots")).body.bots.find(candidate => candidate.id === bot.id);
+  const send = async (threadId, text) => {
+    assert.equal((await api(`/api/bots/${bot.id}/messages`, "POST", { threadId, text })).status, 202);
+    await until(async () => !(await readBot()).busy);
+  };
+  await send(savedThreadId, "Keep this conversation");
+  const keptMessageIds = (await readBot()).messages.map(message => message.id);
+  const pendingTask = (await api(`/api/bots/${bot.id}/tasks`, "POST", { title: "Pending skill" })).body.task;
+  const stage = async () => {
+    const minted = await capability(bot.id, pendingTask.threadId);
+    assert.equal(minted.status, 201);
+    const result = await api("/api/internal/skills/stage", "POST", {
+      fromBotId: bot.id, fromThreadId: pendingTask.threadId, action: "create", source: "conversation",
+      skill_md: "---\nname: fixture-review\ndescription: Review the fixture checklist.\n---\n\n# Fixture review\n\nRead the synthetic checklist and report what passed.\n",
+    }, { authorization: `Bearer ${minted.body.token}` });
+    assert.equal(result.status, 201, JSON.stringify(result.body));
+    return (await readBot()).messages.find(message => message.card?.skillRequest?.stagedId === result.body.stagedId);
+  };
+  const first = await stage();
+  const preview = await mountPreview({ info: { url } }, {
+    entry: "/scripts/testing/skill-approval-preview.tsx", route: "/__skill-approval.html", title: "Isolated skill approvals", logLevel: "silent",
+  });
+  const windows = [0, 1].map(() => new BrowserWindow({ show: false, width: 1280, height: 900, webPreferences: { contextIsolation: true, sandbox: true } }));
+  const evaluate = (window, js) => window.webContents.executeJavaScript(js);
+  const pending = window => evaluate(window, "document.querySelector('[aria-label=\"Pending skill confirmation\"]') !== null");
+  const click = (window, label) => evaluate(window, `(() => {
+    const button = [...document.querySelectorAll('button')].find(b => (b.getAttribute('aria-label') || b.textContent.trim()) === ${JSON.stringify(label)});
+    if (!button || button.disabled) throw new Error('Missing enabled button: ' + ${JSON.stringify(label)});
+    button.click(); return true;
+  })()`);
+  const state = window => evaluate(window, "JSON.parse(document.querySelector('#fixture-state').textContent)");
+  const evidence = join(root, ".omb-scratch/verify-evidence/skill-approval");
+  mkdirSync(evidence, { recursive: true });
+  try {
+    for (const window of windows) await window.loadURL(`${preview.previewUrl}?bot=${bot.id}`);
+    for (const window of windows) await until(() => pending(window));
+    writeFileSync(join(evidence, "pending.png"), (await windows[0].webContents.capturePage()).toPNG());
+    await click(windows[0], "Deny");
+    for (const window of windows) await until(async () => !await pending(window));
+    assert.equal((await readBot()).messages.find(message => message.id === first.id).card.answered, "deny");
+
+    // A missing stage must also remain dismissible; no reviewed code is run.
+    await stage();
+    await until(() => pending(windows[0]));
+    writeFileSync(join(home, "skill-state", bot.id, "staged.json"), JSON.stringify({ writes: {} }));
+    await click(windows[0], "Deny");
+    for (const window of windows) await until(async () => !await pending(window));
+
+    // Reusing the name proves Deny did not leave an invisible reservation.
+    const deletedCard = await stage();
+    for (const window of windows) await until(() => pending(window));
+    await click(windows[0], "All threads");
+    await evaluate(windows[0], `(() => {
+      const title = [...document.querySelectorAll('button')].find(button => button.querySelector('div')?.textContent === 'Pending skill');
+      const remove = title?.parentElement.querySelector('button[aria-label="Delete thread"]');
+      if (!remove || remove.disabled) throw new Error('Missing enabled thread deletion control');
+      remove.click(); return true;
+    })()`);
+    await until(async () => !(await readBot()).tasks.some(task => task.threadId === pendingTask.threadId));
+    // The second client receives only SSE, not the DELETE response.
+    for (const window of windows) {
+      await until(async () => (await state(window)).threadId === savedThreadId && !await pending(window));
+      await until(async () => (await state(window)).messageIds.includes(keptMessageIds.at(-1)));
+      assert.equal((await state(window)).messageIds.includes(deletedCard.id), false);
+      assert.equal(await evaluate(window, "document.querySelector('textarea').disabled"), false);
+    }
+    assert.deepEqual(JSON.parse(readFileSync(join(home, "skill-state", bot.id, "staged.json"), "utf8")).writes, {});
+    assert.deepEqual((await readBot()).messages.map(message => message.id), keptMessageIds);
+    await click(windows[0], "All threads");
+    await evaluate(windows[0], "document.querySelector('textarea').focus(); true");
+    windows[0].webContents.insertText("Still here after deleting the skill thread");
+    windows[0].webContents.sendInputEvent({ type: "keyDown", keyCode: "Return" });
+    windows[0].webContents.sendInputEvent({ type: "keyUp", keyCode: "Return" });
+    await until(async () => (await readBot()).messages.some(message => message.role === "user" && message.text === "Still here after deleting the skill thread"));
+    const reply = await until(async () => {
+      const current = await readBot();
+      return !current.busy && current.messages.find(message => !keptMessageIds.includes(message.id) && message.role === "bot" && message.kind === "text" && message.text === "hello from fake claude");
+    });
+    for (const window of windows) await until(async () => (await state(window)).messageIds.includes(reply.id));
+    writeFileSync(join(evidence, "after-delete.png"), (await windows[0].webContents.capturePage()).toPNG());
+    const result = { deny: true, missingStageDeny: true, activeThreadDeletion: true, secondClient: true, savedConversationIntact: true, sentAfterDeletion: true, botRetained: true };
+    writeFileSync(join(evidence, "results.json"), JSON.stringify(result, null, 2));
+    console.log(JSON.stringify({ ...result, evidence }));
+  } catch (error) {
+    writeFileSync(join(evidence, "failure.json"), JSON.stringify({ bot: await readBot(), ui: await state(windows[0]) }, null, 2));
+    writeFileSync(join(evidence, "failure.png"), (await windows[0].webContents.capturePage()).toPNG());
+    throw error;
+  } finally {
+    for (const window of windows) window.destroy();
+    await preview.close();
+  }
+};

--- a/src/components/ChatView.controls.test.ts
+++ b/src/components/ChatView.controls.test.ts
@@ -43,6 +43,11 @@ const bot: Bot = {
 };
 
 describe("thread control placement", () => {
+  it("keeps the composer inert until the deleted thread's replacement transcript arrives", () => {
+    const markup = renderToStaticMarkup(createElement(ChatView, { bot: { ...bot, awaitingThreadSnapshot: true } }));
+    expect(markup).toMatch(/<textarea[^>]*disabled=""[^>]*aria-busy="true"/);
+    expect(markup).not.toContain("Finish group setup");
+  });
   it("offers scoped Full access only when the bot already has it and the local trusted bridge exists", () => {
     const fullBot = { ...bot, busy: false, approvalMode: "full" as const };
     expect(renderToStaticMarkup(createElement(ChatView, { bot: fullBot }))).not.toContain("Use bot’s Full access for this thread");

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -90,7 +90,7 @@ export function Composer({
   onClearReply,
   onConsumeReply,
   onRestoreReply,
-  locked = false,
+  locked: setupLocked = false,
 }: {
   bot?: Bot;
   group?: Group;
@@ -104,6 +104,7 @@ export function Composer({
   locked?: boolean;
 }) {
   const bot = profile ? currentTaskBot(profile) : undefined;
+  const locked = setupLocked || Boolean(bot?.awaitingThreadSnapshot);
   const { state, dispatch } = useStore();
   const { capabilities } = useDesktopCapabilities();
   const remoteClient = window.ogb?.remoteClient?.active === true;
@@ -952,8 +953,9 @@ export function Composer({
             if (e.key === "Escape" && recording) setRecording(false);
           }}
           disabled={Boolean(approval) || locked || attachmentPending}
+          aria-busy={bot?.awaitingThreadSnapshot || undefined}
           placeholder={
-            locked
+            setupLocked
               ? t("composer.placeholder.locked")
               : approval
               ? t("composer.placeholder.approval")

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -130,6 +130,72 @@ describe("independent bot threads", () => {
     expect(read.bots[0]?.tasks?.[1]?.unread).toBe(true);
   });
 
+  it("drops deleted-thread approvals before a slim deletion frame is followed by its transcript", () => {
+    const approval: Message = { id: "old-approval", role: "bot", kind: "options", at: 2,
+      card: { title: "Enable skill?", subtitle: "Review this skill", options: ["Enable", "Deny"],
+        requestId: "old-request", tool: "stage_skill" } };
+    let state: ReturnType<typeof reducer> = { ...start(), bots: [{ ...bot, messages: [approval], activeLeafId: approval.id }] };
+    const { messages: _messages, ...slim } = bot;
+    const deletion = { ...slim, threadId: "second", activeLeafId: "replacement", tasks: bot.tasks!.slice(1) };
+    state = reducer(state, { type: "botPatched", bot: deletion });
+    expect(state.bots[0]?.threadId).toBe("second");
+    expect(state.bots[0]?.messages).toEqual([]);
+    expect(state.bots[0]?.activeLeafId).toBeNull();
+    expect(state.bots[0]?.awaitingThreadSnapshot).toBe(true);
+    const replacement: Message = { id: "replacement", role: "user", kind: "text", text: "Keep this conversation", at: 3 };
+    const response = { ...deletion, messages: [replacement] };
+    state = reducer(state, { type: "botPatched", bot: response });
+    expect(state.bots[0]?.messages).toEqual([replacement]);
+    expect(state.bots[0]?.activeLeafId).toBe(replacement.id);
+    expect(state.bots[0]?.awaitingThreadSnapshot).toBe(false);
+    // A delayed HTTP duplicate must not undo a later server patch.
+    const edited = { ...replacement, text: "Newer state" };
+    state = reducer(state, { type: "messagePatched", threadId: "second", message: edited });
+    state = reducer(state, { type: "botPatched", bot: response });
+    expect(state.bots[0]?.messages).toEqual([edited]);
+  });
+
+  it("replays replacement-thread events received between deletion and the replacement snapshot", () => {
+    const { messages: _messages, ...slim } = bot;
+    const deletion = { ...slim, threadId: "second", activeLeafId: null, tasks: bot.tasks!.slice(1) };
+    let state = reducer(start(), { type: "botPatched", bot: deletion });
+    const reply: Message = { id: "second-reply", role: "bot", kind: "text", text: "Still working", at: 3, parentId: null };
+    state = reducer(state, { type: "messageAdded", threadId: "second", message: reply });
+    state = reducer(state, { type: "botPatched", bot: { ...deletion, messages: [] } });
+    expect(state.bots[0]?.messages).toEqual([reply]);
+    expect(state.bots[0]?.activeLeafId).toBe(reply.id);
+    expect(state.backgroundThreadEvents.second).toBeUndefined();
+  });
+
+  it("switches atomically when a deletion's full snapshot arrives first", () => {
+    const full = { ...bot, threadId: "second", activeLeafId: null, tasks: bot.tasks!.slice(1), messages: [] };
+    let state = reducer(start(), { type: "botPatched", bot: full });
+    const { messages: _messages, ...slim } = full;
+    state = reducer(state, { type: "botPatched", bot: slim });
+    expect(state.bots[0]).toMatchObject({ threadId: "second", messages: [], activeLeafId: null, awaitingThreadSnapshot: false });
+  });
+
+  it("does not replay old background approvals over the replacement snapshot", () => {
+    const stale: Message = { id: "approval", role: "bot", kind: "options", at: 2,
+      card: { title: "Review", subtitle: "Old state", options: ["Enable", "Deny"], requestId: "request", tool: "stage_skill" } };
+    const settled = { ...stale, card: { ...stale.card!, answered: "deny", dismissed: true } };
+    const full = { ...bot, threadId: "second", activeLeafId: stale.id, tasks: bot.tasks!.slice(1), messages: [settled] };
+    const before = { ...start(), backgroundThreadEvents: { second: [{ type: "messagePatched" as const, threadId: "second", message: stale }] } };
+    const state = reducer(before, { type: "botPatched", bot: full });
+    expect(state.bots[0]?.messages).toEqual([settled]);
+    expect(state.backgroundThreadEvents.second).toBeUndefined();
+  });
+
+  it("does not undo navigation when a deleted thread's replacement snapshot arrives late", () => {
+    const third = { threadId: "third", title: "Third", createdAt: 3 };
+    const { messages: _messages, ...slim } = bot;
+    const deletion = { ...slim, threadId: "second", activeLeafId: null, tasks: [...bot.tasks!.slice(1), third] };
+    let state = reducer(start(), { type: "botPatched", bot: deletion });
+    state = reducer(state, { type: "taskSwitched", bot: { ...deletion, threadId: "third", messages: [] } });
+    state = reducer(state, { type: "botPatched", bot: { ...deletion, messages: bot.messages } });
+    expect(state.bots[0]).toMatchObject({ threadId: "third", messages: [], awaitingThreadSnapshot: false });
+  });
+
   it("folds background messages racing a switch snapshot without changing the original conversation", () => {
     let state = reducer(start(), { type: "switchTask", botId: bot.id, threadId: "second" });
     const reply: Message = { id: "second-reply", role: "bot", kind: "text", text: "Second answer", at: 3, parentId: null };

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -344,6 +344,9 @@ export interface Bot {
    * bot's own session (null is how a clear travels over PATCH). */
   browserProfile?: string | null;
   messages: Message[];
+  /** Renderer-only: a deleted selection moved to a thread whose full
+   * transcript has not arrived yet. Never carry the deleted chat into it. */
+  awaitingThreadSnapshot?: boolean;
   /** leaf of the visible conversation branch (see visibleMessages) */
   activeLeafId?: string | null;
 }
@@ -1043,7 +1046,7 @@ function optimisticUserMessage(
 
 export function reducer(state: AppState, action: Action): AppState {
   if (action.type === "messageAdded" || action.type === "messagePatched" || action.type === "threadActive" || action.type === "optimisticMessageRemoved") {
-    const owner = state.bots.find((bot) => bot.threadId !== action.threadId && bot.tasks?.some((task) => task.threadId === action.threadId));
+    const owner = state.bots.find((bot) => (bot.threadId !== action.threadId || bot.awaitingThreadSnapshot) && bot.tasks?.some((task) => task.threadId === action.threadId));
     if (owner) {
       // ponytail: a bounded race buffer, not a second transcript store. The
       // server supplies complete history whenever this thread is reopened.
@@ -1263,26 +1266,36 @@ export function reducer(state: AppState, action: Action): AppState {
       const switchedThread =
         typeof action.bot.threadId === "string" && action.bot.threadId !== before.threadId &&
         !action.bot.tasks?.some((task) => task.threadId === before.threadId);
-      const patched = updateBot(next, action.bot.id, (b) => ({
+      // As with explicit navigation, the snapshot already includes events
+      // buffered while its thread was in the background. Replay only races
+      // after this switch begins, not older approval patches.
+      let switching = next;
+      if (switchedThread) {
+        const { [action.bot.threadId]: _stale, ...otherThreadEvents } = next.backgroundThreadEvents;
+        switching = { ...next, backgroundThreadEvents: otherThreadEvents };
+      }
+      if ((switchedThread || (before.awaitingThreadSnapshot && action.bot.threadId === before.threadId)) &&
+          Array.isArray(action.bot.messages)) {
+        // The slim deletion broadcast can arrive before the full snapshot.
+        // Finish that switch once, replaying any events received in between.
+        // Later duplicate HTTP snapshots must not overwrite newer messages.
+        return reducer(switching, { type: "taskSwitched", bot: { ...before, ...action.bot, messages: action.bot.messages, browserProfile: action.bot.browserProfile } });
+      }
+      const patched = updateBot(switching, action.bot.id, (b) => ({
         ...b,
         ...action.bot,
         threadId: switchedThread ? action.bot.threadId : b.threadId,
-        activeLeafId: switchedThread ? action.bot.activeLeafId : b.activeLeafId,
+        activeLeafId: switchedThread ? null : b.activeLeafId,
+        awaitingThreadSnapshot: switchedThread || b.awaitingThreadSnapshot,
         // Complete bot frames omit this optional field after switching back
         // to Own browser (or deleting a shared profile). Do not retain the
         // previous profile's name and selection in another window.
         browserProfile: action.bot.browserProfile,
-        // Existing threads keep this window's selection. Only losing the
-        // current thread (deletion, or a legacy server) adopts the frame's
-        // transcript; deliberate navigation uses taskSwitched below.
-        messages:
-          switchedThread && Array.isArray(action.bot.messages)
-            ? action.bot.messages
-            : b.messages,
+        // Clear immediately on deletion: old approvals must never be sent
+        // to the replacement thread while waiting for its transcript.
+        messages: switchedThread ? [] : b.messages,
       }));
-      return switchedThread && Array.isArray(action.bot.messages)
-        ? reconcileSnapshotQueues(patched, [action.bot])
-        : patched;
+      return patched;
     }
     case "messageAdded": {
       const bot = state.bots.find((b) => b.threadId === action.threadId);
@@ -1739,6 +1752,7 @@ export function reducer(state: AppState, action: Action): AppState {
         ...bot,
         ...action.bot,
         messages: action.bot.messages ?? [],
+        awaitingThreadSnapshot: false,
       }));
       for (const frame of state.backgroundThreadEvents[action.bot.threadId] ?? []) switched = reducer(switched, frame);
       const { [action.bot.threadId]: _settled, ...backgroundThreadEvents } = switched.backgroundThreadEvents;


### PR DESCRIPTION
## Problem

Deleting the active thread emits a slim bot update before the full replacement transcript. The renderer switched thread IDs but retained the deleted thread's messages and pending approval. It then ignored the full transcript because the thread ID already matched. Deny consequently targeted the wrong conversation, leaving a stuck card that appeared to require deleting the bot.

## Fix

- Clear the deleted transcript and its approvals immediately when the selected thread disappears.
- Keep the composer inert until the replacement transcript arrives, then complete the switch once.
- Preserve events arriving during that transition, without replaying older background approval patches.
- Ignore duplicate responses and late replacement snapshots after the user navigates elsewhere.
- Keep the existing server-side Deny and staged-skill cleanup behavior; no approval bypass or automatic skill enablement.

## Verification

All checks used disposable data, synthetic skills and fake providers; no live user workspace was modified.

- Added regression tests that failed before the fix for slim-update/full-transcript ordering and cross-thread message contamination.
- Covered full-snapshot-first ordering, duplicate responses, intervening events, old buffered approval patches, and navigation away during deletion.
- Real Electron/server smoke in two windows passed: Deny, Deny with a missing staged record, reuse of the denied skill name, active-thread deletion through the task picker, and SSE-only recovery in the second window.
- Confirmed the surviving conversation's exact messages, removal of the staged skill, retention of the bot, and a new message/reply after deletion.
- State/UI/skill/store tests and the learned-skill server integration test passed.
- Verification-document checks, typecheck, lint and production build passed.

Reproduce with:

```sh
pnpm exec electron scripts/smoke-approval-modes.cjs --skill-ui-only
```

Details: `docs/verification/skill-approval-lifecycle.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added end-to-end verification for skill approval, denial, deletion, synchronization across windows, and follow-up messaging.
  - Added a focused smoke-test mode for skill-approval UI flows.

- **Bug Fixes**
  - Improved chat continuity when switching to a thread whose latest transcript is still loading.
  - Prevented stale events from overriding the updated conversation state.
  - Kept the composer appropriately disabled while thread content is loading.

- **Documentation**
  - Added verification guidance for the skill-approval lifecycle and its supported test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->