### PR TITLE
fix(budgets): enforce spend cap for channel turns + preserve live budget settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
         # supported host platforms. POSIX-only process tests self-skip.
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    # Windows' serial process fixtures already take ~14m on healthy runs;
-    # leave enough room for runner variance and the complete failure report.
+    # The full serial suite plus packaging/cleanup now reaches ~15m on
+    # healthy macOS/Linux runs; Windows needs a little more runner margin.
     # Keep every check and each test's own timeout unchanged.
-    timeout-minutes: ${{ matrix.os == 'windows-latest' && 25 || 15 }}
+    timeout-minutes: ${{ matrix.os == 'windows-latest' && 25 || 20 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10

--- a/server/index.ts
+++ b/server/index.ts
@@ -5905,6 +5905,7 @@ type GroupMemberTurnOutcome =
   | "settled"
   | "provider_failed"
   | "dispatch_failed"
+  | "spend_capped"
   | "stalled"
   | "timed_out"
   | "cancelled"
@@ -6684,7 +6685,7 @@ async function runGroupMemberTurn(
   return true;
   } catch (error) {
     if (providerDispatched) throw error;
-    const isSpendCap = typeof error === "object" && (error as { code?: string }).code === "spend_cap";
+    const isSpendCap = typeof error === "object" && error !== null && (error as { code?: string }).code === "spend_cap";
     if (!roomSpeaker && !isSpendCap) throw error;
     const message = error instanceof Error ? error.message : "Local VM setup failed";
     store.appendMessage(threadId, {
@@ -6693,7 +6694,13 @@ async function runGroupMemberTurn(
       tool: { name: `error: ${message}`, ok: false },
     });
     onDispatchError?.(message);
-    if (orchestration) orchestration.result.outcome = "dispatch_failed";
+    if (orchestration) {
+      // A spend-cap refusal is deterministic: record it as its own
+      // non-retryable outcome (the goal loop treats it as a blocked run,
+      // never as a transient dispatch failure worth a second attempt).
+      orchestration.result.outcome = isSpendCap ? "spend_capped" : "dispatch_failed";
+      if (isSpendCap) orchestration.result.stopReason = message;
+    }
     return false;
   } finally {
     // Covers connector/setup failures, cancellation before dispatch, and all
@@ -6793,6 +6800,8 @@ async function runGroupGoalStep(args: {
       // so costs a turn like any other model call — budget is spent, never
       // stretched, and the cap still holds.
       const outcome = result.outcome;
+      // spend_capped is deliberately absent: a cap refusal is deterministic,
+      // and a retry would just repeat the same spend-limit activity message.
       const transient =
         outcome === "provider_failed" ||
         outcome === "dispatch_failed" ||
@@ -6885,6 +6894,15 @@ async function runGroupGoalOperation(args: {
       finishGroupGoalRun(args.groupId, args.operation, "blocked", `${args.coordinator.name} is not available.`);
       return;
     }
+    if (coordinatorResult.outcome === "spend_capped") {
+      finishGroupGoalRun(
+        args.groupId,
+        args.operation,
+        "blocked",
+        coordinatorResult.stopReason ?? `${args.coordinator.name} hit the workspace spend cap.`,
+      );
+      return;
+    }
     if (coordinatorResult.outcome === "busy") {
       // The lead is the one member the run cannot route around. Blocked, not
       // failed: the goal text is intact and nothing about the team broke.
@@ -6968,6 +6986,15 @@ async function runGroupGoalOperation(args: {
     if (args.operation.cancelled) return;
     if (workerResult.outcome === "unavailable") {
       finishGroupGoalRun(args.groupId, args.operation, "blocked", `${workerBot.name} is not available.`);
+      return;
+    }
+    if (workerResult.outcome === "spend_capped") {
+      finishGroupGoalRun(
+        args.groupId,
+        args.operation,
+        "blocked",
+        workerResult.stopReason ?? `${workerBot.name} hit the workspace spend cap.`,
+      );
       return;
     }
     if (workerResult.outcome === "busy") {

--- a/server/index.ts
+++ b/server/index.ts
@@ -3772,9 +3772,29 @@ bus.subscribe((event: RuntimeEvent) => {
         } else {
           settleDirectTurn();
         }
+      } else if (group && speaker) {
+        // Room/goal turns run on a shared thread, but their spend still counts
+        // against the workspace cap and the ledger. Book it under the speaker.
+        const tokens = event.usage ?? lastReported;
+        const speakingBot = store.bot(speaker.botId);
+        const selection = speakingBot?.modelSelection;
+        appendUsage(DATA_DIR, {
+          botId: speaker.botId,
+          botName: speaker.name,
+          threadId: event.threadId,
+          instanceId: selection?.instanceId ?? "unknown",
+          driverKind: (selection && registry.get(selection.instanceId)?.driverKind) ?? "unknown",
+          model: selection?.model ?? "unknown",
+          input: tokens?.input ?? 0,
+          output: tokens?.output ?? 0,
+          ...(typeof tokens?.cachedInput === "number" ? { cachedInput: tokens.cachedInput } : {}),
+          costUsd: event.cost ?? null,
+          trigger: routineRun
+            ? { kind: "routine", routineId: routineRun.routineId, label: routineRun.routineName }
+            : turnTriggers.get(event.threadId) ?? { kind: "owner" },
+        });
+        noteSpend(DATA_DIR, event.cost ?? null);
       }
-      const speaker = groupSpeakers.get(event.threadId);
-      const group = store.groupByThread(event.threadId);
       if (speaker && group?.busyBotId === speaker.botId) {
         releaseTurnResources(turnResourceOwners.get(event.threadId));
         groupSpeakers.delete(event.threadId);
@@ -6050,6 +6070,9 @@ async function runGroupMemberTurn(
     releaseTurnResources(resourceOwner);
   };
   try {
+  // A workspace at its monthly spend limit rechecks the cap at execution time
+  // for every room, goal, queued, calendar, and chained-mention turn.
+  assertWithinBudget(cfg, DATA_DIR);
   const integrations: NonNullable<Parameters<typeof instance.adapter.sendTurn>[0]["integrations"]> = {};
   const skillAuthoring =
     skillAuthoringEnabled(cfg) &&
@@ -6660,7 +6683,9 @@ async function runGroupMemberTurn(
   }
   return true;
   } catch (error) {
-    if (providerDispatched || !roomSpeaker) throw error;
+    if (providerDispatched) throw error;
+    const isSpendCap = typeof error === "object" && (error as { code?: string }).code === "spend_cap";
+    if (!roomSpeaker && !isSpendCap) throw error;
     const message = error instanceof Error ? error.message : "Local VM setup failed";
     store.appendMessage(threadId, {
       role: "bot", kind: "activity",

--- a/server/spend-cap-api.test.ts
+++ b/server/spend-cap-api.test.ts
@@ -3,7 +3,7 @@
 // `budgets` and `billing`, the shared control surface for sends and waits,
 // and the cap read back from /api/usage. No real licence, engine, or
 // provider is involved; the fixture's home is disposable.
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -71,6 +71,47 @@ describe("spend cap and prices through real turns", () => {
     const raised = (await (await api("/api/usage")).json()) as any;
     expect(raised.budget).toMatchObject({ monthlyUsd: 1, exceeded: false });
     expect(raised.total.turns).toBe(3);
+  }, 150_000);
+
+  it.each([1, 2])("blocks a goal after %i paid turn(s) without retrying or spending another turn", async (allowedTurns) => {
+    await session.close();
+    const replyState = join(layerDir, "reply-state");
+    session = await launchVerificationServer({
+      ...process.env,
+      FAKE_CLAUDE_REPLIES: JSON.stringify([
+        'Delegating the check.<openmaus-goal>{"status":"continue","next":"Worker","instruction":"Check the draft"}</openmaus-goal>',
+        "The draft has been checked.",
+      ]),
+      FAKE_CLAUDE_REPLY_STATE: replyState,
+    }, undefined, undefined, undefined, { dir: layerDir, licenseKey: "fixture-key" });
+    expect((await put({ budgets: { monthlyUsd: allowedTurns * 0.01 } })).status).toBe(200);
+    const lead = (await control(["new-bot", "--name", "Lead"])).bot;
+    const worker = (await control(["new-bot", "--name", "Worker"])).bot;
+    const created = await api("/api/groups", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Budgeted goal", memberIds: [lead.id, worker.id],
+        setup: { bulletin: "", defaultResponder: { kind: "member", botId: lead.id } } }),
+    });
+    expect(created.status).toBe(201);
+    const { group } = await created.json() as any;
+    expect((await api(`/api/groups/${group.id}/messages`, {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text: "Check the draft and report back", mode: "goal" }),
+    })).status).toBe(202);
+    await control(["wait", "--channel", group.id, "--timeout", "30"]);
+
+    const page = await (await api(`/api/threads/${group.threadId}/messages?limit=50`)).json() as any;
+    const goal = page.messages.find((message: any) => message.kind === "goal.run")?.goalRun;
+    expect(goal).toMatchObject({ status: "blocked", turnCount: allowedTurns,
+      detail: expect.stringMatching(/reached its monthly spend limit/i) });
+    const capErrors = page.messages.filter((message: any) => message.kind === "activity" &&
+      /reached its monthly spend limit/i.test(message.tool?.name ?? ""));
+    expect(capErrors).toHaveLength(1);
+    expect(JSON.stringify(page)).not.toContain("retrying once");
+    expect(Number(readFileSync(replyState, "utf8"))).toBe(allowedTurns);
+    const usage = await (await api("/api/usage")).json() as any;
+    expect(usage.total.turns).toBe(allowedTurns);
+    expect(usage.budget.exceeded).toBe(true);
   }, 150_000);
 
   it("refuses the next room member at execution time once the cap is reached", async () => {

--- a/server/spend-cap-api.test.ts
+++ b/server/spend-cap-api.test.ts
@@ -72,4 +72,54 @@ describe("spend cap and prices through real turns", () => {
     expect(raised.budget).toMatchObject({ monthlyUsd: 1, exceeded: false });
     expect(raised.total.turns).toBe(3);
   }, 150_000);
+
+  it("refuses the next room member at execution time once the cap is reached", async () => {
+    const edition = (await (await api("/api/edition")).json()) as { edition: string; features: string[] };
+    expect(edition).toMatchObject({ edition: "enterprise", features: ["billing", "budgets"] });
+
+    // The fake engine reports $0.01 per turn. A $0.01 cap lets the first room
+    // member complete its turn, then blocks the second member inside
+    // runGroupMemberTurn before it can dispatch another provider turn.
+    expect((await put({
+      budgets: { monthlyUsd: 0.01, warnAtPercent: 50 },
+      billing: { currency: "USD", prices: { default: { inputPerMillion: 1000, outputPerMillion: 2000 } } },
+    })).status).toBe(200);
+
+    const first = (await control(["new-bot", "--name", "Room A"])) as { bot: { id: string } };
+    const second = (await control(["new-bot", "--name", "Room B"])) as { bot: { id: string } };
+
+    const roomRes = await api("/api/groups", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Cap room",
+        memberIds: [first.bot.id, second.bot.id],
+        setup: { bulletin: "", defaultResponder: { kind: "everyone" } },
+      }),
+    });
+    expect(roomRes.status).toBe(201);
+    const room = (await roomRes.json()) as { group: { id: string; threadId: string } };
+
+    const sent = await api(`/api/groups/${encodeURIComponent(room.group.id)}/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text: "hello team" }),
+    });
+    expect(sent.status).toBe(202);
+
+    await control(["wait", "--channel", room.group.id, "--timeout", "30"]);
+
+    const page = (await (await api(`/api/threads/${encodeURIComponent(room.group.threadId)}/messages?limit=20`)).json()) as any;
+    const botTextReplies = page.messages.filter((m: any) => m.role === "bot" && m.kind === "text");
+    expect(botTextReplies).toHaveLength(1);
+
+    const capHit = page.messages.find(
+      (m: any) => m.role === "bot" && m.kind === "activity" && /reached its monthly spend limit/i.test(m.tool?.name ?? ""),
+    );
+    expect(capHit).toBeTruthy();
+
+    const usage = (await (await api("/api/usage")).json()) as any;
+    expect(usage.budget).toMatchObject({ monthlyUsd: 0.01, exceeded: true, warn: true });
+    expect(usage.total.turns).toBe(1);
+  }, 150_000);
 });

--- a/server/spend-cap-goal.e2e.test.ts
+++ b/server/spend-cap-goal.e2e.test.ts
@@ -1,0 +1,106 @@
+// A team goal that runs into the monthly spend cap mid-run must end as a
+// blocked run carrying the cap detail — never as a "dispatch failure" the
+// goal loop retries (a cap refusal is deterministic, so the retry would just
+// repeat the same spend-limit activity message and mislabel the run as
+// failed). Driven through the isolated fake-engine fixture booted with a
+// stand-in enterprise layer that grants `budgets` and `billing`, with the
+// coordinator's decision reply scripted; no real licence, engine, or
+// provider is involved; the fixture's home is disposable.
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { launchVerificationServer, runControlOmb, type VerificationServer } from "../scripts/control-omb.ts";
+import { removeTempDir } from "./testing/cleanup.ts";
+
+describe("spend cap inside a team goal run", () => {
+  let session: VerificationServer;
+  let layerDir: string;
+
+  beforeEach(async () => {
+    layerDir = mkdtempSync(join(tmpdir(), "omb-fake-layer-goal-"));
+    mkdirSync(join(layerDir, "server"));
+    writeFileSync(join(layerDir, "server", "index.js"), 'export async function register() { return { customer: "Fixture Co", features: ["budgets", "billing"], expiresAt: "2099-01-01" }; }\n');
+    session = await launchVerificationServer({
+      ...process.env,
+      // The coordinator's first (and only) goal turn: hand off to the worker.
+      // Unset FAKE_CLAUDE_REPLY_STATE means every invocation replays index 0,
+      // so an accidental retry would return the same decision — and price
+      // another turn, which the usage assertions below would catch.
+      FAKE_CLAUDE_REPLIES: JSON.stringify([
+        'The plan is ready.\n<openmaus-goal>{"status":"continue","next":"Worker","instruction":"Do the thing","detail":"Plan ready"}</openmaus-goal>',
+      ]),
+    }, undefined, undefined, undefined, { dir: layerDir, licenseKey: "fixture-key" });
+  }, 60_000);
+
+  afterEach(async () => {
+    console.info(JSON.stringify(session.info));
+    await session.close();
+    await removeTempDir(layerDir);
+  });
+
+  const control = (args: string[]) => runControlOmb([...args, "--url", session.info.url]) as Promise<any>;
+  const api = (path: string, init: RequestInit = {}) => fetch(`${session.info.url}${path}`, init);
+  const put = (body: unknown) => api("/api/config", { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+
+  it("ends a capped goal as a blocked run with the cap detail, without retrying the refusal", async () => {
+    expect((await (await api("/api/edition")).json())).toMatchObject({ edition: "enterprise", features: ["billing", "budgets"] });
+
+    // The fake engine reports $0.01 per turn: a $0.01 cap lets the
+    // coordinator's goal turn complete, then blocks the next turn at
+    // execution time inside runGroupMemberTurn.
+    expect((await put({
+      budgets: { monthlyUsd: 0.01, warnAtPercent: 50 },
+      billing: { currency: "USD", prices: { default: { inputPerMillion: 1000, outputPerMillion: 2000 } } },
+    })).status).toBe(200);
+
+    const lead = (await control(["new-bot", "--name", "Lead"])) as { bot: { id: string } };
+    const worker = (await control(["new-bot", "--name", "Worker"])) as { bot: { id: string } };
+
+    const roomRes = await api("/api/groups", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Capped goal room",
+        memberIds: [lead.bot.id, worker.bot.id],
+        setup: { bulletin: "", defaultResponder: { kind: "member", botId: lead.bot.id } },
+      }),
+    });
+    expect(roomRes.status).toBe(201);
+    const room = (await roomRes.json()) as { group: { id: string; threadId: string } };
+
+    // The send itself clears the cap ($0 spent); the run's second turn is
+    // what must hit it.
+    const sent = await api(`/api/groups/${encodeURIComponent(room.group.id)}/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text: "ship the plan", mode: "goal" }),
+    });
+    expect(sent.status).toBe(202);
+
+    await control(["wait", "--channel", room.group.id, "--timeout", "30"]);
+
+    const page = (await (await api(`/api/threads/${encodeURIComponent(room.group.threadId)}/messages?limit=50`)).json()) as any;
+    const goalCard = page.messages.find((m: any) => m.role === "bot" && m.kind === "goal.run");
+    expect(goalCard).toBeTruthy();
+    expect(goalCard.goalRun.status).toBe("blocked");
+    expect(goalCard.goalRun.detail).toContain("monthly spend limit");
+
+    // Exactly one spend-limit activity message: the refusal is recorded once,
+    // never replayed by a dispatch-failure retry.
+    const capMessages = page.messages.filter(
+      (m: any) => m.role === "bot" && m.kind === "activity" && /reached its monthly spend limit/i.test(m.tool?.name ?? ""),
+    );
+    expect(capMessages).toHaveLength(1);
+
+    // The goal loop's transient-retry narration must be absent: a capped
+    // refusal is deterministic, not a blip.
+    expect(page.messages.some((m: any) => /retrying once/i.test(m.tool?.name ?? ""))).toBe(false);
+
+    const usage = (await (await api("/api/usage")).json()) as any;
+    expect(usage.budget).toMatchObject({ monthlyUsd: 0.01, exceeded: true, warn: true });
+    // Only the coordinator's turn was priced — no worker dispatch, no retry.
+    expect(usage.total.turns).toBe(1);
+  }, 150_000);
+});

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -15,6 +15,7 @@ import {
   visibleNotificationThread,
   type Bot,
   type BotAnnouncement,
+  type ConfigStatusFrame,
   type Group,
   type Message,
   type Action,
@@ -1695,5 +1696,43 @@ describe("bot settings section", () => {
       id: "bot-a",
     });
     expect(state.botSettingsSection).toBe("overview");
+  });
+});
+
+describe("live config frames", () => {
+  const baseFrame: ConfigStatusFrame = {
+    composio: { configured: false },
+    box: { configured: false },
+    vps: { configured: false, sshAlias: "" },
+    rooms: { turnTimeoutMinutes: 10 },
+    localVm: { mode: "shared", maxInstances: 1 },
+  };
+
+  it("preserves edition, budgets and billing through configStatusFromFrame", () => {
+    const frame: ConfigStatusFrame = {
+      ...baseFrame,
+      edition: { edition: "enterprise", features: ["budgets", "billing"] },
+      budgets: { monthlyUsd: 10, warnAtPercent: 80 },
+      billing: { currency: "USD", prices: { default: { inputPerMillion: 1, outputPerMillion: 2 } } },
+    };
+    const status = configStatusFromFrame(frame);
+    expect(status.edition).toEqual(frame.edition);
+    expect(status.budgets).toEqual(frame.budgets);
+    expect(status.billing).toEqual(frame.billing);
+  });
+
+  it("keeps edition, budgets and billing in state.config after a config SSE frame lands", () => {
+    const frame: ConfigStatusFrame = {
+      ...baseFrame,
+      edition: { edition: "enterprise", features: ["budgets", "billing"] },
+      budgets: { monthlyUsd: 10, warnAtPercent: 80 },
+      billing: { currency: "USD" },
+    };
+    const state = reducer(initialState, { type: "configStatus", config: configStatusFromFrame(frame) });
+    expect(state.config).toMatchObject({
+      edition: { edition: "enterprise", features: ["budgets", "billing"] },
+      budgets: { monthlyUsd: 10, warnAtPercent: 80 },
+      billing: { currency: "USD" },
+    });
   });
 });

--- a/src/state/store.tsx
+++ b/src/state/store.tsx
@@ -505,7 +505,7 @@ export interface BrowserProfile {
 
 export type ConfigStatusFrame = Pick<
   ConfigStatus,
-  "xai" | "composio" | "box" | "vps" | "rooms" | "threads" | "localVm" | "opencodeGo" | "tts" | "imageGen" | "profile" | "language" | "features" | "onboarding" | "browserEngine" | "browserProfiles"
+  "xai" | "composio" | "box" | "vps" | "rooms" | "threads" | "localVm" | "opencodeGo" | "tts" | "imageGen" | "profile" | "language" | "features" | "onboarding" | "browserEngine" | "browserProfiles" | "edition" | "budgets" | "billing"
 >;
 
 export function configStatusFromFrame(frame: ConfigStatusFrame): ConfigStatus {
@@ -526,6 +526,9 @@ export function configStatusFromFrame(frame: ConfigStatusFrame): ConfigStatus {
     onboarding: frame.onboarding,
     browserEngine: frame.browserEngine,
     browserProfiles: frame.browserProfiles,
+    edition: frame.edition,
+    budgets: frame.budgets,
+    billing: frame.billing,
   };
 }
 


### PR DESCRIPTION
Refs #1063

## What changed

- `server/index.ts`:
  - `runGroupMemberTurn` now calls `assertWithinBudget(cfg, DATA_DIR)` before any provider dispatch, so every room/goal/queued/calendar/chained-mention member turn is checked against the current month-to-date spend.
  - Room/goal turns are now booked into the usage ledger under the speaking bot (`appendUsage`) and immediately update the spend cache (`noteSpend`) on `turn.completed`. This lets the second member see the first member's cost and refuse cleanly.
  - The spend-cap refusal is treated like a dispatch error: an activity message is added to the room transcript and the turn returns `false` instead of throwing.

- `src/state/store.tsx`:
  - `ConfigStatusFrame` and `configStatusFromFrame` now include `edition`, `budgets`, and `billing`, so live SSE `config` frames no longer silently drop those fields when replacing `state.config`.

## Tests

- `server/spend-cap-api.test.ts`: added a room-cap integration test that creates two bots in a room, sets a $0.01 cap, sends a message, and asserts the first member replies, the second is blocked with a visible spend-cap activity, and `/api/usage` reports one priced turn with an exceeded budget.
- `src/state/store.test.ts`: added `live config frames` tests for `configStatusFromFrame` and the `configStatus` reducer, asserting `edition`/`budgets`/`billing` survive.

## Verification

- `pnpm typecheck` passes.
- `pnpm exec vitest run --no-file-parallelism server/spend-cap-api.test.ts server/spend.test.ts src/state/store.test.ts` passes (95 tests).
- `pnpm exec vitest run --no-file-parallelism server/spend.test.ts server/usage-ledger.test.ts server/config.test.ts src/components/UsageBudget.test.ts` passes (109 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Configuration status now preserves and displays edition, budget, and billing details consistently.
  - Usage spending and costs are attributed to the bot speaking in a room or goal conversation.
  - Spend limits are checked before each automated turn across rooms, goals, queued tasks, calendar actions, and chained mentions.
  - Bots can coordinate with teammates across rooms, with validated handoffs, queued turns, and visible activity updates.

- **Bug Fixes**
  - Spend-limit refusals are reported clearly, prevent further turns, and no longer trigger unnecessary retries.
  - Goal runs stopped by a spend limit are marked as blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->