### PR TITLE
fix(threads): hide bot-closed threads from sidebar

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -8936,7 +8936,7 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
           from: { botId: from.id, name: from.name, color: from.color },
           tool: { name: `Closed by @${from.name}`, ok: true },
         });
-        if (task.unread) store.patchTask(owner.id, threadId, { unread: false });
+        store.patchTask(owner.id, threadId, { unread: false, closed: true });
         return json(res, 200, { closed: true, threadId, title: task.title, botName: owner.name });
       }
       if (method === "GET" && path === "/api/internal/rooms") {

--- a/server/store.ts
+++ b/server/store.ts
@@ -317,6 +317,8 @@ export interface TaskRecord {
   autoApprove?: boolean;
   alwaysAllow?: string[];
   unread?: boolean;
+  /** A bot marked this finished; the transcript remains until the person deletes it. */
+  closed?: boolean;
   rewound?: boolean;
   pinnedMessageId?: string;
   /** Runtime-only state, reset on load and never written to bots.json. */

--- a/server/store.ts
+++ b/server/store.ts
@@ -343,7 +343,7 @@ export interface TaskRecord {
 
 const TASK_PATCH_FIELDS = [
   "title", "projectId", "modelSelection", "approvalMode", "autoApprove", "alwaysAllow",
-  "unread", "rewound", "pinnedMessageId", "resumeCursors", "lastInstanceId", "cwd",
+  "unread", "closed", "rewound", "pinnedMessageId", "resumeCursors", "lastInstanceId", "cwd",
   "routineRunId",
 ] as const satisfies readonly (keyof TaskRecord)[];
 export type TaskPatch = Partial<Pick<TaskRecord, typeof TASK_PATCH_FIELDS[number]>>;

--- a/server/thread-aware-bots.e2e.test.ts
+++ b/server/thread-aware-bots.e2e.test.ts
@@ -549,6 +549,7 @@ describe("close_thread", () => {
       const closed = await close(opened.body.threadId);
       expect(closed.status).toBe(200);
       expect(closed.body).toMatchObject({ closed: true, title: "QA: PR #78", botName: "Quinn" });
+      expect((await botState(qa.id)).tasks.find((task: any) => task.threadId === opened.body.threadId)).toMatchObject({ closed: true, unread: false });
       expect((await messages(opened.body.threadId)).some((message) => message.tool?.name === "Closed by @Parker")).toBe(true);
       // Parker's own second thread closes too; the one it speaks in does not
       const own = (await api("POST", `/api/bots/${pm.id}/tasks`, { title: "Notes" })).body.task.threadId as string;

--- a/src/components/SidebarThreadRow.test.ts
+++ b/src/components/SidebarThreadRow.test.ts
@@ -20,6 +20,10 @@ describe("sidebar thread visibility", () => {
     expect(visibleSidebarThreads(rows, "0", "", [], true).map((task) => task.threadId)).not.toContain("2");
     expect(visibleSidebarThreads(rows, "0", "thread 2", [], true)).toEqual([]);
   });
+  it("fills the six recent rows with open threads when closed threads appear first", () => {
+    const rows = tasks.map((task) => ({ ...task, closed: task.threadId === "1" || task.threadId === "3" }));
+    expect(visibleSidebarThreads(rows, "0").map((task) => task.threadId)).toEqual(["0", "2", "4", "5", "6", "7"]);
+  });
   it("keeps queued older threads visible", () => {
     const rows = tasks.map((task) => ({ ...task, queued: task.threadId === "9" }));
     expect(visibleSidebarThreads(rows, "0").map((task) => task.threadId)).toEqual(["0", "1", "2", "3", "4", "5", "9"]);

--- a/src/components/SidebarThreadRow.test.ts
+++ b/src/components/SidebarThreadRow.test.ts
@@ -15,6 +15,11 @@ describe("sidebar thread visibility", () => {
     expect(visibleSidebarThreads(tasks, "0", "thread 9").map((task) => task.threadId)).toEqual(["9"]);
     expect(visibleSidebarThreads(tasks, "0", "missing")).toEqual([]);
   });
+  it("hides bot-closed threads without deleting their records", () => {
+    const rows = tasks.map((task) => ({ ...task, closed: task.threadId === "2" }));
+    expect(visibleSidebarThreads(rows, "0", "", [], true).map((task) => task.threadId)).not.toContain("2");
+    expect(visibleSidebarThreads(rows, "0", "thread 2", [], true)).toEqual([]);
+  });
   it("keeps queued older threads visible", () => {
     const rows = tasks.map((task) => ({ ...task, queued: task.threadId === "9" }));
     expect(visibleSidebarThreads(rows, "0").map((task) => task.threadId)).toEqual(["0", "1", "2", "3", "4", "5", "9"]);

--- a/src/components/SidebarThreadRow.tsx
+++ b/src/components/SidebarThreadRow.tsx
@@ -7,7 +7,7 @@ import { t } from "@/lib/i18n";
 import { nextRename } from "@/lib/rename";
 import { ConfirmDialog } from "./ConfirmDialog";
 
-type ThreadRowTask = Pick<Task, "threadId" | "title" | "projectId" | "busy" | "activity" | "unread" | "openedBy"> & { queued?: boolean };
+type ThreadRowTask = Pick<Task, "threadId" | "title" | "projectId" | "busy" | "activity" | "unread" | "closed" | "openedBy"> & { queued?: boolean };
 
 /** "opened by Scout" for a thread a bot started, null for the person's own.
  * Shared by the sidebar row and the All-threads picker so both say it the

--- a/src/components/SidebarThreadRow.tsx
+++ b/src/components/SidebarThreadRow.tsx
@@ -19,9 +19,10 @@ export function threadOpenerLabel(task: Pick<Task, "openedBy">): string | null {
 
 export function visibleSidebarThreads<T extends ThreadRowTask>(tasks: T[], activeId: string, query = "", folders: BotProject[] = [], showAll = false): T[] {
   const needle = query.trim().toLowerCase();
-  return tasks.filter((task, index) => !task.closed && (needle
+  const recentOpenIds = new Set(tasks.filter((task) => !task.closed).slice(0, 6).map((task) => task.threadId));
+  return tasks.filter((task) => !task.closed && (needle
     ? task.title.toLowerCase().includes(needle) || folders.some((folder) => folder.id === task.projectId && folder.name.toLowerCase().includes(needle))
-    : showAll || index < 6 || task.threadId === activeId || task.activity === "waiting-on-you" || task.activity === "working" || task.busy || task.queued || task.unread));
+    : showAll || recentOpenIds.has(task.threadId) || task.threadId === activeId || task.activity === "waiting-on-you" || task.activity === "working" || task.busy || task.queued || task.unread));
 }
 
 /** One quiet row for bot and group histories. Surface denotes selection;

--- a/src/components/SidebarThreadRow.tsx
+++ b/src/components/SidebarThreadRow.tsx
@@ -19,9 +19,9 @@ export function threadOpenerLabel(task: Pick<Task, "openedBy">): string | null {
 
 export function visibleSidebarThreads<T extends ThreadRowTask>(tasks: T[], activeId: string, query = "", folders: BotProject[] = [], showAll = false): T[] {
   const needle = query.trim().toLowerCase();
-  return tasks.filter((task, index) => needle
+  return tasks.filter((task, index) => !task.closed && (needle
     ? task.title.toLowerCase().includes(needle) || folders.some((folder) => folder.id === task.projectId && folder.name.toLowerCase().includes(needle))
-    : showAll || index < 6 || task.threadId === activeId || task.activity === "waiting-on-you" || task.activity === "working" || task.busy || task.queued || task.unread);
+    : showAll || index < 6 || task.threadId === activeId || task.activity === "waiting-on-you" || task.activity === "working" || task.busy || task.queued || task.unread));
 }
 
 /** One quiet row for bot and group histories. Surface denotes selection;

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -245,6 +245,8 @@ export interface Task {
   activity?: Bot["activity"];
   busy?: boolean;
   unread?: boolean;
+  /** A bot marked this finished; keep the transcript but hide it from history lists. */
+  closed?: boolean;
   pinnedMessageId?: string;
   /** set when a bot (not the person) started this thread — its own or a
    * teammate's; the sidebar shows a quiet "opened by <name>" under the title */


### PR DESCRIPTION
## Summary

Persist the close_thread result on the task and hide closed tasks from both recent and all/search sidebar lists without deleting their transcript.

Closes #1074

## Validation

- `pnpm exec vitest run src/components/SidebarThreadRow.test.ts server/thread-aware-bots.e2e.test.ts` - 18 passed
- `pnpm typecheck` - passed

## Notes

The task record remains available to server-side history and deletion paths. Only sidebar visibility changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bot-closed threads are now marked as closed while retaining their transcripts.
  * Closed threads are hidden from sidebar history and do not occupy recent-thread slots.

* **Bug Fixes**
  * Closing a thread consistently updates its status and clears its unread indicator.

* **Tests**
  * Added coverage confirming closed-thread persistence, status updates, and correct sidebar ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->