### PR TITLE
fix: explicit setup, clear model scope, and bot file continuity

### DIFF
--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -38,6 +38,7 @@ recipe from sending messages to the user's running app by accident.
 Use only mapped, tested commands:
 
 - [Chat turns](chat-turns.md)
+- [Bot setup, model scope, and file continuity](bot-continuity.md)
 - [Chat UI, driven headlessly](chat-ui.md)
 - [Welcome flow and guided tour](onboarding.md)
 - [Channels](channels.md)

--- a/docs/verification/bot-continuity.md
+++ b/docs/verification/bot-continuity.md
@@ -1,0 +1,51 @@
+# Bot setup, model scope, and file continuity
+
+```sh
+pnpm exec vitest run server/setup-mode.test.ts server/bot-setup.e2e.test.ts server/bot-continuity.e2e.test.ts server/independent-threads-api.test.ts
+OMB_UI_E2E=1 pnpm exec vitest run scripts/testing/control-omb-ui.e2e.test.ts
+```
+
+The server recipe launches the real app in a temporary home with only the
+offline CLI. It sends actual messages through `control-omb`, waits for settled
+turns, and checks the prompt and model delivered to the provider boundary:
+
+- A named bot with no description or SOUL can receive a normal work request
+  without the setup interview or its "Wait for a yes" instruction.
+- `/setup Help me track garden watering` explicitly enables coaching; the next
+  ordinary request disables it, even if no profile card was confirmed.
+- A pinned thread's model change with `updateBotDefault: true` updates that
+  thread and the bot default used by groups and future threads. It does not
+  change a selected sibling, other saved model choices, or approval levels.
+- Without that flag, only the selected thread changes. Group dispatch still
+  uses the bot default. Busy group changes and invalid requests are rejected.
+- Direct and room prompts carry the same saved identity and standing rules,
+  plus explicit current/shared/sibling file locations. Old files are retained;
+  working-directory pins and concurrent-thread isolation do not change.
+
+The test prints a retained `.bot-continuity.json` evidence path with commands,
+wait results, bounded transcripts, and provider-input receipts. Launch
+environments and MCP tokens are not retained. The renderer recipe checks both
+scope buttons in the real model picker, saves a screenshot, changes models,
+checks server persistence, and sends a message through the composer.
+
+## Live Claude smoke — 2026-09-12
+
+Separately, the exact system prompts captured from the disposable app were
+replayed to the signed-in Claude CLI (Sonnet 5). These were synthetic requests,
+not live user conversations. `--safe-mode`, `--restricted`,
+`--strict-mcp-config` and `--no-session-persistence` disabled customizations and
+saved sessions. Tools were disabled except for the final test, which allowed
+only Read inside the disposable working directories.
+
+| Request | Observed response |
+| --- | --- |
+| `What is 17 + 25? Answer with the number.` | `42` |
+| Explicit setup for tracking garden watering | Asked about the job, timing, apps and folder |
+| Find `garden-plan.txt` from earlier work, outside the current directory | Read the shared-bot file and returned its hidden verification code, `MOSS-42` |
+
+An arithmetic control using the old automatic-setup block also answered `42`.
+This does **not** reproduce every reported refusal, establish malicious intent,
+or prove every provider behaves identically. The verified regression is the
+unrequested coaching sent by OMB; live results confirm ordinary work, explicit
+setup and cross-folder reading on the tested Claude model. Group model routing
+and UI persistence use the offline provider. No real bots or files were moved.

--- a/docs/verification/threads.md
+++ b/docs/verification/threads.md
@@ -19,8 +19,10 @@ switching and Stop can be exercised without a real provider or account.
    rows should show Working. Changing the selection must not move messages.
 3. Stop iCloud. Gmail must remain Working; its Stop control still targets Gmail.
 4. In an idle thread, change its model. Select a sibling and return; each
-   should retain its own choice. Model/account/approval controls apply to the
-   visible thread, not all conversations belonging to the bot.
+   should retain its own choice. The model picker defaults to **This bot**:
+   it updates the visible thread plus the default for groups and new threads,
+   not existing siblings. Choose **Only this thread** for an independent
+   model/account/effort override. Approval controls remain thread-scoped.
 5. Rename a thread through its row menu. Remove the Email folder through its
    settings and confirm **Delete folder, keep threads**. Histories and model
    selections must remain, now directly beneath Pepper.

--- a/scripts/testing/control-omb-ui.e2e.test.ts
+++ b/scripts/testing/control-omb-ui.e2e.test.ts
@@ -138,6 +138,37 @@ describe("control-omb ui drives the real renderer", () => {
     // needs no flag; the fixture's default config is what a fresh install has.
     expect(flagged.features).toMatchObject({ skillAuthoring: true });
 
+    // Model changes in the real header default to the bot (groups/new
+    // threads), with an explicit thread-only choice. No permissions change.
+    const savedBot = async () => (await fetch(`${info.url}/api/bots`).then((response) => response.json())).bots.find((bot: any) => bot.id === info.botId);
+    const originalBot = await savedBot();
+    const originalModel = originalBot.modelSelection.model;
+    const models = await runControlOmb(["models", "--url", info.url]) as any;
+    const options = models.instances.find((instance: any) => instance.instanceId === originalBot.modelSelection.instanceId).models.options;
+    const originalLabel = options.find((option: any) => option.id === originalModel).label;
+    const nextModel = options.find((option: any) => option.id !== originalModel);
+    await ui("click", info.ui, "--name", originalLabel);
+    expect(await ui("eval", info.ui, "--js", "[...document.querySelectorAll('[aria-label=\"Apply model changes to\"] button')].find(b => b.textContent === 'This bot').getAttribute('aria-pressed')"))
+      .toMatchObject({ result: "true" });
+    const scopeShot = join(evidenceDir, "model-scope.png");
+    mkdirSync(evidenceDir, { recursive: true });
+    await ui("screenshot", info.ui, "--out", scopeShot);
+    await ui("click", info.ui, "--name", nextModel.label);
+    await expect.poll(async () => (await savedBot()).modelSelection.model, { timeout: 10_000 }).toBe(nextModel.id);
+    expect((await savedBot()).tasks.find((task: any) => task.threadId === originalBot.threadId).modelSelection.model).toBe(nextModel.id);
+    await ui("click", info.ui, "--name", nextModel.label);
+    await ui("click", info.ui, "--name", "Only this thread");
+    // The provider-default badge is part of the accessible model-row name.
+    const modelSnapshot = await ui("snapshot", info.ui, "--interactive");
+    const originalRow = Object.entries(modelSnapshot.refs as Record<string, { name: string; role: string }>)
+      .find(([, value]) => value.role === "button" && value.name.startsWith(originalLabel));
+    expect(originalRow).toBeDefined();
+    await ui("click", info.ui, "--ref", `@${originalRow![0]}`);
+    await expect.poll(async () => (await savedBot()).tasks.find((task: any) => task.threadId === originalBot.threadId).modelSelection.model,
+      { timeout: 10_000 }).toBe(originalModel);
+    expect((await savedBot()).modelSelection.model).toBe(nextModel.id);
+    expect((await savedBot()).approvalMode).toBe(originalBot.approvalMode);
+
     const before = await ui("snapshot", info.ui, "--interactive");
     expect(before.ok).toBe(true);
     const [composer, ...moreComposers] = refsNamed(before, "Message Pepper", "textbox");

--- a/server/bot-continuity.e2e.test.ts
+++ b/server/bot-continuity.e2e.test.ts
@@ -1,0 +1,98 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, it } from "vitest";
+import { launchVerificationServer, runControlOmb } from "../scripts/control-omb.ts";
+
+it("keeps ordinary work out of setup and carries explicit bot defaults and file locations into rooms", async () => {
+  const fixture = await launchVerificationServer();
+  const evidence: unknown[] = [{ fixture: fixture.info }];
+  const control = async (args: string[]) => {
+    const result = await runControlOmb([...args, "--url", fixture.info.url]) as any;
+    evidence.push({ command: args, result });
+    return result;
+  };
+  const api = async (method: string, path: string, body?: unknown, status?: number) => {
+    const response = await fetch(`${fixture.info.url}${path}`, {
+      method, headers: { "content-type": "application/json" },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    const result = await response.json() as any;
+    evidence.push({ method, path, body, status: response.status });
+    if (status) expect(response.status, JSON.stringify(result)).toBe(status);
+    else expect(response.ok, JSON.stringify(result)).toBe(true);
+    return result;
+  };
+  const receipt = () => {
+    const dump = JSON.parse(readFileSync(fixture.fixtureDumpPath, "utf8"));
+    // Never retain the launch environment/MCP config: it holds fixture tokens.
+    const result = { model: dump.argv[dump.argv.indexOf("--model") + 1], system: dump.systemPrompt as string, prompt: dump.prompt };
+    evidence.push({ receipt: result });
+    return result;
+  };
+  try {
+    const catalog = await control(["models"]);
+    const [a, b] = catalog.instances.find((item: any) => item.instanceId === "claude").models.options.map((item: any) => item.id);
+    const selection = (model: string) => ({ instanceId: "claude", model });
+    const { bot } = await api("POST", "/api/bots", { name: "Garden helper", title: "Gardener", modelSelection: selection(a) });
+    const direct = async (text: string) => {
+      await control(["send", "--bot", bot.id, "--task", bot.threadId, "--text", text]);
+      expect((await control(["wait", "--bot", bot.id, "--task", bot.threadId, "--timeout", "30"])).status).toBe("settled");
+      return receipt();
+    };
+    const ordinary = await direct("What is 17 + 25? Answer with the number.");
+    expect(ordinary.system).not.toContain("Wait for a yes");
+    expect(ordinary.system).not.toContain("The user explicitly asked you to set yourself up");
+    const oldFile = join(fixture.info.dataDir, "workspaces", bot.id, "garden-plan.txt");
+    writeFileSync(oldFile, "Water the garden on Friday. Fixture code: MOSS-42.\n");
+    expect(ordinary.system).toContain(join(fixture.info.dataDir, "workspaces", bot.id));
+    expect(ordinary.system).toContain(join(fixture.info.dataDir, "task-workspaces", bot.id, bot.threadId));
+
+    const setup = await direct("/setup Help me track garden watering");
+    expect(setup.system).toContain("The user explicitly asked you to set yourself up");
+    expect(setup.system).toContain("Wait for a yes");
+    // /setup is not sticky; a subsequent task must not carry its coaching.
+    const afterSetup = await direct("Never mind setup. Summarize: the garden needs water Friday.");
+    expect(afterSetup.system).not.toContain("Wait for a yes");
+    expect(JSON.stringify(afterSetup.prompt)).toContain("Never mind setup");
+
+    await api("PATCH", `/api/bots/${bot.id}`, { soul: "You look after the garden. Keep its watering plan.", description: "Garden helper" });
+    const { task: sibling } = await api("POST", `/api/bots/${bot.id}/tasks`, { title: "Sibling keeps its model" });
+    // Change an inactive task, not the newly selected sibling.
+    await api("PATCH", `/api/bots/${bot.id}/tasks/${bot.threadId}`, { modelSelection: selection(b), updateBotDefault: true });
+    expect((await direct("Tell me your responsibility in one sentence.")).model).toBe(b);
+    const { group } = await api("POST", "/api/groups", {
+      name: "Garden room", memberIds: [bot.id],
+      setup: { bulletin: "", defaultResponder: { kind: "member", botId: bot.id } },
+    });
+    const room = async (text: string) => {
+      await control(["send-channel", "--channel", group.id, "--text", text]);
+      expect((await control(["wait", "--channel", group.id, "--timeout", "30"])).status).toBe("settled");
+      return receipt();
+    };
+    const shared = await room("Read the garden-plan.txt you made earlier and tell me its fixture code.");
+    expect(shared.model).toBe(b);
+    expect(shared.system).toContain("You look after the garden");
+    expect(shared.system).toContain(join(fixture.info.dataDir, "task-workspaces", bot.id));
+    expect(shared.system).toContain(join(fixture.info.dataDir, "workspaces", bot.id));
+    expect(readFileSync(oldFile, "utf8")).toContain("MOSS-42");
+    const state = (await api("GET", "/api/bots")).bots.find((item: any) => item.id === bot.id);
+    expect(state.modelSelection).toEqual(selection(b));
+    expect(state.tasks.find((task: any) => task.threadId === sibling.threadId).modelSelection).toEqual(selection(a));
+    const { task: future } = await api("POST", `/api/bots/${bot.id}/tasks`, { title: "Future uses default" });
+    expect(future.modelSelection).toEqual(selection(b));
+
+    await api("PATCH", `/api/bots/${bot.id}/tasks/${bot.threadId}`, { modelSelection: selection(a) });
+    expect((await direct("Reply once for the thread-only model test.")).model).toBe(a);
+    expect((await room("Reply once for the unchanged room default.")).model).toBe(b);
+    await api("PATCH", `/api/bots/${bot.id}/tasks/${bot.threadId}`, { updateBotDefault: true }, 400);
+    await api("PATCH", `/api/bots/${bot.id}/tasks/${bot.threadId}`, { modelSelection: selection(a), updateBotDefault: "yes" }, 400);
+    await api("PATCH", `/api/bots/${bot.id}/tasks/not-a-thread`, { modelSelection: selection(a), updateBotDefault: true }, 404);
+    await control(["messages", "--bot", bot.id, "--task", bot.threadId, "--limit", "20"]);
+    await control(["messages", "--channel", group.id, "--limit", "20"]);
+  } finally {
+    const evidencePath = `${fixture.info.logPath}.bot-continuity.json`;
+    writeFileSync(evidencePath, JSON.stringify(evidence, null, 2));
+    console.info(JSON.stringify({ evidencePath }));
+    await fixture.close();
+  }
+}, 90_000);

--- a/server/bot-setup.e2e.test.ts
+++ b/server/bot-setup.e2e.test.ts
@@ -23,7 +23,7 @@ it("dispatches setup and canonical standing instructions through the real isolat
       return JSON.parse(readFileSync(fixture.fixtureDumpPath, "utf8"));
     };
     const setup = await turn("/setup Help me track garden watering");
-    expect(setup.systemPrompt).toContain("Your job this conversation is to set yourself up");
+    expect(setup.systemPrompt).toContain("The user explicitly asked you to set yourself up");
     expect(setup.systemPrompt).toContain("propose_profile");
     expect(JSON.stringify(setup.prompt)).toContain("Set yourself up for this job: Help me track garden watering");
 
@@ -32,7 +32,7 @@ it("dispatches setup and canonical standing instructions through the real isolat
     const configured = await turn("What is your job?");
     expect(configured.systemPrompt).toContain("Only water the fixture garden after approval.");
     expect(configured.systemPrompt).not.toContain("UNAPPROVED MIRROR INSTRUCTIONS");
-    expect(configured.systemPrompt).not.toContain("Your job this conversation is to set yourself up");
+    expect(configured.systemPrompt).not.toContain("The user explicitly asked you to set yourself up");
     const drift = await api("GET", `/api/bots/${bot.id}/soul`);
     expect(drift.drift).toBe(true);
     expect(drift.fileText).toBe("UNAPPROVED MIRROR INSTRUCTIONS");

--- a/server/independent-threads-api.test.ts
+++ b/server/independent-threads-api.test.ts
@@ -304,12 +304,14 @@ describe("independent bot tasks through the isolated control surface", () => {
     // a no-op relative to the task is not a no-op relative to the Group.
     expect((await api("PATCH", `/api/bots/${botId}/model`, selection)).status).toBe(409);
     expect((await api("PATCH", `/api/bots/${botId}`, { modelSelection: selection })).status).toBe(409);
+    expect((await api("PATCH", `/api/bots/${botId}/tasks/${threadId}`, { modelSelection: selection, updateBotDefault: true })).status).toBe(409);
     expect((await botState(botId)).tasks.find((task: any) => task.taskId === threadId)?.modelSelection).toEqual(selection);
     const profile = (await api("GET", "/api/bots")).body.bots.find((bot: any) => bot.id === botId);
     expect(profile.modelSelection.model).toBe(models[0]);
     expect((await api("POST", `/api/groups/${group.id}/interrupt`, {})).status).toBe(200);
     await expect.poll(async () => (await botState(botId)).busy, { timeout: 10_000 }).toBe(false);
-    expect((await api("PATCH", `/api/bots/${botId}/model`, selection)).status).toBe(200);
+    expect((await api("PATCH", `/api/bots/${botId}/tasks/${threadId}`, { modelSelection: selection, updateBotDefault: true })).status).toBe(200);
+    expect((await botState(botId)).modelSelection).toEqual(selection);
     evidence.push({ groupDefaultPreservedUntilStop: true, groupId: group.id, selectedTaskId: threadId });
   }, 30_000);
 

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -3408,6 +3408,11 @@ describe("harness HTTP API", () => {
         const rejected = await isolatedApi("PATCH", `/api/bots/${seeded.id}/model`, targetSelection);
         expect(rejected.status, seeded.approvalMode).toBe(400);
         expect(rejected.body.error).toMatch(/requires choosing Ask first/i);
+        const scoped = await isolatedApi("PATCH", `/api/bots/${seeded.id}/tasks/${seeded.threadId}`, {
+          modelSelection: targetSelection, updateBotDefault: true, approvalMode: "ask",
+        });
+        expect(scoped.status, seeded.approvalMode).toBe(400);
+        expect(scoped.body.error).toMatch(/Choose Ask in bot settings/i);
         const unchanged = (await isolatedApi("GET", "/api/bots?messages=0")).body.bots.find(
           (candidate: { id: string }) => candidate.id === seeded.id,
         );
@@ -3415,6 +3420,7 @@ describe("harness HTTP API", () => {
           approvalMode: seeded.approvalMode,
           modelSelection: seeded.modelSelection,
         });
+        expect(unchanged.tasks.find((task: { threadId: string }) => task.threadId === seeded.threadId).modelSelection).toEqual(seeded.modelSelection);
       }
 
       // A loopback-capable bot must not escape a restrictive Custom config
@@ -5498,7 +5504,7 @@ describe("harness HTTP API", () => {
     }
   });
 
-  it("coaches a blank bot to set itself up, and stops once it has a description", async () => {
+  it("does not coach an ordinary request even when the bot profile is blank", async () => {
     const bot = (await api("POST", "/api/bots", { name: "Blank" })).body.bot;
     try {
       expect((await api("PATCH", `/api/bots/${bot.id}`, {
@@ -5508,11 +5514,11 @@ describe("harness HTTP API", () => {
       expect((await api("POST", `/api/bots/${bot.id}/messages`, { text: "hello" })).status).toBe(202);
       let system = (await readJsonFileWhenReady<{ systemPrompt: string }>(fakeClaudeDump, 15_000)).systemPrompt;
       expect(system.startsWith("You are Blank, a personal bot in OpenMausBot.")).toBe(true);
-      expect(system).toContain("This bot has not been set up yet");
+      expect(system).not.toContain("Wait for a yes");
       expect(system).toContain("propose_profile");
 
       const preview = await api("GET", `/api/bots/${bot.id}/system-prompt`);
-      expect(preview.body.sections.map((s: { id: string }) => s.id)).toContain("setup");
+      expect(preview.body.sections.map((s: { id: string }) => s.id)).not.toContain("setup");
 
       expect((await api("POST", `/api/bots/${bot.id}/interrupt`)).status).toBe(200);
       // Interrupt requests a stop; the child can still be shutting down.
@@ -5525,7 +5531,7 @@ describe("harness HTTP API", () => {
       rmSync(fakeClaudeDump, { force: true });
       expect((await api("POST", `/api/bots/${bot.id}/messages`, { text: "hello again" })).status).toBe(202);
       system = (await readJsonFileWhenReady<{ systemPrompt: string }>(fakeClaudeDump, 15_000)).systemPrompt;
-      expect(system).not.toContain("This bot has not been set up yet");
+      expect(system).not.toContain("Wait for a yes");
       expect((await api("GET", `/api/bots/${bot.id}/system-prompt`)).body.sections.map((s: { id: string }) => s.id)).not.toContain("setup");
     } finally {
       await api("POST", `/api/bots/${bot.id}/interrupt`);
@@ -5548,7 +5554,7 @@ describe("harness HTTP API", () => {
       // soul first, setup block right after it
       const soulEnd = system.indexOf("--- END STANDING INSTRUCTIONS ---") + "--- END STANDING INSTRUCTIONS ---".length;
       expect(soulEnd).toBeGreaterThan(0);
-      expect(system.slice(soulEnd).startsWith("\n\nThis bot has not been set up yet")).toBe(true);
+      expect(system.slice(soulEnd).startsWith("\n\nThe user explicitly asked you to set yourself up")).toBe(true);
       // the literal /setup never reaches the model — extract the user text the
       // way promptText() in fake-claude-cli.ts does, joining text parts if the
       // content is an array of blocks rather than a plain string

--- a/server/index.ts
+++ b/server/index.ts
@@ -228,6 +228,7 @@ import { TurnResources, workspaceResource, type TurnOwner } from "./turn-resourc
 import {
   ensureWorkspace,
   ensureTaskWorkspace,
+  workspaceLocationsPrompt,
   updateMemory,
   appendMemoryLog,
   isMemoryTopicName,
@@ -5109,6 +5110,7 @@ async function startTurn(
         // to a turn whose engine actually mounted them (setupMode is already
         // false when they are not — see agentsMounted above)
         { id: "setup", label: "Setup", text: setupSystemPrompt(setupMode, { skills: skillAuthoring, cwd: liveBot?.cwd ?? bot.cwd }) },
+        { id: "files", label: "File locations", text: worksInWorkspace && opts?.runOn !== "cloud" ? workspaceLocationsPrompt(bot.id, cwd, liveBot?.cwd ?? bot.cwd) : "" },
         { id: "computer", label: "Computer", text: computerPrompt(computerPromptKind) },
         { id: "plan", label: "Surface", text: plan.note },
         // gated on the integration, not the key: the hint only goes to a
@@ -6315,6 +6317,7 @@ async function runGroupMemberTurn(
     if (drift.drift !== Boolean(bot.soulDrift)) store.patchBot(bot.id, { soulDrift: drift.drift });
   }
   const roomSystem = buildSystemPrompt(system, store.bot(bot.id)?.soul ?? bot.soul ?? "", [
+    { id: "files", label: "File locations", text: workspace ? workspaceLocationsPrompt(bot.id, cwd, readyBot.cwd) : "" },
     { id: "mcp", label: "MCP servers", text: customMcpPrompt(Object.keys(integrations.custom ?? {})) },
     { id: "computer", label: "Computer", text: computerPrompt(roomVmTarget ? localVmMode(cfg) === "per-bot" ? "vm-private" : "vm-shared" : null) },
     { id: "browser", label: "Browser", text: integrations.browser ? BUILT_IN_BROWSER_SYSTEM_PROMPT : "" },
@@ -13152,12 +13155,13 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
       if (!body || typeof body !== "object" || Array.isArray(body)) return json(res, 400, { error: "body must be a JSON object" });
       const current = store.projectBotForTask(m[1], m[2]);
       if (!current) return json(res, 404, { error: "no such task" });
-      const allowed = new Set(["title", "projectId", "modelSelection", "approvalMode", "autoApprove", "requireAvailableModel", "pinnedMessageId", "acknowledgeLocalAuto"]);
+      const allowed = new Set(["title", "projectId", "modelSelection", "updateBotDefault", "approvalMode", "autoApprove", "requireAvailableModel", "pinnedMessageId", "acknowledgeLocalAuto"]);
       if (Object.keys(body).some((key) => !allowed.has(key))) return json(res, 400, { error: "unsupported thread setting" });
-      for (const key of ["requireAvailableModel", "acknowledgeLocalAuto"] as const) {
+      for (const key of ["requireAvailableModel", "acknowledgeLocalAuto", "updateBotDefault"] as const) {
         if (body[key] !== undefined && typeof body[key] !== "boolean") return json(res, 400, { error: `${key} must be a boolean` });
       }
       if (body.requireAvailableModel === true && body.modelSelection === undefined) return json(res, 400, { error: "requireAvailableModel requires modelSelection" });
+      if (body.updateBotDefault === true && body.modelSelection === undefined) return json(res, 400, { error: "updateBotDefault requires modelSelection" });
       const patch: Parameters<typeof store.patchTask>[2] = {};
       if (body.projectId !== undefined) {
         if (body.projectId === null) patch.projectId = undefined;
@@ -13204,6 +13208,23 @@ const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
         (!supportsApprovalMode(registry.cliTarget(patch.modelSelection.instanceId)?.driverKind, mode) ||
           registry.cliTarget(patch.modelSelection.instanceId)?.driverKind !== registry.cliTarget(current.modelSelection.instanceId)?.driverKind)) {
         return json(res, 400, { error: "Choose Ask for this thread before changing providers with elevated permissions" });
+      }
+      if (body.updateBotDefault === true && patch.modelSelection) {
+        const profile = store.bot(current.id)!;
+        const checked = checkedModelSelection(patch.modelSelection, {
+          selection: profile.modelSelection, busy: Boolean(activeGroupTurnForBot(current.id)),
+        });
+        if (!checked.ok) return json(res, checked.status, { error: checked.error });
+        const defaultMode = approvalModeFor(profile);
+        if ((defaultMode === "full" || defaultMode === "custom") &&
+          (!supportsApprovalMode(registry.cliTarget(patch.modelSelection.instanceId)?.driverKind, defaultMode) ||
+            registry.cliTarget(patch.modelSelection.instanceId)?.driverKind !== registry.cliTarget(profile.modelSelection.instanceId)?.driverKind)) {
+          return json(res, 400, { error: "Choose Ask in bot settings before changing its default provider with elevated permissions" });
+        }
+        // Validate both scopes before saving either. Existing sibling threads
+        // retain their selections; only this pinned thread and future/group
+        // turns adopt the new default. Do not target the currently selected tab.
+        store.patchBot(current.id, { modelSelection: patch.modelSelection });
       }
       const task = store.patchTask(m[1], m[2], patch)!;
       const fresh = botWithThread(store.bot(m[1])!);

--- a/server/setup-mode.test.ts
+++ b/server/setup-mode.test.ts
@@ -1,4 +1,4 @@
-// Setup mode: a blank bot, or a /setup message, turns on a coaching block
+// Setup mode: only a /setup message turns on a coaching block
 // that makes the bot interview the user and configure itself through cards.
 import { describe, expect, it } from "vitest";
 
@@ -38,13 +38,16 @@ describe("expandSetupTurnText", () => {
 });
 
 describe("setupModeActive", () => {
-  it("is on for a blank bot regardless of the message", () => {
-    expect(setupModeActive({ soul: "", description: "", text: "hello" })).toBe(true);
-    expect(setupModeActive({ soul: "  \n", description: undefined, text: "hello" })).toBe(true);
-    expect(setupModeActive({ text: "hello" })).toBe(true);
+  it("does not turn an ordinary request into onboarding for a blank bot", () => {
+    for (const text of ["hello", "Summarize this report", "Run the daily check", "A teammate asked you to review this diff"]) {
+      expect(setupModeActive({ soul: "", description: "", text })).toBe(false);
+      expect(setupModeActive({ soul: "  \n", description: undefined, text })).toBe(false);
+      expect(setupModeActive({ text })).toBe(false);
+    }
   });
 
-  it("is off once either field is set, unless the message is /setup", () => {
+  it("requires /setup whether or not the profile has been filled in", () => {
+    expect(setupModeActive({ text: "/setup" })).toBe(true);
     expect(setupModeActive({ soul: "Be brief.", description: "", text: "hello" })).toBe(false);
     expect(setupModeActive({ soul: "", description: "Files bugs.", text: "hello" })).toBe(false);
     expect(setupModeActive({ soul: "Be brief.", description: "Files bugs.", text: "/setup" })).toBe(true);

--- a/server/setup-mode.ts
+++ b/server/setup-mode.ts
@@ -1,5 +1,5 @@
-// Setup mode: the coaching block a bot gets when it has not been set up yet,
-// or when the user asks for it with /setup. The bot interviews the user, says
+// Setup mode: optional coaching when the user asks for it with /setup.
+// An empty profile is not a request to interview the user. The bot says
 // what it intends, and then configures itself only through proposal cards
 // (propose_profile, propose_routine, skill_manage, request_credential) — so
 // nothing changes without the user's approval. Mirrors skill-learn.ts:
@@ -31,11 +31,10 @@ export function expandSetupTurnText(userText: string): string {
     : "Set yourself up. Ask me what you need to know, then propose your configuration.";
 }
 
-/** A bot with neither standing instructions nor a description has not been
- * set up. /setup re-enters the mode for a configured bot. */
+/** Only an explicit setup request enters coaching. Existing/blank bots must
+ * still do ordinary work, including delegated and scheduled requests. */
 export function setupModeActive(input: { soul?: string; description?: string; text: string }): boolean {
-  const blank = !(input.soul ?? "").trim() && !(input.description ?? "").trim();
-  return blank || parseSetupCommand(input.text) !== null;
+  return parseSetupCommand(input.text) !== null;
 }
 
 // skill_manage is only ever mounted alongside the other agent tools when
@@ -52,7 +51,7 @@ function folderClause(cwd: string | undefined): string {
 
 function buildSetupPrompt(profileAside: string, cwd?: string): string {
   return (
-    "\n\nThis bot has not been set up yet, or the user asked you to set yourself up. Your job this conversation is to set yourself up from what the user tells you." +
+    "\n\nThe user explicitly asked you to set yourself up. For this setup request, help configure the bot from what the user tells you." +
     ` First ask at most four questions that change what you would build: what the job is, when it should happen (on demand, on a schedule, or when something arrives), which apps or accounts it touches, and ${folderClause(cwd)}.` +
     " Then, before any tool call, tell the user in plain language what you intend: who you will be, what you will do and when, where you will work, what you will need from them, and what you will not do. Wait for a yes." +
     " When they say yes, first send one message that lists the cards you are about to raise, then make the tool calls — the cards must appear after that message, never before it. After the tool calls add at most one short line and do not repeat the list." +

--- a/server/workspace.test.ts
+++ b/server/workspace.test.ts
@@ -23,6 +23,7 @@ import {
   searchMemoryFiles,
   syncMemoryIndex,
   workspaceDir,
+  workspaceLocationsPrompt,
   writeMemoryTopic,
   writeMemoryFile,
   updateMemory,
@@ -48,6 +49,22 @@ describe("workspace", () => {
     rmSync(DATA_DIR, { recursive: true, force: true });
     rmSync(WORKSPACES_DIR, { recursive: true, force: true });
     rmSync(TASK_WORKSPACES_DIR, { recursive: true, force: true });
+  });
+
+  it("describes current and earlier file locations without moving or exposing their contents", () => {
+    const shared = ensureWorkspace(BOT);
+    const thread = ensureTaskWorkspace(BOT, "thread-first");
+    writeFileSync(join(shared, "old.txt"), "existing private file contents");
+    const prompt = workspaceLocationsPrompt(BOT, thread, '/projects/quoted "folder"');
+    expect(prompt).toContain(JSON.stringify(thread));
+    expect(prompt).toContain(JSON.stringify(shared));
+    expect(prompt).toContain(JSON.stringify(join(TASK_WORKSPACES_DIR, BOT)));
+    expect(prompt).toContain(JSON.stringify('/projects/quoted "folder"'));
+    expect(prompt).not.toContain("existing private file contents");
+    expect(prompt).toContain("Do not move old files");
+    expect(readFileSync(join(shared, "old.txt"), "utf8")).toBe("existing private file contents");
+    expect(existsSync(join(thread, "old.txt"))).toBe(false);
+    expect(workspaceLocationsPrompt(BOT, undefined)).toContain("inspect the working directory");
   });
 
   it("creates distinct private task desks outside shared memory and refuses path traversal", () => {

--- a/server/workspace.ts
+++ b/server/workspace.ts
@@ -60,6 +60,20 @@ export function workspaceDir(botId: string): string {
   return join(WORKSPACES_DIR, botId);
 }
 
+/** File locations, not file contents or wider tool permissions. Threads keep
+ * independent working directories; the same bot can find its earlier output
+ * without assuming that a file absent from the current directory was lost. */
+export function workspaceLocationsPrompt(botId: string, cwd: string | undefined, botCwd?: string): string {
+  return "\n\nFile locations for this bot (absolute paths): " + JSON.stringify({
+    currentWorkingFolder: cwd ?? "Provider default; inspect the working directory before using relative paths",
+    sharedBotFolder: workspaceDir(botId),
+    otherThreadFiles: join(TASK_WORKSPACES_DIR, botId),
+    ...(botCwd ? { configuredProjectFolder: botCwd } : {}),
+  }) + ". Different conversations can have different working folders. For an existing file, use the exact path from the conversation; if missing here, check this bot's listed folders before saying it is gone or recreating it." +
+    " Follow an explicitly requested destination. Otherwise put new task output in the current working folder and report its absolute path so another thread or room can use it." +
+    " Do not move old files, edit another active thread's work, or read another bot's private folders without authorization. These paths do not grant additional access.";
+}
+
 /** Lines as a person counts them: a file that ends in a newline has no
  * extra empty line after it. Every budget check and every "N lines"
  * message uses this one count. */

--- a/src/components/ModelPicker.test.ts
+++ b/src/components/ModelPicker.test.ts
@@ -68,6 +68,14 @@ function renderEffort(instances: InstanceInfo[], effort?: EffortLevel): string {
 }
 
 describe("EffortRow", () => {
+  it("can apply effort to the pinned thread and bot default together", () => {
+    fixture.instances = [engine(["high"])];
+    const row = EffortRow({ bot: bot(), threadId: "thread-atlas", updateBotDefault: true })!;
+    const levels = Children.toArray(row.props.children).at(-1) as ReactElement<{ children: ReactNode }>;
+    const high = Children.toArray(levels.props.children)[1] as ReactElement<{ onClick: () => void }>;
+    high.props.onClick();
+    expect(fixture.dispatch).toHaveBeenLastCalledWith({ type: "setModel", botId: "atlas", threadId: "thread-atlas", updateBotDefault: true, selection: { instanceId: "codex", model: "gpt-5.6", effort: "high" } });
+  });
   it("pins thread effort changes without changing profile defaults", () => {
     fixture.instances = [engine(["high"])];
     const row = EffortRow({ bot: bot(), threadId: "independent-thread" })!;

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -50,11 +50,13 @@ export function effortLabel(level: EffortLevel): string {
 export function EffortRow({
   bot,
   threadId,
+  updateBotDefault,
   className,
   label,
 }: {
   bot: Bot;
   threadId?: string;
+  updateBotDefault?: boolean;
   className?: string;
   label?: ReactNode;
 }) {
@@ -81,7 +83,7 @@ export function EffortRow({
                 ? "Send no effort level and let the engine decide"
                 : `Ask for ${effortLabel(level)} reasoning effort`
             }
-            onClick={() => dispatch({ type: "setModel", botId: bot.id, threadId, selection: { ...selection, effort: level } })}
+            onClick={() => dispatch({ type: "setModel", botId: bot.id, threadId, ...(updateBotDefault ? { updateBotDefault: true } : {}), selection: { ...selection, effort: level } })}
             className={cn(
               "rounded-full border px-2.5 py-1 text-[12px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70",
               selection.effort === level
@@ -257,6 +259,7 @@ export function ModelPicker({
   const [query, setQuery] = useState("");
   const [showAll, setShowAll] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const [scope, setScope] = useState<"bot" | "thread">("bot");
   const rootRef = useRef<HTMLDivElement>(null);
   const refreshingRef = useRef(false);
   const lastClaudeIdRef = useRef<string | null>(null);
@@ -363,6 +366,7 @@ export function ModelPicker({
       type: "setModel",
       botId: bot.id,
       threadId,
+      ...(threadId && scope === "bot" ? { updateBotDefault: true } : {}),
       selection: nextSelection,
     });
     setOpen(false);
@@ -489,6 +493,21 @@ export function ModelPicker({
           <ModelEngineRail instances={state.instances} selectedInstance={railInstance} claudeInstance={claudeRailInstance} onSelect={selectRail} />
 
           <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+            {threadId && (
+              <div className="shrink-0 border-b border-hairline/40 px-3 py-2">
+                <div role="group" aria-label="Apply model changes to" className="flex gap-1">
+                  {(["bot", "thread"] as const).map((value) => (
+                    <button key={value} type="button" aria-pressed={scope === value} onClick={() => setScope(value)}
+                      className={cn("rounded-lg px-2 py-1 text-[12px]", scope === value ? "bg-control text-ink" : "text-ink-secondary hover:bg-control/60")}>
+                      {value === "bot" ? "This bot" : "Only this thread"}
+                    </button>
+                  ))}
+                </div>
+                <p className="mt-1 text-[11px] text-ink-secondary">
+                  {scope === "bot" ? "This thread, groups, and new threads. Other existing threads keep their model." : "Other threads and groups keep their model."}
+                </p>
+              </div>
+            )}
             {railInstance ? (
               <>
                 <div className="shrink-0 px-4 pb-2 pt-3.5">
@@ -533,7 +552,7 @@ export function ModelPicker({
                     </p>
                   )}
                   <div className="mt-0.5 text-[11.5px] text-ink-secondary">
-                    {pane === "custom" ? t("model.localHint") : t(threadId ? "model.chooseThreadHint" : "model.chooseHint")}
+                    {pane === "custom" ? t("model.localHint") : t(threadId && scope === "thread" ? "model.chooseThreadHint" : "model.chooseHint")}
                   </div>
                 </div>
 
@@ -663,6 +682,7 @@ export function ModelPicker({
                   <EffortRow
                     bot={bot}
                     threadId={threadId}
+                    updateBotDefault={Boolean(threadId && scope === "bot")}
                     className="shrink-0 border-t border-hairline/40 px-4 py-3"
                     label={<span className="text-[12.5px] font-medium text-ink">Effort</span>}
                   />

--- a/src/components/bot-settings/ModelSection.tsx
+++ b/src/components/bot-settings/ModelSection.tsx
@@ -18,7 +18,7 @@ export function ModelSection({ bot }: { bot: Bot }) {
             <div>
               <div className="text-[15px] font-medium text-ink">Default model</div>
               <div className="mt-0.5 text-[13px] text-ink-secondary">
-                For new threads. Existing threads keep their own model choices.
+                For groups and new threads. Also updates the selected idle thread; other existing threads keep their model.
               </div>
             </div>
           }
@@ -38,7 +38,7 @@ export function ModelSection({ bot }: { bot: Bot }) {
                 we could not keep for a thread that had already been sent
                 one. Sending nothing is true on every engine. */}
             <div className="mt-0.5 text-[13px] text-ink-secondary">
-              How hard new threads think{bot.modelSelection.effort ? "" : " (Default: no level is sent)"}
+              How hard this bot thinks in groups and new threads{bot.modelSelection.effort ? "" : " (Default: no level is sent)"}
             </div>
           </div>
         }

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -107,6 +107,12 @@ describe("independent bot threads", () => {
     expect(updated.bots[0]?.tasks?.[1]).toEqual(bot.tasks?.[1]);
   });
 
+  it("does not persist request-only model scope on a task", () => {
+    const updated = reducer(start(), { type: "updateTask", botId: bot.id, threadId: "first", patch: { modelSelection: bot.modelSelection, updateBotDefault: true } });
+    expect(updated.bots[0]?.tasks?.[0]).not.toHaveProperty("updateBotDefault");
+    expect(updated.bots[0]?.tasks?.[1]).toEqual(bot.tasks?.[1]);
+  });
+
   it("pins send, stop, edit, approval and queued-message actions before navigation", () => {
     const actions: Action[] = [
       { type: "send", botId: bot.id, text: "Go" }, { type: "interrupt", botId: bot.id },

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -397,11 +397,12 @@ export function currentTaskBot(bot: Bot, threadId = bot.threadId): Bot {
 
 export type TaskUpdatePatch = Partial<Pick<Task, "modelSelection" | "approvalMode" | "autoApprove" | "pinnedMessageId">> & {
   acknowledgeLocalAuto?: boolean;
+  updateBotDefault?: boolean;
   projectId?: string | null;
 };
 
 function taskPatchFields(patch: TaskUpdatePatch): Partial<Task> {
-  const { acknowledgeLocalAuto: _localAck, projectId, ...fields } = patch;
+  const { acknowledgeLocalAuto: _localAck, updateBotDefault: _modelDefault, projectId, ...fields } = patch;
   return { ...fields, ...(projectId === undefined ? {} : { projectId: projectId ?? undefined }) };
 }
 
@@ -879,7 +880,7 @@ export type Action =
   | { type: "screenFrame"; botId: string; png: string; mime: string }
   | { type: "provisioning"; botId: string; on: boolean }
   | { type: "computerControl"; botId: string; held: boolean; helpReason: string | null }
-  | { type: "setModel"; botId: string; selection: ModelSelection; threadId?: string }
+  | { type: "setModel"; botId: string; selection: ModelSelection; threadId?: string; updateBotDefault?: boolean }
   | { type: "interrupt"; botId: string; threadId?: string; onError?: () => void }
   | { type: "connected"; value: boolean }
   | { type: "error"; message: string | null }
@@ -2153,7 +2154,7 @@ const StoreContext = createContext<{
 } | null>(null);
 
 export function StoreProvider({ children }: { children: ReactNode }) {
-  const taskWrites = useRef(new Map<string, { promise: Promise<BotAnnouncement>; execution: Promise<unknown>; patch: TaskUpdatePatch }>()).current;
+  const taskWrites = useRef(new Map<string, { botId: string; updatesDefault: boolean; promise: Promise<BotAnnouncement>; execution: Promise<unknown>; patch: TaskUpdatePatch }>()).current;
   const withTaskWrites = (bot: BotAnnouncement): BotAnnouncement => ({
     ...bot,
     tasks: bot.tasks?.map((task) => ({ ...task, ...taskPatchFields(taskWrites.get(task.threadId)?.patch ?? {}) })),
@@ -2250,7 +2251,8 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       // Reconciliation may clear a failed lane meanwhile; that must not turn
       // an already-waiting send into work under reverted settings.
       const taskWrite = threadId ? taskWrites.get(threadId)?.execution : undefined;
-      await Promise.all([taskWrite, ...expectedBots.map(async (expected) => {
+      const defaultWrites = [...taskWrites.values()].filter((write) => write.updatesDefault && expectedBots.some((bot) => bot.id === write.botId));
+      await Promise.all([taskWrite, ...defaultWrites.map((write) => write.execution), ...expectedBots.map(async (expected) => {
         const persisted = await botPatchQueue.flush(expected.id);
         if (!persisted) return;
         const expectedSelection = expected.modelSelection;
@@ -2268,7 +2270,10 @@ export function StoreProvider({ children }: { children: ReactNode }) {
 
     const persistTaskPatch = (botId: string, threadId: string, patch: TaskUpdatePatch) => {
       const previous = taskWrites.get(threadId);
-      const promise = (previous?.promise.catch(() => {}) ?? Promise.resolve())
+      // A quick tab switch may queue two default changes on different threads.
+      // Keep their order, and don't let a group send race either pending save.
+      const defaults = patch.updateBotDefault ? [...taskWrites.values()].filter((write) => write.botId === botId && write.updatesDefault) : [];
+      const promise = Promise.all([previous?.promise, ...defaults.map((write) => write.promise)].map((save) => save?.catch(() => {})))
         .then(async () => {
           // Full/Custom grants still belong to the private desktop bridge.
           if (patch.approvalMode === "full" || patch.approvalMode === "custom") {
@@ -2284,7 +2289,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       // successful folder move is not confirmation of a failed model change.
       const execution = Promise.all([previous?.execution, promise]);
       void execution.catch(() => {}); // handled by the write and send paths
-      const pending = { patch: { ...previous?.patch, ...patch }, promise, execution };
+      const pending = { botId, updatesDefault: Boolean(patch.updateBotDefault || previous?.updatesDefault), patch: { ...previous?.patch, ...patch }, promise, execution };
       taskWrites.set(threadId, pending);
       void pending.promise.then((bot) => {
         if (taskWrites.get(threadId) !== pending) return;
@@ -2740,7 +2745,10 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           break;
         case "setModel":
           if (action.threadId) {
-            persistTaskPatch(action.botId, action.threadId, { modelSelection: action.selection });
+            persistTaskPatch(action.botId, action.threadId, {
+              modelSelection: action.selection,
+              ...(action.updateBotDefault ? { updateBotDefault: true } : {}),
+            });
             break;
           }
           if (botBeforeUpdate) {


### PR DESCRIPTION
## Summary

Fixes the continuity surprises traced to #833 and #981 without rolling back independent threads or changing saved work.

- **Setup is explicit:** only a message starting with `/setup` adds the coaching/interview block. An empty description or SOUL no longer turns ordinary work into onboarding. The next ordinary request does not retain the setup block.
- **Model scope is visible:** the header picker defaults to **This bot** (current thread, groups, future threads), with **Only this thread** for independent overrides. Existing sibling selections remain intact. Model/account/effort changes use the pinned thread, and group sends await pending default saves.
- **Files are discoverable:** local-provider prompts identify the current folder, shared bot folder, same-bot thread folders and configured project folder. Bots are told to check those locations before declaring earlier output missing and to return absolute output paths. No files move, working-directory pins change, or conversations reset.
- Keep busy-group and elevated-permission provider-switch guards. The new model operation validates both scopes before saving either.

## Verification

- 174 focused tests passed across setup, prompt assembly, bot/group routing, independent and paired threads, memory, model UI and state. Additional workspace/document checks and focused `index.test.ts` permission/setup checks passed.
- Real Chromium UI recipe passed: both scope choices, persistence, composer send/response, screenshot and no console errors.
- Typecheck, lint, locale validation and diff checks passed.
- Live **Claude Sonnet 5** smoke with system prompts captured from the isolated app: ordinary arithmetic returned `42`; explicit setup asked the setup questions; Read-only file lookup found a synthetic file outside the current thread folder and returned its hidden `MOSS-42` code.

Live testing disabled customizations/MCP and session persistence; only the file case enabled Read within disposable directories. Group routing and UI tests use the offline provider. The old setup prompt also answered the arithmetic control correctly: this does not claim to reproduce every reported refusal or prove all providers' model behaviour. The user's particular missing files were not accessed or migrated.

Recipe and exact verification boundaries: `docs/verification/bot-continuity.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Model changes can now apply to the entire bot—including groups and new threads—or only the current thread.
  - Added clearer model and effort descriptions, including how changes affect existing threads.
  - Bot prompts now provide clearer guidance about workspace locations and file handling.

- **Bug Fixes**
  - Blank bots no longer start setup coaching for ordinary messages; setup begins only after an explicit `/setup` request.
  - Improved validation for model changes and bot-default updates.

- **Documentation**
  - Added verification guidance for bot setup, model scope, and file continuity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->